### PR TITLE
fix(e2e): resolve Mobile Safari strict mode and timing flake

### DIFF
--- a/packages/workout-spa-editor/e2e/calendar-empty-states.spec.ts
+++ b/packages/workout-spa-editor/e2e/calendar-empty-states.spec.ts
@@ -22,7 +22,9 @@ test.describe("Calendar Empty States", () => {
   test("No workouts shows FirstVisitState", async ({ page }) => {
     await page.reload();
 
-    await expect(page.getByTestId("first-visit-state")).toBeVisible();
+    await expect(page.getByTestId("first-visit-state")).toBeVisible({
+      timeout: 10_000,
+    });
     await expect(page.getByText("Welcome to Kaiord")).toBeVisible();
   });
 

--- a/packages/workout-spa-editor/e2e/calendar-empty-states.spec.ts
+++ b/packages/workout-spa-editor/e2e/calendar-empty-states.spec.ts
@@ -22,9 +22,7 @@ test.describe("Calendar Empty States", () => {
   test("No workouts shows FirstVisitState", async ({ page }) => {
     await page.reload();
 
-    await expect(page.getByTestId("first-visit-state")).toBeVisible({
-      timeout: 10_000,
-    });
+    await expect(page.getByTestId("first-visit-state")).toBeVisible();
     await expect(page.getByText("Welcome to Kaiord")).toBeVisible();
   });
 

--- a/packages/workout-spa-editor/e2e/helpers/mobile-menu.ts
+++ b/packages/workout-spa-editor/e2e/helpers/mobile-menu.ts
@@ -25,8 +25,8 @@ export async function openHeaderAction(
   page: Page,
   actionName: string | RegExp
 ): Promise<void> {
-  // Filter by visible to avoid strict mode violations when both
-  // DesktopNav and MobileMenuPanel have buttons with the same aria-label
+  // Both DesktopNav and MobileMenuPanel render buttons with the same
+  // aria-label. Filter to visible ones to avoid strict mode violations.
   const visible = page
     .getByRole("button", { name: actionName })
     .filter({ visible: true });
@@ -40,12 +40,12 @@ export async function openHeaderAction(
   const menuButton = page.getByLabel("Menu");
   if (await menuButton.isVisible().catch(() => false)) {
     await menuButton.click();
-    await page.waitForTimeout(200);
-    // After menu opens, the item becomes visible
-    await page
+    // Wait for dropdown item to become visible instead of fixed delay
+    const menuItem = page
       .getByRole("button", { name: actionName })
       .filter({ visible: true })
-      .first()
-      .click();
+      .first();
+    await menuItem.waitFor({ state: "visible" });
+    await menuItem.click();
   }
 }

--- a/packages/workout-spa-editor/e2e/helpers/mobile-menu.ts
+++ b/packages/workout-spa-editor/e2e/helpers/mobile-menu.ts
@@ -25,10 +25,14 @@ export async function openHeaderAction(
   page: Page,
   actionName: string | RegExp
 ): Promise<void> {
-  const directButton = page.getByRole("button", { name: actionName });
+  // Filter by visible to avoid strict mode violations when both
+  // DesktopNav and MobileMenuPanel have buttons with the same aria-label
+  const visible = page
+    .getByRole("button", { name: actionName })
+    .filter({ visible: true });
 
-  if (await directButton.isVisible().catch(() => false)) {
-    await directButton.click();
+  if ((await visible.count()) > 0) {
+    await visible.first().click();
     return;
   }
 
@@ -36,10 +40,12 @@ export async function openHeaderAction(
   const menuButton = page.getByLabel("Menu");
   if (await menuButton.isVisible().catch(() => false)) {
     await menuButton.click();
-    // Wait for the dropdown to appear
     await page.waitForTimeout(200);
-    // Now find and click the action in the dropdown
-    const menuItem = page.getByRole("button", { name: actionName });
-    await menuItem.click();
+    // After menu opens, the item becomes visible
+    await page
+      .getByRole("button", { name: actionName })
+      .filter({ visible: true })
+      .first()
+      .click();
   }
 }

--- a/packages/workout-spa-editor/e2e/settings.spec.ts
+++ b/packages/workout-spa-editor/e2e/settings.spec.ts
@@ -69,8 +69,10 @@ test.describe("Settings Panel", () => {
     await dialog.getByRole("tab", { name: /extensions/i }).click();
 
     // Should show both bridges in the status table
-    await expect(dialog.getByText("Garmin Connect")).toBeVisible();
-    await expect(dialog.getByText("Train2Go")).toBeVisible();
+    await expect(
+      dialog.getByText("Garmin Connect", { exact: true })
+    ).toBeVisible();
+    await expect(dialog.getByText("Train2Go", { exact: true })).toBeVisible();
 
     // Should have a refresh button
     await expect(

--- a/packages/workout-spa-editor/playwright.config.ts
+++ b/packages/workout-spa-editor/playwright.config.ts
@@ -21,6 +21,10 @@ export default defineConfig({
     actionTimeout: 10000, // 10 seconds for actions (click, fill, etc.)
   },
 
+  expect: {
+    timeout: 10_000, // 10s for assertions (Dexie clear + reload is slow on Mobile Safari)
+  },
+
   // Global timeout for tests
   timeout: 60000, // 60 seconds per test
 


### PR DESCRIPTION
## Summary

- Fix strict mode violation in Mobile Safari: `getByRole('button', { name: /open settings/i })` resolved to 2 elements (DesktopNav hidden + MobileMenuPanel visible)
- Fix FirstVisitState timing flake on slow Mobile Safari hydration

## Root cause

WebKit includes `display: none` elements in the accessibility tree in some cases. The `openHeaderAction` helper now filters by visibility and uses `.first()` to avoid strict mode violations.

## Test plan

- [x] Fixes the 2 Mobile Safari failures from CI run #24359705771

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved mobile menu interaction reliability by enhancing visible-element detection and wait behavior in end-to-end tests.
  * Increased global assertion timeout to reduce flaky failures.
  * Tightened visibility checks in the settings E2E test by using exact text matching for extension names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->