### PR TITLE
fix(docs): prevent sidebar expansion on wide screens

### DIFF
--- a/packages/docs/.vitepress/theme/custom.css
+++ b/packages/docs/.vitepress/theme/custom.css
@@ -86,6 +86,23 @@
   }
 }
 
+/* Wide screen layout fix.
+   Default VP: at >1440px, sidebar and content padding grow with calc() to
+   center a 1440px layout, wasting space on large monitors.
+   We override the centering calc with fixed values so content stays left-aligned
+   and uses available space. */
+@media (min-width: 1440px) {
+  .VPSidebar.VPSidebar {
+    padding-left: 32px;
+    width: var(--vp-sidebar-width);
+  }
+
+  .VPContent.has-sidebar {
+    padding-left: var(--vp-sidebar-width);
+    padding-right: 0;
+  }
+}
+
 /* Content link accessibility — underline for accent-blue contrast */
 .vp-doc a {
   text-decoration: underline;


### PR DESCRIPTION
## Summary

- Caps sidebar width to `--vp-sidebar-width` (272px) at >1440px viewport
- Removes VitePress default centering padding on content area
- Prevents sidebar from growing to 800px+ on ultrawide/4K displays

## Before
At 1920px+, sidebar had calc()-based padding that expanded it to 500-800px of empty space.

## After
Sidebar stays at 272px, content starts immediately after sidebar + 32px gap.

## Test plan
- [x] Build passes
- [x] Lint passes  
- [x] Verified via Playwright at 1440px, 1728px, 1920px, 2560px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved documentation site layout for desktop screens (1440px and above) with adjusted sidebar and content spacing to enhance visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->