### PR TITLE
fix(ci): update claude-code-review workflow to v1 API

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,6 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
@@ -31,10 +25,15 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          plugin_marketplaces: |
-            https://github.com/anthropics/claude-code.git
-          plugins: |
-            code-review@claude-code-plugins
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          track_progress: true
+          prompt: |
+            Review pull request #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            Focus on:
+            - Code quality and best practices
+            - Potential bugs or security issues
+            - Compliance with project standards (see CLAUDE.md)
+
+            Use inline comments for specific issues and a summary comment for overall feedback.
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"


### PR DESCRIPTION
## Summary

- Remove deprecated `plugin_marketplaces` and `plugins` parameters from the Claude Code review workflow
- These parameters were removed in `claude-code-action@v1` and cause an SDK crash on every PR
- Use standard `prompt` + `claude_args` with MCP-based inline comment tools instead

## Context

The workflow was added in PR #124 using the old plugin-based API. The `claude-code-action@v1` migrated to MCP servers and no longer supports `plugin_marketplaces`/`plugins`.

**This PR must be merged to `main` before the `claude-review` check can work on other PRs**, because the action validates that the workflow file matches the default branch via OIDC.

## Test plan

- [x] Workflow syntax is valid YAML
- [ ] `claude-review` check passes on subsequent PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review workflow configuration with streamlined settings and refined review scope focusing on code quality, security, and standards compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->