### PR TITLE
fix(ci): build all packages for SPA deployment

### DIFF
--- a/.github/workflows/deploy-spa-editor.yml
+++ b/.github/workflows/deploy-spa-editor.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "packages/workout-spa-editor/**"
       - "packages/core/**"
+      - "packages/all/**"
+      - "packages/fit/**"
+      - "packages/tcx/**"
+      - "packages/zwo/**"
       - ".github/workflows/deploy-spa-editor.yml"
   workflow_dispatch:
 
@@ -40,20 +44,26 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build core package
-        run: pnpm --filter @kaiord/core build
+      - name: Build all packages (dependencies for SPA)
+        run: pnpm -r build
 
-      - name: Verify core build
+      - name: Verify packages build
         run: |
+          # Verify core package
           if [ ! -d "packages/core/dist" ]; then
             echo "❌ Core package build output not found"
             exit 1
           fi
-          if [ ! -f "packages/core/dist/index.d.ts" ]; then
-            echo "❌ Core package TypeScript declaration files not found"
-            exit 1
-          fi
-          echo "✅ Core package build verified"
+
+          # Verify adapter packages
+          for pkg in fit tcx zwo all; do
+            if [ ! -d "packages/$pkg/dist" ]; then
+              echo "❌ @kaiord/$pkg package build output not found"
+              exit 1
+            fi
+          done
+
+          echo "✅ All packages build verified"
 
       - name: Build SPA Editor
         env:


### PR DESCRIPTION
## Problem

The SPA deployment workflow was failing with:
```
error TS2307: Cannot find module '@kaiord/all' or its corresponding type declarations.
```

## Root Cause

After extracting adapters to separate packages (v2.0), the SPA now depends on `@kaiord/all` which requires all adapter packages (`@kaiord/fit`, `@kaiord/tcx`, `@kaiord/zwo`) to be built first.

The deployment workflow was only building `@kaiord/core`.

## Solution

- Build all packages with `pnpm -r build` instead of just `@kaiord/core`
- Add verification for all adapter packages (fit, tcx, zwo, all)
- Add adapter package paths to workflow triggers

## Verification

✅ Builds all required packages in correct order
✅ Verifies all package outputs exist before building SPA
✅ Consistent with CI workflow approach

## Related

- Fixes deployment failure from #81
- Part of adapter extraction effort (v2.0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the build-and-deploy workflow to include all package types (core and adapters), perform broader pre-build verification across packages, and run a consolidated build step prior to the SPA deployment.
  * Improved verification messaging to reflect full-package build validation and clearer success feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->