### PR TITLE
chore(infra): upgrade tailscale-lambda-extension to v0.1.2

### DIFF
--- a/packages/infra/package.json
+++ b/packages/infra/package.json
@@ -23,7 +23,7 @@
     "aws-cdk-lib": "^2.180.0",
     "constructs": "^10.4.2",
     "fetch-socks": "^1.3.3",
-    "tailscale-lambda-extension": "https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.1/tailscale-lambda-extension-0.1.1.tgz",
+    "tailscale-lambda-extension": "https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.2/tailscale-lambda-extension-0.1.2.tgz",
     "undici": "^8.0.2",
     "zod": "^4.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         version: 9.39.1(jiti@2.6.1)
       eslint-plugin-boundaries:
         specifier: ^6.0.2
-        version: 6.0.2(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
+        version: 6.0.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-simple-import-sort:
         specifier: ^12.1.1
         version: 12.1.1(eslint@9.39.1(jiti@2.6.1))
@@ -345,8 +345,8 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
       tailscale-lambda-extension:
-        specifier: https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.1/tailscale-lambda-extension-0.1.1.tgz
-        version: https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.1/tailscale-lambda-extension-0.1.1.tgz(aws-cdk-lib@2.241.0(constructs@10.5.1))(constructs@10.5.1)
+        specifier: https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.2/tailscale-lambda-extension-0.1.2.tgz
+        version: https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.2/tailscale-lambda-extension-0.1.2.tgz(aws-cdk-lib@2.241.0(constructs@10.5.1))(constructs@10.5.1)
       undici:
         specifier: ^8.0.2
         version: 8.0.2
@@ -7406,10 +7406,10 @@ packages:
         integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==,
       }
 
-  tailscale-lambda-extension@https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.1/tailscale-lambda-extension-0.1.1.tgz:
+  tailscale-lambda-extension@https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.2/tailscale-lambda-extension-0.1.2.tgz:
     resolution:
       {
-        tarball: https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.1/tailscale-lambda-extension-0.1.1.tgz,
+        tarball: https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.2/tailscale-lambda-extension-0.1.2.tgz,
       }
     version: 0.0.0
     engines: { node: ~20.*, npm: ~10.* }
@@ -8450,10 +8450,10 @@ snapshots:
 
   "@bcoe/v8-coverage@1.0.2": {}
 
-  "@boundaries/elements@2.0.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))":
+  "@boundaries/elements@2.0.1(eslint@9.39.1(jiti@2.6.1))":
     dependencies:
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
       handlebars: 4.7.9
       is-core-module: 2.16.1
       micromatch: 4.0.8
@@ -10637,23 +10637,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      "@typescript-eslint/parser": 8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-boundaries@6.0.2(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-boundaries@6.0.2(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
-      "@boundaries/elements": 2.0.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
+      "@boundaries/elements": 2.0.1(eslint@9.39.1(jiti@2.6.1))
       chalk: 4.1.2
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
       handlebars: 4.7.9
       micromatch: 4.0.8
     transitivePeerDependencies:
@@ -12410,7 +12409,7 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
-  tailscale-lambda-extension@https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.1/tailscale-lambda-extension-0.1.1.tgz(aws-cdk-lib@2.241.0(constructs@10.5.1))(constructs@10.5.1):
+  tailscale-lambda-extension@https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/download/v0.1.2/tailscale-lambda-extension-0.1.2.tgz(aws-cdk-lib@2.241.0(constructs@10.5.1))(constructs@10.5.1):
     dependencies:
       aws-cdk-lib: 2.241.0(constructs@10.5.1)
       constructs: 10.5.1


### PR DESCRIPTION
## Summary

- Upgrades `tailscale-lambda-extension` from `v0.1.1` to `v0.1.2` in `@kaiord/infra`

## What's in v0.1.2

Addresses all review comments on [rehanvdm/tailscale-lambda-extension#6](https://github.com/rehanvdm/tailscale-lambda-extension/pull/6):

- **fix:** Bash array for `EXTRA_ARGS` to prevent word-splitting
- **fix:** `tailscale ping` to verify the specific exit node (was `grep "Online":true` matching any peer)
- **feat:** `TS_EXIT_NODE_REQUIRED` env var for fail-closed behavior when exit node routing is critical
- **docs:** README wording fixes ("internet-bound traffic", fail-open/fail-closed docs)

Release: https://github.com/pablo-albaladejo/tailscale-lambda-extension/releases/tag/v0.1.2

## Test plan

- [x] `pnpm -r --filter @kaiord/infra build` passes
- [x] `pnpm -r --filter @kaiord/infra test` — 36/36 tests passing
- [ ] Manual: deploy Lambda with `TS_EXIT_NODE_REQUIRED=true` and verify fail-closed behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded infrastructure dependency to the latest v0.1.2 release for improved system stability and support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->