### PR TITLE
ci(release): use kaiord-release-bot GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,23 @@ jobs:
     name: Version & Publish
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived (1h) token from the kaiord-release-bot GitHub App.
+      # Required so the "Version Packages" PR pushed by changesets/action
+      # triggers branch-protection-required workflows on the new commit
+      # (GITHUB_TOKEN-authored pushes are intentionally excluded by GitHub
+      # Actions, which would leave the PR unmergeable).
+      - name: Mint release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
       - name: Setup pnpm
@@ -48,14 +60,14 @@ jobs:
           version: ./scripts/changeset-version.sh
           publish: ./scripts/changeset-publish.sh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: true
 
       - name: Create GitHub Releases
         if: steps.changesets.outputs.published == 'true'
         run: node scripts/create-github-releases.js
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,12 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Least-privilege: the release scripts only bump versions,
+          # publish to npm, and open the Version Packages PR. They never
+          # modify .github/workflows/, so deny workflows:write even though
+          # the App grants it (kept at App level for future extensions).
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Checkout repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Mint a 1h installation token from the `kaiord-release-bot` GitHub App and pass it to `actions/checkout` and `changesets/action`, replacing `secrets.GITHUB_TOKEN`.

### Why

GitHub Actions intentionally does **not** trigger workflows on commits authored via the default `GITHUB_TOKEN` (security guard against runaway loops). This left the auto-generated "Version Packages" PR (#318) with zero check_runs and a permanent `BLOCKED` merge state — branch protection requires `lint`/`test`/`typecheck`/`build`/`round-trip`/`Check for Changeset`, none of which ever ran.

Pushes authored by a GitHub App identity DO trigger workflows, so after this change the Version Packages PR will run the same CI as any human-authored PR — restoring dev/prod parity (Twelve-Factor X) and ensuring the release pipeline produces a fully validated artifact (Twelve-Factor V).

### Why a GitHub App over a PAT

- Scoped per-repo (PAT is account-wide).
- Token minted at run time, expires in 1h (Twelve-Factor IX, disposability).
- Identity is the bot, not a person — survives owner rotation.
- Auditable: actions attributable to `kaiord-release-bot[bot]`.

### Repo provisioning (already done)

- Variable: `RELEASE_APP_ID = 3432455`
- Secret: `RELEASE_APP_PRIVATE_KEY` (uploaded from generated `.pem`)
- App installed on `pablo-albaladejo/kaiord` with `contents:write`, `pull_requests:write`, `workflows:write`

## Test plan

- [x] Lint/build/test pass locally (pre-commit hook)
- [ ] After merge: next push to `main` triggers Release workflow → it pushes to `changeset-release/main` as the App → the resulting "Version Packages" PR shows the full CI matrix and reaches `MERGEABLE` (no longer `BLOCKED`)
- [ ] Once mergeable, merging that PR triggers Release again with `publish=true` → packages publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release workflow authentication by switching to short-lived app-based credentials for CI actions.
  * Release PR creation, versioning, and release publishing now use the new short-lived authentication to enhance security and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->