### PR TITLE
fix(cli): remove redundant pnpm build from smoke test to fix flaky CI

### DIFF
--- a/packages/cli/src/tests/cli-smoke.test.ts
+++ b/packages/cli/src/tests/cli-smoke.test.ts
@@ -2,19 +2,12 @@ import { execa } from "execa";
 import { dirname, join } from "path";
 import stripAnsi from "strip-ansi";
 import { fileURLToPath } from "url";
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe("CLI smoke tests", () => {
-  beforeAll(async () => {
-    // Build the CLI before running tests
-    await execa("pnpm", ["build"], {
-      cwd: join(__dirname, "../.."),
-    });
-  });
-
   it("should display help with --help flag", async () => {
     // Arrange & Act
     const { stdout } = await execa("./dist/bin/kaiord.js", ["--help"], {


### PR DESCRIPTION
## Summary

- Removes `beforeAll` block in `cli-smoke.test.ts` that triggered `pnpm build` during test execution
- This caused a race condition: vitest runs test files in parallel workers, so the build in `cli-smoke.test.ts` ran concurrently with `diff-integration.test.ts`, cleaning `dist/` while other tests were spawning the CLI binary
- The CI test command is already `pnpm build && vitest run --coverage`, so the `beforeAll` build was redundant

## Root cause

`diff-integration.test.ts > should compare files of different formats` failed with:
```
Error: Cannot find module '.../packages/cli/dist/bin/kaiord.js'
```
...only on the 6th test (48ms duration vs ~600ms for others), because it ran exactly when `cli-smoke.test.ts`'s `beforeAll` was cleaning/recreating `dist/`.

## Test plan

- [ ] `test-cli` CI jobs pass without flakiness across Node 20.x / 22.x / 24.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized smoke test execution by removing the pre-test build step, reducing test duration while maintaining existing test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->