### PR TITLE
fix(bridges): read version from package.json in bridge tests

### DIFF
--- a/packages/garmin-bridge/test/background.test.js
+++ b/packages/garmin-bridge/test/background.test.js
@@ -8,6 +8,7 @@ const {
   getCsrfToken,
   checkSession,
 } = require("../background.js");
+const pkg = require("../package.json");
 
 const externalCb =
   chrome.runtime.onMessageExternal.addListener.mock.calls[0][0];
@@ -31,15 +32,13 @@ describe("background.js", () => {
       expect(BRIDGE_MANIFEST).toEqual({
         id: "garmin-bridge",
         name: "Garmin Connect",
-        version: "0.1.0",
+        version: pkg.version,
         protocolVersion: 1,
         capabilities: ["write:workouts"],
       });
     });
 
     it("version matches package.json (no drift between background.js and the published version)", () => {
-      const pkg = require("../package.json");
-
       expect(BRIDGE_MANIFEST.version).toBe(pkg.version);
     });
 
@@ -236,7 +235,7 @@ describe("background.js", () => {
       expect(response.data).toMatchObject({
         id: "garmin-bridge",
         name: "Garmin Connect",
-        version: "0.1.0",
+        version: pkg.version,
         protocolVersion: 1,
         capabilities: ["write:workouts"],
       });
@@ -315,7 +314,7 @@ describe("background.js", () => {
         data: {
           id: "garmin-bridge",
           name: "Garmin Connect",
-          version: "0.1.0",
+          version: pkg.version,
           protocolVersion: 1,
           capabilities: ["write:workouts"],
           csrfCaptured: true,
@@ -340,7 +339,7 @@ describe("background.js", () => {
       const result = await checkSession();
 
       expect(result.id).toBe("garmin-bridge");
-      expect(result.version).toBe("0.1.0");
+      expect(result.version).toBe(pkg.version);
       // The rogue keys are inside gcApi, which Zod will strip.
       expect(result.gcApi.id).toBe("ATTACKER");
     });
@@ -353,7 +352,7 @@ describe("background.js", () => {
       expect(result).toMatchObject({
         id: "garmin-bridge",
         name: "Garmin Connect",
-        version: "0.1.0",
+        version: pkg.version,
         protocolVersion: 1,
         capabilities: ["write:workouts"],
       });

--- a/packages/train2go-bridge/test/background.test.js
+++ b/packages/train2go-bridge/test/background.test.js
@@ -9,6 +9,7 @@ const {
   openTrain2Go,
 } = require("../background.js");
 const parser = require("../parser.js");
+const pkg = require("../package.json");
 
 describe("background service worker", () => {
   beforeEach(() => __resetChromeMock());
@@ -22,7 +23,7 @@ describe("background service worker", () => {
       expect(BRIDGE_MANIFEST).toEqual({
         id: "train2go-bridge",
         name: "Kaiord Train2Go Bridge",
-        version: "0.1.0",
+        version: pkg.version,
         protocolVersion: 1,
         capabilities: ["read:training-plan"],
       });
@@ -33,8 +34,6 @@ describe("background service worker", () => {
     });
 
     it("version matches package.json (no drift between background.js and the published version)", () => {
-      const pkg = require("../package.json");
-
       expect(BRIDGE_MANIFEST.version).toBe(pkg.version);
     });
 
@@ -184,7 +183,7 @@ describe("background service worker", () => {
       expect(result).toMatchObject({
         id: "train2go-bridge",
         name: "Kaiord Train2Go Bridge",
-        version: "0.1.0",
+        version: pkg.version,
         protocolVersion: 1,
         capabilities: ["read:training-plan"],
         sessionActive: true,


### PR DESCRIPTION
## Summary

- Fixes the `Release` workflow failure that prevented the `Version Packages` PR (#287) from being regenerated since 2026-04-15.
- `scripts/changeset-version.sh` runs `sync-extension-version.mjs` which bumps `BRIDGE_MANIFEST.version` inside `packages/*-bridge/background.js`. The husky `pre-commit` hook then runs `pnpm test` → tests were asserting against the hardcoded literal `"0.1.0"` → commit blocked → changesets PR never pushed.
- Tests now read `pkg.version` from each bridge's `package.json`. Drift between `background.js` and `package.json` is still caught by the existing `"version matches package.json"` assertion.

## Test plan

- [x] `pnpm -r test` green locally
- [x] Simulated version bump (0.1.0 → 0.1.1 for train2go-bridge, 0.1.0 → 0.2.0 for garmin-bridge) + `sync-extension-version.mjs` run → all 97 bridge tests still pass
- [x] Pre-commit hook (build + tsc + full test suite) passes
- [ ] After merge: `Release` workflow on `main` must succeed and regenerate the `Version Packages` PR with all 13 pending changesets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions in bridge packages to dynamically reference version information from package configuration, improving test maintainability and reducing hardcoded values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->