### PR TITLE
chore(openspec): fix validation error in hardening MODIFIED requirement

### DIFF
--- a/openspec/changes/spa-editor-focus-management-hardening/specs/spa-editor-focus-management/spec.md
+++ b/openspec/changes/spa-editor-focus-management-hardening/specs/spa-editor-focus-management/spec.md
@@ -120,7 +120,25 @@ Only the two scenarios below change in this delta; all other scenarios under thi
 
 `pendingFocusTarget` and `undoHistory` SHALL NOT span a Dexie reload. Upon reloading a workout from Dexie, the workout store SHALL initialize `pendingFocusTarget` to `null`, `undoHistory` to an empty array, `historyIndex` to its initial value, and regenerate all `ItemId` values via the configured `IdProvider`. Every Dexie write SHALL strip `id` fields via a single `stripIds` helper so that no `ItemId` values are persisted.
 
-Only the "history reset" concern changes here; the "Dexie reload clears pendingFocusTarget", "Dexie reload regenerates ItemId values", and "Dexie persisted payload contains no ItemId values" scenarios in the base spec are preserved unchanged.
+Scenarios below are re-published verbatim from the base spec (unchanged semantically; required by OpenSpec's MODIFIED delta format, which replaces the entire requirement including its scenario block).
+
+#### Scenario: Dexie reload clears pendingFocusTarget
+
+- **GIVEN** the user set `pendingFocusTarget` to a non-null value before reloading the workout from Dexie
+- **WHEN** the workout is reloaded
+- **THEN** `pendingFocusTarget` SHALL be `null`
+
+#### Scenario: Dexie reload regenerates ItemId values
+
+- **GIVEN** a workout with known `ItemId` values is persisted to Dexie (after stripping)
+- **WHEN** the workout is reloaded
+- **THEN** every step and block SHALL receive a freshly generated `ItemId`
+- **AND** none of the newly assigned ids SHALL equal any id from before the reload
+
+#### Scenario: Dexie persisted payload contains no ItemId values
+
+- **WHEN** the store writes a workout to Dexie
+- **THEN** the persisted JSON SHALL contain no `id` property on any step or block
 
 ## REMOVED Requirements
 


### PR DESCRIPTION
## Summary

Post-merge review of OpenSpec state surfaced a structural validation error in the hardening spec delta:

\`\`\`
✗ [ERROR] spa-editor-focus-management/spec.md: MODIFIED "Focus target and selection history reset across Dexie reloads" must include at least one scenario
\`\`\`

The MODIFIED block changed only the requirement text (renaming \`selectionHistory\` → \`undoHistory\`) but relied on prose saying "scenarios are preserved unchanged from the base." OpenSpec's MODIFIED delta format replaces the full requirement (text + all scenarios), so an empty scenario block is invalid.

**Fix:** re-publish the three unchanged scenarios verbatim from the base spec, with a one-line note explaining why they appear here despite being semantically identical.

## Why it wasn't caught earlier

The upstream PR (#307) merged without \`openspec validate\` in the PR workflow. I ran it manually after the stack (#306 → #307 → #312) merged and caught this as the only validation issue across both pending changes.

After this fix:

\`\`\`
$ openspec validate spa-editor-focus-management           # clean
Change 'spa-editor-focus-management' is valid

$ openspec validate spa-editor-focus-management-hardening # clean
Change 'spa-editor-focus-management-hardening' is valid
\`\`\`

## Test plan

- [ ] CI green
- [ ] \`openspec validate spa-editor-focus-management-hardening\` returns "valid" locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)