### PR TITLE
fix(ci,spa): build all deps for E2E and suppress console-spy output

### DIFF
--- a/.github/workflows/workout-spa-editor-e2e.yml
+++ b/.github/workflows/workout-spa-editor-e2e.yml
@@ -64,7 +64,7 @@ jobs:
         run: pnpm --filter @kaiord/workout-spa-editor test:e2e:install
 
       - name: Build workspace dependencies
-        run: pnpm --filter @kaiord/core build
+        run: pnpm -r build
 
       - name: Run E2E tests
         run: pnpm --filter @kaiord/workout-spa-editor test:e2e --project=${{ matrix.browser }}
@@ -131,7 +131,7 @@ jobs:
         run: pnpm --filter @kaiord/workout-spa-editor test:e2e:install
 
       - name: Build workspace dependencies
-        run: pnpm --filter @kaiord/core build
+        run: pnpm -r build
 
       - name: Run mobile E2E tests
         run: pnpm --filter @kaiord/workout-spa-editor test:e2e --project="${{ matrix.device }}"

--- a/packages/workout-spa-editor/src/test-utils/console-spy.ts
+++ b/packages/workout-spa-editor/src/test-utils/console-spy.ts
@@ -26,7 +26,7 @@ type ConsoleSpy = ReturnType<typeof vi.spyOn>;
  * ```
  */
 export const expectNoReactWarnings = () => {
-  const consoleSpy = vi.spyOn(console, "error");
+  const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
   return {
     /**
@@ -83,7 +83,7 @@ export const expectNoReactWarnings = () => {
  * ```
  */
 export const setupConsoleErrorSpy = (): ConsoleSpy => {
-  return vi.spyOn(console, "error");
+  return vi.spyOn(console, "error").mockImplementation(() => {});
 };
 
 /**


### PR DESCRIPTION
## Summary

Two fixes:

1. **E2E workflow**: Build all workspace packages, not just `@kaiord/core`
2. **console-spy.ts**: Suppress console output during spy capture

## Details

### E2E build fix

The E2E workflow only ran `pnpm --filter @kaiord/core build`, but Vite dev server needs all adapter packages built to resolve their exports:

```
Failed to resolve entry for package "@kaiord/fit".
The package may have incorrect main/module/exports specified in its package.json.
```

Changed to `pnpm -r build` which builds all workspace packages topologically.

### Console spy fix

`vi.spyOn(console, "error")` records calls but passes them through to the real `console.error`, leaking output to stderr. Added `.mockImplementation(() => {})` to suppress output while still recording calls for assertions.

## Test plan

- [ ] CI passes (unit tests, lint, typecheck)
- [ ] E2E tests pass on all browsers after merge to main
- [ ] No console-spy output in test logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration for workspace dependency handling
  * Enhanced testing infrastructure for console error handling during test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->