### PR TITLE
fix(spa): fix root causes of E2E failures on all viewports

### DIFF
--- a/packages/workout-spa-editor/e2e/copy-paste.spec.ts
+++ b/packages/workout-spa-editor/e2e/copy-paste.spec.ts
@@ -19,13 +19,6 @@ import { loadTestWorkout } from "./helpers/load-test-workout";
 
 test.describe("Copy/Paste Functionality", () => {
   test.beforeEach(async ({ page }) => {
-    // Skip on mobile projects - CopyButton uses absolute positioning (right-28)
-    // that places it off-screen on small viewports (< 500px)
-    test.skip(
-      test.info().project.name.startsWith("Mobile"),
-      "Copy-paste buttons not accessible on mobile viewports"
-    );
-
     // Clear localStorage before navigation to start fresh
     await page.addInitScript(() => localStorage.clear());
     await page.goto("/");

--- a/packages/workout-spa-editor/e2e/delete-undo.spec.ts
+++ b/packages/workout-spa-editor/e2e/delete-undo.spec.ts
@@ -106,9 +106,7 @@ test.describe("Delete with Undo Flow", () => {
     await page.waitForTimeout(300);
 
     // Verify undo notification appears
-    const toast = page
-      .locator('[role="status"]')
-      .filter({ hasText: "Step deleted" });
+    const toast = page.getByText(/step deleted/i).first();
     await expect(toast).toBeVisible({ timeout: 2000 });
 
     // Verify undo button is present in the notification
@@ -143,9 +141,7 @@ test.describe("Delete with Undo Flow", () => {
     await expect(stepCards).toHaveCount(2);
 
     // Click undo button in the notification
-    const toast = page
-      .locator('[role="status"]')
-      .filter({ hasText: "Step deleted" });
+    const toast = page.getByText(/step deleted/i).first();
     const undoButton = page.getByTestId("undo-delete-button");
     await undoButton.click();
 
@@ -177,9 +173,7 @@ test.describe("Delete with Undo Flow", () => {
     await page.waitForTimeout(300);
 
     // Verify notification appears
-    const toast = page
-      .locator('[role="status"]')
-      .filter({ hasText: "Step deleted" });
+    const toast = page.getByText(/step deleted/i).first();
     await expect(toast).toBeVisible();
 
     // Wait for notification to auto-dismiss (5 seconds + buffer)
@@ -207,10 +201,9 @@ test.describe("Delete with Undo Flow", () => {
     await page.waitForTimeout(300);
 
     // Verify first notification appears (allow extra time for webkit toast animation)
-    const toasts = page
-      .locator('[role="status"]')
-      .filter({ hasText: "Step deleted" });
-    await expect(toasts.first()).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(/step deleted/i).first()).toBeVisible({
+      timeout: 5000,
+    });
 
     // Delete another step (now at index 0 after first deletion)
     const secondDeleteButton = stepCards
@@ -219,18 +212,14 @@ test.describe("Delete with Undo Flow", () => {
     await secondDeleteButton.click();
 
     // Wait for both deletions to process
-    await page.waitForTimeout(800);
+    await page.waitForTimeout(1000);
 
     // Verify only 1 step remains (both deletions completed)
     await expect(stepCards).toHaveCount(1);
 
-    // Both "Step deleted" toasts should be visible simultaneously
-    // (5s duration means first toast is still visible when second appears)
-    await expect(toasts).toHaveCount(2, { timeout: 5000 });
-
-    // Verify both undo buttons are present
+    // Both undo buttons should be visible (one per deletion)
     const undoButtons = page.getByTestId("undo-delete-button");
-    await expect(undoButtons).toHaveCount(2);
+    await expect(undoButtons).toHaveCount(2, { timeout: 5000 });
   });
 
   test("should handle undo correctly with step reindexing", async ({
@@ -286,9 +275,7 @@ test.describe("Delete with Undo Flow", () => {
     await page.waitForTimeout(300);
 
     // Verify notification appears (allow extra time for webkit toast animation)
-    const toast = page
-      .locator('[role="status"]')
-      .filter({ hasText: "Step deleted" });
+    const toast = page.getByText(/step deleted/i).first();
     await expect(toast).toBeVisible({ timeout: 5000 });
 
     // Perform another action - select a different step

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/CopyButton.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/CopyButton.tsx
@@ -14,7 +14,7 @@ export function CopyButton({ stepIndex, onCopy }: CopyButtonProps) {
   return (
     <button
       onClick={handleCopy}
-      className="absolute right-28 bottom-3 rounded-full p-2 bg-white dark:bg-gray-700 border-2 border-gray-200 dark:border-gray-600 text-gray-500 hover:border-green-500 hover:bg-green-50 hover:text-green-600 dark:hover:border-green-400 dark:hover:bg-green-900/30 dark:hover:text-green-400 transition-all duration-200 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+      className="rounded-full p-2 bg-white dark:bg-gray-700 border-2 border-gray-200 dark:border-gray-600 text-gray-500 hover:border-green-500 hover:bg-green-50 hover:text-green-600 dark:hover:border-green-400 dark:hover:bg-green-900/30 dark:hover:text-green-400 transition-colors duration-200 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
       aria-label={`Copy step ${stepIndex + 1}`}
       title="Copy step to clipboard"
       data-testid="copy-step-button"

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/DeleteButton.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/DeleteButton.tsx
@@ -14,7 +14,7 @@ export function DeleteButton({ stepIndex, onDelete }: DeleteButtonProps) {
   return (
     <button
       onClick={handleDelete}
-      className="absolute right-3 bottom-3 rounded-full p-2 bg-white dark:bg-gray-700 border-2 border-gray-200 dark:border-gray-600 text-gray-500 hover:border-red-500 hover:bg-red-50 hover:text-red-600 dark:hover:border-red-400 dark:hover:bg-red-900/30 dark:hover:text-red-400 transition-all duration-200 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+      className="rounded-full p-2 bg-white dark:bg-gray-700 border-2 border-gray-200 dark:border-gray-600 text-gray-500 hover:border-red-500 hover:bg-red-50 hover:text-red-600 dark:hover:border-red-400 dark:hover:bg-red-900/30 dark:hover:text-red-400 transition-colors duration-200 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
       aria-label={`Delete step ${stepIndex + 1}`}
       title="Delete step"
       data-testid="delete-step-button"

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/DuplicateButton.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/DuplicateButton.tsx
@@ -17,7 +17,7 @@ export function DuplicateButton({
   return (
     <button
       onClick={handleDuplicate}
-      className="absolute right-14 bottom-3 rounded-full p-2 bg-white dark:bg-gray-700 border-2 border-gray-200 dark:border-gray-600 text-gray-500 hover:border-blue-500 hover:bg-blue-50 hover:text-blue-600 dark:hover:border-blue-400 dark:hover:bg-blue-900/30 dark:hover:text-blue-400 transition-all duration-200 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+      className="rounded-full p-2 bg-white dark:bg-gray-700 border-2 border-gray-200 dark:border-gray-600 text-gray-500 hover:border-blue-500 hover:bg-blue-50 hover:text-blue-600 dark:hover:border-blue-400 dark:hover:bg-blue-900/30 dark:hover:text-blue-400 transition-colors duration-200 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
       aria-label={`Duplicate step ${stepIndex + 1}`}
       title="Duplicate step"
       data-testid="duplicate-step-button"

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/StepCardActions.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/StepCardActions.tsx
@@ -16,12 +16,12 @@ export function StepCardActions({
   onCopy,
 }: StepCardActionsProps) {
   return (
-    <>
-      {onDelete && <DeleteButton stepIndex={stepIndex} onDelete={onDelete} />}
+    <div className="absolute right-3 bottom-3 flex gap-2">
       {onCopy && <CopyButton stepIndex={stepIndex} onCopy={onCopy} />}
       {onDuplicate && (
         <DuplicateButton stepIndex={stepIndex} onDuplicate={onDuplicate} />
       )}
-    </>
+      {onDelete && <DeleteButton stepIndex={stepIndex} onDelete={onDelete} />}
+    </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/molecules/delete-button-styling.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/delete-button-styling.test.tsx
@@ -187,9 +187,6 @@ describe("Delete Button Styling Consistency", () => {
       expect(button).toHaveClass("dark:hover:text-red-400");
 
       // Verify appropriate styling for overlay context (Requirement 5.5)
-      expect(button).toHaveClass("absolute"); // Positioned absolutely
-      expect(button).toHaveClass("right-3");
-      expect(button).toHaveClass("bottom-3");
       expect(button).toHaveClass("p-2"); // Larger padding for overlay
       expect(button).toHaveClass("rounded-full"); // Circular shape
       expect(button).toHaveClass("bg-white"); // Background for visibility
@@ -218,8 +215,8 @@ describe("Delete Button Styling Consistency", () => {
       // RepetitionBlock: inline (no absolute positioning)
       expect(blockButton).not.toHaveClass("absolute");
 
-      // StepCard: overlay (absolute positioning)
-      expect(stepButton).toHaveClass("absolute");
+      // StepCard: overlay (positioned via parent container)
+      expect(stepButton).not.toHaveClass("absolute");
     });
 
     it("should have different initial state styling", () => {


### PR DESCRIPTION
## Summary

Root cause fixes for E2E failures -- component CSS and test selector fixes, not just timing workarounds.

## Changes

### StepCard button layout (root cause)
- **Before**: 3 buttons each with `absolute right-3/14/28 bottom-3` (CopyButton at 112px from right = off-screen on mobile, not-stable on desktop)
- **After**: Buttons wrapped in `<div class="absolute right-3 bottom-3 flex gap-2">` container. Individual buttons no longer absolute-positioned.
- Changed `transition-all` to `transition-colors` to prevent Playwright "not stable" detection.

### Toast selectors (root cause)
- **Before**: `page.locator('[role="status"]').filter({ hasText: "Step deleted" })` returned count 0 on mobile
- **After**: `page.getByText(/step deleted/i).first()` -- reliably matches regardless of Radix DOM structure

### Copy-paste mobile skip removed
No longer needed since buttons are visible on all viewports.

## Test plan
- [x] 1698 unit tests passing
- [x] Lint clean
- [ ] E2E all browsers pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)