### PR TITLE
chore(deps): bump tj-actions/changed-files from v40 to v47

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Detect changed files
         id: changed-files
-        uses: tj-actions/changed-files@v40
+        uses: tj-actions/changed-files@v47
         with:
           files_yaml: |
             core:


### PR DESCRIPTION
## Summary

Upgrade tj-actions/changed-files GitHub Action from v40 to v47.

This PR replaces Dependabot PR #51 which couldn't be merged due to stale base branch causing typecheck failures.

## Test plan

- CI will run on this PR to verify the action works correctly

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow tooling to the latest version for improved reliability and compatibility with the development process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->