### PR TITLE
feat(infra): configure Tailscale exit node from handler

### DIFF
--- a/openspec/changes/lambda-tailscale-exit-node/design.md
+++ b/openspec/changes/lambda-tailscale-exit-node/design.md
@@ -70,7 +70,45 @@ fi
 
 This would allow using OAuth client keys (no expiry) with `TS_ADVERTISE_TAGS=tag:lambda` as an environment variable. Consider contributing this upstream to `rehanvdm/tailscale-lambda-extension`.
 
-## Decision 4: Tunnel health check on every invocation
+The forked script should also support `TS_EXIT_NODE` natively:
+
+```bash
+# Forked (with exit-node + advertise-tags support):
+EXTRA_ARGS=""
+if [ -n "${TS_ADVERTISE_TAGS}" ]; then
+  EXTRA_ARGS="--advertise-tags=${TS_ADVERTISE_TAGS}"
+fi
+/opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock up \
+  --authkey="${TS_KEY}" \
+  --hostname="${TS_HOSTNAME}" \
+  ${EXTRA_ARGS}
+
+if [ -n "${TS_EXIT_NODE}" ]; then
+  /opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock set \
+    --exit-node="${TS_EXIT_NODE}"
+fi
+```
+
+**Benefits of fork over current workaround:**
+
+- OAuth client keys (no 90-day expiry, no rotation needed)
+- Exit node configured in extension lifecycle (before handler runs)
+- Cleaner separation of concerns (handler doesn't manage Tailscale)
+- Could contribute upstream to `rehanvdm/tailscale-lambda-extension`
+
+## Decision 4: Exit node configuration from handler
+
+**Layer:** adapters (`@kaiord/infra`)
+
+**Choice:** Call `tailscale set --exit-node` from the Lambda handler on first invocation (cold start only). The construct's extension starts Tailscale but does not support `--exit-node`.
+
+**Rationale:** The extension runs `tailscale up` before the handler starts, but only with `--authkey` and `--hostname`. The `tailscale set` command can modify the running configuration after the fact. This avoids forking the construct.
+
+**Implementation:** `tailscale-exit-node.ts` calls `/opt/extensions/bin/tailscale --socket=/tmp/tailscale.sock set --exit-node=X` once per container. Cached via module-level flag.
+
+**Trade-off:** When the construct is forked (see above), this workaround can be removed and exit node will be configured natively in the extension lifecycle.
+
+## Decision 5: Tunnel health check on every invocation
 
 **Layer:** adapters (`@kaiord/infra`)
 
@@ -80,15 +118,13 @@ This would allow using OAuth client keys (no expiry) with `TS_ADVERTISE_TAGS=tag
 
 **Implementation:** Attempt a TCP connection through SOCKS5 before proxying to Garmin. If it fails, kill `tailscaled` and reinitialize.
 
-## Decision 5: Reserved concurrency limit
+## Decision 6: Reserved concurrency (deferred)
 
 **Layer:** adapters (`@kaiord/infra`)
 
-**Choice:** Set Lambda reserved concurrency to 5.
+**Status:** Removed — AWS account quota too low (10). Increase to 1000 requested. API Gateway throttle (10 rps, burst 5) provides protection in the meantime. Re-add `reservedConcurrentExecutions: 5` once quota is approved.
 
-**Rationale (from Lambda engineer review):** Each concurrent invocation creates a separate ephemeral Tailscale node. Burst traffic can overwhelm the coordination server ([GitHub issue #14956](https://github.com/tailscale/tailscale/issues/14956)). The API Gateway throttle (10 rps, burst 5) provides some protection, but explicit concurrency limits prevent node flood.
-
-## Decision 6: Disable minification, enable source maps
+## Decision 7: Disable minification, enable source maps
 
 **Layer:** adapters (`@kaiord/infra`)
 
@@ -96,7 +132,7 @@ This would allow using OAuth client keys (no expiry) with `TS_ADVERTISE_TAGS=tag
 
 **Rationale:** Minification obscured error types (`ServiceAuthError` → `Op`), making debugging impossible. Bundle size increase (~100KB) is negligible for server-side. Already deployed during debug session.
 
-## Decision 7: Tailscale ACLs for `tag:lambda`
+## Decision 8: Tailscale ACLs for `tag:lambda`
 
 **Layer:** external (Tailscale admin console)
 

--- a/packages/infra/src/lambda/handler.ts
+++ b/packages/infra/src/lambda/handler.ts
@@ -3,6 +3,7 @@ import { pushRequestSchema } from "./request-schema";
 import { pushToGarmin } from "./garmin-push";
 import { checkTunnelHealth } from "./proxy-fetch";
 import { errorResponse, jsonResponse } from "./response";
+import { ensureExitNode } from "./tailscale-exit-node";
 
 const MAX_BODY_BYTES = 512_000;
 const useTailscale = (): boolean => Boolean(process.env.TS_SECRET_API_KEY);
@@ -54,6 +55,8 @@ export const handler = async (event: APIGatewayProxyEventV2) => {
   if (!validation.success) {
     return errorResponse(400, "Invalid request: check KRD and credentials");
   }
+
+  if (useTailscale()) ensureExitNode();
 
   if (useTailscale() && !(await checkTunnelHealth())) {
     console.error("Tailscale tunnel unavailable", { requestId });

--- a/packages/infra/src/lambda/tailscale-exit-node.test.ts
+++ b/packages/infra/src/lambda/tailscale-exit-node.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExecFileSync = vi.fn();
+vi.mock("node:child_process", () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+describe("ensureExitNode", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.TS_EXIT_NODE;
+  });
+
+  it("should call tailscale set with exit node from env", async () => {
+    process.env.TS_EXIT_NODE = "100.116.150.51";
+
+    const { ensureExitNode } = await import("./tailscale-exit-node");
+    ensureExitNode();
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "/opt/extensions/bin/tailscale",
+      ["--socket=/tmp/tailscale.sock", "set", "--exit-node=100.116.150.51"],
+      { stdio: "pipe", timeout: 5000, shell: false }
+    );
+  });
+
+  it("should skip when TS_EXIT_NODE is not set", async () => {
+    const { ensureExitNode } = await import("./tailscale-exit-node");
+    ensureExitNode();
+
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it("should only configure once per container", async () => {
+    process.env.TS_EXIT_NODE = "100.116.150.51";
+
+    const { ensureExitNode } = await import("./tailscale-exit-node");
+    ensureExitNode();
+    ensureExitNode();
+
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("should log error and continue if tailscale set fails", async () => {
+    process.env.TS_EXIT_NODE = "100.116.150.51";
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("Command failed");
+    });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { ensureExitNode } = await import("./tailscale-exit-node");
+    ensureExitNode();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Failed to set Tailscale exit node",
+      expect.objectContaining({ exitNode: "100.116.150.51" })
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/infra/src/lambda/tailscale-exit-node.ts
+++ b/packages/infra/src/lambda/tailscale-exit-node.ts
@@ -1,0 +1,29 @@
+import { execFileSync } from "node:child_process";
+
+const TS_CLI = "/opt/extensions/bin/tailscale";
+const TS_SOCKET = "/tmp/tailscale.sock";
+
+let configured = false;
+
+export const ensureExitNode = (): void => {
+  if (configured) return;
+
+  const exitNode = process.env.TS_EXIT_NODE;
+  if (!exitNode) return;
+
+  try {
+    execFileSync(
+      TS_CLI,
+      [`--socket=${TS_SOCKET}`, "set", `--exit-node=${exitNode}`],
+      { stdio: "pipe", timeout: 5000, shell: false }
+    );
+    configured = true;
+    console.log("Tailscale exit node configured", { exitNode });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message.slice(0, 100) : "";
+    console.error("Failed to set Tailscale exit node", {
+      exitNode,
+      error: msg,
+    });
+  }
+};


### PR DESCRIPTION
## Summary

The `tailscale-lambda-extension` construct doesn't support `--exit-node`. Without it, SOCKS5 traffic routes within the tailnet only — not to the internet via the exit node.

**Fix:** Call `tailscale set --exit-node` from the handler on cold start using `/opt/extensions/bin/tailscale` (available from the layer). Cached per container via module-level flag.

**Also documented:** Fork alternative for OAuth client key support (no 90-day expiry) with `--advertise-tags` + `--exit-node` in extension script.

## Test plan

- [x] 29 infra tests passing
- [ ] Deploy and verify Lambda connects through exit node
- [ ] Push workout to Garmin via Lambda

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lambda functions now support automatic Tailscale exit node configuration on container startup, controlled via environment variable with comprehensive error handling.

* **Documentation**
  * Added design documentation detailing exit node configuration options and updated reserved concurrency management approach with interim API Gateway-based throttling protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->