### PR TITLE
fix(release): include workout-spa-editor in changesets flow

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -43,7 +43,7 @@ This will prompt you to:
 
 ## Configuration
 
-- **Linked packages**: `@kaiord/core`, `@kaiord/cli`, and `@kaiord/mcp` are linked (same major/minor versions)
-- **Ignored packages**: `@kaiord/workout-spa-editor` (private, not published)
+- **Linked packages**: `@kaiord/core`, `@kaiord/fit`, `@kaiord/tcx`, `@kaiord/zwo`, `@kaiord/garmin`, `@kaiord/garmin-connect`, `@kaiord/cli`, `@kaiord/mcp`, and `@kaiord/ai` are linked (same major/minor versions)
+- **Private packages** (`@kaiord/workout-spa-editor`, `@kaiord/garmin-bridge`, `@kaiord/train2go-bridge`) participate in the changesets flow — they get versioned and changelogged, but `"private": true` in their `package.json` keeps `npm publish` from uploading them
 
 See `config.json` for full configuration.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -19,6 +19,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@kaiord/workout-spa-editor"],
+  "ignore": [],
   "tagFormat": "${packageName}@${version}"
 }


### PR DESCRIPTION
## Summary

Removes \`@kaiord/workout-spa-editor\` from \`.changeset/config.json\`'s \`ignore\` list. The SPA's \`"private": true\` already prevents \`npm publish\` from uploading it, so the \`ignore\` entry adds no publishing protection while creating a serious failure mode.

### Why

When the only pending changesets target an ignored package, \`changesets/action\` stays in **version mode** forever and never falls through to **publish mode**. This just bit us:

- #318 (\`Version Packages\`) was merged → 11 packages bumped on main (\`core@7.0.0\` etc.)
- Next Release run found 8 SPA-only orphan changesets in \`.changeset/\`
- Action tried to open an empty Version Packages PR → GitHub rejected with \`No commits between main and changeset-release/main\`
- Publish step **never ran** → main is now 3 majors ahead of npm for the 9 publishable packages

### Long-term fix per Twelve-Factor X (dev/prod parity)

Every package goes through the same release pipeline regardless of whether it ships to npm. The SPA gets versioned and changelogged like any other package; \`private: true\` is the npm-side guard, so no second allowlist is needed.

### Rollout (automatic after merge)

1. Release runs on main → consumes the 8 orphan SPA changesets → opens a fresh Version Packages PR with the SPA bump.
2. We merge that PR → next Release sees no pending changesets → **publish step finally runs** → \`core@7.0.0\`, \`cli@7.0.0\`, etc. land on npm.

## Test plan

- [x] Config diff is minimal (one line)
- [ ] After merge: Release workflow opens a Version Packages PR containing only the SPA bump (consumes the 8 orphan changesets)
- [ ] After that PR merges: publish step runs and the 9 npm packages reach \`v7.0.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration settings.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal build and versioning configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->