### PR TITLE
fix(e2e): retry accordion click to handle React hydration gap on slow CI

### DIFF
--- a/packages/workout-spa-editor/e2e/helpers/expand-file-upload.ts
+++ b/packages/workout-spa-editor/e2e/helpers/expand-file-upload.ts
@@ -5,15 +5,20 @@ import type { Page } from "@playwright/test";
  * so the file input becomes visible in the DOM.
  */
 export async function expandFileUpload(page: Page) {
-  // The file input might already be in the DOM if accordion was expanded
   const fileInput = page.locator('input[type="file"]');
   if ((await fileInput.count()) > 0) return;
 
-  // Click the accordion button to reveal file upload
   const accordion = page.getByRole("button", {
     name: /create manually.*import/i,
   });
   await accordion.waitFor({ state: "visible", timeout: 10000 });
   await accordion.click();
-  await fileInput.waitFor({ state: "attached", timeout: 5000 });
+
+  // Retry click if React hadn't hydrated the onClick handler yet
+  try {
+    await fileInput.waitFor({ state: "attached", timeout: 3000 });
+  } catch {
+    await accordion.click();
+    await fileInput.waitFor({ state: "attached", timeout: 5000 });
+  }
 }


### PR DESCRIPTION
## Summary

- Retry accordion click in expandFileUpload helper if file input doesn't appear after first click
- Root cause: on slow Firefox CI runners, React may not have hydrated the onClick handler when Playwright clicks the visible button

## Test plan

- [ ] Firefox E2E tests pass with zero flaky tests
- [ ] All other browsers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced file upload test reliability with improved retry logic to handle delayed component initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->