### PR TITLE
debug(cli): add stderr logging to flaky diff integration test

### DIFF
--- a/packages/cli/src/commands/diff-integration.test.ts
+++ b/packages/cli/src/commands/diff-integration.test.ts
@@ -45,7 +45,7 @@ describe("diff command integration", () => {
       const file2 = join(FIXTURES_PATH, "fit/WorkoutRepeatSteps.fit");
 
       // Act - use reject: false to capture non-zero exit codes
-      const { stdout, exitCode } = await execa(
+      const { stdout, stderr, exitCode } = await execa(
         "node",
         [CLI_PATH, "diff", "--file1", file1, "--file2", file2],
         { reject: false }
@@ -53,6 +53,9 @@ describe("diff command integration", () => {
 
       // Assert
       // Exit code 0 = identical, 10 = differences found (not an error)
+      if (![ExitCode.SUCCESS, ExitCode.DIFFERENCES_FOUND].includes(exitCode)) {
+        console.error("Unexpected exit code", { exitCode, stderr, stdout });
+      }
       expect([ExitCode.SUCCESS, ExitCode.DIFFERENCES_FOUND]).toContain(
         exitCode
       );
@@ -148,7 +151,7 @@ describe("diff command integration", () => {
       const krdFile = join(FIXTURES_PATH, "krd/WorkoutIndividualSteps.krd");
 
       // Act - use reject: false to capture non-zero exit codes
-      const { stdout, exitCode } = await execa(
+      const { stdout, stderr, exitCode } = await execa(
         "node",
         [CLI_PATH, "diff", "--file1", fitFile, "--file2", krdFile],
         { reject: false }
@@ -156,6 +159,10 @@ describe("diff command integration", () => {
 
       // Assert
       // Exit code 0 = identical, 10 = differences found (not an error)
+      // Log stderr for debugging flaky CI failures (exit code 1 under load)
+      if (![ExitCode.SUCCESS, ExitCode.DIFFERENCES_FOUND].includes(exitCode)) {
+        console.error("Unexpected exit code", { exitCode, stderr, stdout });
+      }
       expect([ExitCode.SUCCESS, ExitCode.DIFFERENCES_FOUND]).toContain(
         exitCode
       );


### PR DESCRIPTION
## Summary

Add stderr capture and logging to the flaky `diff-integration.test.ts` tests. When exit code is unexpected (not 0 or 10), stderr is logged to CI output, revealing the actual error (OOM, module resolution, uncaught exception).

This is diagnostic instrumentation, not a fix. The next CI failure will show the root cause.

## Context

The test "should compare files of different formats" intermittently fails in CI (Node 20.x/22.x) with exit code 1 instead of 0/10. Only happens under load when multiple Node.js matrix jobs run in parallel.

## Test plan

- [x] 6 diff integration tests passing locally
- [ ] Next CI flaky failure will log stderr with root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved integration test diagnostics: tests now capture and log additional runtime output (exit code, standard output, and standard error) when unexpected exit codes occur to aid debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->