### PR TITLE
fix: wrap changesets/action commands in bash -c

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm exec changeset version && pnpm install --no-frozen-lockfile
-          publish: pnpm -r build && pnpm exec changeset publish
+          version: bash -c "pnpm exec changeset version && pnpm install --no-frozen-lockfile"
+          publish: bash -c "pnpm -r build && pnpm exec changeset publish"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ poc-*/
 # OpenSpec
 openspec/.cache/
 packages/docs/.vitepress/cache/
+*.gcn


### PR DESCRIPTION
## Summary

The `changesets/action@v1` version/publish inputs pass commands to `exec()`, so `&&` chains are interpreted as extra arguments to the first command. Wrapping in `bash -c "..."` fixes this.

Also adds `*.gcn` to `.gitignore` (generated workout files).

**Error fixed:** `Too many arguments passed to changesets - we only accept the command name as an argument`

## Test plan
- [ ] Merge to main and verify release workflow creates a Version Packages PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration for improved command execution handling.
  * Updated version control ignore patterns to exclude additional file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->