### PR TITLE
fix(infra): replace socks-proxy-agent with undici Socks5ProxyAgent

### DIFF
--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -22,8 +22,8 @@
     "@kaiord/garmin-connect": "workspace:^",
     "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.4.2",
-    "socks-proxy-agent": "^10.0.0",
     "tailscale-lambda-extension": "^0.0.8",
+    "undici": "^8.0.1",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/infra/src/lambda/proxy-fetch.test.ts
+++ b/packages/infra/src/lambda/proxy-fetch.test.ts
@@ -1,15 +1,15 @@
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockedFunction } from "vitest";
 
-class MockSocksProxyAgent {
-  url: string;
-  constructor(url: string) {
-    this.url = url;
+class MockSocks5ProxyAgent {
+  uri: string;
+  constructor(uri: string) {
+    this.uri = uri;
   }
 }
 
-vi.mock("socks-proxy-agent", () => ({
-  SocksProxyAgent: MockSocksProxyAgent,
+vi.mock("undici", () => ({
+  Socks5ProxyAgent: MockSocks5ProxyAgent,
 }));
 
 let mockFetch: MockedFunction<typeof fetch>;
@@ -25,7 +25,7 @@ afterAll(() => {
 });
 
 describe("proxyFetch", () => {
-  it("should pass dispatcher with SOCKS5 agent to fetch", async () => {
+  it("should pass dispatcher with SOCKS5 proxy agent to fetch", async () => {
     mockFetch.mockResolvedValueOnce(new Response("ok"));
     const { proxyFetch } = await import("./proxy-fetch");
 
@@ -35,7 +35,7 @@ describe("proxyFetch", () => {
       "https://example.com",
       expect.objectContaining({
         method: "GET",
-        dispatcher: expect.any(MockSocksProxyAgent),
+        dispatcher: expect.any(MockSocks5ProxyAgent),
       })
     );
   });

--- a/packages/infra/src/lambda/proxy-fetch.ts
+++ b/packages/infra/src/lambda/proxy-fetch.ts
@@ -1,17 +1,18 @@
-import { SocksProxyAgent } from "socks-proxy-agent";
+import { Socks5ProxyAgent } from "undici";
 
-const SOCKS5_URL = "socks://localhost:1055";
+const SOCKS5_URL = "socks5://localhost:1055";
 
-let agent: SocksProxyAgent | undefined;
+let proxy: Socks5ProxyAgent | undefined;
 
-const getAgent = (): SocksProxyAgent => {
-  agent ??= new SocksProxyAgent(SOCKS5_URL);
-  return agent;
+const getProxy = (): Socks5ProxyAgent => {
+  proxy ??= new Socks5ProxyAgent(SOCKS5_URL);
+  return proxy;
 };
 
 export const proxyFetch: typeof globalThis.fetch = (input, init) =>
+  // Socks5ProxyAgent is a valid undici Dispatcher but types are experimental
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  globalThis.fetch(input, { ...init, dispatcher: getAgent() } as any);
+  globalThis.fetch(input, { ...init, dispatcher: getProxy() as any });
 
 export const checkTunnelHealth = async (): Promise<boolean> => {
   try {

--- a/packages/infra/src/stack/garmin-proxy-stack.ts
+++ b/packages/infra/src/stack/garmin-proxy-stack.ts
@@ -74,7 +74,7 @@ export class GarminProxyStack extends Stack {
         target: "node24",
         format: OutputFormat.ESM,
         mainFields: ["module", "main"],
-        nodeModules: ["socks-proxy-agent", "socks", "smart-buffer"],
+        nodeModules: ["undici"],
       },
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,10 +55,10 @@ importers:
         version: 9.39.1(jiti@2.6.1)
       eslint-plugin-boundaries:
         specifier: ^6.0.2
-        version: 6.0.2(eslint@9.39.1(jiti@2.6.1))
+        version: 6.0.2(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(eslint@9.39.1(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -341,12 +341,12 @@ importers:
       constructs:
         specifier: ^10.4.2
         version: 10.5.1
-      socks-proxy-agent:
-        specifier: ^10.0.0
-        version: 10.0.0
       tailscale-lambda-extension:
         specifier: ^0.0.8
         version: 0.0.8(aws-cdk-lib@2.241.0(constructs@10.5.1))(constructs@10.5.1)
+      undici:
+        specifier: ^8.0.1
+        version: 8.0.1
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -3887,13 +3887,6 @@ packages:
         integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==,
       }
     engines: { node: ">= 14" }
-
-  agent-base@9.0.0:
-    resolution:
-      {
-        integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==,
-      }
-    engines: { node: ">= 20" }
 
   ai@6.0.97:
     resolution:
@@ -8003,33 +7996,12 @@ packages:
         integrity: sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==,
       }
 
-  smart-buffer@4.2.0:
-    resolution:
-      {
-        integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==,
-      }
-    engines: { node: ">= 6.0.0", npm: ">= 3.0.0" }
-
   smol-toml@1.6.1:
     resolution:
       {
         integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==,
       }
     engines: { node: ">= 18" }
-
-  socks-proxy-agent@10.0.0:
-    resolution:
-      {
-        integrity: sha512-pyp2YR3mNxAMu0mGLtzs4g7O3uT4/9sQOLAKcViAkaS9fJWkud7nmaf6ZREFqQEi24IPkBcjfHjXhPTUWjo3uA==,
-      }
-    engines: { node: ">= 20" }
-
-  socks@2.8.7:
-    resolution:
-      {
-        integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==,
-      }
-    engines: { node: ">= 10.0.0", npm: ">= 3.0.0" }
 
   source-map-js@1.2.1:
     resolution:
@@ -8712,6 +8684,13 @@ packages:
       }
     engines: { node: ">=22.19.0" }
 
+  undici@8.0.1:
+    resolution:
+      {
+        integrity: sha512-6qdTUr+jabXmYKeYkv/+pIvO7d0bs1k9uy+5PFnXr4segNVwILH1KExhwRh3/iGa6gSLmySK3hTnSs3k7ZPnjQ==,
+      }
+    engines: { node: ">=22.19.0" }
+
   unicorn-magic@0.3.0:
     resolution:
       {
@@ -9249,7 +9228,7 @@ snapshots:
   "@actions/http-client@2.2.3":
     dependencies:
       tunnel: 0.0.6
-      undici: 7.24.0
+      undici: 8.0.0
 
   "@actions/io@1.1.3": {}
 
@@ -9534,10 +9513,10 @@ snapshots:
 
   "@bcoe/v8-coverage@1.0.2": {}
 
-  "@boundaries/elements@2.0.1(eslint@9.39.1(jiti@2.6.1))":
+  "@boundaries/elements@2.0.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))":
     dependencies:
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
       handlebars: 4.7.9
       is-core-module: 2.16.1
       micromatch: 4.0.8
@@ -11318,8 +11297,6 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  agent-base@9.0.0: {}
-
   ai@6.0.97(zod@4.3.6):
     dependencies:
       "@ai-sdk/gateway": 3.0.53(zod@4.3.6)
@@ -12032,22 +12009,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      "@typescript-eslint/parser": 8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-boundaries@6.0.2(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-boundaries@6.0.2(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
-      "@boundaries/elements": 2.0.1(eslint@9.39.1(jiti@2.6.1))
+      "@boundaries/elements": 2.0.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
       chalk: 4.1.2
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
       handlebars: 4.7.9
       micromatch: 4.0.8
     transitivePeerDependencies:
@@ -12056,7 +12034,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       "@rtsao/scc": 1.1.0
       array-includes: 3.1.9
@@ -12067,7 +12045,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12078,6 +12056,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      "@typescript-eslint/parser": 8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -13911,22 +13891,7 @@ snapshots:
 
   slide@1.1.6: {}
 
-  smart-buffer@4.2.0: {}
-
   smol-toml@1.6.1: {}
-
-  socks-proxy-agent@10.0.0:
-    dependencies:
-      agent-base: 9.0.0
-      debug: 4.4.3
-      socks: 2.8.7
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.7:
-    dependencies:
-      ip-address: 10.1.0
-      smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
 
@@ -14332,6 +14297,8 @@ snapshots:
   undici@7.24.0: {}
 
   undici@8.0.0: {}
+
+  undici@8.0.1: {}
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
## Summary

`socks-proxy-agent` is an `http.Agent` (old Node.js API) which doesn't work as a fetch `dispatcher`. `globalThis.fetch` in Node 24 uses undici internally and requires an undici `Dispatcher`.

Replace with undici's native `Socks5ProxyAgent` (available since v7.23.0) which is a proper undici Dispatcher and works with `globalThis.fetch`.

This fixes the 503 "Proxy tunnel unavailable" error — the tunnel was actually connected but `socks-proxy-agent` couldn't route through it.

## Test plan

- [x] 33 infra tests passing
- [x] Build succeeds
- [ ] Deploy and verify Lambda push works through Tailscale tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal proxy handling dependency to improve performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->