### PR TITLE
fix: disable husky hooks for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,12 +102,12 @@ jobs:
             echo "cli-changed=false" >> $GITHUB_OUTPUT
           fi
 
-          # Commit version changes
+          # Commit version changes (skip hooks for automated version bumps)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit --no-verify -m "chore: version packages [skip ci]"
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:main
+          HUSKY=0 git commit --no-verify -m "chore: version packages [skip ci]"
+          HUSKY=0 git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:main
 
       - name: Build packages
         if: steps.changesets.outputs.has-changesets == 'true'

--- a/packages/tcx/src/adapters/round-trip/round-trip.test.ts
+++ b/packages/tcx/src/adapters/round-trip/round-trip.test.ts
@@ -1,9 +1,7 @@
-import { readFileSync } from "fs";
-import { join } from "path";
 import { describe, expect, it } from "vitest";
 import type { KRD } from "@kaiord/core";
 import { createToleranceChecker } from "@kaiord/core";
-import { createMockLogger } from "@kaiord/core/test-utils";
+import { createMockLogger, loadTcxFixture } from "@kaiord/core/test-utils";
 import {
   createFastXmlTcxReader,
   createFastXmlTcxWriter,
@@ -18,11 +16,7 @@ describe("Round-trip: TCX → KRD → TCX", () => {
     const reader = createFastXmlTcxReader(logger);
     const writer = createFastXmlTcxWriter(logger, validator);
     const toleranceChecker = createToleranceChecker();
-    const tcxPath = join(
-      __dirname,
-      "../../../tests/fixtures/tcx-files/WorkoutHeartRateTargets.tcx"
-    );
-    const originalXml = readFileSync(tcxPath, "utf-8");
+    const originalXml = loadTcxFixture("WorkoutHeartRateTargets.tcx");
 
     // Act - TCX → KRD → TCX → KRD
     const krd1 = await reader(originalXml);
@@ -98,11 +92,7 @@ describe("Round-trip: TCX → KRD → TCX", () => {
     const reader = createFastXmlTcxReader(logger);
     const writer = createFastXmlTcxWriter(logger, validator);
     const toleranceChecker = createToleranceChecker();
-    const tcxPath = join(
-      __dirname,
-      "../../../tests/fixtures/tcx-files/WorkoutSpeedTargets.tcx"
-    );
-    const originalXml = readFileSync(tcxPath, "utf-8");
+    const originalXml = loadTcxFixture("WorkoutSpeedTargets.tcx");
 
     // Act - TCX → KRD → TCX → KRD
     const krd1 = await reader(originalXml);


### PR DESCRIPTION
Use HUSKY=0 to disable all husky hooks during automated version bump operations in the release workflow.