### PR TITLE
fix(infra): wait for exit node route before health check

### DIFF
--- a/packages/infra/src/lambda/handler.ts
+++ b/packages/infra/src/lambda/handler.ts
@@ -56,7 +56,7 @@ export const handler = async (event: APIGatewayProxyEventV2) => {
     return errorResponse(400, "Invalid request: check KRD and credentials");
   }
 
-  if (useTailscale()) ensureExitNode();
+  if (useTailscale()) await ensureExitNode();
 
   if (useTailscale() && !(await checkTunnelHealth())) {
     console.error("Tailscale tunnel unavailable", { requestId });

--- a/packages/infra/src/lambda/proxy-fetch.ts
+++ b/packages/infra/src/lambda/proxy-fetch.ts
@@ -9,10 +9,14 @@ const getProxy = (): Socks5ProxyAgent => {
   return proxy;
 };
 
+// Node.js 24 globalThis.fetch supports `dispatcher` via undici but
+// the types are experimental (Socks5ProxyAgent doesn't match Dispatcher).
+// Cast is safe: Socks5ProxyAgent IS an undici Dispatcher at runtime.
 export const proxyFetch: typeof globalThis.fetch = (input, init) =>
-  // Socks5ProxyAgent is a valid undici Dispatcher but types are experimental
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  globalThis.fetch(input, { ...init, dispatcher: getProxy() as any });
+  globalThis.fetch(input, {
+    ...init,
+    dispatcher: getProxy(),
+  } as unknown as RequestInit);
 
 export const checkTunnelHealth = async (): Promise<boolean> => {
   try {

--- a/packages/infra/src/lambda/tailscale-exit-node.test.ts
+++ b/packages/infra/src/lambda/tailscale-exit-node.test.ts
@@ -5,6 +5,8 @@ vi.mock("node:child_process", () => ({
   execFileSync: mockExecFileSync,
 }));
 
+const STATUS_ONLINE = JSON.stringify({ ExitNodeStatus: { Online: true } });
+
 describe("ensureExitNode", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -12,11 +14,14 @@ describe("ensureExitNode", () => {
     delete process.env.TS_EXIT_NODE;
   });
 
-  it("should call tailscale set with exit node from env", async () => {
+  it("should call tailscale set and wait for exit node", async () => {
     process.env.TS_EXIT_NODE = "100.116.150.51";
+    mockExecFileSync
+      .mockReturnValueOnce("") // set command
+      .mockReturnValue(Buffer.from(STATUS_ONLINE)); // status command
 
     const { ensureExitNode } = await import("./tailscale-exit-node");
-    ensureExitNode();
+    await ensureExitNode();
 
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "/opt/extensions/bin/tailscale",
@@ -27,19 +32,27 @@ describe("ensureExitNode", () => {
 
   it("should skip when TS_EXIT_NODE is not set", async () => {
     const { ensureExitNode } = await import("./tailscale-exit-node");
-    ensureExitNode();
+    await ensureExitNode();
 
     expect(mockExecFileSync).not.toHaveBeenCalled();
   });
 
   it("should only configure once per container", async () => {
     process.env.TS_EXIT_NODE = "100.116.150.51";
+    mockExecFileSync
+      .mockReturnValueOnce("")
+      .mockReturnValue(Buffer.from(STATUS_ONLINE));
 
     const { ensureExitNode } = await import("./tailscale-exit-node");
-    ensureExitNode();
-    ensureExitNode();
+    await ensureExitNode();
+    await ensureExitNode();
 
-    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    // set called once, status called once (second ensureExitNode skips)
+    expect(
+      mockExecFileSync.mock.calls.filter((c: string[][]) =>
+        c[1]?.includes("set")
+      )
+    ).toHaveLength(1);
   });
 
   it("should log error and continue if tailscale set fails", async () => {
@@ -50,7 +63,7 @@ describe("ensureExitNode", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     const { ensureExitNode } = await import("./tailscale-exit-node");
-    ensureExitNode();
+    await ensureExitNode();
 
     expect(consoleSpy).toHaveBeenCalledWith(
       "Failed to set Tailscale exit node",

--- a/packages/infra/src/lambda/tailscale-exit-node.ts
+++ b/packages/infra/src/lambda/tailscale-exit-node.ts
@@ -5,7 +5,31 @@ const TS_SOCKET = "/tmp/tailscale.sock";
 
 let configured = false;
 
-export const ensureExitNode = (): void => {
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitForExitNode = async (maxWaitMs = 10000): Promise<boolean> => {
+  const start = Date.now();
+  while (Date.now() - start < maxWaitMs) {
+    try {
+      const status = execFileSync(
+        TS_CLI,
+        [`--socket=${TS_SOCKET}`, "status", "--json"],
+        { stdio: "pipe", timeout: 3000, shell: false }
+      ).toString();
+      const parsed = JSON.parse(status) as {
+        ExitNodeStatus?: { Online: boolean };
+      };
+      if (parsed.ExitNodeStatus?.Online) return true;
+    } catch {
+      // status command failed, retry
+    }
+    await sleep(500);
+  }
+  return false;
+};
+
+export const ensureExitNode = async (): Promise<void> => {
   if (configured) return;
 
   const exitNode = process.env.TS_EXIT_NODE;
@@ -17,8 +41,9 @@ export const ensureExitNode = (): void => {
       [`--socket=${TS_SOCKET}`, "set", `--exit-node=${exitNode}`],
       { stdio: "pipe", timeout: 5000, shell: false }
     );
-    configured = true;
-    console.log("Tailscale exit node configured", { exitNode });
+    const ready = await waitForExitNode();
+    configured = ready;
+    console.log("Tailscale exit node configured", { exitNode, ready });
   } catch (error) {
     const msg = error instanceof Error ? error.message.slice(0, 100) : "";
     console.error("Failed to set Tailscale exit node", {


### PR DESCRIPTION
## Summary

`tailscale set --exit-node` returns immediately but the route to the exit node takes seconds to establish. The health check was failing because it ran before the tunnel was ready.

**Fix:** After setting exit node, poll `tailscale status --json` until `ExitNodeStatus.Online` is true (max 10s with 500ms intervals).

## Test plan

- [x] 33 infra tests passing
- [ ] Deploy and verify push works (exit node route fully established before health check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exit node initialization now waits for the exit node to be online and ready before proceeding, ensuring proper sequencing of dependent operations.

* **Refactor**
  * Improved type safety in proxy request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->