### PR TITLE
fix(ci): handle empty version commits in release workflow

### DIFF
--- a/.changeset/codecov-bundle-analysis.md
+++ b/.changeset/codecov-bundle-analysis.md
@@ -1,5 +1,0 @@
----
-"@kaiord/workout-spa-editor": patch
----
-
-Add Codecov Bundle Analysis to track SPA bundle size changes on pull requests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,28 +123,34 @@ jobs:
             echo "cli-changed=false" >> $GITHUB_OUTPUT
           fi
 
-          # Commit version changes
+          # Commit version changes (if any packages were actually bumped)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .
-          git commit -m "chore: version packages [skip ci]"
-          git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:main
+          if git diff --cached --quiet; then
+            echo "No version changes to commit (changesets may only affect ignored packages)"
+            echo "has-version-changes=false" >> $GITHUB_OUTPUT
+          else
+            git commit -m "chore: version packages [skip ci]"
+            git push https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git HEAD:main
+            echo "has-version-changes=true" >> $GITHUB_OUTPUT
+          fi
 
       - name: Publish to npm with provenance
-        if: steps.changesets.outputs.has-changesets == 'true'
+        if: steps.changesets.outputs.has-changesets == 'true' && steps.version.outputs.has-version-changes == 'true'
         env:
           NPM_CONFIG_PROVENANCE: true
         run: pnpm exec changeset publish
 
       - name: Create GitHub Releases
-        if: steps.changesets.outputs.has-changesets == 'true'
+        if: steps.changesets.outputs.has-changesets == 'true' && steps.version.outputs.has-version-changes == 'true'
         run: node scripts/create-github-releases.js
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Summary
-        if: steps.changesets.outputs.has-changesets == 'true'
+        if: steps.changesets.outputs.has-changesets == 'true' && steps.version.outputs.has-version-changes == 'true'
         run: |
           echo "## 📦 Release Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

- Remove changeset targeting ignored package (`@kaiord/workout-spa-editor`) that caused release failure
- Make release workflow resilient to empty commits when changesets only affect ignored packages
- Guard publish/release/summary steps with `has-version-changes` check

## Root Cause

PR #110 included a changeset for `@kaiord/workout-spa-editor`, which is in the `"ignore"` list in `.changeset/config.json`. When the release workflow ran:

1. `changeset version` consumed the `.md` file but produced no version bumps
2. `git add . && git commit` failed with "nothing to commit" (exit code 1)
3. Workflow failed, but the changeset file remained on main (commit never pushed)

## Fix

- **Immediate**: Delete the orphaned changeset file
- **Preventive**: Use `git diff --cached --quiet` before committing, skip publish/release steps when no versions changed

## Test plan

- [ ] Release workflow passes on main after merge
- [ ] Future changesets for ignored packages don't break the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to add conditional version change checks, preventing unnecessary publication steps when no version updates are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->