### PR TITLE
fix(infra): remove reserved concurrency (account quota too low)

### DIFF
--- a/packages/infra/src/stack/garmin-proxy-stack.ts
+++ b/packages/infra/src/stack/garmin-proxy-stack.ts
@@ -61,7 +61,6 @@ export class GarminProxyStack extends Stack {
       runtime: Runtime.NODEJS_24_X,
       timeout: Duration.seconds(60),
       memorySize: 512,
-      reservedConcurrentExecutions: 5,
       logGroup,
       layers: [tailscale.layer],
       environment: {


### PR DESCRIPTION
## Summary

Remove `reservedConcurrentExecutions: 5` — AWS account doesn't have enough unreserved concurrency quota (minimum 10 required). API Gateway throttle (10 rps, burst 5) already protects against Tailscale node flood.

## Test plan

- [x] Build and tests passing
- [ ] CDK deploy should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration for improved service scalability and handling of concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->