### PR TITLE
fix: build packages before commit in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,14 @@ jobs:
           # Update lock file after version bump
           pnpm install --no-frozen-lockfile
 
+          # Build packages so TypeScript can resolve workspace dependencies in pre-push hook
+          pnpm --filter @kaiord/core build
+          pnpm --filter @kaiord/fit build
+          pnpm --filter @kaiord/tcx build
+          pnpm --filter @kaiord/zwo build
+          pnpm --filter @kaiord/all build
+          pnpm --filter @kaiord/cli build
+
           # Get new versions
           CORE_VERSION_AFTER=$(node -p "require('./packages/core/package.json').version")
           CLI_VERSION_AFTER=$(node -p "require('./packages/cli/package.json').version")
@@ -106,14 +114,8 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit --no-verify -m "chore: version packages [skip ci]"
+          git commit -m "chore: version packages [skip ci]"
           git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:main
-
-      - name: Build packages
-        if: steps.changesets.outputs.has-changesets == 'true'
-        run: |
-          pnpm --filter @kaiord/core build
-          pnpm --filter @kaiord/cli build
 
       - name: Publish to npm
         if: steps.changesets.outputs.has-changesets == 'true'


### PR DESCRIPTION
## Summary

Fix the release workflow to build all packages BEFORE committing version bumps. This ensures TypeScript can resolve workspace dependencies when the pre-push hook runs type checking.

## Problem

After `changeset version` updates package.json files, the pre-push hook fails with TypeScript errors because workspace dependencies (@kaiord/core, @kaiord/fit, etc.) haven't been built yet. The hook's `tsc --noEmit` cannot resolve these dependencies without their dist folders and type definitions.

## Solution

1. **Build all packages after `pnpm install` but before `git commit`**
   - Added build commands for all 6 packages (core, fit, tcx, zwo, all, cli)
   - Build step now runs between lock file update and version commit

2. **Remove `--no-verify` flag from git commit**
   - Respects git hooks as intended (per user feedback)
   - Pre-push hook can now succeed because packages are built

3. **Remove duplicate build step**
   - Eliminated the build step that was after commit
   - Packages are now built once, at the correct time

## Changes

- `.github/workflows/release.yml`:
  - Add build commands for all 6 packages after `pnpm install --no-frozen-lockfile`
  - Remove `--no-verify` from `git commit` command
  - Remove duplicate "Build packages" step that was after commit

## Testing Strategy

After merge, manually trigger the release workflow to verify:
- [ ] Changeset version bump completes
- [ ] Lock file updates successfully
- [ ] All packages build successfully
- [ ] Pre-push hook passes (TypeScript can resolve dependencies)
- [ ] Version commit and push succeed
- [ ] Packages publish to npm
- [ ] GitHub releases created

## Related Issues

- Fixes release workflow failures where pre-push hook failed with TypeScript errors
- Addresses user concern about disabling git hooks
- Completes Node.js 24 support release (pending changeset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)