### PR TITLE
Revert: disable husky hooks for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,12 +102,12 @@ jobs:
             echo "cli-changed=false" >> $GITHUB_OUTPUT
           fi
 
-          # Commit version changes (skip hooks for automated version bumps)
+          # Commit version changes
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          HUSKY=0 git commit --no-verify -m "chore: version packages [skip ci]"
-          HUSKY=0 git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:main
+          git commit --no-verify -m "chore: version packages [skip ci]"
+          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:main
 
       - name: Build packages
         if: steps.changesets.outputs.has-changesets == 'true'

--- a/packages/tcx/src/adapters/round-trip/round-trip.test.ts
+++ b/packages/tcx/src/adapters/round-trip/round-trip.test.ts
@@ -1,7 +1,9 @@
+import { readFileSync } from "fs";
+import { join } from "path";
 import { describe, expect, it } from "vitest";
 import type { KRD } from "@kaiord/core";
 import { createToleranceChecker } from "@kaiord/core";
-import { createMockLogger, loadTcxFixture } from "@kaiord/core/test-utils";
+import { createMockLogger } from "@kaiord/core/test-utils";
 import {
   createFastXmlTcxReader,
   createFastXmlTcxWriter,
@@ -16,7 +18,11 @@ describe("Round-trip: TCX → KRD → TCX", () => {
     const reader = createFastXmlTcxReader(logger);
     const writer = createFastXmlTcxWriter(logger, validator);
     const toleranceChecker = createToleranceChecker();
-    const originalXml = loadTcxFixture("WorkoutHeartRateTargets.tcx");
+    const tcxPath = join(
+      __dirname,
+      "../../../tests/fixtures/tcx-files/WorkoutHeartRateTargets.tcx"
+    );
+    const originalXml = readFileSync(tcxPath, "utf-8");
 
     // Act - TCX → KRD → TCX → KRD
     const krd1 = await reader(originalXml);
@@ -92,7 +98,11 @@ describe("Round-trip: TCX → KRD → TCX", () => {
     const reader = createFastXmlTcxReader(logger);
     const writer = createFastXmlTcxWriter(logger, validator);
     const toleranceChecker = createToleranceChecker();
-    const originalXml = loadTcxFixture("WorkoutSpeedTargets.tcx");
+    const tcxPath = join(
+      __dirname,
+      "../../../tests/fixtures/tcx-files/WorkoutSpeedTargets.tcx"
+    );
+    const originalXml = readFileSync(tcxPath, "utf-8");
 
     // Act - TCX → KRD → TCX → KRD
     const krd1 = await reader(originalXml);


### PR DESCRIPTION
Revert PR #90. Disabling husky hooks is not the right solution - we need to fix the underlying dependency resolution issue instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release workflow to use explicit flag for skipping git hooks instead of environment variable.

* **Tests**
  * Refactored test fixture loading to use direct filesystem reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->