### PR TITLE
fix(docs): align navbar and sidebar on wide screens

### DIFF
--- a/packages/docs/.vitepress/theme/custom.css
+++ b/packages/docs/.vitepress/theme/custom.css
@@ -92,14 +92,31 @@
    We override the centering calc with fixed values so content stays left-aligned
    and uses available space. */
 @media (min-width: 1440px) {
+  /* Sidebar: fixed width, no centering padding */
   .VPSidebar.VPSidebar {
     padding-left: 32px;
     width: var(--vp-sidebar-width);
   }
 
+  /* Content area: left-aligned after sidebar */
   .VPContent.has-sidebar {
     padding-left: var(--vp-sidebar-width);
     padding-right: 0;
+  }
+
+  /* Navbar: doubled selectors to beat VP's scoped styles */
+  .VPNavBar.has-sidebar.VPNavBar.has-sidebar .title {
+    padding-left: 32px;
+    width: var(--vp-sidebar-width);
+  }
+
+  .VPNavBar.has-sidebar.VPNavBar.has-sidebar .content {
+    padding-left: var(--vp-sidebar-width);
+    padding-right: 32px;
+  }
+
+  .VPNavBar.has-sidebar.VPNavBar.has-sidebar .divider {
+    padding-left: var(--vp-sidebar-width);
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix navbar logo drifting right on >1440px viewports
- Fix sidebar expanding to 800px+ on ultrawide/4K
- Doubled selectors override VitePress scoped calc()-based centering

Verified via Playwright at 1440px, 1728px, 1920px, 2560px — logo stays at 32px, sidebar at 272px.

## Test plan
- [x] Build + lint pass
- [x] Logo at 32px on all viewport widths
- [x] Sidebar fixed at 272px

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced navigation bar styling and alignment on larger screens (1440px and above) for improved visual consistency with the overall layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->