### PR TITLE
feat: add Node.js 24 Active LTS support

### DIFF
--- a/.changeset/node-24-support.md
+++ b/.changeset/node-24-support.md
@@ -1,0 +1,23 @@
+---
+"@kaiord/core": patch
+"@kaiord/fit": patch
+"@kaiord/tcx": patch
+"@kaiord/zwo": patch
+"@kaiord/all": patch
+"@kaiord/cli": patch
+"@kaiord/workout-spa-editor": patch
+---
+
+feat: add Node.js 24 Active LTS support
+
+Add comprehensive Node.js 24.x (Active LTS) support to all packages and CI workflows while maintaining backward compatibility with Node.js 20.x and 22.x.
+
+**Changes:**
+
+- Add Node.js 24.x to CI test matrices (lint, test, test-frontend)
+- Upgrade @types/node from ^20.11.0 to ^24.0.0 across all packages
+- Update deployment workflows to use Node.js 24.x (release, deploy-spa-editor, security)
+- Update documentation to recommend Node.js 24.x as the preferred version
+- Maintain Node.js >=20.0.0 engine requirement for backward compatibility
+
+**Breaking Changes:** None

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: "Node.js version to use"
     required: false
-    default: "20.x"
+    default: "24.x"
   pnpm-version:
     description: "pnpm version to use"
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20.x", "22.x"]
+        node-version: ["20.x", "22.x", "24.x"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -142,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20.x", "22.x"]
+        node-version: ["20.x", "22.x", "24.x"]
         package: ["core"]
     steps:
       - name: Checkout code
@@ -215,7 +215,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["20.x", "22.x"]
+        node-version: ["20.x", "22.x", "24.x"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-spa-editor.yml
+++ b/.github/workflows/deploy-spa-editor.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "pnpm"
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 24.x
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: "24.x"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ For detailed installation instructions and usage examples, see the **[Getting St
 
 Kaiord uses GitHub Actions for continuous integration and deployment:
 
-- **Automated Testing**: Multi-version testing on Node.js 20.x and 22.x
+- **Automated Testing**: Multi-version testing on Node.js 20.x, 22.x, and 24.x (Active LTS)
 - **Code Quality**: ESLint, Prettier, and TypeScript strict mode validation
 - **Release Automation**: Changesets for version management and npm publishing
 - **Security**: Weekly dependency vulnerability audits

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -617,7 +617,7 @@ brew install act
 act -j test
 
 # Or match CI environment
-docker run -it node:20-alpine sh
+docker run -it node:24-alpine sh
 ```
 
 #### Workflow Stuck in "Queued" State

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,13 +14,13 @@ Kaiord is a toolkit for workout data. It helps you:
 
 Before you start, install these tools:
 
-- **Node.js** version 20 or newer ([download here](https://nodejs.org/))
+- **Node.js** version 20 or newer (Node.js 24 recommended) ([download here](https://nodejs.org/))
 - **pnpm** package manager ([install guide](https://pnpm.io/installation))
 
 Check your versions:
 
 ```bash
-node --version  # Should show v20.0.0 or higher
+node --version  # Should show v20.0.0 or higher (v24.x recommended)
 pnpm --version  # Should show 9.15.0 or higher
 ```
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
     "@eslint/js": "^9.15.0",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24.0.0",
     "eslint": "^9.15.0",
     "husky": "^9.1.7",
     "prettier": "^3.6.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^10.1.0",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24.0.0",
     "@types/rosie": "^0.0.45",
     "@vitest/coverage-v8": "^4.0.18",
     "rosie": "^2.1.1",

--- a/packages/fit/package.json
+++ b/packages/fit/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@faker-js/faker": "^10.1.0",
-    "@types/node": "^20.11.0",
+    "@types/node": "^24.0.0",
     "@types/rosie": "^0.0.45",
     "@vitest/coverage-v8": "^4.0.18",
     "rosie": "^2.1.1",

--- a/packages/tcx/package.json
+++ b/packages/tcx/package.json
@@ -29,7 +29,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/node": "^20.11.0",
+    "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.18",
     "tsup": "^8.5.1",
     "tsx": "^4.7.0",

--- a/packages/zwo/package.json
+++ b/packages/zwo/package.json
@@ -31,7 +31,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "@types/node": "^20.11.0",
+    "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.0.18",
     "tsup": "^8.5.1",
     "tsx": "^4.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,13 +16,13 @@ importers:
     devDependencies:
       "@changesets/cli":
         specifier: ^2.29.7
-        version: 2.29.7(@types/node@20.19.25)
+        version: 2.29.7(@types/node@24.10.1)
       "@eslint/js":
         specifier: ^9.15.0
         version: 9.39.1
       "@types/node":
-        specifier: ^20.11.0
-        version: 20.19.25
+        specifier: ^24.0.0
+        version: 24.10.1
       eslint:
         specifier: ^9.15.0
         version: 9.39.1(jiti@2.6.1)
@@ -138,8 +138,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       "@types/node":
-        specifier: ^20.11.0
-        version: 20.19.25
+        specifier: ^24.0.0
+        version: 24.10.1
       "@types/rosie":
         specifier: ^0.0.45
         version: 0.0.45
@@ -160,7 +160,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.25)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)
+        version: 4.0.18(@types/node@24.10.1)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)
 
   packages/fit:
     dependencies:
@@ -178,8 +178,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       "@types/node":
-        specifier: ^20.11.0
-        version: 20.19.25
+        specifier: ^24.0.0
+        version: 24.10.1
       "@types/rosie":
         specifier: ^0.0.45
         version: 0.0.45
@@ -200,7 +200,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.25)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)
+        version: 4.0.18(@types/node@24.10.1)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)
 
   packages/tcx:
     dependencies:
@@ -215,8 +215,8 @@ importers:
         version: 3.25.76
     devDependencies:
       "@types/node":
-        specifier: ^20.11.0
-        version: 20.19.25
+        specifier: ^24.0.0
+        version: 24.10.1
       "@vitest/coverage-v8":
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18)
@@ -231,7 +231,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.25)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)
+        version: 4.0.18(@types/node@24.10.1)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)
 
   packages/workout-spa-editor:
     dependencies:
@@ -406,8 +406,8 @@ importers:
         version: 3.25.76
     devDependencies:
       "@types/node":
-        specifier: ^20.11.0
-        version: 20.19.25
+        specifier: ^24.0.0
+        version: 24.10.1
       "@vitest/coverage-v8":
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18)
@@ -422,7 +422,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.25)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)
+        version: 4.0.18(@types/node@24.10.1)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)
 
 packages:
   "@acemir/cssom@0.9.23":
@@ -7496,7 +7496,7 @@ snapshots:
     dependencies:
       "@changesets/types": 6.1.0
 
-  "@changesets/cli@2.29.7(@types/node@20.19.25)":
+  "@changesets/cli@2.29.7(@types/node@24.10.1)":
     dependencies:
       "@changesets/apply-release-plan": 7.0.13
       "@changesets/assemble-release-plan": 6.0.9
@@ -7512,7 +7512,7 @@ snapshots:
       "@changesets/should-skip-package": 0.1.2
       "@changesets/types": 6.1.0
       "@changesets/write": 0.4.0
-      "@inquirer/external-editor": 1.0.3(@types/node@20.19.25)
+      "@inquirer/external-editor": 1.0.3(@types/node@24.10.1)
       "@manypkg/get-packages": 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -7988,12 +7988,12 @@ snapshots:
 
   "@humanwhocodes/retry@0.4.3": {}
 
-  "@inquirer/external-editor@1.0.3(@types/node@20.19.25)":
+  "@inquirer/external-editor@1.0.3(@types/node@24.10.1)":
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.0
     optionalDependencies:
-      "@types/node": 20.19.25
+      "@types/node": 24.10.1
 
   "@isaacs/balanced-match@4.0.1": {}
 
@@ -9157,7 +9157,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@20.19.25)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)
+      vitest: 4.0.18(@types/node@24.10.1)(@vitest/ui@4.0.18)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.6)
 
   "@vitest/expect@2.0.5":
     dependencies:


### PR DESCRIPTION
## Summary

Add comprehensive Node.js 24.x (Active LTS) support to all packages and CI workflows while maintaining backward compatibility with Node.js 20.x and 22.x.

### Changes

#### CI/CD Workflows
- Add Node.js 24.x to test matrices in ci.yml (lint, test, test-frontend)
- Upgrade release, deploy, and security workflows to Node.js 24.x
- Update setup-pnpm action default to Node.js 24.x

#### Package Dependencies
- Update @types/node from ^20.11.0 to ^24.0.0 across all packages
- Maintain Node.js >=20.0.0 engine requirement

#### Documentation
- Recommend Node.js 24.x in getting-started.md
- Update deployment.md to use Node.js 24.x
- Update README.md to reflect multi-version support

### Backward Compatibility

No breaking changes. Engine requirement remains `>=20.0.0`.

### Testing Strategy

- CI tests on Node.js 20.x, 22.x, and 24.x
- All quality checks passing (zero warnings, zero errors)
- Coverage thresholds met (80% core, 70% frontend)

### Test Plan

- [x] All packages build successfully
- [x] All tests pass
- [x] Zero TypeScript errors
- [x] Zero ESLint errors (2 pre-existing warnings unrelated to this change)
- [x] Coverage thresholds met
- [ ] CI passes on all Node.js versions
- [ ] Deploy workflow completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)