### PR TITLE
fix: use shell scripts for changesets/action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,8 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          version: bash -c "pnpm exec changeset version && pnpm install --no-frozen-lockfile"
-          publish: bash -c "pnpm -r build && pnpm exec changeset publish"
+          version: ./scripts/changeset-version.sh
+          publish: ./scripts/changeset-publish.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true

--- a/scripts/changeset-publish.sh
+++ b/scripts/changeset-publish.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pnpm -r build
+pnpm exec changeset publish

--- a/scripts/changeset-version.sh
+++ b/scripts/changeset-version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pnpm exec changeset version
+pnpm install --no-frozen-lockfile


### PR DESCRIPTION
## Summary

Follow-up to #278. `bash -c "..."` gets mangled by the YAML → action exec chain (unexpected EOF looking for matching quote). Use standalone shell scripts instead.

## Test plan
- [ ] Trigger `workflow_dispatch` after merge — should create Version Packages PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored release workflow to use dedicated scripts for improved reliability and maintainability of versioning and publishing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->