### PR TITLE
fix: remove private package from changeset

### DIFF
--- a/.changeset/node-24-support.md
+++ b/.changeset/node-24-support.md
@@ -5,7 +5,6 @@
 "@kaiord/zwo": patch
 "@kaiord/all": patch
 "@kaiord/cli": patch
-"@kaiord/workout-spa-editor": patch
 ---
 
 feat: add Node.js 24 Active LTS support


### PR DESCRIPTION
## Summary

Fix release workflow failure by removing @kaiord/workout-spa-editor from the changeset.

## Issue

The release workflow was failing with this error:


## Solution

Remove @kaiord/workout-spa-editor from the changeset since it's a private package (not published to npm).

## Changes

- Remove  from 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release documentation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->