### PR TITLE
fix(spa): stabilize E2E CI with waitFor and increased job timeout

### DIFF
--- a/.github/workflows/workout-spa-editor-e2e.yml
+++ b/.github/workflows/workout-spa-editor-e2e.yml
@@ -22,7 +22,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    timeout-minutes: 15
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     needs: check-ci-status
     if: needs.check-ci-status.outputs.should-run == 'true'
@@ -89,7 +89,7 @@ jobs:
 
   e2e-mobile:
     name: E2E Mobile Tests
-    timeout-minutes: 15
+    timeout-minutes: 25
     runs-on: ubuntu-latest
     needs: check-ci-status
     if: needs.check-ci-status.outputs.should-run == 'true'

--- a/packages/workout-spa-editor/e2e/helpers/expand-file-upload.ts
+++ b/packages/workout-spa-editor/e2e/helpers/expand-file-upload.ts
@@ -13,6 +13,7 @@ export async function expandFileUpload(page: Page) {
   const accordion = page.getByRole("button", {
     name: /create manually.*import/i,
   });
+  await accordion.waitFor({ state: "visible", timeout: 10000 });
   await accordion.click();
   await fileInput.waitFor({ state: "attached", timeout: 5000 });
 }


### PR DESCRIPTION
## Summary
- Add `waitFor({ state: "visible" })` before clicking the accordion button in `expandFileUpload` to fix flaky Firefox E2E test (`repetition-blocks.spec.ts:686`)
- Increase `timeout-minutes` from 15 to 25 for both `e2e-tests` and `e2e-mobile` jobs to prevent Mobile Chrome, Mobile Safari, and WebKit cancellations

## Test plan
- [ ] Verify Firefox E2E tests pass without flaky failures on `repetition-blocks.spec.ts:686`
- [ ] Verify Mobile Chrome, Mobile Safari, and WebKit E2E jobs complete within 25 minutes
- [ ] Confirm desktop Chromium/Firefox/WebKit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended end-to-end testing job timeout limits to allow longer test execution windows
  * Improved test reliability with enhanced synchronization checks during file upload operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->