### PR TITLE
fix(e2e): relax performance thresholds for WebKit CI variability

### DIFF
--- a/packages/workout-spa-editor/e2e/repetition-blocks.spec.ts
+++ b/packages/workout-spa-editor/e2e/repetition-blocks.spec.ts
@@ -2469,8 +2469,8 @@ test.describe("Repetition Blocks - Performance", () => {
     await expect(page.locator('[data-testid="step-card"]')).toHaveCount(0);
     const collapseTime = Date.now() - startTime;
 
-    // Should complete in under 1 second
-    expect(collapseTime).toBeLessThan(1000);
+    // Should complete in under 2 seconds
+    expect(collapseTime).toBeLessThan(2000);
 
     // Expand again
     const expandStartTime = Date.now();
@@ -2478,8 +2478,8 @@ test.describe("Repetition Blocks - Performance", () => {
     await expect(page.locator('[data-testid="step-card"]')).toHaveCount(25);
     const expandTime = Date.now() - expandStartTime;
 
-    // Should complete in under 2 seconds
-    expect(expandTime).toBeLessThan(2000);
+    // Should complete in under 3 seconds
+    expect(expandTime).toBeLessThan(3000);
   });
 
   test("should handle deeply nested repetitions", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Increase collapse performance threshold from 1s to 2s in the repetition blocks E2E test
- Increase expand performance threshold from 2s to 3s
- Fixes flaky WebKit CI failures (observed 1204ms collapse time on GitHub Actions)

## Test plan
- [ ] Verify the E2E performance test passes on WebKit CI
- [ ] Confirm thresholds still catch genuine regressions (e.g., O(n^2) rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Adjusted performance test timing thresholds for repetition block E2E tests to accommodate varied render performance across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->