### PR TITLE
chore(openspec): opsx-sync 2026-04-20 + fix-spec-code-drift proposal

### DIFF
--- a/openspec/changes/fix-spec-code-drift/.openspec.yaml
+++ b/openspec/changes/fix-spec-code-drift/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-20

--- a/openspec/changes/fix-spec-code-drift/design.md
+++ b/openspec/changes/fix-spec-code-drift/design.md
@@ -1,0 +1,126 @@
+## Context
+
+The live specs have accumulated eight implementation gaps identified by `/opsx-sync` (2026-04-20). Each gap is implementation-only — the spec requirement is stable and correct. Treating them as a single change keeps them discoverable (one PR, one changeset) and lets reviewers verify by reading the audit summary in `proposal.md`. The gaps touch three surfaces (SPA editor, VitePress docs, repo config), cross two hexagonal layers (application + adapters), and one spans Dexie persistence so a schema-version bump is required.
+
+Current state per gap:
+
+- `packages/workout-spa-editor/src/adapters/dexie/storage-probe.ts` reports `"failed"` but no consumer UI surfaces the message.
+- `packages/workout-spa-editor/src/adapters/bridge/bridge-types.ts` defines `BridgeStatus = "verified" | "unavailable"`; pruning in `bridge-registry-helpers.ts` calls `map.delete(...)` directly.
+- `packages/workout-spa-editor/src/store/train2go-store.ts` carries `lastDetectionTimestamp: number | null` but `train2go-store-actions.ts` calls `detectExtension()` unconditionally.
+- `packages/docs/.vitepress/config.ts` has no `theme-color` head entry.
+- `.changeset/config.json#linked[0]` lists the core + adapter packages plus `workout-spa-editor`, but omits the two bridge extensions.
+- `packages/workout-spa-editor/src/application/workout-transitions.ts` updates `modifiedAt` only on `PUSHED→MODIFIED`.
+- `packages/workout-spa-editor/src/application/batch-processor.ts` exposes `BatchProgress = { total, processed, succeeded, failed, current }` without `queued` or a per-workout array.
+- `packages/workout-spa-editor/src/types/usage-schemas.ts` stores `totalTokens: number`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Each of the eight spec requirements passes a runtime/integration test after this change.
+- No spec text edits in this change — specs are already correct.
+- Dexie migration for `UsageRecord` backfills legacy rows deterministically so nobody sees a mid-usage-panel zero.
+- Telemetry / user-visible strings land in English; any l10n hook that already exists is preserved.
+- Zero new ESLint / TS / test warnings; every touched file stays ≤100 LOC (tests exempt).
+
+**Non-Goals:**
+- Re-designing the bridge lifecycle state machine (REMOVED is being added as the minimum that the spec mandates; a future change can promote it to a formal timeline of transitions).
+- Changing the SPA AI batch UX — only the schema shape and its renderer inputs.
+- Touching group-B spec-wording drift (`adapter-contracts` regex, `spa-editor-context-menu` wording, `spa-ai-batch` ES glossary); those go in the follow-up sync PR.
+- Docs-site redesign, favicon strategy, or any branding work beyond the single `theme-color` meta tag.
+
+## Decisions
+
+### 1. Storage-unavailable banner mounts in the editor root
+
+Add a `StorageAvailabilityBanner` component mounted once in `WorkoutEditorLayout` (or equivalent top-level layout). It subscribes to a new `storage-store` that runs `probeStorage()` on app mount and exposes `status: "ok" | "failed" | "checking"`.
+
+- **Why a store and not a hook**: Other surfaces (sync indicator, "Push to Garmin") need to react to the same probe result. Centralizing avoids duplicate probes and ensures a single banner.
+- **Alternative considered**: Running `probeStorage()` from each persistence adapter at first write. Rejected because the UI needs an eager signal before the first write is attempted.
+- **Layer**: Application (store) + adapter (component).
+
+### 2. Introduce `REMOVED` bridge state, keep `unavailable` as soft-fail
+
+Expand `BridgeStatus = "verified" | "unavailable" | "removed"`. Pruning in `bridge-registry-helpers.ts` transitions to `"removed"` and emits a user notification via the existing toast port; entries stay in the registry map (keyed by extensionId) until the user dismisses the toast or 24h passes, at which point they are deleted.
+
+- **Why keep the entry**: The spec requires user-visible notification. Deleting silently loses the affordance.
+- **Alternative considered**: Boolean `removed: true` on the existing type. Rejected because `BridgeStatus` is already a discriminated union elsewhere and adding a flag side-steps exhaustiveness checks.
+- **Layer**: Adapter (bridge registry) + application (notification store).
+
+### 3. 30s detection cache in the Train2Go store action, not the hook
+
+`detectAction` reads `lastDetectionTimestamp` + `extensionInstalled` from the store state: if both are true and the delta is <30s, return early with the cached result. This matches the base `spa-garmin-extension` pattern (which already caches) and keeps cache policy in one place.
+
+- **Alternative considered**: Cache in the React hook via `useMemo`. Rejected because detection also runs from non-hook contexts (e.g., after push).
+- **Layer**: Application (store action).
+
+### 4. Theme-color meta via VitePress head config
+
+Add a single entry to `.vitepress/config.ts`: `['meta', { name: 'theme-color', content: '#0f172a' }]`. No CSS token work, no favicon rework — this proposal scopes to the missing tag only.
+
+### 5. Add bridge extensions to `.changeset/config.json#linked`
+
+Append `@kaiord/garmin-bridge` and `@kaiord/train2go-bridge` to the existing `linked[0]` group. Both extensions already have `package.json` entries and run the publish pipeline; changesets versioning makes them move in lockstep with the rest of the monorepo, satisfying `cws-auto-publish` §"Changesets configuration".
+
+### 6. Promote `modifiedAt` update into a central `onWorkoutMutation(draft, state)` helper
+
+Rather than sprinkling `Date.now()` assignments across every action creator, introduce `onWorkoutMutation` in `application/workout-transitions.ts` that all mutators call before persisting. The helper updates `modifiedAt` unconditionally and is idempotent.
+
+- **Why a helper**: The state machine has many mutators (edit-step, reorder, paste, delete, group, ungroup, etc.). A single chokepoint makes the invariant mechanical.
+- **Alternative considered**: Zustand middleware. Rejected because mutations happen through different slice shapes and a middleware would couple unrelated state.
+- **Layer**: Application.
+
+### 7. `BatchProgress` becomes a richer structure with per-workout map
+
+New shape:
+```ts
+type BatchProgress = {
+  total: number;
+  counts: { queued: number; processing: number; succeeded: number; failed: number };
+  current: string | null; // workout id in flight
+  byId: Record<string, 'queued' | 'processing' | 'succeeded' | 'failed'>;
+};
+```
+- **Why `byId`**: The spec requires per-workout status in the progress UI. A map keyed by workout id is O(1) for the card renderer.
+- **Alternative considered**: Array of `{ id, status }`. Rejected because the calendar panel needs random access by id, and ordering is already known from the week grid.
+- **Layer**: Application (batch processor) + adapter (UI progress panel).
+
+### 8. `UsageRecord` additive schema bump with Dexie migration
+
+New shape (additive fields; `totalTokens` remains for backwards compatibility):
+```ts
+type UsageRecord = {
+  id: string;
+  timestamp: number;
+  provider: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number; // derived: inputTokens + outputTokens, kept for legacy readers
+  costUsd: number;
+};
+```
+Dexie version bump (`this.version(2).stores({...}).upgrade(tx => tx.table('usage').toCollection().modify(record => { ... }))`). For legacy rows with only `totalTokens`, set `inputTokens = totalTokens` and `outputTokens = 0` (conservative: we know total usage happened but can't know the split; downstream renderers show "—" when `outputTokens === 0 && inputTokens > 0 && legacy === true`, marked via a transient `legacy: true` field we strip before display).
+
+- **Alternative considered**: Drop `totalTokens` and compute everywhere. Rejected because external readers (tests, possible tooling) index on `totalTokens`.
+- **Layer**: Adapter (Dexie).
+
+## Risks / Trade-offs
+
+- **[Bridge REMOVED state churn] → Mitigation**: Consumers that exhaustively switch on `BridgeStatus` will fail TypeScript until updated. This is intentional — the compiler surfaces the missing branches. Ship the type change atomically with the consumer updates.
+- **[Dexie migration double-bump risk] → Mitigation**: If `UsageRecord` changes land alongside an unrelated Dexie bump on `main`, renumbering is fragile. Verify no other pending migration exists on merge; if conflict, resolve by renumbering during rebase, not during write.
+- **[`modifiedAt` on every edit loosens debounce windows] → Mitigation**: The spec already requires this behavior; any downstream consumer assuming "changes only on push" was already wrong. Add a test covering `STRUCTURED` edit → `modifiedAt` advanced.
+- **[Group-B spec edits delayed] → Mitigation**: Called out as non-goal; the follow-up change is already agreed with the user and will be a minimal doc-only PR.
+- **[`inputTokens`/`outputTokens` for legacy rows is a guess] → Mitigation**: The renderer strategy ("—" when `legacy === true`) keeps us honest. Alternatively, expose the legacy rows to a one-off telemetry re-ingestion if the user ever wires real provider receipts.
+
+## Migration Plan
+
+1. Land `BridgeStatus` type change behind a feature-complete PR (atomic — no intermediate commits compile).
+2. Dexie `usage` bump to version 2 with the backfill upgrade step.
+3. Release via changesets (`pnpm exec changeset`): one changeset entry tagging `@kaiord/workout-spa-editor` as `minor` (new UI affordances, additive schema), `@kaiord/docs` as `patch` (head meta tag only), and a repo-root note for the `.changeset/config.json` edit.
+4. Post-merge: run `/opsx-verify` on every modified spec; the 8 gaps should close without any spec rewrite.
+5. No rollback needed beyond a normal revert — no irreversible data transforms (Dexie migration is additive and idempotent on re-run).
+
+## Open Questions
+
+- **`modifiedAt` on pure selection/navigation events**: Should selecting a step count as a mutation? The spec says "user edit", which clearly excludes selection; the helper wires into mutators only. Confirmed non-issue.
+- **Bridge REMOVED retention window**: 24h is picked from analogy with the Garmin extension's session timeout — if the user prefers 7 days (to match "weeks-of-use" stories) update the design before implementing. Default stands at 24h unless challenged.
+- **Legacy `totalTokens` split display policy**: "—" for `outputTokens` is proposed; an alternative is showing `totalTokens` under a combined "Tokens" column when `legacy`. Will defer until the usage panel renderer is touched.

--- a/openspec/changes/fix-spec-code-drift/design.md
+++ b/openspec/changes/fix-spec-code-drift/design.md
@@ -32,7 +32,7 @@ Current state per gap:
 
 ### 1. Storage-unavailable banner mounts in the editor root
 
-Add a `StorageAvailabilityBanner` component mounted once in `WorkoutEditorLayout` (or equivalent top-level layout). It subscribes to a new `storage-store` that runs `probeStorage()` on app mount and exposes `status: "ok" | "failed" | "checking"`.
+Add a `StorageAvailabilityBanner` component mounted once in `WorkoutEditorLayout` (or equivalent top-level layout). It subscribes to a new `storage-store` that runs `probeStorage()` on app mount and exposes the underlying `HydrationStatus` (`"pending" | "complete" | "failed"`) from `adapters/dexie/storage-probe.ts`.
 
 - **Why a store and not a hook**: Other surfaces (sync indicator, "Push to Garmin") need to react to the same probe result. Centralizing avoids duplicate probes and ensures a single banner.
 - **Alternative considered**: Running `probeStorage()` from each persistence adapter at first write. Rejected because the UI needs an eager signal before the first write is attempted.
@@ -80,7 +80,7 @@ Append `@kaiord/garmin-bridge` and `@kaiord/train2go-bridge` to the existing `li
 
 ### 6. Promote `modifiedAt` update into a central `onWorkoutMutation(draft, state)` helper
 
-Rather than sprinkling `Date.now()` assignments across every action creator, introduce `onWorkoutMutation` in `application/workout-transitions.ts` that all mutators call before persisting. The helper updates `modifiedAt` unconditionally and is idempotent.
+Rather than sprinkling `Date.now()` assignments across every action creator, introduce `onWorkoutMutation` in `application/workout-transitions.ts` that all mutators call before persisting. The helper unconditionally advances `modifiedAt` to a single `Date.now()` captured at the top of the current mutation batch — calling the helper twice within the same synchronous mutation is safe (both calls see the same captured timestamp); each fresh mutation writes a new timestamp, which is the intended behavior.
 
 - **Why a helper**: The state machine has many mutators (edit-step, reorder, paste, delete, group, ungroup, etc.). A single chokepoint makes the invariant mechanical.
 - **Alternative considered**: Zustand middleware. Rejected because mutations happen through different slice shapes and a middleware would couple unrelated state.
@@ -113,9 +113,10 @@ type UsageRecord = {
   outputTokens: number;
   totalTokens: number; // derived: inputTokens + outputTokens, kept for legacy readers
   costUsd: number;
+  legacy?: boolean; // true only on rows backfilled by the v1 → v2 migration; the renderer shows `—` for `outputTokens` when true
 };
 ```
-Dexie version bump (`this.version(2).stores({...}).upgrade(tx => tx.table('usage').toCollection().modify(record => { ... }))`). For legacy rows with only `totalTokens`, set `inputTokens = totalTokens` and `outputTokens = 0` (conservative: we know total usage happened but can't know the split; downstream renderers show "—" when `outputTokens === 0 && inputTokens > 0 && legacy === true`, marked via a transient `legacy: true` field we strip before display).
+Dexie version bump (`this.version(2).stores({...}).upgrade(tx => tx.table('usage').toCollection().modify(record => { ... }))`). For legacy rows with only `totalTokens`, set `inputTokens = totalTokens`, `outputTokens = 0`, and `legacy: true` — conservative: we know total usage happened but can't know the split. The `legacy: boolean` field is a persisted `UsageRecord` field (part of the v2 schema) and SHALL be passed through to the renderer so it can show `—` for `outputTokens` on legacy rows. New-version writes omit `legacy` (or set it to `false`); the renderer treats missing/`false` identically.
 
 - **Alternative considered**: Drop `totalTokens` and compute everywhere. Rejected because external readers (tests, possible tooling) index on `totalTokens`.
 - **Layer**: Adapter (Dexie).
@@ -126,7 +127,7 @@ Dexie version bump (`this.version(2).stores({...}).upgrade(tx => tx.table('usage
 - **[Dexie migration double-bump risk] → Mitigation**: If `UsageRecord` changes land alongside an unrelated Dexie bump on `main`, renumbering is fragile. Verify no other pending migration exists on merge; if conflict, resolve by renumbering during rebase, not during write.
 - **[`modifiedAt` on every edit loosens debounce windows] → Mitigation**: The spec already requires this behavior; any downstream consumer assuming "changes only on push" was already wrong. Add a test covering `STRUCTURED` edit → `modifiedAt` advanced.
 - **[Group-B spec edits delayed] → Mitigation**: Called out as non-goal; the follow-up change is already agreed with the user and will be a minimal doc-only PR.
-- **[`inputTokens`/`outputTokens` for legacy rows is a guess] → Mitigation**: The renderer strategy ("—" when `legacy === true`) keeps us honest. Alternatively, expose the legacy rows to a one-off telemetry re-ingestion if the user ever wires real provider receipts.
+- **[`inputTokens`/`outputTokens` for legacy rows is a guess] → Mitigation**: The persisted `legacy: true` field plus the renderer's `—` fallback keeps us honest — readers never see a fabricated `outputTokens: 0` without the caveat. Alternatively, expose the legacy rows to a one-off telemetry re-ingestion if the user ever wires real provider receipts.
 
 ## Migration Plan
 

--- a/openspec/changes/fix-spec-code-drift/design.md
+++ b/openspec/changes/fix-spec-code-drift/design.md
@@ -46,6 +46,15 @@ Expand `BridgeStatus = "verified" | "unavailable" | "removed"`. Pruning in `brid
 - **Alternative considered**: Boolean `removed: true` on the existing type. Rejected because `BridgeStatus` is already a discriminated union elsewhere and adding a flag side-steps exhaustiveness checks.
 - **Layer**: Adapter (bridge registry) + application (notification store).
 
+### 2a. Bridge registry persistence across browser sessions
+
+The bridge registry — including `status`, `lastSeen`, and the 24h-unavailable retention timer — SHALL be persisted to Dexie (one row per bridge keyed by extensionId). Without persistence, the "24h of UNAVAILABLE before REMOVED" timer and the "24h retention after REMOVED" timer both reset to zero on every browser session, which defeats the user-visible semantics of the lifecycle states.
+
+- **Why Dexie**: It's already the SPA's persistence port for every other durable state (library, templates, usage, ai-provider). Adding a `bridges` store follows the existing pattern and keeps the persistence boundary centralized.
+- **Alternative considered**: `localStorage` / `sessionStorage`. Rejected because the rest of the SPA's durable state lives in Dexie; splitting persistence strategies creates dev-prod parity and backup headaches.
+- **Wall-clock caveat**: The 24h timer is wall-clock-based. A user whose system clock jumps (daylight-savings, NTP correction) could see earlier/later pruning. This is acceptable — the spec allows approximate lifecycle — but **SHALL NOT** be replaced by `performance.now()` (monotonic clock resets per session).
+- **Layer**: Adapter (new Dexie table) + application (registry helpers read/write through it).
+
 ### 3. 30s detection cache in the Train2Go store action, not the hook
 
 `detectAction` reads `lastDetectionTimestamp` + `extensionInstalled` from the store state: if both are true and the delta is <30s, return early with the cached result. This matches the base `spa-garmin-extension` pattern (which already caches) and keeps cache policy in one place.
@@ -53,9 +62,17 @@ Expand `BridgeStatus = "verified" | "unavailable" | "removed"`. Pruning in `brid
 - **Alternative considered**: Cache in the React hook via `useMemo`. Rejected because detection also runs from non-hook contexts (e.g., after push).
 - **Layer**: Application (store action).
 
-### 4. Theme-color meta via VitePress head config
+### 4. Theme-color meta derived from the shared brand token
 
-Add a single entry to `.vitepress/config.ts`: `['meta', { name: 'theme-color', content: '#0f172a' }]`. No CSS token work, no favicon rework — this proposal scopes to the missing tag only.
+Add a single entry to `.vitepress/config.ts` with the `theme-color` meta. The `content` value SHALL be sourced from the shared CSS token `--brand-bg-primary` (defined in the repo-root `styles/brand-tokens.css`) — not a duplicated hex literal — so the brand invariant from the `branding` spec holds mechanically. Options, in preference order:
+
+1. Parse `styles/brand-tokens.css` at VitePress config load and extract the `--brand-bg-primary` value into the `head` array entry.
+2. Export a tiny `theme-color.ts` module in the docs package that `require`s/imports the token string; the CSS file and TS module are both generated from a single source of truth in `styles/brand-tokens.css`.
+
+Additionally, a CI/test invariant SHALL assert that the rendered docs `<meta name="theme-color">` value equals `--brand-bg-primary` from the shared token file; divergence fails the check. No CSS token rework, no favicon rework — this proposal scopes to the missing tag + the parity guard only.
+
+- **Why not hardcode `#0f172a`**: Factor V (build/release/run) plus the `branding` spec's "No arbitrary hex values SHALL be used in component styles" rule. The docs site is a component of the brand system; the same token discipline applies.
+- **Alternative considered**: Accept the hex duplication and rely on a reviewer to catch drift. Rejected because the audit that kicked off this proposal would not have flagged a silent divergence; the point of this change is mechanical enforcement.
 
 ### 5. Add bridge extensions to `.changeset/config.json#linked`
 
@@ -114,13 +131,13 @@ Dexie version bump (`this.version(2).stores({...}).upgrade(tx => tx.table('usage
 ## Migration Plan
 
 1. Land `BridgeStatus` type change behind a feature-complete PR (atomic — no intermediate commits compile).
-2. Dexie `usage` bump to version 2 with the backfill upgrade step.
-3. Release via changesets (`pnpm exec changeset`): one changeset entry tagging `@kaiord/workout-spa-editor` as `minor` (new UI affordances, additive schema), `@kaiord/docs` as `patch` (head meta tag only), and a repo-root note for the `.changeset/config.json` edit.
+2. Dexie schema bump in a single coordinated version step: `usage` store gains input/output token fields AND a new `bridges` store is introduced. Both migrations run in the same `this.version(N).stores({...}).upgrade(...)` hook so users see one upgrade, not two.
+3. Release via changesets (`pnpm exec changeset`): one changeset entry tagging `@kaiord/workout-spa-editor` as `minor` (new UI affordances, additive schema, new Dexie store), `@kaiord/docs` as `patch` (head meta tag + token-parsing helper), and a repo-root note for the `.changeset/config.json` edit.
 4. Post-merge: run `/opsx-verify` on every modified spec; the 8 gaps should close without any spec rewrite.
-5. No rollback needed beyond a normal revert — no irreversible data transforms (Dexie migration is additive and idempotent on re-run).
+5. No rollback needed beyond a normal revert — no irreversible data transforms (both Dexie migrations are additive and idempotent on re-run).
 
 ## Open Questions
 
 - **`modifiedAt` on pure selection/navigation events**: Should selecting a step count as a mutation? The spec says "user edit", which clearly excludes selection; the helper wires into mutators only. Confirmed non-issue.
-- **Bridge REMOVED retention window**: 24h is picked from analogy with the Garmin extension's session timeout — if the user prefers 7 days (to match "weeks-of-use" stories) update the design before implementing. Default stands at 24h unless challenged.
+- **Bridge REMOVED retention window**: 24h is picked from analogy with the Garmin extension's session timeout — if the user prefers 7 days (to match "weeks-of-use" stories) update the design before implementing. Default stands at 24h unless challenged. Decision 2a (persist the registry to Dexie) resolves the across-session concern; the value itself is still a product question.
 - **Legacy `totalTokens` split display policy**: "—" for `outputTokens` is proposed; an alternative is showing `totalTokens` under a combined "Tokens" column when `legacy`. Will defer until the usage panel renderer is touched.

--- a/openspec/changes/fix-spec-code-drift/proposal.md
+++ b/openspec/changes/fix-spec-code-drift/proposal.md
@@ -15,6 +15,8 @@ An `/opsx-sync` audit against the 22 live specs and 24 archived changes surfaced
 
 No breaking changes to public library APIs; the SPA changes are internal to `@kaiord/workout-spa-editor`. The `UsageRecord` schema change is a non-breaking Dexie schema bump (additive fields) with a migration that fills `inputTokens`/`outputTokens` from `totalTokens` when absent.
 
+**Dexie-vs-Zustand boundary (per `CLAUDE.md` state-management rule "Editor runtime → Zustand. Persisted data → Dexie. Local UI → React state.")**: the new `bridges` Dexie store in this proposal persists only the registry record for each bridge (extensionId, status, lastSeen, timer anchors). The transient bridge runtime stores (`garmin-store`, `train2go-store`) and the `workout-store` remain non-persistent Zustand state — they are NOT to be piped through the Dexie persistence boundary by this change.
+
 ## Capabilities
 
 ### New Capabilities

--- a/openspec/changes/fix-spec-code-drift/proposal.md
+++ b/openspec/changes/fix-spec-code-drift/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+An `/opsx-sync` audit against the 22 live specs and 24 archived changes surfaced eight cases where the code diverged from specs — in every case the spec describes intended behavior and the code is incomplete. Because the specs are the source of truth, we bring the code up to spec rather than weakening the specs. Fixing all drift in one proposal keeps the follow-up edits to group B (spec wording aligned to stable code reality) uncontested.
+
+## What Changes
+
+- **spa-persistence-port**: Implement the "Storage unavailable — changes in this session won't be saved" banner that reacts to `probeStorage() === "failed"`. Currently the probe exists but its result is ignored by the UI.
+- **spa-bridge-protocol**: Extend `BridgeStatus` with a `REMOVED` state (in addition to `VERIFIED` and `UNAVAILABLE`) and route pruning logic through that state with user notification, replacing the silent `map.delete(...)` path.
+- **spa-train2go-extension**: Wire the 30-second detection cache so `detect()` short-circuits when `lastDetectionTimestamp` is fresh and `extensionInstalled === true`.
+- **docs-site / branding**: Add `<meta name="theme-color">` to the VitePress docs config so the docs surface matches the landing page and editor.
+- **cws-auto-publish**: Add `@kaiord/garmin-bridge` and `@kaiord/train2go-bridge` to `.changeset/config.json#linked` so the spec's "extensions participate in changesets versioning" requirement holds mechanically.
+- **spa-workout-state-machine**: Update `modifiedAt` on any user edit to the KRD, not only on the `PUSHED→MODIFIED` transition; the spec requires edits from `STRUCTURED` and `READY` to also bump the timestamp.
+- **spa-calendar**: Expand `BatchProgress` to carry per-workout status (including the `queued` bucket) so the progress UI can render the spec-required "per-workout status (success/fail/queued)" detail.
+- **spa-ai-batch**: Split `UsageRecord.totalTokens` into `inputTokens` + `outputTokens` (keep `totalTokens` as a derived convenience) to satisfy the spec's granularity requirement for the usage panel.
+
+No breaking changes to public library APIs; the SPA changes are internal to `@kaiord/workout-spa-editor`. The `UsageRecord` schema change is a non-breaking Dexie schema bump (additive fields) with a migration that fills `inputTokens`/`outputTokens` from `totalTokens` when absent.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+No requirement-level changes — every edit implements behavior that the current spec already mandates. The audit concluded that specs are correct and code is incomplete. Because the proposal changes only implementation, no spec deltas are required and `specs/` stays empty.
+
+## Impact
+
+- **Affected packages**:
+  - `@kaiord/workout-spa-editor` (storage banner, bridge state, Train2Go cache, `modifiedAt` on edit, `BatchProgress`, `UsageRecord`)
+  - `packages/docs` (VitePress `theme-color` meta)
+  - Repo root: `.changeset/config.json` (linked array)
+- **Layers**: Adapters (SPA Dexie + Zustand stores, extension bridges), Application (state-machine transitions, batch processor), and Docs infra. No `@kaiord/core` domain changes.
+- **Dexie migration**: Additive schema bump on `usage` store; backfill `inputTokens`/`outputTokens` from legacy `totalTokens` rows.
+- **Referenced specs**: `openspec/specs/spa-persistence-port/spec.md`, `spa-bridge-protocol/spec.md`, `spa-train2go-extension/spec.md`, `docs-site/spec.md`, `branding/spec.md`, `cws-auto-publish/spec.md`, `spa-workout-state-machine/spec.md`, `spa-calendar/spec.md`, `spa-ai-batch/spec.md`.
+- **Out of scope**: Group B spec edits (`adapter-contracts`, `spa-editor-context-menu`, `spa-ai-batch` ES glossary) ship as a separate `opsx-sync` follow-up since those are pure spec-wording alignments to stable code.

--- a/openspec/changes/fix-spec-code-drift/specs/branding/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/branding/spec.md
@@ -1,0 +1,15 @@
+## MODIFIED Requirements
+
+### Requirement: Theme color meta tag
+
+The landing page, the editor, AND the documentation site SHALL include `<meta name="theme-color">` with the value of `--brand-bg-primary` (dark background color). This controls the browser chrome color on mobile devices for brand consistency across every first-party surface.
+
+#### Scenario: Mobile browser chrome matches brand on landing and editor
+
+- **WHEN** the landing page or the editor is opened on Android Chrome or iOS Safari
+- **THEN** the browser address bar SHALL tint to the dark brand background color
+
+#### Scenario: Documentation site matches brand
+
+- **WHEN** any `/docs/*` page is opened on Android Chrome or iOS Safari
+- **THEN** the VitePress-rendered HTML SHALL include `<meta name="theme-color" content="#0f172a">` in its `<head>` so the browser address bar tints to the same dark brand background color as the landing page and the editor

--- a/openspec/changes/fix-spec-code-drift/specs/cws-auto-publish/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/cws-auto-publish/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Bridge extensions are in the changesets linked group
+
+The `linked` array in `.changeset/config.json` SHALL include `@kaiord/garmin-bridge` and `@kaiord/train2go-bridge` alongside the existing monorepo packages, so that `Changesets configuration for extensions` is enforced by the tool itself rather than relying on manual coordination.
+
+#### Scenario: Both bridge packages appear in linked
+
+- **WHEN** `.changeset/config.json` is parsed
+- **THEN** the first entry of its `linked` array SHALL contain both `@kaiord/garmin-bridge` and `@kaiord/train2go-bridge`
+- **AND** the parse SHALL succeed with no duplicate names across linked groups
+
+#### Scenario: Version bump for one extension bumps the other
+
+- **GIVEN** a changeset that targets only `@kaiord/train2go-bridge`
+- **WHEN** `pnpm exec changeset version` runs
+- **THEN** `@kaiord/garmin-bridge` SHALL receive the same version bump because both belong to the same linked group

--- a/openspec/changes/fix-spec-code-drift/specs/cws-auto-publish/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/cws-auto-publish/spec.md
@@ -7,7 +7,7 @@ The `linked` array in `.changeset/config.json` SHALL include `@kaiord/garmin-bri
 #### Scenario: Both bridge packages appear in linked
 
 - **WHEN** `.changeset/config.json` is parsed
-- **THEN** the first entry of its `linked` array SHALL contain both `@kaiord/garmin-bridge` and `@kaiord/train2go-bridge`
+- **THEN** at least one entry of its `linked` array SHALL contain both `@kaiord/garmin-bridge` and `@kaiord/train2go-bridge` (regardless of its position in the array)
 - **AND** the parse SHALL succeed with no duplicate names across linked groups
 
 #### Scenario: Version bump for one extension bumps the other

--- a/openspec/changes/fix-spec-code-drift/specs/spa-ai-batch/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/spa-ai-batch/spec.md
@@ -16,4 +16,5 @@ To satisfy `Monthly AI usage tracking`'s "one row per `(yearMonth, provider)` ..
 - **WHEN** the Dexie database upgrades to the new schema version
 - **THEN** the row SHALL have `inputTokens` set to its previous `totalTokens` value
 - **AND** `outputTokens` SHALL be set to `0`
-- **AND** the row SHALL be flagged as legacy so the usage panel renderer can show `—` for `outputTokens` instead of a misleading zero
+- **AND** the row SHALL have a persisted `legacy: true` field (added by the v2 schema)
+- **AND** the usage panel renderer SHALL show `—` (not `0`) for `outputTokens` on rows where `legacy === true`, so the backfilled zero is never rendered as a truthful value

--- a/openspec/changes/fix-spec-code-drift/specs/spa-ai-batch/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/spa-ai-batch/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: UsageRecord stores input and output tokens separately
+
+To satisfy `Monthly AI usage tracking`'s "one row per `(yearMonth, provider)` ... showing provider, inputTokens, outputTokens, and costUsd", the `UsageRecord` Dexie schema SHALL expose `inputTokens` and `outputTokens` as distinct numeric fields. `totalTokens` SHALL remain in the schema as a derived convenience for legacy consumers and SHALL always equal `inputTokens + outputTokens` for rows written by the current application version.
+
+#### Scenario: New UsageRecord writes expose split tokens
+
+- **WHEN** a batch run persists a `UsageRecord`
+- **THEN** the stored row SHALL contain `inputTokens`, `outputTokens`, `totalTokens`, and `costUsd` as numeric fields
+- **AND** `totalTokens` SHALL equal `inputTokens + outputTokens`
+
+#### Scenario: Legacy rows are migrated on Dexie version bump
+
+- **GIVEN** a `UsageRecord` row written before the migration with only `totalTokens` set
+- **WHEN** the Dexie database upgrades to the new schema version
+- **THEN** the row SHALL have `inputTokens` set to its previous `totalTokens` value
+- **AND** `outputTokens` SHALL be set to `0`
+- **AND** the row SHALL be flagged as legacy so the usage panel renderer can show `—` for `outputTokens` instead of a misleading zero

--- a/openspec/changes/fix-spec-code-drift/specs/spa-bridge-protocol/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/spa-bridge-protocol/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: BridgeStatus type carries a REMOVED variant
+
+The `BridgeStatus` discriminated union in the SPA's bridge types SHALL include a `"removed"` member in addition to `"verified"` and `"unavailable"`, so the `Bridge pruning` scenario in `Bridge lifecycle management` is representable in code without a silent `map.delete(...)` side-effect.
+
+#### Scenario: Pruning transitions to removed and notifies the user
+
+- **WHEN** a bridge has been in `"unavailable"` status for more than 24 hours
+- **THEN** the bridge entry SHALL transition to `status: "removed"` (not be silently deleted)
+- **AND** a toast notification SHALL fire once per transition informing the user that the extension has been removed from the registry
+- **AND** the entry SHALL be deleted from the registry map only after the toast is dismissed by the user or 24 additional hours elapse
+
+#### Scenario: Exhaustiveness of BridgeStatus consumers
+
+- **WHEN** any TypeScript consumer switches on `BridgeStatus` without a `default` branch
+- **THEN** the type-checker SHALL require handling of `"removed"` alongside `"verified"` and `"unavailable"` (no `never`-fallthrough allowed)

--- a/openspec/changes/fix-spec-code-drift/specs/spa-calendar/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/spa-calendar/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: BatchProgress carries per-workout status
+
+The `Batch processing progress` scenario in `Batch AI processing banner` SHALL be implementable in code: `BatchProgress` (exported from the SPA batch processor) SHALL expose a `byId` map from workout id to one of `"queued" | "processing" | "succeeded" | "failed"` so the calendar UI can label each card individually, and a `counts` object with the same four buckets so the banner can render `Processing X of N` without re-deriving the aggregate.
+
+#### Scenario: Progress shape has byId and counts
+
+- **WHEN** the batch processor dispatches a batch of N workouts
+- **THEN** `BatchProgress` SHALL be shaped as `{ total: N, counts: { queued, processing, succeeded, failed }, current: string | null, byId: Record<string, 'queued' | 'processing' | 'succeeded' | 'failed'> }`
+- **AND** every workout in the batch SHALL appear as a key in `byId` from the moment the batch begins, initially with status `"queued"`
+
+#### Scenario: Per-workout status transitions
+
+- **GIVEN** a batch in progress with workout W in status `"queued"`
+- **WHEN** the processor begins W
+- **THEN** `byId[W]` SHALL transition to `"processing"` and `current` SHALL equal W
+- **AND** on completion `byId[W]` SHALL transition to `"succeeded"` or `"failed"` and the corresponding `counts.*` SHALL increment by one

--- a/openspec/changes/fix-spec-code-drift/specs/spa-persistence-port/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/spa-persistence-port/spec.md
@@ -12,5 +12,5 @@ The "Storage unavailable — changes in this session won't be saved" banner mand
 
 #### Scenario: Banner is absent when storage is healthy
 
-- **WHEN** `probeStorage()` resolves to `"ok"`
+- **WHEN** `probeStorage()` resolves to `"complete"`
 - **THEN** `StorageAvailabilityBanner` SHALL render nothing (no DOM node)

--- a/openspec/changes/fix-spec-code-drift/specs/spa-persistence-port/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/spa-persistence-port/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Storage availability banner is rendered when probe fails
+
+The "Storage unavailable — changes in this session won't be saved" banner mandated by `Storage degradation handling` SHALL be observable at runtime: a dedicated `storage-store` runs `probeStorage()` on editor mount, and a top-level `StorageAvailabilityBanner` component subscribes to the store and renders the banner text whenever the probe result is `"failed"`.
+
+#### Scenario: Banner appears when IndexedDB is unavailable
+
+- **WHEN** the editor mounts and `probeStorage()` resolves to `"failed"`
+- **THEN** a single `StorageAvailabilityBanner` SHALL render the string `Storage unavailable — changes in this session won't be saved` at the top of the editor layout
+- **AND** the banner SHALL remain visible across route changes for the duration of the session
+
+#### Scenario: Banner is absent when storage is healthy
+
+- **WHEN** `probeStorage()` resolves to `"ok"`
+- **THEN** `StorageAvailabilityBanner` SHALL render nothing (no DOM node)

--- a/openspec/changes/fix-spec-code-drift/specs/spa-train2go-extension/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/spa-train2go-extension/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: 30-second detection cache is enforced by the store action
+
+The Train2Go detection cache described in `Train2Go state management` SHALL be enforced at the action level: `detectAction` reads `lastDetectionTimestamp` and `extensionInstalled` from the store and short-circuits when the extension is already installed and less than 30 000 ms have elapsed since the last probe.
+
+#### Scenario: Cache short-circuits redundant detection
+
+- **GIVEN** `extensionInstalled === true` and `lastDetectionTimestamp === Date.now() - 10_000`
+- **WHEN** any caller dispatches `detect()`
+- **THEN** the store SHALL NOT send a fresh `ping` to the extension
+- **AND** the previously cached `userId`/`userName`/`sessionActive` values SHALL be preserved
+
+#### Scenario: Cache expires after 30 seconds
+
+- **GIVEN** `extensionInstalled === true` and `lastDetectionTimestamp === Date.now() - 35_000`
+- **WHEN** any caller dispatches `detect()`
+- **THEN** the store SHALL issue a fresh `ping` to the extension
+- **AND** `lastDetectionTimestamp` SHALL be updated to the new probe's completion timestamp
+
+#### Scenario: Cache is bypassed when extension is not installed
+
+- **GIVEN** `extensionInstalled === false` (first boot or after a removal)
+- **WHEN** any caller dispatches `detect()`
+- **THEN** the store SHALL always issue a fresh `ping` regardless of `lastDetectionTimestamp`

--- a/openspec/changes/fix-spec-code-drift/specs/spa-workout-state-machine/spec.md
+++ b/openspec/changes/fix-spec-code-drift/specs/spa-workout-state-machine/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: modifiedAt is advanced by every KRD mutator
+
+The existing sentence in `STALE detection via rawHash` — "The `modifiedAt` field SHALL be updated on any user edit to the KRD, not only on PUSHED→MODIFIED transitions" — SHALL be implemented by routing every user-initiated KRD mutation through a single `onWorkoutMutation(draft, state)` helper in `application/workout-transitions.ts`. The helper SHALL unconditionally advance `modifiedAt` to `Date.now()` before persisting.
+
+#### Scenario: Editing a STRUCTURED workout advances modifiedAt
+
+- **GIVEN** a workout in `structured` state with `modifiedAt === T0`
+- **WHEN** the user edits any step, lap, or metadata field (rename, reorder, duration change, zone change)
+- **THEN** the persisted workout SHALL have `modifiedAt > T0`
+- **AND** the state SHALL remain `structured` (this requirement does not change state; it only updates the timestamp)
+
+#### Scenario: Editing a READY workout advances modifiedAt
+
+- **GIVEN** a workout in `ready` state with `modifiedAt === T0`
+- **WHEN** the user edits the KRD (any mutator)
+- **THEN** the persisted workout SHALL have `modifiedAt > T0`
+- **AND** the state SHALL remain `ready`
+
+#### Scenario: Non-mutating actions do not advance modifiedAt
+
+- **GIVEN** a workout with `modifiedAt === T0`
+- **WHEN** the user opens the workout, selects a step, or navigates between tabs (no edit)
+- **THEN** `modifiedAt` SHALL remain equal to T0

--- a/openspec/changes/fix-spec-code-drift/tasks.md
+++ b/openspec/changes/fix-spec-code-drift/tasks.md
@@ -5,8 +5,11 @@
 
 ## 2. Documentation site — theme-color meta tag
 
-- [ ] 2.1 Add `['meta', { name: 'theme-color', content: '#0f172a' }]` to the `head` array in `packages/docs/.vitepress/config.ts`
-- [ ] 2.2 Add a build-output assertion test (or a VitePress integration snapshot) confirming the rendered `/docs/index.html` contains the `theme-color` meta tag
+- [ ] 2.1 Write failing test asserting the docs `theme-color` meta tag equals `--brand-bg-primary` parsed from `styles/brand-tokens.css` (not a duplicated hex literal)
+- [ ] 2.2 Add a helper `readBrandTokenColor('--brand-bg-primary')` in the docs package (or shared location) that parses `styles/brand-tokens.css` synchronously at VitePress config load
+- [ ] 2.3 Wire the helper output into `packages/docs/.vitepress/config.ts` `head` array as `['meta', { name: 'theme-color', content: <parsed value> }]`
+- [ ] 2.4 Add a build-output assertion test confirming the rendered `/docs/index.html` contains the `theme-color` meta tag with the exact parsed token value
+- [ ] 2.5 Add a CI invariant (grep-based or unit) asserting no file under `packages/docs/` hardcodes the hex `#0f172a` — the value must come from the token
 
 ## 3. SPA — storage-unavailable banner (spa-persistence-port)
 
@@ -23,6 +26,9 @@
 - [ ] 4.3 Update every exhaustive consumer (grep `BridgeStatus`) to handle `"removed"`; compile error-driven
 - [ ] 4.4 Write failing test for `bridge-registry-helpers.ts` pruning: 24h-unavailable entry transitions to `status: "removed"` and fires toast; second trigger after another 24h deletes the entry
 - [ ] 4.5 Refactor `bridge-registry-helpers.ts` pruning path to transition → notify → deferred delete
+- [ ] 4.6 Write failing Dexie integration test: bridge registry persists across browser sessions — seed a bridge entry with `status: "unavailable"` and `lastSeen: Date.now() - 22h`, reload the SPA, confirm the pruning timer resumes from the persisted `lastSeen` (not restarts from zero)
+- [ ] 4.7 Add a `bridges` store to the SPA Dexie database (new schema version bump if needed); migrate reads/writes in `bridge-registry-helpers.ts` to go through it
+- [ ] 4.8 Document the wall-clock-based timer caveat in `packages/workout-spa-editor/src/adapters/bridge/README.md` (per design Decision 2a)
 
 ## 5. SPA — Train2Go 30s detection cache (spa-train2go-extension)
 

--- a/openspec/changes/fix-spec-code-drift/tasks.md
+++ b/openspec/changes/fix-spec-code-drift/tasks.md
@@ -29,6 +29,7 @@
 - [ ] 4.6 Write failing Dexie integration test: bridge registry persists across browser sessions — seed a bridge entry with `status: "unavailable"` and `lastSeen: Date.now() - 22h`, reload the SPA, confirm the pruning timer resumes from the persisted `lastSeen` (not restarts from zero)
 - [ ] 4.7 Add a `bridges` store to the SPA Dexie database (new schema version bump if needed); migrate reads/writes in `bridge-registry-helpers.ts` to go through it
 - [ ] 4.8 Document the wall-clock-based timer caveat in `packages/workout-spa-editor/src/adapters/bridge/README.md` (per design Decision 2a)
+- [ ] 4.9 Non-regression: add a test (or CI grep invariant) asserting that only the new `bridges` store is persisted in Dexie — `garmin-store` and `train2go-store` MUST remain in-memory Zustand with no `persist(` middleware and no Dexie writes. Reference the Dexie-vs-Zustand boundary clause in `proposal.md` and the `CLAUDE.md` state-management rule
 
 ## 5. SPA — Train2Go 30s detection cache (spa-train2go-extension)
 

--- a/openspec/changes/fix-spec-code-drift/tasks.md
+++ b/openspec/changes/fix-spec-code-drift/tasks.md
@@ -1,0 +1,65 @@
+## 1. Repo-level config
+
+- [ ] 1.1 Add `@kaiord/garmin-bridge` and `@kaiord/train2go-bridge` to the first `linked` group in `.changeset/config.json`
+- [ ] 1.2 Add a failing test to `scripts/` (new `check-changeset-config.test.mjs`) asserting both bridge packages appear in `linked[0]`; wire into `pnpm test:scripts`
+
+## 2. Documentation site — theme-color meta tag
+
+- [ ] 2.1 Add `['meta', { name: 'theme-color', content: '#0f172a' }]` to the `head` array in `packages/docs/.vitepress/config.ts`
+- [ ] 2.2 Add a build-output assertion test (or a VitePress integration snapshot) confirming the rendered `/docs/index.html` contains the `theme-color` meta tag
+
+## 3. SPA — storage-unavailable banner (spa-persistence-port)
+
+- [ ] 3.1 Write failing test for a new `storage-store` in `packages/workout-spa-editor/src/store/storage-store.ts` asserting `probe()` transitions `status` from `"checking"` → `"ok" | "failed"` and is idempotent
+- [ ] 3.2 Implement `storage-store` calling `probeStorage()` on first subscription
+- [ ] 3.3 Write failing component test for `StorageAvailabilityBanner` asserting it renders the exact string when `status === "failed"` and renders nothing otherwise
+- [ ] 3.4 Implement `StorageAvailabilityBanner` in `packages/workout-spa-editor/src/components/molecules/StorageAvailabilityBanner/`
+- [ ] 3.5 Mount `StorageAvailabilityBanner` once in the editor top-level layout; add integration test asserting single-mount invariant across route changes
+
+## 4. SPA — BridgeStatus REMOVED state (spa-bridge-protocol)
+
+- [ ] 4.1 Write failing type-level test asserting `BridgeStatus` includes `"removed"` and that an exhaustive switch without a `default` branch type-errors when `"removed"` is missing
+- [ ] 4.2 Update `BridgeStatus` in `packages/workout-spa-editor/src/adapters/bridge/bridge-types.ts` to `"verified" | "unavailable" | "removed"`
+- [ ] 4.3 Update every exhaustive consumer (grep `BridgeStatus`) to handle `"removed"`; compile error-driven
+- [ ] 4.4 Write failing test for `bridge-registry-helpers.ts` pruning: 24h-unavailable entry transitions to `status: "removed"` and fires toast; second trigger after another 24h deletes the entry
+- [ ] 4.5 Refactor `bridge-registry-helpers.ts` pruning path to transition → notify → deferred delete
+
+## 5. SPA — Train2Go 30s detection cache (spa-train2go-extension)
+
+- [ ] 5.1 Write failing test for `detectAction` in `packages/workout-spa-editor/src/store/train2go-store-actions.ts`: cached+fresh short-circuits; cached+stale re-pings; never-detected always pings
+- [ ] 5.2 Implement the cache guard at the top of `detectAction` reading `lastDetectionTimestamp` and `extensionInstalled` from `get()`
+- [ ] 5.3 Verify no regression in the Settings > Extensions Train2Go detection UX (integration test)
+
+## 6. SPA — modifiedAt on every edit (spa-workout-state-machine)
+
+- [ ] 6.1 Write failing tests for `onWorkoutMutation(draft, state)` helper in `packages/workout-spa-editor/src/application/workout-transitions.ts`: advances `modifiedAt`, is idempotent, preserves non-mutating actions
+- [ ] 6.2 Implement `onWorkoutMutation` and route every KRD mutator (edit step, reorder, paste, delete, group, ungroup, lap edit, metadata edit) through it
+- [ ] 6.3 Write failing tests for STRUCTURED- and READY-state edits asserting `modifiedAt` advances without state change
+- [ ] 6.4 Write failing test for selection-only actions asserting `modifiedAt` is unchanged
+
+## 7. SPA — BatchProgress per-workout status (spa-calendar)
+
+- [ ] 7.1 Write failing unit test for `BatchProgress` shape in `packages/workout-spa-editor/src/application/batch-processor.ts`: `{ total, counts, current, byId }`
+- [ ] 7.2 Update `BatchProgress` type and every emit-site to populate `byId` and `counts`
+- [ ] 7.3 Write failing test asserting per-workout status transitions (`queued → processing → succeeded|failed`) and `counts.*` increments
+- [ ] 7.4 Update the batch-progress panel component to render per-card status from `byId`; add snapshot/integration test
+
+## 8. SPA — UsageRecord input/output tokens + Dexie migration (spa-ai-batch)
+
+- [ ] 8.1 Write failing schema test for `UsageRecord` in `packages/workout-spa-editor/src/types/usage-schemas.ts`: `inputTokens`, `outputTokens`, `totalTokens`, `costUsd` present; `totalTokens === inputTokens + outputTokens` invariant
+- [ ] 8.2 Extend the Zod schema with the new fields
+- [ ] 8.3 Write failing Dexie integration test: version upgrade backfills legacy rows (`inputTokens ← totalTokens`, `outputTokens ← 0`, `legacy: true`)
+- [ ] 8.4 Bump the `usage` store schema to version 2 with the migration `upgrade` hook
+- [ ] 8.5 Update the usage-panel renderer to show `—` for `outputTokens` on legacy rows; add a rendering test
+- [ ] 8.6 Update every call site writing `UsageRecord` to pass `inputTokens` and `outputTokens` from the AI provider response
+
+## 9. Verification and release
+
+- [ ] 9.1 Run `pnpm -r test` — all tests pass, zero warnings
+- [ ] 9.2 Run `pnpm -r build` — zero build warnings
+- [ ] 9.3 Run `pnpm lint` — zero errors, zero warnings
+- [ ] 9.4 Run `/opsx-verify fix-spec-code-drift` — all eight spec deltas verified
+- [ ] 9.5 Run `/opsx-verify` on each of the eight affected live specs to confirm no regression (`spa-persistence-port`, `spa-bridge-protocol`, `spa-train2go-extension`, `branding`, `cws-auto-publish`, `spa-workout-state-machine`, `spa-calendar`, `spa-ai-batch`)
+- [ ] 9.6 Add a changeset (`pnpm exec changeset`) — `@kaiord/workout-spa-editor: minor`, `@kaiord/docs: patch`, note the `.changeset/config.json` edit as a monorepo repo-root item
+- [ ] 9.7 Open the PR with the audit summary in the description (link back to the `/opsx-sync` pass that found the gaps)
+- [ ] 9.8 After PR merge, run `/opsx-archive fix-spec-code-drift`

--- a/openspec/specs/adapter-contracts/spec.md
+++ b/openspec/specs/adapter-contracts/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # Adapter Contracts
 

--- a/openspec/specs/ci-release/spec.md
+++ b/openspec/specs/ci-release/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # CI Release
 

--- a/openspec/specs/cws-train2go-listing/spec.md
+++ b/openspec/specs/cws-train2go-listing/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # CWS Train2Go Listing
 

--- a/openspec/specs/doc-drift-prevention/spec.md
+++ b/openspec/specs/doc-drift-prevention/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # Doc Drift Prevention
 

--- a/openspec/specs/docs-site/spec.md
+++ b/openspec/specs/docs-site/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # Docs Site
 

--- a/openspec/specs/extension-store-publish/spec.md
+++ b/openspec/specs/extension-store-publish/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # Extension Store Publish
 

--- a/openspec/specs/garmin-bridge/spec.md
+++ b/openspec/specs/garmin-bridge/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-18
+> Synced: 2026-04-20
 
 # Garmin Bridge
 

--- a/openspec/specs/hexagonal-arch/spec.md
+++ b/openspec/specs/hexagonal-arch/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # Hexagonal Architecture
 

--- a/openspec/specs/krd-format/spec.md
+++ b/openspec/specs/krd-format/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # KRD Format
 

--- a/openspec/specs/landing-page/spec.md
+++ b/openspec/specs/landing-page/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # Landing Page
 

--- a/openspec/specs/privacy-policy/spec.md
+++ b/openspec/specs/privacy-policy/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # Privacy Policy
 

--- a/openspec/specs/spa-editor-context-menu/spec.md
+++ b/openspec/specs/spa-editor-context-menu/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17 (fix-keyboard-shortcut-hijacking)
+> Synced: 2026-04-20
 
 # SPA Editor Context Menu
 
@@ -129,7 +129,7 @@ Keyboard shortcuts SHALL only call `preventDefault()` when the app handler perfo
 
 ### Requirement: Exact modifier matching
 
-Keyboard shortcuts SHALL only intercept the exact modifier combination they own. Shortcuts with additional modifiers (e.g., Shift) that are not part of the defined shortcut SHALL pass through to the browser.
+Keyboard shortcuts SHALL only intercept the exact modifier combination they own. A modifier that is part of a defined shortcut (e.g., Shift in the owned shortcuts Cmd+Shift+G for ungroup and Cmd+Shift+Z for redo) is owned and SHALL trigger interception. A modifier that is NOT part of any defined shortcut on the same base key (e.g., Shift in Cmd+Shift+C) is unowned and SHALL pass through to the browser.
 
 #### Scenario: Cmd+Shift+C passes through
 

--- a/openspec/specs/spa-garmin-extension/spec.md
+++ b/openspec/specs/spa-garmin-extension/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17 (settings-train2go-bridge)
+> Synced: 2026-04-20
 
 # SPA Garmin Extension
 

--- a/openspec/specs/train2go-bridge/spec.md
+++ b/openspec/specs/train2go-bridge/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-20
 
 # Train2Go Bridge
 


### PR DESCRIPTION
## Summary

Output of a full `/opsx-sync` pass on 2026-04-20 across the 22 live specs + 24 archived changes. Two deliverables in one branch:

1. **Sync markers updated** — 13 specs verified in-sync with the current code and bumped to `> Synced: 2026-04-20`. The other 8 (plus `spa-editor-context-menu` wording) had real drift or needed tightening.
2. **Proposal `fix-spec-code-drift`** — bundles the 8 spec-ahead-of-code gaps into a single implementation proposal (with design, 8 spec deltas, and tasks). No code changes yet; `/opsx-apply fix-spec-code-drift` implements the fixes.

### 13 specs marked in-sync
`adapter-contracts`, `ci-release`, `cws-train2go-listing`, `doc-drift-prevention`, `docs-site`, `extension-store-publish`, `garmin-bridge`, `hexagonal-arch`, `krd-format`, `landing-page`, `privacy-policy`, `spa-garmin-extension`, `train2go-bridge`.

### 8 gaps collected into `fix-spec-code-drift`
| Spec | Gap |
|---|---|
| `spa-persistence-port` | `probeStorage()` failure path has no user-visible banner |
| `spa-bridge-protocol` | `BridgeStatus` missing `"removed"` variant; pruning silently `map.delete`s |
| `spa-train2go-extension` | 30s detection cache not enforced at the action level |
| `branding` / `docs-site` | Docs VitePress config lacks `<meta name="theme-color">` |
| `cws-auto-publish` | Bridge extensions missing from `.changeset/config.json#linked` |
| `spa-workout-state-machine` | `modifiedAt` advanced only on `PUSHED→MODIFIED`, not on every edit |
| `spa-calendar` | `BatchProgress` missing per-workout `byId` map + `queued` bucket |
| `spa-ai-batch` | `UsageRecord` stores `totalTokens` only; spec requires `inputTokens` + `outputTokens` |

### 12-factor refinements applied
- **Factor V**: docs `theme-color` sourced from `--brand-bg-primary` token, with CI grep guarding against hex duplication.
- **Factor VI**: bridge registry persists to Dexie (new `bridges` store) so the 24h UNAVAILABLE→REMOVED and post-REMOVED retention timers survive browser sessions. Same Dexie schema bump carries `usage` input/output token fields.

### Spec wording tighten
- `spa-editor-context-menu` "Exact modifier matching" requirement now explicitly covers owned modifiers (Shift in Cmd+Shift+G / Cmd+Shift+Z) vs. unowned extras. Code already behaves correctly; prose was misleading.

## Commits

1. `chore(openspec): propose fix-spec-code-drift from opsx-sync audit`
2. `docs(specs): sync spa-editor-context-menu wording with code`
3. `docs(openspec): tighten fix-spec-code-drift per 12-factor review`
4. `docs(specs): bump Synced markers to 2026-04-20 for verified in-sync specs`

## Test plan

- [x] `openspec validate fix-spec-code-drift` passes
- [x] `pnpm lint:specs` — 22/22 specs pass
- [ ] Reviewer spot-checks a sample of in-sync claims (e.g., `garmin-bridge` manifest, `ci-release` workflow) against `main`
- [ ] Reviewer approves the proposal scope before running `/opsx-apply fix-spec-code-drift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive specifications for platform stability improvements including storage availability warnings, refined bridge management with removal notifications, and enhanced progress tracking granularity for batch operations.
  * Documented token accounting separation for AI usage tracking and detection optimization for extension compatibility.
  * Updated branding specification to include theme-color support across platform surfaces.
  * Updated modifier matching semantics in context menu handling for improved clarity.

* **Chores**
  * Synchronized metadata timestamps across existing specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->