### PR TITLE
fix(spec-code-drift): close eight spec-vs-code gaps from opsx-sync 2026-04-20

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -13,7 +13,9 @@
       "@kaiord/garmin-connect",
       "@kaiord/cli",
       "@kaiord/mcp",
-      "@kaiord/ai"
+      "@kaiord/ai",
+      "@kaiord/garmin-bridge",
+      "@kaiord/train2go-bridge"
     ]
   ],
   "access": "public",

--- a/.changeset/fix-spec-code-drift.md
+++ b/.changeset/fix-spec-code-drift.md
@@ -1,0 +1,50 @@
+---
+"@kaiord/workout-spa-editor": minor
+"@kaiord/docs": patch
+---
+
+Close eight spec-vs-code drift gaps identified by the 2026-04-20
+`/opsx-sync` audit. No public API breaks; the SPA changes are
+internal to `@kaiord/workout-spa-editor` and ship behind a Dexie
+v2+v3 schema bump with additive, backwards-compatible migrations.
+
+**`@kaiord/workout-spa-editor` (minor — new UI affordances, new
+Dexie stores, additive schema):**
+
+- Surface a storage-unavailable banner when `probeStorage()` reports
+  failure ("Storage unavailable — changes in this session won't be
+  saved"). Wired through a new `storage-store` + single-mount
+  invariant in `MainLayout`.
+- Introduce `BridgeStatus = "verified" | "unavailable" | "removed"`.
+  Pruning now transitions `unavailable → removed` after 24h (with a
+  user notification) and deletes the row 24h after that. Registry
+  persists to a new `bridges` Dexie store so the lifecycle timers
+  survive browser restarts.
+- Pin the Train2Go 30s detection cache behavior (never-detected,
+  cached-and-stale, cached-not-installed, no-rolling-window).
+- Advance `modifiedAt` on every KRD edit via a new
+  `onWorkoutMutation` helper wired into the editor save path — edits
+  in STRUCTURED/READY now bump the timestamp, not only the legacy
+  PUSHED→MODIFIED transition.
+- Enrich `BatchProgress` with `counts` and per-workout `byId` so the
+  calendar batch-progress panel can render per-workout status.
+- Split `UsageRecord.totalTokens` into `inputTokens` / `outputTokens`
+  (derived `totalTokens` retained for legacy readers, Zod `.refine`
+  pins the invariant). Dexie v3 migration backfills legacy rows
+  (`inputTokens = totalTokens`, `outputTokens = 0`, `legacy: true`);
+  the usage-panel renderer shows `—` for `outputTokens` on legacy
+  rows.
+
+**`@kaiord/docs` (patch — head meta tag + token-parsing helper):**
+
+- Add `<meta name="theme-color">` to the VitePress docs head. Value
+  is parsed at config-load time from `--brand-bg-primary` in
+  `styles/brand-tokens.css`; CI invariant blocks re-introducing a
+  hex literal under `packages/docs/`.
+
+**Repo-level** (not a publishable-package bump, called out here for
+the release log):
+
+- `.changeset/config.json` adds `@kaiord/garmin-bridge` and
+  `@kaiord/train2go-bridge` to `linked[0]` so bridge extensions
+  version in lockstep; guarded by `scripts/check-changeset-config.test.mjs`.

--- a/openspec/changes/fix-spec-code-drift/design.md
+++ b/openspec/changes/fix-spec-code-drift/design.md
@@ -16,6 +16,7 @@ Current state per gap:
 ## Goals / Non-Goals
 
 **Goals:**
+
 - Each of the eight spec requirements passes a runtime/integration test after this change.
 - No spec text edits in this change — specs are already correct.
 - Dexie migration for `UsageRecord` backfills legacy rows deterministically so nobody sees a mid-usage-panel zero.
@@ -23,6 +24,7 @@ Current state per gap:
 - Zero new ESLint / TS / test warnings; every touched file stays ≤100 LOC (tests exempt).
 
 **Non-Goals:**
+
 - Re-designing the bridge lifecycle state machine (REMOVED is being added as the minimum that the spec mandates; a future change can promote it to a formal timeline of transitions).
 - Changing the SPA AI batch UX — only the schema shape and its renderer inputs.
 - Touching group-B spec-wording drift (`adapter-contracts` regex, `spa-editor-context-menu` wording, `spa-ai-batch` ES glossary); those go in the follow-up sync PR.
@@ -89,14 +91,21 @@ Rather than sprinkling `Date.now()` assignments across every action creator, int
 ### 7. `BatchProgress` becomes a richer structure with per-workout map
 
 New shape:
+
 ```ts
 type BatchProgress = {
   total: number;
-  counts: { queued: number; processing: number; succeeded: number; failed: number };
+  counts: {
+    queued: number;
+    processing: number;
+    succeeded: number;
+    failed: number;
+  };
   current: string | null; // workout id in flight
-  byId: Record<string, 'queued' | 'processing' | 'succeeded' | 'failed'>;
+  byId: Record<string, "queued" | "processing" | "succeeded" | "failed">;
 };
 ```
+
 - **Why `byId`**: The spec requires per-workout status in the progress UI. A map keyed by workout id is O(1) for the card renderer.
 - **Alternative considered**: Array of `{ id, status }`. Rejected because the calendar panel needs random access by id, and ordering is already known from the week grid.
 - **Layer**: Application (batch processor) + adapter (UI progress panel).
@@ -104,6 +113,7 @@ type BatchProgress = {
 ### 8. `UsageRecord` additive schema bump with Dexie migration
 
 New shape (additive fields; `totalTokens` remains for backwards compatibility):
+
 ```ts
 type UsageRecord = {
   id: string;
@@ -116,6 +126,7 @@ type UsageRecord = {
   legacy?: boolean; // true only on rows backfilled by the v1 → v2 migration; the renderer shows `—` for `outputTokens` when true
 };
 ```
+
 Dexie version bump (`this.version(2).stores({...}).upgrade(tx => tx.table('usage').toCollection().modify(record => { ... }))`). For legacy rows with only `totalTokens`, set `inputTokens = totalTokens`, `outputTokens = 0`, and `legacy: true` — conservative: we know total usage happened but can't know the split. The `legacy: boolean` field is a persisted `UsageRecord` field (part of the v2 schema) and SHALL be passed through to the renderer so it can show `—` for `outputTokens` on legacy rows. New-version writes omit `legacy` (or set it to `false`); the renderer treats missing/`false` identically.
 
 - **Alternative considered**: Drop `totalTokens` and compute everywhere. Rejected because external readers (tests, possible tooling) index on `totalTokens`.

--- a/packages/docs/.vitepress/brand-tokens.mjs
+++ b/packages/docs/.vitepress/brand-tokens.mjs
@@ -1,0 +1,40 @@
+// Synchronously reads a CSS variable from the shared brand tokens file.
+// Used at VitePress config load time to wire the <meta name="theme-color">
+// value from the same source of truth as the landing page and editor.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export const BRAND_TOKENS_PATH = resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "styles",
+  "brand-tokens.css"
+);
+
+export function readBrandTokenColor(name, tokensPath = BRAND_TOKENS_PATH) {
+  if (!name.startsWith("--")) {
+    throw new Error(
+      `readBrandTokenColor: token name must start with "--"; got ${name}`
+    );
+  }
+
+  const source = readFileSync(tokensPath, "utf8");
+  const pattern = new RegExp(
+    `${name.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}\\s*:\\s*([^;]+?)\\s*(?:;|\\n)`
+  );
+  const match = source.match(pattern);
+
+  if (!match) {
+    throw new Error(
+      `readBrandTokenColor: token ${name} not found in ${tokensPath}`
+    );
+  }
+
+  return match[1].trim();
+}

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -3,6 +3,8 @@ import { transformerTwoslash } from "@shikijs/vitepress-twoslash";
 import llmstxt from "vitepress-plugin-llms";
 import type { HeadConfig } from "vitepress";
 
+import { buildStaticHead } from "./head-config.mjs";
+
 const SITE_URL = "https://kaiord.com";
 const DOCS_BASE = "/docs/";
 const OG_IMAGE = `${SITE_URL}${DOCS_BASE}og-image-docs.png`;
@@ -88,32 +90,7 @@ export default defineConfig({
     "Open-source health & fitness data framework for TypeScript. Convert FIT, TCX, ZWO, and GCN formats.",
   base: DOCS_BASE,
 
-  head: [
-    ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:image", content: OG_IMAGE }],
-    ["meta", { property: "og:image:width", content: "1200" }],
-    ["meta", { property: "og:image:height", content: "630" }],
-    ["meta", { name: "twitter:card", content: "summary_large_image" }],
-    ["meta", { name: "twitter:image", content: OG_IMAGE }],
-    [
-      "link",
-      {
-        rel: "icon",
-        type: "image/svg+xml",
-        href: `${DOCS_BASE}logo.svg`,
-      },
-    ],
-    [
-      "link",
-      {
-        rel: "preload",
-        href: `${DOCS_BASE}fonts/inter-var-latin.woff2`,
-        as: "font",
-        type: "font/woff2",
-        crossorigin: "",
-      },
-    ],
-  ],
+  head: buildStaticHead({ docsBase: DOCS_BASE, ogImage: OG_IMAGE }),
 
   sitemap: {
     hostname: SITE_URL,

--- a/packages/docs/.vitepress/head-config.mjs
+++ b/packages/docs/.vitepress/head-config.mjs
@@ -1,0 +1,44 @@
+// Builds the static `head` array for the VitePress config. Extracted into
+// a module (not inlined into config.ts) so that Node's test runner can
+// import and assert on it without a TypeScript loader.
+//
+// Every entry here renders into every page; page-specific metadata stays
+// in `transformHead` inside config.ts.
+
+import { readBrandTokenColor } from "./brand-tokens.mjs";
+
+/**
+ * @param {{ docsBase: string; ogImage: string }} options
+ * @returns {Array<[string, Record<string, string>]>}
+ */
+export function buildStaticHead({ docsBase, ogImage }) {
+  const themeColor = readBrandTokenColor("--brand-bg-primary");
+
+  return [
+    ["meta", { property: "og:type", content: "website" }],
+    ["meta", { property: "og:image", content: ogImage }],
+    ["meta", { property: "og:image:width", content: "1200" }],
+    ["meta", { property: "og:image:height", content: "630" }],
+    ["meta", { name: "twitter:card", content: "summary_large_image" }],
+    ["meta", { name: "twitter:image", content: ogImage }],
+    ["meta", { name: "theme-color", content: themeColor }],
+    [
+      "link",
+      {
+        rel: "icon",
+        type: "image/svg+xml",
+        href: `${docsBase}logo.svg`,
+      },
+    ],
+    [
+      "link",
+      {
+        rel: "preload",
+        href: `${docsBase}fonts/inter-var-latin.woff2`,
+        as: "font",
+        type: "font/woff2",
+        crossorigin: "",
+      },
+    ],
+  ];
+}

--- a/packages/docs/scripts/brand-tokens.test.mjs
+++ b/packages/docs/scripts/brand-tokens.test.mjs
@@ -1,0 +1,57 @@
+// Verifies that `readBrandTokenColor` parses the shared brand-tokens file
+// and returns the expected CSS variable value. The VitePress config uses
+// this helper to wire `<meta name="theme-color">` from the token, so the
+// test pins the parity between the docs head tag and the source of truth.
+
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+
+import {
+  BRAND_TOKENS_PATH,
+  readBrandTokenColor,
+} from "../.vitepress/brand-tokens.mjs";
+
+test("reads --brand-bg-primary from the shared tokens file", () => {
+  const value = readBrandTokenColor("--brand-bg-primary");
+
+  assert.equal(value, "#0f172a");
+});
+
+test("reads --brand-text-primary from the shared tokens file", () => {
+  const value = readBrandTokenColor("--brand-text-primary");
+
+  assert.equal(value, "#f8fafc");
+});
+
+test("throws when the token is missing", () => {
+  assert.throws(
+    () => readBrandTokenColor("--brand-does-not-exist"),
+    /--brand-does-not-exist not found/
+  );
+});
+
+test("throws when the name is not a CSS custom property", () => {
+  assert.throws(
+    () => readBrandTokenColor("brand-bg-primary"),
+    /must start with "--"/
+  );
+});
+
+test("reads from an override path (unit-testable isolation)", () => {
+  const dir = mkdtempSync(join(tmpdir(), "brand-tokens-"));
+  const p = join(dir, "brand.css");
+  writeFileSync(p, ":root { --demo: #123456; }\n");
+
+  try {
+    assert.equal(readBrandTokenColor("--demo", p), "#123456");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("canonical path points to repo-root styles/brand-tokens.css", () => {
+  assert.match(BRAND_TOKENS_PATH, /styles\/brand-tokens\.css$/);
+});

--- a/packages/docs/scripts/build-output-meta.test.mjs
+++ b/packages/docs/scripts/build-output-meta.test.mjs
@@ -1,0 +1,39 @@
+// End-to-end assertion: after `pnpm build`, the rendered `/docs/index.html`
+// contains the `<meta name="theme-color">` tag with the exact value parsed
+// from the shared `--brand-bg-primary` token.
+//
+// Skipped when `dist/` does not exist (local runs without a prior build).
+// CI runs `pnpm -r build` before `pnpm lint` (via lint:specs), so this
+// fires post-build and catches divergence in the rendered artifact — not
+// just the config shape.
+
+import { strict as assert } from "node:assert";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+import { readBrandTokenColor } from "../.vitepress/brand-tokens.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const INDEX_HTML = resolve(__dirname, "..", ".vitepress", "dist", "index.html");
+
+test(
+  "rendered index.html contains theme-color meta with the token value",
+  { skip: !existsSync(INDEX_HTML) && "dist/ not built" },
+  () => {
+    const html = readFileSync(INDEX_HTML, "utf8");
+    const expected = readBrandTokenColor("--brand-bg-primary");
+
+    const match = html.match(
+      /<meta\s+name="theme-color"\s+content="([^"]+)"\s*\/?>/i
+    );
+
+    assert.ok(match, `theme-color meta not found in rendered index.html`);
+    assert.equal(
+      match[1],
+      expected,
+      `theme-color in rendered HTML (${match[1]}) does not match --brand-bg-primary (${expected})`
+    );
+  }
+);

--- a/packages/docs/scripts/generate-og-image.mjs
+++ b/packages/docs/scripts/generate-og-image.mjs
@@ -3,12 +3,14 @@ import { statSync, mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { readBrandTokenColor } from "../.vitepress/brand-tokens.mjs";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const docsRoot = join(__dirname, "..");
 const publicDir = join(docsRoot, "public");
 
-const BRAND_BG = "#0f172a";
-const BRAND_ACCENT = "#0284c7";
+const BRAND_BG = readBrandTokenColor("--brand-bg-primary");
+const BRAND_ACCENT = readBrandTokenColor("--brand-accent-blue");
 
 function createDocsOgSvg() {
   return Buffer.from(`<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">

--- a/packages/docs/scripts/head-config.test.mjs
+++ b/packages/docs/scripts/head-config.test.mjs
@@ -1,0 +1,47 @@
+// The branding spec requires the docs surface to carry a `theme-color`
+// meta tag derived from the shared `--brand-bg-primary` token. These tests
+// pin that invariant at the head-builder layer (upstream of VitePress) so
+// any drift fails before the site is rendered.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { readBrandTokenColor } from "../.vitepress/brand-tokens.mjs";
+import { buildStaticHead } from "../.vitepress/head-config.mjs";
+
+const SAMPLE_OPTIONS = {
+  docsBase: "/docs/",
+  ogImage: "https://kaiord.com/docs/og-image-docs.png",
+};
+
+test("emits a theme-color meta tag", () => {
+  const head = buildStaticHead(SAMPLE_OPTIONS);
+
+  const themeColor = head.find(
+    ([tag, attrs]) => tag === "meta" && attrs.name === "theme-color"
+  );
+
+  assert.ok(themeColor, "head is missing <meta name='theme-color'>");
+});
+
+test("theme-color value equals --brand-bg-primary from the shared tokens", () => {
+  const head = buildStaticHead(SAMPLE_OPTIONS);
+  const themeColor = head.find(
+    ([tag, attrs]) => tag === "meta" && attrs.name === "theme-color"
+  );
+
+  const expected = readBrandTokenColor("--brand-bg-primary");
+  assert.equal(themeColor[1].content, expected);
+});
+
+test("theme-color parity is mechanical — it is never a literal hex", () => {
+  const head = buildStaticHead(SAMPLE_OPTIONS);
+  const themeColor = head.find(
+    ([tag, attrs]) => tag === "meta" && attrs.name === "theme-color"
+  );
+
+  // Exact match against the token; if someone hard-codes a hex in the
+  // builder, this test fails when the token changes.
+  const fromToken = readBrandTokenColor("--brand-bg-primary");
+  assert.equal(themeColor[1].content, fromToken);
+});

--- a/packages/docs/scripts/no-hex-literals.test.mjs
+++ b/packages/docs/scripts/no-hex-literals.test.mjs
@@ -1,0 +1,85 @@
+// Enforces the branding-spec invariant: no file under `packages/docs/`
+// hardcodes the `#0f172a` hex. The value SHALL come from the shared
+// `--brand-bg-primary` token in `styles/brand-tokens.css`.
+//
+// Fails if someone re-introduces a literal, including in generated API
+// docs (those are regenerated every build, so committing a hex would be
+// a regression).
+
+import { strict as assert } from "node:assert";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const DOCS_ROOT = resolve(__dirname, "..");
+
+const SKIP_DIRS = new Set([
+  "node_modules",
+  "dist",
+  ".vitepress/cache",
+  ".vitepress/dist",
+  "api", // auto-generated on build; never committed with literals
+]);
+
+const EXT_ALLOWLIST = new Set([
+  ".ts",
+  ".tsx",
+  ".mts",
+  ".mjs",
+  ".js",
+  ".cjs",
+  ".vue",
+  ".css",
+  ".scss",
+  ".md",
+  ".html",
+  ".json",
+]);
+
+function walk(dir, relPrefix = "") {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry.startsWith(".")) {
+      // Skip hidden dirs except .vitepress (we want to check config there).
+      if (entry !== ".vitepress") continue;
+    }
+    const full = join(dir, entry);
+    const rel = relPrefix ? join(relPrefix, entry) : entry;
+    if (SKIP_DIRS.has(rel) || SKIP_DIRS.has(entry)) continue;
+
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      files.push(...walk(full, rel));
+    } else {
+      files.push({ full, rel });
+    }
+  }
+  return files;
+}
+
+test("no file under packages/docs/ hardcodes #0f172a", () => {
+  const offenders = [];
+  for (const { full, rel } of walk(DOCS_ROOT)) {
+    const ext = "." + rel.split(".").pop();
+    if (!EXT_ALLOWLIST.has(ext)) continue;
+
+    // Test files are allowed to pin the expected literal value — that's
+    // the whole point of the parity check.
+    if (rel.endsWith(".test.mjs")) continue;
+
+    const content = readFileSync(full, "utf8");
+    if (/#0f172a/i.test(content)) {
+      offenders.push(rel);
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `Found hardcoded #0f172a literals in packages/docs/. ` +
+      `Use readBrandTokenColor('--brand-bg-primary') instead. Files:\n` +
+      offenders.map((f) => `  - ${f}`).join("\n")
+  );
+});

--- a/packages/workout-spa-editor/src/adapters/bridge/README.md
+++ b/packages/workout-spa-editor/src/adapters/bridge/README.md
@@ -1,0 +1,53 @@
+# Bridge Adapters
+
+Runtime adapters for extension bridges (Garmin Connect, Train2Go). The
+registry tracks each bridge's lifecycle (`verified` → `unavailable` →
+`removed`) and persists it to Dexie via `dexie-bridge-repository.ts` so
+the 24h timers survive browser restarts.
+
+## Persistence boundary
+
+- **Persisted (Dexie)**: the bridge registry — one row per extension
+  keyed by `extensionId`, carrying `status`, `lastSeen`, `removedAt`
+  and `failCount`. The lifecycle timers anchor on these fields.
+- **Transient (Zustand)**: the bridge runtime stores
+  (`train2go-store`, and any future `garmin-store`) remain in-memory
+  — they hold ephemeral UX state (detection result, in-flight
+  operations) that MUST NOT be written through the Dexie boundary.
+  The non-regression guard lives in
+  `bridge-store-persistence-boundary.test.ts`.
+
+See `CLAUDE.md` ("Editor runtime → Zustand. Persisted data → Dexie.
+Local UI → React state.") and the proposal's Dexie-vs-Zustand
+boundary clause in `openspec/changes/fix-spec-code-drift/`.
+
+## Wall-clock caveat (lifecycle timers)
+
+The 24h-unavailable and 24h-removed intervals are measured against
+`Date.now()` / `new Date(lastSeen).getTime()` — wall-clock time.
+
+- A user whose system clock jumps (daylight-savings, NTP correction,
+  laptop resume from sleep) can see earlier or later transitions than
+  exactly 24h. This is acceptable; the spec allows approximate
+  lifecycle transitions.
+- We SHALL NOT substitute `performance.now()` here, because that clock
+  resets on every browser session and the whole point of the Dexie
+  persistence is to survive reloads.
+
+## State machine
+
+```
+verified ──(3 failed heartbeats)──► unavailable
+                                    │
+                                    │  24h elapsed since lastSeen
+                                    ▼
+                                 removed   (notifier fires)
+                                    │
+                                    │  24h elapsed since removedAt
+                                    ▼
+                                 deleted   (row leaves map + repo)
+```
+
+A successful heartbeat from any non-`verified` state clears
+`failCount`, resets `removedAt`, and returns the bridge to
+`verified`.

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-registry-helpers.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-registry-helpers.ts
@@ -1,15 +1,23 @@
 /**
  * Bridge Registry Helpers
  *
- * Heartbeat management, manifest parsing, and bridge pruning.
+ * Heartbeat management + manifest parsing. The lifecycle pruner lives
+ * in `bridge-registry-prune.ts`; see `README.md` for the wall-clock
+ * timer caveat.
  */
 
 import { bridgeManifestSchema } from "../../types/bridge-schemas";
+import {
+  PRUNE_AFTER_MS,
+  type PruneBridgesOptions,
+  pruneStale,
+} from "./bridge-registry-prune";
 import { sendBridgeMessage } from "./bridge-transport";
 import type { RegisteredBridge } from "./bridge-types";
 
+export { PRUNE_AFTER_MS, pruneStale } from "./bridge-registry-prune";
+
 const MAX_FAIL_COUNT = 3;
-const PRUNE_AFTER_MS = 24 * 60 * 60 * 1_000;
 const DEFAULT_HEARTBEAT_MS = 60_000;
 
 export function parseManifestFromPing(
@@ -17,13 +25,11 @@ export function parseManifestFromPing(
   response: { ok: boolean; data?: unknown }
 ): RegisteredBridge | null {
   if (!response.ok || !response.data) return null;
-
   const result = bridgeManifestSchema.safeParse(response.data);
   if (!result.success) {
     console.warn(`Bridge ${extensionId}: invalid manifest`);
     return null;
   }
-
   return {
     extensionId,
     ...result.data,
@@ -33,42 +39,50 @@ export function parseManifestFromPing(
   };
 }
 
-async function pingAndUpdate(bridge: RegisteredBridge): Promise<void> {
-  const res = await sendBridgeMessage(bridge.extensionId, {
-    action: "ping",
-  });
-
+async function pingAndUpdate(
+  bridge: RegisteredBridge,
+  persist: (b: RegisteredBridge) => void
+): Promise<void> {
+  const res = await sendBridgeMessage(bridge.extensionId, { action: "ping" });
   if (res.ok) {
     bridge.status = "verified";
     bridge.lastSeen = new Date().toISOString();
     bridge.failCount = 0;
+    bridge.removedAt = undefined;
+    persist(bridge);
     return;
   }
-
   bridge.failCount += 1;
-  if (bridge.failCount >= MAX_FAIL_COUNT) {
+  if (bridge.failCount >= MAX_FAIL_COUNT && bridge.status === "verified") {
     bridge.status = "unavailable";
   }
+  persist(bridge);
 }
 
-function pruneStale(bridges: Map<string, RegisteredBridge>): void {
-  const now = Date.now();
-  for (const [id, bridge] of bridges) {
-    if (bridge.status !== "unavailable") continue;
-    const elapsed = now - new Date(bridge.lastSeen).getTime();
-    if (elapsed >= PRUNE_AFTER_MS) bridges.delete(id);
-  }
-}
-
-export function createHeartbeatManager(bridges: Map<string, RegisteredBridge>) {
+export function createHeartbeatManager(
+  bridges: Map<string, RegisteredBridge>,
+  options: PruneBridgesOptions = {}
+) {
+  const { notifier, repository } = options;
   let hbTimer: ReturnType<typeof setInterval> | null = null;
   let pruneTimer: ReturnType<typeof setInterval> | null = null;
+  const persist = (b: RegisteredBridge) => void repository?.put(b);
+  const remove = (id: string) => void repository?.delete(id);
 
   function start(intervalMs = DEFAULT_HEARTBEAT_MS): void {
     stop();
-    const beat = () => Promise.all([...bridges.values()].map(pingAndUpdate));
+    const beat = () =>
+      Promise.all([...bridges.values()].map((b) => pingAndUpdate(b, persist)));
     hbTimer = setInterval(() => void beat(), intervalMs);
-    pruneTimer = setInterval(() => pruneStale(bridges), PRUNE_AFTER_MS);
+    pruneTimer = setInterval(
+      () =>
+        pruneStale(bridges, {
+          notifier,
+          onDeleted: remove,
+          onPersist: persist,
+        }),
+      PRUNE_AFTER_MS
+    );
   }
 
   function stop(): void {

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-registry-prune.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-registry-prune.ts
@@ -1,0 +1,71 @@
+/**
+ * Bridge lifecycle pruning.
+ *
+ * See `README.md` for the wall-clock-based timer caveat.
+ */
+
+import type {
+  BridgeNotifier,
+  BridgeRepository,
+  RegisteredBridge,
+} from "./bridge-types";
+
+export const PRUNE_AFTER_MS = 24 * 60 * 60 * 1_000;
+
+function demoteToRemoved(
+  bridge: RegisteredBridge,
+  now: number,
+  options: {
+    notifier?: BridgeNotifier;
+    onPersist?: (b: RegisteredBridge) => void;
+  }
+): void {
+  bridge.status = "removed";
+  bridge.removedAt = now;
+  options.onPersist?.(bridge);
+  options.notifier?.({ type: "removed", bridge });
+}
+
+/**
+ * Transitions bridges through the lifecycle:
+ *  - `unavailable` for >=24h → `removed` (notify + keep the row)
+ *  - `removed` for >=24h     → deleted (entry leaves the map + repo)
+ *
+ * Anchors on `lastSeen` (for `unavailable`) or `removedAt` (falling
+ * back to `lastSeen` if missing) so the timer resumes correctly across
+ * browser sessions when the rows are loaded from Dexie.
+ */
+export function pruneStale(
+  bridges: Map<string, RegisteredBridge>,
+  options: {
+    now?: number;
+    notifier?: BridgeNotifier;
+    onDeleted?: (extensionId: string) => void;
+    onPersist?: (bridge: RegisteredBridge) => void;
+  } = {}
+): void {
+  const { now = Date.now(), notifier, onDeleted, onPersist } = options;
+
+  for (const [id, bridge] of bridges) {
+    if (bridge.status === "unavailable") {
+      const elapsed = now - new Date(bridge.lastSeen).getTime();
+      if (elapsed >= PRUNE_AFTER_MS) {
+        demoteToRemoved(bridge, now, { notifier, onPersist });
+      }
+      continue;
+    }
+
+    if (bridge.status === "removed") {
+      const anchor = bridge.removedAt ?? new Date(bridge.lastSeen).getTime();
+      if (now - anchor >= PRUNE_AFTER_MS) {
+        bridges.delete(id);
+        onDeleted?.(id);
+      }
+    }
+  }
+}
+
+export type PruneBridgesOptions = {
+  notifier?: BridgeNotifier;
+  repository?: BridgeRepository;
+};

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-registry-pruning.test.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-registry-pruning.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PRUNE_AFTER_MS, pruneStale } from "./bridge-registry-helpers";
+import type { RegisteredBridge } from "./bridge-types";
+
+function seedBridge(
+  overrides: Partial<RegisteredBridge> = {}
+): RegisteredBridge {
+  return {
+    extensionId: "ext-1",
+    id: "garmin-bridge",
+    name: "Garmin Bridge",
+    version: "1.0.0",
+    protocolVersion: 1,
+    capabilities: ["write:workouts"],
+    status: "verified",
+    lastSeen: new Date().toISOString(),
+    failCount: 0,
+    ...overrides,
+  };
+}
+
+describe("pruneStale — REMOVED lifecycle", () => {
+  it("transitions unavailable → removed after 24h and notifies", () => {
+    const now = Date.now();
+    const bridge = seedBridge({
+      status: "unavailable",
+      lastSeen: new Date(now - PRUNE_AFTER_MS - 1).toISOString(),
+    });
+    const bridges = new Map([[bridge.extensionId, bridge]]);
+    const notifier = vi.fn();
+
+    pruneStale(bridges, { now, notifier });
+
+    expect(bridge.status).toBe("removed");
+    expect(bridge.removedAt).toBe(now);
+    expect(notifier).toHaveBeenCalledWith({
+      type: "removed",
+      bridge,
+    });
+    expect(bridges.has("ext-1")).toBe(true); // entry kept
+  });
+
+  it("does not fire the notifier for unavailable bridges still fresh", () => {
+    const now = Date.now();
+    const bridge = seedBridge({
+      status: "unavailable",
+      lastSeen: new Date(now - 60_000).toISOString(),
+    });
+    const bridges = new Map([[bridge.extensionId, bridge]]);
+    const notifier = vi.fn();
+
+    pruneStale(bridges, { now, notifier });
+
+    expect(bridge.status).toBe("unavailable");
+    expect(notifier).not.toHaveBeenCalled();
+  });
+
+  it("does not re-notify on a second prune tick when already removed", () => {
+    const now = Date.now();
+    const bridge = seedBridge({
+      status: "removed",
+      removedAt: now - 60_000,
+      lastSeen: new Date(now - PRUNE_AFTER_MS - 60_000).toISOString(),
+    });
+    const bridges = new Map([[bridge.extensionId, bridge]]);
+    const notifier = vi.fn();
+
+    pruneStale(bridges, { now, notifier });
+
+    // Still within 24h of removedAt, so no deletion yet, and no second
+    // notification.
+    expect(bridges.has("ext-1")).toBe(true);
+    expect(notifier).not.toHaveBeenCalled();
+  });
+
+  it("deletes the entry 24h after it was marked removed (second tick)", () => {
+    const now = Date.now();
+    const bridge = seedBridge({
+      status: "removed",
+      removedAt: now - PRUNE_AFTER_MS - 1,
+      lastSeen: new Date(now - 2 * PRUNE_AFTER_MS).toISOString(),
+    });
+    const bridges = new Map([[bridge.extensionId, bridge]]);
+    const onDeleted = vi.fn();
+
+    pruneStale(bridges, { now, onDeleted });
+
+    expect(bridges.has("ext-1")).toBe(false);
+    expect(onDeleted).toHaveBeenCalledWith("ext-1");
+  });
+
+  it("calls onPersist when transitioning to removed so Dexie stays in sync", () => {
+    const now = Date.now();
+    const bridge = seedBridge({
+      status: "unavailable",
+      lastSeen: new Date(now - PRUNE_AFTER_MS - 1).toISOString(),
+    });
+    const bridges = new Map([[bridge.extensionId, bridge]]);
+    const onPersist = vi.fn();
+
+    pruneStale(bridges, { now, onPersist });
+
+    expect(onPersist).toHaveBeenCalledWith(bridge);
+    expect(onPersist.mock.calls[0][0].status).toBe("removed");
+  });
+
+  it("falls back to lastSeen when removedAt is missing on a restored row", () => {
+    // Simulates a bridge loaded from Dexie that was persisted before the
+    // `removedAt` field existed. The timer must still resolve.
+    const now = Date.now();
+    const bridge = seedBridge({
+      status: "removed",
+      lastSeen: new Date(now - PRUNE_AFTER_MS - 10).toISOString(),
+    });
+    const bridges = new Map([[bridge.extensionId, bridge]]);
+
+    pruneStale(bridges, { now });
+
+    expect(bridges.has("ext-1")).toBe(false);
+  });
+
+  it("leaves verified bridges untouched", () => {
+    const bridge = seedBridge({ status: "verified" });
+    const bridges = new Map([[bridge.extensionId, bridge]]);
+    const notifier = vi.fn();
+
+    pruneStale(bridges, { now: Date.now(), notifier });
+
+    expect(bridge.status).toBe("verified");
+    expect(notifier).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-registry.test.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-registry.test.ts
@@ -143,7 +143,7 @@ describe("createBridgeRegistry", () => {
       registry.destroy();
     });
 
-    it("prunes bridge after 24h of unavailable status", async () => {
+    it("transitions bridge through unavailable → removed → deleted (24h each)", async () => {
       vi.mocked(transport.sendBridgeMessage)
         .mockResolvedValueOnce(VALID_PING_RESPONSE) // detect
         .mockResolvedValue({ ok: false, error: "gone" }); // all heartbeats fail
@@ -161,24 +161,22 @@ describe("createBridgeRegistry", () => {
       // Stop heartbeat to avoid 864k tick iterations
       registry.stopHeartbeat();
 
-      // Backdate lastSeen to 25 hours ago so prune condition is met
+      // First 24h tick: unavailable → removed (entry kept, notification fires)
       const bridge = registry.getBridge("ext-123")!;
       bridge.lastSeen = new Date(
         Date.now() - 25 * 60 * 60 * 1_000
       ).toISOString();
-
-      // Restart heartbeat — pruneStale runs on PRUNE_AFTER_MS interval
-      // but we can advance just enough to trigger one prune cycle
-      registry.startHeartbeat(100);
-
-      // The prune timer fires at PRUNE_AFTER_MS (24h) intervals.
-      // Advance 24h worth of time. To avoid excessive heartbeat ticks,
-      // stop heartbeat, advance, then check.
+      registry.startHeartbeat(24 * 60 * 60 * 1_000);
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1_000);
       registry.stopHeartbeat();
 
-      // Manually trigger the prune by calling startHeartbeat then
-      // advancing exactly the prune interval
-      registry.startHeartbeat(24 * 60 * 60 * 1_000); // heartbeat = 24h
+      expect(registry.getBridge("ext-123")?.status).toBe("removed");
+      expect(registry.getBridge("ext-123")).toBeDefined();
+
+      // Second 24h tick: removed → deleted
+      const removed = registry.getBridge("ext-123")!;
+      removed.removedAt = Date.now() - 25 * 60 * 60 * 1_000;
+      registry.startHeartbeat(24 * 60 * 60 * 1_000);
       await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1_000);
 
       expect(registry.getBridge("ext-123")).toBeUndefined();

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-registry.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-registry.ts
@@ -11,11 +11,24 @@ import {
   parseManifestFromPing,
 } from "./bridge-registry-helpers";
 import { sendBridgeMessage } from "./bridge-transport";
-import type { BridgeRegistry, RegisteredBridge } from "./bridge-types";
+import type {
+  BridgeNotifier,
+  BridgeRegistry,
+  BridgeRepository,
+  RegisteredBridge,
+} from "./bridge-types";
 
-export function createBridgeRegistry(): BridgeRegistry {
+export type CreateBridgeRegistryOptions = {
+  notifier?: BridgeNotifier;
+  repository?: BridgeRepository;
+};
+
+export function createBridgeRegistry(
+  options: CreateBridgeRegistryOptions = {}
+): BridgeRegistry {
+  const { notifier, repository } = options;
   const bridges = new Map<string, RegisteredBridge>();
-  const hb = createHeartbeatManager(bridges);
+  const hb = createHeartbeatManager(bridges, { notifier, repository });
 
   async function detectBridge(
     extensionId: string
@@ -24,12 +37,22 @@ export function createBridgeRegistry(): BridgeRegistry {
       action: "ping",
     });
     const bridge = parseManifestFromPing(extensionId, response);
-    if (bridge) bridges.set(extensionId, bridge);
+    if (bridge) {
+      bridges.set(extensionId, bridge);
+      if (repository) void repository.put(bridge);
+    }
     return bridge;
+  }
+
+  async function hydrate(): Promise<void> {
+    if (!repository) return;
+    const rows = await repository.getAll();
+    for (const row of rows) bridges.set(row.extensionId, row);
   }
 
   return {
     detectBridge,
+    hydrate,
     getBridge: (id) => bridges.get(id),
     getAllBridges: () => [...bridges.values()],
     hasCapability: (cap) =>

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-status-exhaustiveness.test.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-status-exhaustiveness.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import type { BridgeStatus } from "./bridge-types";
+
+// Exhaustiveness guard: every BridgeStatus must be handled here. If the
+// union ever adds a new member (or removes "removed"), the `assertNever`
+// call fails at compile time.
+function assertNever(x: never): never {
+  throw new Error(`Unhandled BridgeStatus: ${x as string}`);
+}
+
+function bridgeStatusLabel(status: BridgeStatus): string {
+  switch (status) {
+    case "verified":
+      return "Verified";
+    case "unavailable":
+      return "Unavailable";
+    case "removed":
+      return "Removed";
+    default:
+      return assertNever(status);
+  }
+}
+
+describe("BridgeStatus exhaustiveness", () => {
+  it("includes 'removed' as a first-class state", () => {
+    const s: BridgeStatus = "removed";
+
+    expect(bridgeStatusLabel(s)).toBe("Removed");
+  });
+
+  it("handles 'verified' and 'unavailable' too", () => {
+    expect(bridgeStatusLabel("verified")).toBe("Verified");
+    expect(bridgeStatusLabel("unavailable")).toBe("Unavailable");
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-store-persistence-boundary.test.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-store-persistence-boundary.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Enforces the Dexie-vs-Zustand persistence boundary for bridge-related
+ * runtime state:
+ *
+ *   - The new `bridges` Dexie store IS the persistence layer for the
+ *     registry.
+ *   - `train2go-store` and any `garmin-store` / bridge runtime store
+ *     MUST remain in-memory Zustand — no `persist(` middleware import
+ *     and no direct Dexie writes.
+ *
+ * See `CLAUDE.md` rule: "Editor runtime → Zustand. Persisted data →
+ * Dexie. Local UI → React state." — and the proposal's
+ * Dexie-vs-Zustand boundary clause.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const STORE_ROOT = resolve(__dirname, "..", "..", "store");
+
+const BRIDGE_RUNTIME_STORES = [
+  "train2go-store.ts",
+  "train2go-store-actions.ts",
+  "train2go-extension-transport.ts",
+  // Future-proof: if a dedicated garmin-store lands, enforce the same
+  // rule there too.
+  "garmin-store.ts",
+  "garmin-store-actions.ts",
+];
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...walk(full));
+    else out.push(full);
+  }
+  return out;
+}
+
+describe("bridge runtime stores stay in Zustand, never in Dexie", () => {
+  it("no bridge-runtime store imports zustand/middleware persist", () => {
+    const offenders: string[] = [];
+    for (const name of BRIDGE_RUNTIME_STORES) {
+      const path = join(STORE_ROOT, name);
+      let source: string;
+      try {
+        source = readFileSync(path, "utf8");
+      } catch {
+        continue; // file may not exist yet
+      }
+      if (/from\s+["']zustand\/middleware["']/.test(source)) {
+        offenders.push(name);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("no bridge-runtime store writes to Dexie directly", () => {
+    const offenders: string[] = [];
+    for (const name of BRIDGE_RUNTIME_STORES) {
+      const path = join(STORE_ROOT, name);
+      let source: string;
+      try {
+        source = readFileSync(path, "utf8");
+      } catch {
+        continue;
+      }
+      if (
+        /from\s+["'][^"']*adapters\/dexie/.test(source) ||
+        /createDexiePersistence|KaiordDatabase|dexie-database/i.test(source)
+      ) {
+        offenders.push(name);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("the Dexie bridges repository is the ONLY bridge-named persistence adapter", () => {
+    const dexieDir = resolve(__dirname, "..", "dexie");
+    const files = walk(dexieDir)
+      .map((f) => f.substring(dexieDir.length + 1))
+      .filter((f) => /bridge/i.test(f) && !f.endsWith(".test.ts"));
+
+    // Exactly one adapter source + any non-test bridge artefact if added
+    // later. The regression bar is: no duplicated persistence paths.
+    const adapterFiles = files.filter((f) => f.endsWith(".ts"));
+    expect(adapterFiles).toEqual(["dexie-bridge-repository.ts"]);
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-types.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-types.ts
@@ -6,7 +6,7 @@
 
 import type { BridgeCapability } from "../../types/bridge-schemas";
 
-export type BridgeStatus = "verified" | "unavailable";
+export type BridgeStatus = "verified" | "unavailable" | "removed";
 
 export type RegisteredBridge = {
   extensionId: string;
@@ -18,10 +18,35 @@ export type RegisteredBridge = {
   status: BridgeStatus;
   lastSeen: string;
   failCount: number;
+  /**
+   * Wall-clock timestamp (ms) when the bridge transitioned to
+   * `"removed"`. Used to decide when to delete the row (24h after
+   * transition). Undefined for bridges never marked removed.
+   */
+  removedAt?: number;
 };
+
+export type BridgePersistedRow = Omit<RegisteredBridge, never>;
+
+export type BridgeRepository = {
+  getAll: () => Promise<RegisteredBridge[]>;
+  put: (bridge: RegisteredBridge) => Promise<void>;
+  delete: (extensionId: string) => Promise<void>;
+};
+
+export type BridgeNotifier = (event: {
+  type: "removed";
+  bridge: RegisteredBridge;
+}) => void;
 
 export type BridgeRegistry = {
   detectBridge: (extensionId: string) => Promise<RegisteredBridge | null>;
+  /**
+   * Loads any persisted bridges from the configured repository. Called
+   * once on boot before `startHeartbeat()` so the 24h-unavailable /
+   * 24h-removed timers resume from the stored `lastSeen` / `removedAt`.
+   */
+  hydrate: () => Promise<void>;
   getBridge: (extensionId: string) => RegisteredBridge | undefined;
   getAllBridges: () => RegisteredBridge[];
   hasCapability: (capability: BridgeCapability) => boolean;

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-bridge-repository.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-bridge-repository.test.ts
@@ -1,0 +1,169 @@
+import "fake-indexeddb/auto";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { pruneStale } from "../bridge/bridge-registry-helpers";
+import type { RegisteredBridge } from "../bridge/bridge-types";
+import { createDexieBridgeRepository } from "./dexie-bridge-repository";
+import { KaiordDatabase } from "./dexie-database";
+
+const HOUR = 60 * 60 * 1_000;
+const DAY = 24 * HOUR;
+
+describe("DexieBridgeRepository", () => {
+  let db: KaiordDatabase;
+
+  beforeEach(async () => {
+    // Fresh database name per test isolates IDB state without needing
+    // cross-suite cleanup.
+    db = new KaiordDatabase(
+      `kaiord-bridges-test-${Date.now()}-${Math.random()}`
+    );
+  });
+
+  it("persists bridges keyed by extensionId", async () => {
+    const repo = createDexieBridgeRepository(db);
+    const bridge: RegisteredBridge = {
+      extensionId: "ext-1",
+      id: "garmin-bridge",
+      name: "Garmin Bridge",
+      version: "1.0.0",
+      protocolVersion: 1,
+      capabilities: ["write:workouts"],
+      status: "verified",
+      lastSeen: "2026-04-20T10:00:00Z",
+      failCount: 0,
+    };
+
+    await repo.put(bridge);
+    const all = await repo.getAll();
+
+    expect(all).toHaveLength(1);
+    expect(all[0]).toEqual(bridge);
+  });
+
+  it("upserts on put", async () => {
+    const repo = createDexieBridgeRepository(db);
+    const base: RegisteredBridge = {
+      extensionId: "ext-1",
+      id: "garmin-bridge",
+      name: "Garmin Bridge",
+      version: "1.0.0",
+      protocolVersion: 1,
+      capabilities: ["write:workouts"],
+      status: "verified",
+      lastSeen: "2026-04-20T10:00:00Z",
+      failCount: 0,
+    };
+
+    await repo.put(base);
+    await repo.put({ ...base, status: "unavailable", failCount: 3 });
+    const all = await repo.getAll();
+
+    expect(all).toHaveLength(1);
+    expect(all[0].status).toBe("unavailable");
+    expect(all[0].failCount).toBe(3);
+  });
+
+  it("deletes by extensionId", async () => {
+    const repo = createDexieBridgeRepository(db);
+    await repo.put({
+      extensionId: "ext-1",
+      id: "garmin-bridge",
+      name: "Garmin Bridge",
+      version: "1.0.0",
+      protocolVersion: 1,
+      capabilities: ["write:workouts"],
+      status: "removed",
+      lastSeen: "2026-04-18T10:00:00Z",
+      failCount: 4,
+      removedAt: Date.UTC(2026, 3, 19),
+    });
+
+    await repo.delete("ext-1");
+
+    expect(await repo.getAll()).toHaveLength(0);
+  });
+
+  it("resumes the 24h-unavailable timer from persisted lastSeen", async () => {
+    // Seed a bridge 22h into its unavailable state, then simulate a
+    // page reload by re-reading from Dexie. The pruning timer must
+    // resume from the persisted lastSeen (not from zero).
+    const repo = createDexieBridgeRepository(db);
+    const now = Date.UTC(2026, 3, 20, 10, 0, 0);
+    await repo.put({
+      extensionId: "ext-reload",
+      id: "garmin-bridge",
+      name: "Garmin Bridge",
+      version: "1.0.0",
+      protocolVersion: 1,
+      capabilities: ["write:workouts"],
+      status: "unavailable",
+      lastSeen: new Date(now - 22 * HOUR).toISOString(),
+      failCount: 3,
+    });
+
+    // Simulate reload: fresh in-memory map populated from Dexie.
+    const restored = await repo.getAll();
+    const bridges = new Map(restored.map((b) => [b.extensionId, b]));
+
+    // 3 hours later (25h total elapsed since lastSeen) — must transition
+    // to removed because the timer picked up from the persisted anchor.
+    pruneStale(bridges, { now: now + 3 * HOUR });
+
+    expect(bridges.get("ext-reload")?.status).toBe("removed");
+  });
+
+  it("keeps the 'unavailable' status if elapsed is still under 24h across reload", async () => {
+    const repo = createDexieBridgeRepository(db);
+    const now = Date.UTC(2026, 3, 20, 10, 0, 0);
+    await repo.put({
+      extensionId: "ext-fresh",
+      id: "garmin-bridge",
+      name: "Garmin Bridge",
+      version: "1.0.0",
+      protocolVersion: 1,
+      capabilities: ["write:workouts"],
+      status: "unavailable",
+      lastSeen: new Date(now - 10 * HOUR).toISOString(),
+      failCount: 3,
+    });
+
+    const restored = await repo.getAll();
+    const bridges = new Map(restored.map((b) => [b.extensionId, b]));
+
+    // Still only 10h elapsed after a hypothetical reload right after.
+    pruneStale(bridges, { now });
+
+    expect(bridges.get("ext-fresh")?.status).toBe("unavailable");
+  });
+
+  it("deletes via onDeleted callback routing to repo.delete", async () => {
+    const repo = createDexieBridgeRepository(db);
+    const now = Date.UTC(2026, 3, 20, 10, 0, 0);
+    await repo.put({
+      extensionId: "ext-gone",
+      id: "garmin-bridge",
+      name: "Garmin Bridge",
+      version: "1.0.0",
+      protocolVersion: 1,
+      capabilities: ["write:workouts"],
+      status: "removed",
+      lastSeen: new Date(now - 3 * DAY).toISOString(),
+      removedAt: now - DAY - HOUR,
+      failCount: 4,
+    });
+
+    const restored = await repo.getAll();
+    const bridges = new Map(restored.map((b) => [b.extensionId, b]));
+
+    pruneStale(bridges, {
+      now,
+      onDeleted: (id) => void repo.delete(id),
+    });
+
+    // Allow microtasks to drain the void-awaited delete.
+    await Promise.resolve();
+
+    expect(await repo.getAll()).toHaveLength(0);
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-bridge-repository.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-bridge-repository.ts
@@ -1,0 +1,30 @@
+/**
+ * Dexie Bridge Repository
+ *
+ * Persists the bridge registry across browser sessions so the
+ * 24h-unavailable and 24h-removed lifecycle timers resume from the
+ * stored `lastSeen` / `removedAt` anchors instead of restarting on
+ * every reload.
+ */
+
+import type {
+  BridgeRepository,
+  RegisteredBridge,
+} from "../bridge/bridge-types";
+import type { KaiordDatabase } from "./dexie-database";
+
+export function createDexieBridgeRepository(
+  db: KaiordDatabase
+): BridgeRepository {
+  const table = () => db.table<RegisteredBridge>("bridges");
+
+  return {
+    getAll: async () => table().toArray(),
+    put: async (bridge) => {
+      await table().put(bridge);
+    },
+    delete: async (extensionId) => {
+      await table().delete(extensionId);
+    },
+  };
+}

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
@@ -20,6 +20,19 @@ export class KaiordDatabase extends Dexie {
       usage: "yearMonth",
       meta: "key",
     });
+
+    // v2 — bridge registry persistence so the 24h-unavailable and
+    // 24h-removed lifecycle timers survive browser restarts.
+    this.version(2).stores({
+      workouts: "id, date, [date+state], [source+sourceId], sport, *tags",
+      templates: "id, sport, *tags",
+      profiles: "id",
+      aiProviders: "id",
+      syncState: "source",
+      usage: "yearMonth",
+      meta: "key",
+      bridges: "extensionId, status, lastSeen",
+    });
   }
 }
 

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
@@ -33,6 +33,41 @@ export class KaiordDatabase extends Dexie {
       meta: "key",
       bridges: "extensionId, status, lastSeen",
     });
+
+    // v3 — UsageRecord gains `inputTokens`/`outputTokens` (split of
+    // the legacy `totalTokens`). Schema keys unchanged; only the
+    // row shape grows, hence no store redefinition — just an
+    // `.upgrade()` backfill marking pre-v3 rows as `legacy`.
+    this.version(3)
+      .stores({
+        workouts: "id, date, [date+state], [source+sourceId], sport, *tags",
+        templates: "id, sport, *tags",
+        profiles: "id",
+        aiProviders: "id",
+        syncState: "source",
+        usage: "yearMonth",
+        meta: "key",
+        bridges: "extensionId, status, lastSeen",
+      })
+      .upgrade(async (tx) => {
+        await tx.table("usage").toCollection().modify(backfillUsageRow);
+      });
+  }
+}
+
+export function backfillUsageRow(row: Record<string, unknown>): void {
+  if (typeof row.inputTokens === "number") return;
+  const total = typeof row.totalTokens === "number" ? row.totalTokens : 0;
+  row.inputTokens = total;
+  row.outputTokens = 0;
+  row.legacy = true;
+
+  if (Array.isArray(row.entries)) {
+    row.entries = row.entries.map((entry: Record<string, unknown>) => {
+      if (typeof entry.inputTokens === "number") return entry;
+      const tokens = typeof entry.tokens === "number" ? entry.tokens : 0;
+      return { ...entry, inputTokens: tokens, outputTokens: 0 };
+    });
   }
 }
 

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-persistence-adapter.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-persistence-adapter.test.ts
@@ -440,9 +440,19 @@ describe("DexieUsageRepository", () => {
     const { usage } = createDexiePersistence(testDb);
     const record: UsageRecord = {
       yearMonth: "2026-04",
+      inputTokens: 1200,
+      outputTokens: 300,
       totalTokens: 1500,
       totalCost: 0.03,
-      entries: [{ date: "2026-04-07", tokens: 1500, cost: 0.03 }],
+      entries: [
+        {
+          date: "2026-04-07",
+          inputTokens: 1200,
+          outputTokens: 300,
+          tokens: 1500,
+          cost: 0.03,
+        },
+      ],
     };
 
     await usage.put(record);
@@ -461,6 +471,8 @@ describe("DexieUsageRepository", () => {
     const { usage } = createDexiePersistence(testDb);
     await usage.put({
       yearMonth: "2026-04",
+      inputTokens: 80,
+      outputTokens: 20,
       totalTokens: 100,
       totalCost: 0.01,
       entries: [],
@@ -468,9 +480,19 @@ describe("DexieUsageRepository", () => {
 
     await usage.put({
       yearMonth: "2026-04",
+      inputTokens: 160,
+      outputTokens: 40,
       totalTokens: 200,
       totalCost: 0.02,
-      entries: [{ date: "2026-04-11", tokens: 200, cost: 0.02 }],
+      entries: [
+        {
+          date: "2026-04-11",
+          inputTokens: 160,
+          outputTokens: 40,
+          tokens: 200,
+          cost: 0.02,
+        },
+      ],
     });
     const result = await usage.getByMonth("2026-04");
 

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-usage-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-usage-migration.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Dexie v2 → v3 migration: backfill `inputTokens` / `outputTokens`
+ * on legacy `usage` rows that only had `totalTokens`.
+ *
+ * Exercises both:
+ *   1. The pure `backfillUsageRow` helper (unit).
+ *   2. The full Dexie upgrade hook end-to-end (integration): seed
+ *      a v2-shape database, open it at v3, and verify migrated
+ *      rows.
+ */
+
+import "fake-indexeddb/auto";
+import Dexie from "dexie";
+import { describe, expect, it } from "vitest";
+
+import { backfillUsageRow, KaiordDatabase } from "./dexie-database";
+
+describe("backfillUsageRow (unit)", () => {
+  it("fills inputTokens from totalTokens and sets outputTokens=0, legacy=true", () => {
+    const row: Record<string, unknown> = {
+      yearMonth: "2026-03",
+      totalTokens: 500,
+      totalCost: 0.01,
+      entries: [{ date: "2026-03-12", tokens: 500, cost: 0.01 }],
+    };
+
+    backfillUsageRow(row);
+
+    expect(row.inputTokens).toBe(500);
+    expect(row.outputTokens).toBe(0);
+    expect(row.legacy).toBe(true);
+    expect(row.totalTokens).toBe(500);
+  });
+
+  it("backfills every entry alongside the record-level fields", () => {
+    const row: Record<string, unknown> = {
+      yearMonth: "2026-03",
+      totalTokens: 80,
+      totalCost: 0.001,
+      entries: [{ date: "2026-03-12", tokens: 80, cost: 0.001 }],
+    };
+
+    backfillUsageRow(row);
+
+    const entry = (row.entries as Array<Record<string, unknown>>)[0];
+    expect(entry.inputTokens).toBe(80);
+    expect(entry.outputTokens).toBe(0);
+    expect(entry.tokens).toBe(80);
+  });
+
+  it("is idempotent — rows already carrying inputTokens are untouched", () => {
+    const row: Record<string, unknown> = {
+      yearMonth: "2026-04",
+      inputTokens: 120,
+      outputTokens: 30,
+      totalTokens: 150,
+      totalCost: 0.02,
+      entries: [],
+    };
+
+    const before = JSON.stringify(row);
+    backfillUsageRow(row);
+
+    expect(JSON.stringify(row)).toBe(before);
+  });
+
+  it("handles rows missing totalTokens gracefully", () => {
+    const row: Record<string, unknown> = {
+      yearMonth: "2026-02",
+      totalCost: 0,
+      entries: [],
+    };
+
+    backfillUsageRow(row);
+
+    expect(row.inputTokens).toBe(0);
+    expect(row.outputTokens).toBe(0);
+    expect(row.legacy).toBe(true);
+  });
+});
+
+describe("Dexie v2 → v3 upgrade (integration)", () => {
+  it("migrates legacy usage rows in-place on open", async () => {
+    const dbName = `kaiord-usage-migration-${Date.now()}-${Math.random()}`;
+
+    // Seed a v2-shape database directly (no `inputTokens` field).
+    const v2 = new Dexie(dbName);
+    v2.version(2).stores({
+      workouts: "id, date, [date+state], [source+sourceId], sport, *tags",
+      templates: "id, sport, *tags",
+      profiles: "id",
+      aiProviders: "id",
+      syncState: "source",
+      usage: "yearMonth",
+      meta: "key",
+      bridges: "extensionId, status, lastSeen",
+    });
+    await v2.open();
+    await v2.table("usage").put({
+      yearMonth: "2026-03",
+      totalTokens: 750,
+      totalCost: 0.015,
+      entries: [{ date: "2026-03-12", tokens: 750, cost: 0.015 }],
+    });
+    v2.close();
+
+    // Open via the current KaiordDatabase (version 3) — triggers upgrade.
+    const v3 = new KaiordDatabase(dbName);
+    await v3.open();
+    const migrated = await v3
+      .table<{
+        yearMonth: string;
+        totalTokens: number;
+        inputTokens: number;
+        outputTokens: number;
+        legacy?: boolean;
+        entries: Array<Record<string, unknown>>;
+      }>("usage")
+      .get("2026-03");
+
+    expect(migrated).toBeDefined();
+    expect(migrated!.inputTokens).toBe(750);
+    expect(migrated!.outputTokens).toBe(0);
+    expect(migrated!.totalTokens).toBe(750);
+    expect(migrated!.legacy).toBe(true);
+    expect(migrated!.entries[0].inputTokens).toBe(750);
+    expect(migrated!.entries[0].outputTokens).toBe(0);
+
+    v3.close();
+  });
+});

--- a/packages/workout-spa-editor/src/application/batch-processor.test.ts
+++ b/packages/workout-spa-editor/src/application/batch-processor.test.ts
@@ -137,6 +137,104 @@ describe("processBatch", () => {
     vi.useRealTimers();
   });
 
+  it("reports per-workout status via byId (queued → processing → succeeded)", async () => {
+    const workouts = makeWorkouts(2);
+    const processOne = vi.fn().mockResolvedValue(ok);
+    const onProgress = vi.fn();
+
+    await processBatch(
+      workouts,
+      processOne,
+      onProgress,
+      new AbortController().signal
+    );
+
+    const [w0, w1] = workouts;
+    const frames = onProgress.mock.calls.map((c) => c[0]);
+
+    // First frame: w0 processing, w1 queued
+    expect(frames[0].byId[w0.id]).toBe("processing");
+    expect(frames[0].byId[w1.id]).toBe("queued");
+    expect(frames[0].counts.queued).toBe(1);
+    expect(frames[0].counts.processing).toBe(1);
+
+    // After w0 done: succeeded=1, next w1 queued
+    expect(frames[1].byId[w0.id]).toBe("succeeded");
+    expect(frames[1].byId[w1.id]).toBe("queued");
+    expect(frames[1].counts.succeeded).toBe(1);
+
+    // Final frame: both succeeded
+    const last = frames[frames.length - 1];
+    expect(last.byId[w0.id]).toBe("succeeded");
+    expect(last.byId[w1.id]).toBe("succeeded");
+    expect(last.counts.succeeded).toBe(2);
+    expect(last.counts.queued).toBe(0);
+    expect(last.counts.processing).toBe(0);
+  });
+
+  it("records 'failed' per-workout status on processOne failure", async () => {
+    const workouts = makeWorkouts(2);
+    const processOne = vi
+      .fn()
+      .mockResolvedValueOnce(fail)
+      .mockResolvedValueOnce(ok);
+    const onProgress = vi.fn();
+
+    await processBatch(
+      workouts,
+      processOne,
+      onProgress,
+      new AbortController().signal
+    );
+
+    const last = onProgress.mock.calls[onProgress.mock.calls.length - 1][0];
+    expect(last.byId[workouts[0].id]).toBe("failed");
+    expect(last.byId[workouts[1].id]).toBe("succeeded");
+    expect(last.counts.failed).toBe(1);
+    expect(last.counts.succeeded).toBe(1);
+  });
+
+  it("initial frames include every workout as queued before processing starts", async () => {
+    const workouts = makeWorkouts(3);
+    const processOne = vi.fn().mockResolvedValue(ok);
+    const onProgress = vi.fn();
+
+    await processBatch(
+      workouts,
+      processOne,
+      onProgress,
+      new AbortController().signal
+    );
+
+    const firstFrame = onProgress.mock.calls[0][0];
+
+    // Three workouts total, one immediately flipped to processing,
+    // the remaining two still queued.
+    expect(firstFrame.total).toBe(3);
+    expect(Object.keys(firstFrame.byId)).toHaveLength(3);
+    expect(firstFrame.counts.queued + firstFrame.counts.processing).toBe(3);
+  });
+
+  it("byId snapshots are isolated — later mutations don't leak back", async () => {
+    const workouts = makeWorkouts(2);
+    const processOne = vi.fn().mockResolvedValue(ok);
+    const frames: Array<Record<string, string>> = [];
+    const onProgress = (p: { byId: Record<string, string> }) => {
+      frames.push(p.byId);
+    };
+
+    await processBatch(
+      workouts,
+      processOne,
+      onProgress,
+      new AbortController().signal
+    );
+
+    // The first frame must still report w0 as "processing", not
+    // "succeeded" — each emit should be a fresh snapshot.
+    expect(frames[0][workouts[0].id]).toBe("processing");
+  });
+
   it("passes allowRetry=true until budget exhausted", async () => {
     const workouts = makeWorkouts(5);
     const retriedResult: ProcessResult = {

--- a/packages/workout-spa-editor/src/application/batch-processor.ts
+++ b/packages/workout-spa-editor/src/application/batch-processor.ts
@@ -4,18 +4,22 @@
  * Processes multiple workouts sequentially with continue-on-failure
  * semantics, 500ms cadence, and cancellation support.
  * Enforces a batch-level retry budget of 3.
+ *
+ * Emits per-workout status via `byId` + summary `counts` so the
+ * calendar progress panel can render the spec-required
+ * "per-workout status (success/fail/queued)" detail.
  */
 
 import type { WorkoutRecord } from "../types/calendar-record";
 import type { ProcessResult } from "./ai-workout-processor";
+import type { WorkoutBatchStatus } from "./batch-progress";
+import { type BatchProgress, buildBatchProgress } from "./batch-progress";
 
-export type BatchProgress = {
-  total: number;
-  processed: number;
-  succeeded: number;
-  failed: number;
-  current: string | null;
-};
+export type {
+  BatchProgress,
+  BatchProgressCounts,
+  WorkoutBatchStatus,
+} from "./batch-progress";
 
 export type BatchResult = {
   succeeded: string[];
@@ -37,11 +41,10 @@ export async function processBatch(
   onProgress: (progress: BatchProgress) => void,
   signal: AbortSignal
 ): Promise<BatchResult> {
-  const result: BatchResult = {
-    succeeded: [],
-    failed: [],
-    cancelled: false,
-  };
+  const result: BatchResult = { succeeded: [], failed: [], cancelled: false };
+  const byId: Record<string, WorkoutBatchStatus> = Object.fromEntries(
+    workouts.map((w) => [w.id, "queued"])
+  );
   let retriesUsed = 0;
 
   for (let i = 0; i < workouts.length; i++) {
@@ -51,41 +54,27 @@ export async function processBatch(
     }
 
     const workout = workouts[i];
-    onProgress(buildProgress(workouts.length, result, workout.id));
+    byId[workout.id] = "processing";
+    onProgress(buildBatchProgress(workouts.length, workout.id, byId));
 
     const canRetry = retriesUsed < MAX_BATCH_RETRIES;
     const outcome = await processOne(workout, canRetry);
-
     if (outcome.retried) retriesUsed++;
 
     if (outcome.ok) {
       result.succeeded.push(workout.id);
+      byId[workout.id] = "succeeded";
     } else {
       result.failed.push({ id: workout.id, error: outcome.error });
+      byId[workout.id] = "failed";
     }
 
-    onProgress(buildProgress(workouts.length, result, null));
+    onProgress(buildBatchProgress(workouts.length, null, byId));
 
-    if (i < workouts.length - 1 && !signal.aborted) {
-      await delay(CADENCE_MS);
-    }
+    if (i < workouts.length - 1 && !signal.aborted) await delay(CADENCE_MS);
   }
 
   return result;
-}
-
-function buildProgress(
-  total: number,
-  r: BatchResult,
-  current: string | null
-): BatchProgress {
-  return {
-    total,
-    processed: r.succeeded.length + r.failed.length,
-    succeeded: r.succeeded.length,
-    failed: r.failed.length,
-    current,
-  };
 }
 
 function delay(ms: number): Promise<void> {

--- a/packages/workout-spa-editor/src/application/batch-progress.ts
+++ b/packages/workout-spa-editor/src/application/batch-progress.ts
@@ -1,0 +1,59 @@
+/**
+ * Batch progress shape emitted by `processBatch`.
+ *
+ * `counts` + `byId` are the spec-required fields (spa-calendar
+ * "per-workout status (success/fail/queued)"). The legacy
+ * `processed`/`succeeded`/`failed` mirrors are kept for back-compat
+ * with existing consumers and will fold into `counts.*` once all
+ * readers migrate.
+ */
+
+export type WorkoutBatchStatus =
+  | "queued"
+  | "processing"
+  | "succeeded"
+  | "failed";
+
+export type BatchProgressCounts = {
+  queued: number;
+  processing: number;
+  succeeded: number;
+  failed: number;
+};
+
+export type BatchProgress = {
+  total: number;
+  counts: BatchProgressCounts;
+  current: string | null;
+  byId: Record<string, WorkoutBatchStatus>;
+  /** Back-compat aggregate — `counts.succeeded + counts.failed`. */
+  processed: number;
+  /** Back-compat alias for `counts.succeeded`. */
+  succeeded: number;
+  /** Back-compat alias for `counts.failed`. */
+  failed: number;
+};
+
+export function buildBatchProgress(
+  total: number,
+  current: string | null,
+  byId: Record<string, WorkoutBatchStatus>
+): BatchProgress {
+  const counts: BatchProgressCounts = {
+    queued: 0,
+    processing: 0,
+    succeeded: 0,
+    failed: 0,
+  };
+  for (const status of Object.values(byId)) counts[status]++;
+
+  return {
+    total,
+    counts,
+    current,
+    byId: { ...byId },
+    processed: counts.succeeded + counts.failed,
+    succeeded: counts.succeeded,
+    failed: counts.failed,
+  };
+}

--- a/packages/workout-spa-editor/src/application/on-workout-mutation.test.ts
+++ b/packages/workout-spa-editor/src/application/on-workout-mutation.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkoutRecord } from "../types/calendar-record";
+import { onWorkoutMutation } from "./workout-transitions";
+
+function makeRecord(overrides: Partial<WorkoutRecord> = {}): WorkoutRecord {
+  return {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    date: "2026-04-20",
+    sport: "running",
+    source: "train2go",
+    sourceId: "ext-1",
+    planId: null,
+    state: "structured",
+    raw: null,
+    krd: {
+      version: "1.0",
+      type: "structured_workout",
+      metadata: { created: "2026-04-20T08:00:00Z", sport: "running" },
+    },
+    lastProcessingError: null,
+    feedback: null,
+    aiMeta: null,
+    garminPushId: null,
+    tags: [],
+    previousState: null,
+    createdAt: "2026-04-20T08:00:00Z",
+    modifiedAt: null,
+    updatedAt: "2026-04-20T08:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("onWorkoutMutation", () => {
+  it("advances modifiedAt and updatedAt when no timestamp is given", () => {
+    const record = makeRecord({ modifiedAt: null });
+
+    const result = onWorkoutMutation(record);
+
+    expect(result.modifiedAt).not.toBeNull();
+    expect(result.updatedAt).not.toBe(record.updatedAt);
+  });
+
+  it("uses the supplied batch timestamp so two calls in one batch share it", () => {
+    const record = makeRecord({ modifiedAt: null });
+    const stamp = "2026-04-20T09:00:00.000Z";
+
+    const first = onWorkoutMutation(record, { timestamp: stamp });
+    const second = onWorkoutMutation(first, { timestamp: stamp });
+
+    expect(first.modifiedAt).toBe(stamp);
+    expect(second.modifiedAt).toBe(stamp);
+    expect(first.updatedAt).toBe(stamp);
+  });
+
+  it("preserves the state by default — mutation alone does not transition", () => {
+    const record = makeRecord({ state: "structured" });
+
+    const result = onWorkoutMutation(record);
+
+    expect(result.state).toBe("structured");
+  });
+
+  it("passes through an optional nextState when a transition applies", () => {
+    const record = makeRecord({
+      state: "pushed",
+      garminPushId: "garmin-1",
+      krd: {
+        version: "1.0",
+        type: "structured_workout",
+        metadata: { created: "2026-04-20T08:00:00Z", sport: "running" },
+      },
+    });
+
+    const result = onWorkoutMutation(record, { nextState: "modified" });
+
+    expect(result.state).toBe("modified");
+    expect(result.modifiedAt).not.toBeNull();
+  });
+
+  it("is a pure function — does not mutate the input", () => {
+    const record = makeRecord({ modifiedAt: null });
+    const snapshot = JSON.stringify(record);
+
+    onWorkoutMutation(record);
+
+    expect(JSON.stringify(record)).toBe(snapshot);
+  });
+
+  it("carries a replacement KRD when provided (edit-step / reorder / paste)", () => {
+    const record = makeRecord();
+    const nextKrd = {
+      version: "1.0" as const,
+      type: "structured_workout" as const,
+      metadata: { created: "2026-04-20T08:00:00Z", sport: "cycling" as const },
+    };
+
+    const result = onWorkoutMutation(record, { krd: nextKrd });
+
+    expect(result.krd).toBe(nextKrd);
+    expect(result.modifiedAt).not.toBeNull();
+  });
+
+  it("advances modifiedAt for STRUCTURED edits without changing state", () => {
+    const record = makeRecord({ state: "structured", modifiedAt: null });
+
+    const result = onWorkoutMutation(record);
+
+    expect(result.state).toBe("structured");
+    expect(result.modifiedAt).not.toBeNull();
+  });
+
+  it("advances modifiedAt for READY edits without changing state", () => {
+    const record = makeRecord({ state: "ready", modifiedAt: null });
+
+    const result = onWorkoutMutation(record);
+
+    expect(result.state).toBe("ready");
+    expect(result.modifiedAt).not.toBeNull();
+  });
+
+  it("selection-only actions do NOT go through the helper — guarding note", () => {
+    // The helper is the chokepoint for mutations only. Selection-only
+    // actions (focus, hover, highlight) MUST NOT call it. We encode
+    // that contract by asserting: if the helper is never called,
+    // modifiedAt stays unchanged — trivially true in the test, but the
+    // assertion guards readers against the anti-pattern of wrapping
+    // everything in onWorkoutMutation.
+    const record = makeRecord({ modifiedAt: "2026-04-20T07:00:00Z" });
+
+    // No helper call — simulate selection-only path.
+    const unchanged = record;
+
+    expect(unchanged.modifiedAt).toBe("2026-04-20T07:00:00Z");
+  });
+});

--- a/packages/workout-spa-editor/src/application/on-workout-mutation.ts
+++ b/packages/workout-spa-editor/src/application/on-workout-mutation.ts
@@ -1,0 +1,44 @@
+/**
+ * Central chokepoint for every KRD-mutating user action.
+ *
+ * Advances `modifiedAt` + `updatedAt`, optionally swaps in a
+ * replacement KRD, and optionally transitions state. Every mutator
+ * (edit step, reorder, paste, delete, group, ungroup, lap edit,
+ * metadata edit) SHALL route through here before persisting — per
+ * spa-workout-state-machine spec: "modifiedAt SHALL be updated on
+ * any user edit to the KRD, not only on PUSHED→MODIFIED transitions".
+ *
+ * Pure: never mutates `draft`.
+ *
+ * Batch idempotency: pass a shared `timestamp` when multiple mutators
+ * run in the same synchronous batch so they agree on one value.
+ *
+ * Selection-only actions (focus, hover, highlight) MUST NOT call this
+ * helper — they are not mutations.
+ */
+
+import type { WorkoutState } from "../types/calendar-enums";
+import type { WorkoutRecord } from "../types/calendar-record";
+import type { KRD } from "../types/schemas";
+
+export type OnWorkoutMutationOptions = {
+  nextState?: WorkoutState;
+  krd?: KRD;
+  timestamp?: string;
+};
+
+const currentTimestamp = (): string => new Date().toISOString();
+
+export function onWorkoutMutation(
+  draft: WorkoutRecord,
+  options: OnWorkoutMutationOptions = {}
+): WorkoutRecord {
+  const timestamp = options.timestamp ?? currentTimestamp();
+  return {
+    ...draft,
+    state: options.nextState ?? draft.state,
+    krd: options.krd ?? draft.krd,
+    modifiedAt: timestamp,
+    updatedAt: timestamp,
+  };
+}

--- a/packages/workout-spa-editor/src/application/workout-transitions.ts
+++ b/packages/workout-spa-editor/src/application/workout-transitions.ts
@@ -3,11 +3,18 @@
  *
  * Pure functions that validate and apply state transitions.
  * Each returns a new WorkoutRecord (immutable).
+ *
+ * Mutation-without-transition goes through `onWorkoutMutation`
+ * (see ./on-workout-mutation.ts) — re-exported here as the
+ * canonical entry point for consumers.
  */
 
 import type { AiMeta } from "../types/calendar-fragments";
 import type { WorkoutRecord } from "../types/calendar-record";
 import type { KRD } from "../types/schemas";
+
+export type { OnWorkoutMutationOptions } from "./on-workout-mutation";
+export { onWorkoutMutation } from "./on-workout-mutation";
 
 const now = (): string => new Date().toISOString();
 

--- a/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/BatchProcessingBanner.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/BatchProcessingBanner.test.tsx
@@ -135,4 +135,43 @@ describe("BatchProcessingBanner", () => {
 
     expect(screen.getByText(/1 raw workout this/)).toBeInTheDocument();
   });
+
+  it("renders the per-bucket breakdown from progress.counts", () => {
+    render(
+      <BatchProcessingBanner
+        rawCount={5}
+        isProcessing={true}
+        progress={{
+          total: 5,
+          processed: 2,
+          succeeded: 1,
+          failed: 1,
+          current: "w3",
+          counts: { queued: 2, processing: 1, succeeded: 1, failed: 1 },
+          byId: {
+            w1: "succeeded",
+            w2: "failed",
+            w3: "processing",
+            w4: "queued",
+            w5: "queued",
+          },
+        }}
+        onProcess={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId("batch-count-queued")).toHaveTextContent(
+      "Queued 2"
+    );
+    expect(screen.getByTestId("batch-count-processing")).toHaveTextContent(
+      "Processing 1"
+    );
+    expect(screen.getByTestId("batch-count-succeeded")).toHaveTextContent(
+      "Succeeded 1"
+    );
+    expect(screen.getByTestId("batch-count-failed")).toHaveTextContent(
+      "Failed 1"
+    );
+  });
 });

--- a/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/BatchProcessingBanner.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/BatchProcessingBanner.tsx
@@ -1,12 +1,15 @@
 /**
  * BatchProcessingBanner - Shows raw workout count and batch action.
  *
- * During processing, shows progress with cancel button.
+ * During processing, shows progress with cancel button + the
+ * spec-required per-workout status breakdown
+ * (queued / processing / succeeded / failed).
  */
 
-import { Bot, X } from "lucide-react";
+import { Bot } from "lucide-react";
 
 import type { BatchProgress } from "../../../application/batch-processor";
+import { ProcessingStatus } from "./ProcessingStatus";
 
 export type BatchProcessingBannerProps = {
   rawCount: number;
@@ -58,30 +61,6 @@ function IdleStatus({
         className="rounded-md bg-primary-600 px-3 py-1 text-sm text-white hover:bg-primary-700"
       >
         Process all with AI
-      </button>
-    </>
-  );
-}
-
-function ProcessingStatus({
-  progress,
-  onCancel,
-}: {
-  progress: BatchProgress;
-  onCancel: () => void;
-}) {
-  return (
-    <>
-      <span className="flex-1 text-sm" data-testid="batch-progress">
-        Processing {progress.processed} of {progress.total}
-      </span>
-      <button
-        type="button"
-        onClick={onCancel}
-        aria-label="Cancel batch processing"
-        className="rounded p-1 hover:bg-yellow-100 dark:hover:bg-yellow-900"
-      >
-        <X className="h-4 w-4" />
       </button>
     </>
   );

--- a/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/ProcessingStatus.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/ProcessingStatus.tsx
@@ -1,0 +1,57 @@
+import { X } from "lucide-react";
+
+import type { BatchProgress } from "../../../application/batch-processor";
+
+function deriveCounts(progress: BatchProgress) {
+  // Back-compat: `counts` is the spec-required shape but legacy emit
+  // sites may still provide only the aggregate totals.
+  return (
+    progress.counts ?? {
+      queued: Math.max(progress.total - progress.processed - 1, 0),
+      processing: progress.current ? 1 : 0,
+      succeeded: progress.succeeded,
+      failed: progress.failed,
+    }
+  );
+}
+
+export function ProcessingStatus({
+  progress,
+  onCancel,
+}: {
+  progress: BatchProgress;
+  onCancel: () => void;
+}) {
+  const counts = deriveCounts(progress);
+
+  return (
+    <>
+      <div className="flex-1 text-sm">
+        <div data-testid="batch-progress">
+          Processing {progress.processed} of {progress.total}
+        </div>
+        <div
+          data-testid="batch-progress-breakdown"
+          className="mt-0.5 flex gap-3 text-xs text-gray-600 dark:text-gray-400"
+        >
+          <span data-testid="batch-count-queued">Queued {counts.queued}</span>
+          <span data-testid="batch-count-processing">
+            Processing {counts.processing}
+          </span>
+          <span data-testid="batch-count-succeeded">
+            Succeeded {counts.succeeded}
+          </span>
+          <span data-testid="batch-count-failed">Failed {counts.failed}</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={onCancel}
+        aria-label="Cancel batch processing"
+        className="rounded p-1 hover:bg-yellow-100 dark:hover:bg-yellow-900"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/StorageAvailabilityBanner/StorageAvailabilityBanner.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StorageAvailabilityBanner/StorageAvailabilityBanner.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { StorageAvailabilityBanner } from "./StorageAvailabilityBanner";
+
+const STORAGE_UNAVAILABLE_MESSAGE =
+  "Storage unavailable — changes in this session won't be saved";
+
+describe("StorageAvailabilityBanner", () => {
+  it("renders the spec-exact message when status is 'failed'", () => {
+    render(<StorageAvailabilityBanner status="failed" />);
+
+    expect(screen.getByText(STORAGE_UNAVAILABLE_MESSAGE)).toBeInTheDocument();
+  });
+
+  it("uses role='alert' so assistive tech announces it", () => {
+    render(<StorageAvailabilityBanner status="failed" />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      STORAGE_UNAVAILABLE_MESSAGE
+    );
+  });
+
+  it("renders nothing when status is 'checking'", () => {
+    const { container } = render(
+      <StorageAvailabilityBanner status="checking" />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when status is 'ok'", () => {
+    const { container } = render(<StorageAvailabilityBanner status="ok" />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/StorageAvailabilityBanner/StorageAvailabilityBanner.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StorageAvailabilityBanner/StorageAvailabilityBanner.tsx
@@ -1,0 +1,32 @@
+import { AlertTriangle } from "lucide-react";
+
+import type { StorageStatus } from "../../../store/storage-store";
+import { useStorageStore } from "../../../store/storage-store";
+
+type Props = {
+  status?: StorageStatus;
+};
+
+const STORAGE_UNAVAILABLE_MESSAGE =
+  "Storage unavailable — changes in this session won't be saved";
+
+export function StorageAvailabilityBanner({ status: injected }: Props = {}) {
+  const storeStatus = useStorageStore((s) => s.status);
+  const status = injected ?? storeStatus;
+
+  if (status !== "failed") return null;
+
+  return (
+    <div
+      role="alert"
+      data-testid="storage-unavailable-banner"
+      className="flex items-center gap-3 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200"
+    >
+      <AlertTriangle
+        aria-hidden="true"
+        className="h-5 w-5 flex-shrink-0 text-red-600 dark:text-red-400"
+      />
+      <span>{STORAGE_UNAVAILABLE_MESSAGE}</span>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/StorageAvailabilityBanner/index.ts
+++ b/packages/workout-spa-editor/src/components/molecules/StorageAvailabilityBanner/index.ts
@@ -1,0 +1,1 @@
+export { StorageAvailabilityBanner } from "./StorageAvailabilityBanner";

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageTab.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageTab.test.tsx
@@ -45,18 +45,24 @@ describe("UsageTab", () => {
     mockRows = [
       {
         yearMonth: "2026-02",
+        inputTokens: 800,
+        outputTokens: 200,
         totalTokens: 1000,
         totalCost: 0.003,
         entries: [],
       },
       {
         yearMonth: "2026-04",
+        inputTokens: 4000,
+        outputTokens: 1000,
         totalTokens: 5000,
         totalCost: 0.015,
         entries: [],
       },
       {
         yearMonth: "2026-03",
+        inputTokens: 1600,
+        outputTokens: 400,
         totalTokens: 2000,
         totalCost: 0.006,
         entries: [],
@@ -76,6 +82,8 @@ describe("UsageTab", () => {
     mockRows = [
       {
         yearMonth: "2026-04",
+        inputTokens: 10000,
+        outputTokens: 2345,
         totalTokens: 12345,
         totalCost: 0.01234567,
         entries: [],

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageTable.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageTable.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { UsageRecord } from "../../../types/usage-schemas";
+import { UsageTable } from "./UsageTable";
+
+function makeRow(overrides: Partial<UsageRecord> = {}): UsageRecord {
+  return {
+    yearMonth: "2026-04",
+    inputTokens: 1200,
+    outputTokens: 300,
+    totalTokens: 1500,
+    totalCost: 0.02,
+    entries: [],
+    ...overrides,
+  };
+}
+
+describe("UsageTable", () => {
+  it("renders input and output tokens as separate columns for fresh rows", () => {
+    render(<UsageTable rows={[makeRow()]} monthsWindow={3} />);
+
+    expect(screen.getByTestId("usage-input-2026-04")).toHaveTextContent(
+      "1,200"
+    );
+    expect(screen.getByTestId("usage-output-2026-04")).toHaveTextContent("300");
+  });
+
+  it("shows `—` under Output for legacy rows", () => {
+    const legacy = makeRow({
+      yearMonth: "2026-03",
+      inputTokens: 500,
+      outputTokens: 0,
+      totalTokens: 500,
+      legacy: true,
+    });
+
+    render(<UsageTable rows={[legacy]} monthsWindow={3} />);
+
+    expect(screen.getByTestId("usage-output-2026-03")).toHaveTextContent("—");
+    // Input column still shows the conservative backfill value.
+    expect(screen.getByTestId("usage-input-2026-03")).toHaveTextContent("500");
+  });
+
+  it("renders multiple rows without cross-row leakage", () => {
+    const fresh = makeRow({ yearMonth: "2026-04" });
+    const legacy = makeRow({
+      yearMonth: "2026-03",
+      legacy: true,
+      outputTokens: 0,
+      inputTokens: 500,
+      totalTokens: 500,
+    });
+
+    render(<UsageTable rows={[fresh, legacy]} monthsWindow={3} />);
+
+    expect(screen.getByTestId("usage-output-2026-04")).toHaveTextContent("300");
+    expect(screen.getByTestId("usage-output-2026-03")).toHaveTextContent("—");
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageTable.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageTable.tsx
@@ -1,6 +1,8 @@
 /**
  * UsageTab rendered table — one row per UsageRecord, reverse-chron
- * sorted by the caller.
+ * sorted by the caller. Tokens are shown split into input / output
+ * columns; legacy rows (migrated from the pre-split schema) display
+ * `—` under "Output" to avoid presenting a fabricated zero as fact.
  */
 
 import type { UsageRecord } from "../../../types/usage-schemas";
@@ -9,6 +11,10 @@ export type UsageTableProps = {
   rows: UsageRecord[];
   monthsWindow: number;
 };
+
+function formatOutput(row: UsageRecord): string {
+  return row.legacy ? "—" : row.outputTokens.toLocaleString();
+}
 
 export function UsageTable({ rows, monthsWindow }: UsageTableProps) {
   return (
@@ -20,7 +26,9 @@ export function UsageTable({ rows, monthsWindow }: UsageTableProps) {
         <thead>
           <tr className="border-b border-gray-200 text-left text-gray-500 dark:border-gray-700 dark:text-gray-400">
             <th className="py-2 pr-4 font-medium">Month</th>
-            <th className="py-2 pr-4 font-medium">Tokens</th>
+            <th className="py-2 pr-4 font-medium">Input</th>
+            <th className="py-2 pr-4 font-medium">Output</th>
+            <th className="py-2 pr-4 font-medium">Total</th>
             <th className="py-2 font-medium">Cost (USD)</th>
           </tr>
         </thead>
@@ -34,6 +42,18 @@ export function UsageTable({ rows, monthsWindow }: UsageTableProps) {
               <td className="py-2 pr-4 text-gray-900 dark:text-gray-100">
                 {r.yearMonth}
               </td>
+              <td
+                className="py-2 pr-4 text-gray-900 dark:text-gray-100"
+                data-testid={`usage-input-${r.yearMonth}`}
+              >
+                {r.inputTokens.toLocaleString()}
+              </td>
+              <td
+                className="py-2 pr-4 text-gray-900 dark:text-gray-100"
+                data-testid={`usage-output-${r.yearMonth}`}
+              >
+                {formatOutput(r)}
+              </td>
               <td className="py-2 pr-4 text-gray-900 dark:text-gray-100">
                 {r.totalTokens.toLocaleString()}
               </td>
@@ -46,7 +66,9 @@ export function UsageTable({ rows, monthsWindow }: UsageTableProps) {
       </table>
       <p className="text-xs text-gray-500 dark:text-gray-400">
         Values reflect actual usage recorded per batch run — not the pre-run
-        estimate shown in the confirmation dialog.
+        estimate shown in the confirmation dialog. Rows marked{" "}
+        <span aria-hidden="true">—</span> are from a legacy schema where the
+        input / output split was not captured.
       </p>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/use-editor-actions.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-editor-actions.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Verifies that edits persisted from STRUCTURED and READY states bump
+ * `modifiedAt` on the underlying WorkoutRecord — per
+ * spa-workout-state-machine §"STALE detection" ("modifiedAt SHALL be
+ * updated on any user edit to the KRD, not only on PUSHED→MODIFIED
+ * transitions").
+ *
+ * Exercises `useEditorActions` against an in-memory Dexie (fake-
+ * indexeddb) and a pre-seeded workout-store to simulate the flow:
+ *   load → edit in Zustand → accept/push → persist.
+ */
+
+import "fake-indexeddb/auto";
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { db } from "../../adapters/dexie/dexie-database";
+import { useWorkoutStore } from "../../store/workout-store";
+import type { WorkoutRecord } from "../../types/calendar-record";
+import type { KRD } from "../../types/krd";
+import { useEditorActions } from "./use-editor-actions";
+
+const ORIGINAL_KRD: KRD = {
+  version: "1.0",
+  type: "structured_workout",
+  metadata: { created: "2026-04-20T08:00:00Z", sport: "running" },
+};
+
+const EDITED_KRD: KRD = {
+  version: "1.0",
+  type: "structured_workout",
+  metadata: { created: "2026-04-20T08:00:00Z", sport: "cycling" },
+};
+
+function makeRecord(overrides: Partial<WorkoutRecord> = {}): WorkoutRecord {
+  return {
+    id: "550e8400-e29b-41d4-a716-446655440099",
+    date: "2026-04-20",
+    sport: "running",
+    source: "train2go",
+    sourceId: "ext-1",
+    planId: null,
+    state: "structured",
+    raw: null,
+    krd: ORIGINAL_KRD,
+    lastProcessingError: null,
+    feedback: null,
+    aiMeta: null,
+    garminPushId: null,
+    tags: [],
+    previousState: null,
+    createdAt: "2026-04-20T08:00:00Z",
+    modifiedAt: null,
+    updatedAt: "2026-04-20T08:00:00Z",
+    ...overrides,
+  };
+}
+
+async function loadPersisted(id: string): Promise<WorkoutRecord | undefined> {
+  return db.table<WorkoutRecord>("workouts").get(id);
+}
+
+describe("useEditorActions — modifiedAt on STRUCTURED / READY edits", () => {
+  beforeEach(async () => {
+    await db.table("workouts").clear();
+    useWorkoutStore.setState({ currentWorkout: null });
+  });
+
+  it("acceptWorkout on STRUCTURED with edits bumps modifiedAt", async () => {
+    const record = makeRecord({ state: "structured" });
+    useWorkoutStore.setState({ currentWorkout: EDITED_KRD });
+
+    const { result } = renderHook(() => useEditorActions(record));
+    await act(async () => {
+      await result.current.acceptWorkout();
+    });
+
+    const persisted = await loadPersisted(record.id);
+    expect(persisted?.state).toBe("ready");
+    expect(persisted?.krd).toEqual(EDITED_KRD);
+    expect(persisted?.modifiedAt).not.toBeNull();
+  });
+
+  it("acceptWorkout on STRUCTURED without edits does NOT bump modifiedAt", async () => {
+    const record = makeRecord({ state: "structured" });
+    // currentWorkout matches the record's KRD — no edit.
+    useWorkoutStore.setState({ currentWorkout: ORIGINAL_KRD });
+
+    const { result } = renderHook(() => useEditorActions(record));
+    await act(async () => {
+      await result.current.acceptWorkout();
+    });
+
+    const persisted = await loadPersisted(record.id);
+    expect(persisted?.state).toBe("ready");
+    expect(persisted?.modifiedAt).toBeNull();
+  });
+
+  it("pushWorkout on READY with edits bumps modifiedAt", async () => {
+    const record = makeRecord({ state: "ready", krd: ORIGINAL_KRD });
+    useWorkoutStore.setState({ currentWorkout: EDITED_KRD });
+
+    const { result } = renderHook(() => useEditorActions(record));
+    await act(async () => {
+      await result.current.pushWorkout("garmin-xyz");
+    });
+
+    const persisted = await loadPersisted(record.id);
+    expect(persisted?.state).toBe("pushed");
+    expect(persisted?.garminPushId).toBe("garmin-xyz");
+    expect(persisted?.krd).toEqual(EDITED_KRD);
+    expect(persisted?.modifiedAt).not.toBeNull();
+  });
+
+  it("markModified on PUSHED bumps modifiedAt (regression check)", async () => {
+    const record = makeRecord({
+      state: "pushed",
+      krd: ORIGINAL_KRD,
+      garminPushId: "garmin-1",
+    });
+    useWorkoutStore.setState({ currentWorkout: EDITED_KRD });
+
+    const { result } = renderHook(() => useEditorActions(record));
+    await act(async () => {
+      await result.current.markModified(EDITED_KRD);
+    });
+
+    const persisted = await loadPersisted(record.id);
+    expect(persisted?.state).toBe("modified");
+    expect(persisted?.modifiedAt).not.toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/use-editor-actions.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-editor-actions.ts
@@ -4,16 +4,22 @@
  * Transition functions for the editor-calendar integration:
  * accept (structured->ready), push (ready->pushed),
  * and modify (pushed->modified).
+ *
+ * All KRD-carrying persistence paths route through `onWorkoutMutation`
+ * so `modifiedAt` advances on every user edit in STRUCTURED / READY
+ * (per spa-workout-state-machine spec), not only on PUSHED→MODIFIED.
  */
 
 import { useCallback } from "react";
 
 import { db } from "../../adapters/dexie/dexie-database";
 import {
+  onWorkoutMutation,
   transitionToModified,
   transitionToPushed,
   transitionToReady,
 } from "../../application/workout-transitions";
+import { useWorkoutStore } from "../../store/workout-store";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { KRD } from "../../types/krd";
 
@@ -21,20 +27,32 @@ async function persistRecord(record: WorkoutRecord) {
   await db.table("workouts").put(record);
 }
 
+function saveEditedKrd(
+  record: WorkoutRecord,
+  editedKrd: KRD | undefined
+): WorkoutRecord {
+  if (!editedKrd || editedKrd === record.krd) return record;
+  return onWorkoutMutation(record, { krd: editedKrd });
+}
+
 export function useEditorActions(record: WorkoutRecord | undefined) {
+  const currentWorkout = useWorkoutStore((s) => s.currentWorkout);
+
   const acceptWorkout = useCallback(async () => {
     if (!record) return;
-    const updated = transitionToReady(record);
+    const withEdits = saveEditedKrd(record, currentWorkout ?? undefined);
+    const updated = transitionToReady(withEdits);
     await persistRecord(updated);
-  }, [record]);
+  }, [record, currentWorkout]);
 
   const pushWorkout = useCallback(
     async (garminPushId: string) => {
       if (!record) return;
-      const updated = transitionToPushed(record, garminPushId);
+      const withEdits = saveEditedKrd(record, currentWorkout ?? undefined);
+      const updated = transitionToPushed(withEdits, garminPushId);
       await persistRecord(updated);
     },
-    [record]
+    [record, currentWorkout]
   );
 
   const markModified = useCallback(

--- a/packages/workout-spa-editor/src/components/templates/MainLayout/MainLayout.test.tsx
+++ b/packages/workout-spa-editor/src/components/templates/MainLayout/MainLayout.test.tsx
@@ -133,4 +133,23 @@ describe("MainLayout", () => {
     // Assert - Component renders without error
     expect(screen.getByText("Content")).toBeInTheDocument();
   });
+
+  it("mounts the storage-availability banner region exactly once", () => {
+    // Arrange & Act
+    const { container } = renderWithProviders(
+      <MainLayout>
+        <div>Content</div>
+      </MainLayout>,
+      { defaultTheme: "light" }
+    );
+
+    // Assert — the banner is mounted once, in the layout shell shared by
+    // every route. The probe runs via useStoreHydration; the banner
+    // renders null while status is "checking" (initial state in tests).
+    // Re-rendering different children must not duplicate it.
+    const banners = container.querySelectorAll(
+      '[data-testid="storage-unavailable-banner"]'
+    );
+    expect(banners.length).toBeLessThanOrEqual(1);
+  });
 });

--- a/packages/workout-spa-editor/src/components/templates/MainLayout/MainLayout.tsx
+++ b/packages/workout-spa-editor/src/components/templates/MainLayout/MainLayout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { StorageAvailabilityBanner } from "../../molecules/StorageAvailabilityBanner";
 import { LayoutHeader } from "./LayoutHeader";
 
 type MainLayoutProps = {
@@ -11,6 +12,9 @@ export const MainLayout = ({ children, onReplayTutorial }: MainLayoutProps) => {
   return (
     <div className="flex min-h-screen flex-col bg-gray-50 dark:bg-slate-900">
       <LayoutHeader onReplayTutorial={onReplayTutorial} />
+      <div className="mx-auto w-full max-w-7xl px-4 pt-3 sm:px-6 lg:px-8">
+        <StorageAvailabilityBanner />
+      </div>
       <main className="mx-auto w-full max-w-7xl flex-1 overflow-x-hidden px-4 py-6 sm:px-6 lg:px-8">
         {children}
       </main>

--- a/packages/workout-spa-editor/src/hooks/use-storage-probe.ts
+++ b/packages/workout-spa-editor/src/hooks/use-storage-probe.ts
@@ -1,0 +1,9 @@
+import { useEffect } from "react";
+
+import { storageStore } from "../store/storage-store";
+
+export const useStorageProbe = () => {
+  useEffect(() => {
+    void storageStore.getState().probe();
+  }, []);
+};

--- a/packages/workout-spa-editor/src/hooks/use-store-hydration.ts
+++ b/packages/workout-spa-editor/src/hooks/use-store-hydration.ts
@@ -1,8 +1,10 @@
 import { useAiHydration } from "./use-ai-hydration";
 import { useGarminDetection } from "./use-garmin-detection";
+import { useStorageProbe } from "./use-storage-probe";
 import { useTrain2GoDetection } from "./use-train2go-detection";
 
 export const useStoreHydration = () => {
+  useStorageProbe();
   useAiHydration();
   useGarminDetection();
   useTrain2GoDetection();

--- a/packages/workout-spa-editor/src/store/storage-store.test.ts
+++ b/packages/workout-spa-editor/src/store/storage-store.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createStorageStore } from "./storage-store";
+
+describe("storage-store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts in the 'checking' status", () => {
+    const probe = vi.fn().mockResolvedValue("complete");
+    const store = createStorageStore({ probe });
+
+    expect(store.getState().status).toBe("checking");
+  });
+
+  it("transitions to 'ok' when the probe resolves 'complete'", async () => {
+    const probe = vi.fn().mockResolvedValue("complete");
+    const store = createStorageStore({ probe });
+
+    await store.getState().probe();
+
+    expect(store.getState().status).toBe("ok");
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("transitions to 'failed' when the probe resolves 'failed'", async () => {
+    const probe = vi.fn().mockResolvedValue("failed");
+    const store = createStorageStore({ probe });
+
+    await store.getState().probe();
+
+    expect(store.getState().status).toBe("failed");
+  });
+
+  it("transitions to 'failed' when the probe throws", async () => {
+    const probe = vi.fn().mockRejectedValue(new Error("boom"));
+    const store = createStorageStore({ probe });
+
+    await store.getState().probe();
+
+    expect(store.getState().status).toBe("failed");
+  });
+
+  it("is idempotent — second call does not re-probe", async () => {
+    const probe = vi.fn().mockResolvedValue("complete");
+    const store = createStorageStore({ probe });
+
+    await store.getState().probe();
+    await store.getState().probe();
+
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(store.getState().status).toBe("ok");
+  });
+
+  it("concurrent calls share the same in-flight probe", async () => {
+    const probe = vi.fn().mockResolvedValue("complete");
+    const store = createStorageStore({ probe });
+
+    await Promise.all([store.getState().probe(), store.getState().probe()]);
+
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes a stable status shape for subscribers", async () => {
+    const probe = vi.fn().mockResolvedValue("failed");
+    const store = createStorageStore({ probe });
+
+    const observed: string[] = [];
+    store.subscribe((state) => observed.push(state.status));
+
+    await store.getState().probe();
+
+    expect(observed[observed.length - 1]).toBe("failed");
+  });
+});

--- a/packages/workout-spa-editor/src/store/storage-store.ts
+++ b/packages/workout-spa-editor/src/store/storage-store.ts
@@ -1,0 +1,48 @@
+import { useStore } from "zustand";
+import { createStore } from "zustand/vanilla";
+
+import type { HydrationStatus } from "../adapters/dexie/storage-probe";
+import { probeStorage } from "../adapters/dexie/storage-probe";
+
+export type StorageStatus = "checking" | "ok" | "failed";
+
+export type StorageStoreState = {
+  status: StorageStatus;
+  probe: () => Promise<void>;
+};
+
+type Deps = {
+  probe: () => Promise<HydrationStatus>;
+};
+
+export function createStorageStore(deps: Deps) {
+  let inflight: Promise<void> | null = null;
+
+  return createStore<StorageStoreState>((set, get) => ({
+    status: "checking",
+    probe: async () => {
+      if (get().status !== "checking") return;
+      if (inflight) return inflight;
+
+      inflight = (async () => {
+        try {
+          const result = await deps.probe();
+          set({ status: result === "complete" ? "ok" : "failed" });
+        } catch {
+          set({ status: "failed" });
+        }
+      })();
+
+      try {
+        await inflight;
+      } finally {
+        inflight = null;
+      }
+    },
+  }));
+}
+
+export const storageStore = createStorageStore({ probe: probeStorage });
+
+export const useStorageStore = <T>(selector: (s: StorageStoreState) => T): T =>
+  useStore(storageStore, selector);

--- a/packages/workout-spa-editor/src/store/train2go-detect-integration.test.ts
+++ b/packages/workout-spa-editor/src/store/train2go-detect-integration.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Integration: the 30s detection cache short-circuits re-entrant calls
+ * from the Settings > Extensions Train2Go flow. Exercises the real
+ * `createDetectAction` against a mocked transport.
+ *
+ * Acts as a regression-fence for the UX noted in spa-train2go-extension:
+ * opening Settings twice in <30s must NOT emit two extension pings.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createDetectAction } from "./train2go-detect";
+
+vi.mock("./train2go-extension-transport", () => ({
+  ping: vi.fn(),
+}));
+
+// eslint-disable-next-line simple-import-sort/imports
+import { ping } from "./train2go-extension-transport";
+
+describe("Train2Go detection cache — integration", () => {
+  type State = {
+    extensionInstalled: boolean;
+    sessionActive: boolean;
+    userId: number | null;
+    userName: string | null;
+    lastError: string | null;
+    lastDetectionTimestamp: number | null;
+  };
+
+  let state: State;
+  let detect: () => Promise<void>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state = {
+      extensionInstalled: false,
+      sessionActive: false,
+      userId: null,
+      userName: null,
+      lastError: null,
+      lastDetectionTimestamp: null,
+    };
+    const set = (p: Partial<State>) => Object.assign(state, p);
+    const get = () => state;
+    detect = createDetectAction(set as never, get as never, "train2go-ext-id");
+    vi.mocked(ping).mockResolvedValue({
+      ok: true,
+      protocolVersion: 1,
+      data: { sessionActive: true, userId: 42, userName: "Test" },
+    });
+  });
+
+  it("Settings opens twice in <30s — ping fires once", async () => {
+    await detect();
+    await detect();
+    await detect();
+
+    expect(ping).toHaveBeenCalledTimes(1);
+    expect(state.extensionInstalled).toBe(true);
+  });
+
+  it("Settings re-opened after 30s — ping fires again", async () => {
+    await detect();
+
+    state.lastDetectionTimestamp =
+      (state.lastDetectionTimestamp as number) - 30_001;
+    await detect();
+
+    expect(ping).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/workout-spa-editor/src/store/train2go-detect.test.ts
+++ b/packages/workout-spa-editor/src/store/train2go-detect.test.ts
@@ -100,4 +100,76 @@ describe("createDetectAction", () => {
     expect(state.sessionActive).toBe(false);
     expect(state.userId).toBeNull();
   });
+
+  describe("30s detection cache (spa-train2go-extension spec)", () => {
+    it("re-pings when the cached timestamp is older than 30s", async () => {
+      mockPing.mockResolvedValue({
+        ok: true,
+        protocolVersion: 1,
+        data: { sessionActive: true, userId: 1, userName: "A" },
+      });
+
+      await detect();
+      expect(mockPing).toHaveBeenCalledTimes(1);
+
+      // Age the cache entry past the 30s window.
+      state.lastDetectionTimestamp =
+        (state.lastDetectionTimestamp as number) - 31_000;
+      await detect();
+
+      expect(mockPing).toHaveBeenCalledTimes(2);
+    });
+
+    it("always pings when no detection has ever run (timestamp = null)", async () => {
+      mockPing.mockResolvedValue({
+        ok: true,
+        protocolVersion: 1,
+        data: { sessionActive: true, userId: 1, userName: "A" },
+      });
+
+      expect(state.lastDetectionTimestamp).toBeNull();
+
+      await detect();
+
+      expect(mockPing).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-pings even within 30s when the cached result was 'not installed'", async () => {
+      mockPing.mockResolvedValue({ ok: false, error: "nope" });
+
+      await detect();
+      expect(state.extensionInstalled).toBe(false);
+      expect(mockPing).toHaveBeenCalledTimes(1);
+
+      // A subsequent detect() within 30s must retry because the cache
+      // short-circuit only applies when extensionInstalled === true.
+      mockPing.mockResolvedValueOnce({
+        ok: true,
+        protocolVersion: 1,
+        data: { sessionActive: true },
+      });
+
+      await detect();
+
+      expect(mockPing).toHaveBeenCalledTimes(2);
+    });
+
+    it("short-circuits without updating lastDetectionTimestamp", async () => {
+      mockPing.mockResolvedValue({
+        ok: true,
+        protocolVersion: 1,
+        data: { sessionActive: true },
+      });
+
+      await detect();
+      const firstStamp = state.lastDetectionTimestamp;
+
+      await detect();
+
+      // The cache short-circuit returns before `set(...)` runs, so the
+      // stamp stays pinned to the first detection. Verifies the
+      // "rolling window" anti-pattern is NOT present.
+      expect(state.lastDetectionTimestamp).toBe(firstStamp);
+    });
+  });
 });

--- a/packages/workout-spa-editor/src/test-utils/in-memory-persistence.test.ts
+++ b/packages/workout-spa-editor/src/test-utils/in-memory-persistence.test.ts
@@ -411,9 +411,19 @@ describe("UsageRepository", () => {
     const { usage } = createInMemoryPersistence();
     const record: UsageRecord = {
       yearMonth: "2026-04",
+      inputTokens: 1200,
+      outputTokens: 300,
       totalTokens: 1500,
       totalCost: 0.03,
-      entries: [{ date: "2026-04-07", tokens: 1500, cost: 0.03 }],
+      entries: [
+        {
+          date: "2026-04-07",
+          inputTokens: 1200,
+          outputTokens: 300,
+          tokens: 1500,
+          cost: 0.03,
+        },
+      ],
     };
 
     await usage.put(record);
@@ -432,6 +442,8 @@ describe("UsageRepository", () => {
     const { usage } = createInMemoryPersistence();
     await usage.put({
       yearMonth: "2026-04",
+      inputTokens: 80,
+      outputTokens: 20,
       totalTokens: 100,
       totalCost: 0.01,
       entries: [],
@@ -439,9 +451,19 @@ describe("UsageRepository", () => {
 
     await usage.put({
       yearMonth: "2026-04",
+      inputTokens: 160,
+      outputTokens: 40,
       totalTokens: 200,
       totalCost: 0.02,
-      entries: [{ date: "2026-04-11", tokens: 200, cost: 0.02 }],
+      entries: [
+        {
+          date: "2026-04-11",
+          inputTokens: 160,
+          outputTokens: 40,
+          tokens: 200,
+          cost: 0.02,
+        },
+      ],
     });
     const result = await usage.getByMonth("2026-04");
 

--- a/packages/workout-spa-editor/src/types/usage-schemas.test.ts
+++ b/packages/workout-spa-editor/src/types/usage-schemas.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { usageEntrySchema, usageRecordSchema } from "./usage-schemas";
+
+describe("usageEntrySchema", () => {
+  it("requires inputTokens and outputTokens", () => {
+    const entry = {
+      date: "2026-04-20",
+      inputTokens: 80,
+      outputTokens: 20,
+      tokens: 100,
+      cost: 0.001,
+    };
+
+    expect(usageEntrySchema.parse(entry)).toEqual(entry);
+  });
+
+  it("rejects entries missing inputTokens", () => {
+    expect(() =>
+      usageEntrySchema.parse({
+        date: "2026-04-20",
+        outputTokens: 20,
+        tokens: 100,
+        cost: 0.001,
+      })
+    ).toThrow();
+  });
+
+  it("enforces tokens === inputTokens + outputTokens", () => {
+    expect(() =>
+      usageEntrySchema.parse({
+        date: "2026-04-20",
+        inputTokens: 10,
+        outputTokens: 20,
+        tokens: 999,
+        cost: 0.001,
+      })
+    ).toThrow(/tokens/);
+  });
+});
+
+describe("usageRecordSchema", () => {
+  it("requires inputTokens, outputTokens, totalTokens, totalCost", () => {
+    const record = {
+      yearMonth: "2026-04",
+      inputTokens: 120,
+      outputTokens: 30,
+      totalTokens: 150,
+      totalCost: 0.02,
+      entries: [
+        {
+          date: "2026-04-20",
+          inputTokens: 120,
+          outputTokens: 30,
+          tokens: 150,
+          cost: 0.02,
+        },
+      ],
+    };
+
+    expect(usageRecordSchema.parse(record)).toMatchObject({
+      inputTokens: 120,
+      outputTokens: 30,
+      totalTokens: 150,
+    });
+  });
+
+  it("enforces totalTokens === inputTokens + outputTokens", () => {
+    expect(() =>
+      usageRecordSchema.parse({
+        yearMonth: "2026-04",
+        inputTokens: 100,
+        outputTokens: 50,
+        totalTokens: 999,
+        totalCost: 0.02,
+        entries: [],
+      })
+    ).toThrow(/totalTokens/);
+  });
+
+  it("accepts `legacy: true` on migrated rows", () => {
+    const record = {
+      yearMonth: "2026-03",
+      inputTokens: 200,
+      outputTokens: 0,
+      totalTokens: 200,
+      totalCost: 0.01,
+      entries: [],
+      legacy: true,
+    };
+
+    const parsed = usageRecordSchema.parse(record);
+    expect(parsed.legacy).toBe(true);
+  });
+
+  it("treats `legacy` as optional and absent by default", () => {
+    const record = {
+      yearMonth: "2026-04",
+      inputTokens: 100,
+      outputTokens: 50,
+      totalTokens: 150,
+      totalCost: 0.02,
+      entries: [],
+    };
+
+    const parsed = usageRecordSchema.parse(record);
+    expect(parsed.legacy).toBeUndefined();
+  });
+});

--- a/packages/workout-spa-editor/src/types/usage-schemas.ts
+++ b/packages/workout-spa-editor/src/types/usage-schemas.ts
@@ -1,24 +1,50 @@
 /**
  * Usage Record Schema
  *
- * Zod schema for AI token usage tracking records.
+ * Zod schemas for AI token usage tracking records. The
+ * `inputTokens` / `outputTokens` split satisfies the spa-ai-batch
+ * spec's granularity requirement for the usage panel.
+ *
+ * `totalTokens` is kept as a derived convenience (= input + output)
+ * so existing readers don't break; the `.refine` invariant guards
+ * against drift.
+ *
+ * `legacy` is set only on rows backfilled by the v2 → v3 Dexie
+ * migration: those rows came from a pre-split write and the
+ * `outputTokens: 0` value is a conservative default that the
+ * renderer SHALL present as "—".
  */
 
 import { z } from "zod";
 
-export const usageEntrySchema = z.object({
-  date: z.iso.date(),
-  tokens: z.number().int().nonnegative(),
-  cost: z.number().nonnegative(),
-});
+export const usageEntrySchema = z
+  .object({
+    date: z.iso.date(),
+    inputTokens: z.number().int().nonnegative(),
+    outputTokens: z.number().int().nonnegative(),
+    tokens: z.number().int().nonnegative(),
+    cost: z.number().nonnegative(),
+  })
+  .refine((v) => v.tokens === v.inputTokens + v.outputTokens, {
+    message: "tokens MUST equal inputTokens + outputTokens",
+    path: ["tokens"],
+  });
 
 export type UsageEntry = z.infer<typeof usageEntrySchema>;
 
-export const usageRecordSchema = z.object({
-  yearMonth: z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/),
-  totalTokens: z.number().int().nonnegative(),
-  totalCost: z.number().nonnegative(),
-  entries: z.array(usageEntrySchema),
-});
+export const usageRecordSchema = z
+  .object({
+    yearMonth: z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/),
+    inputTokens: z.number().int().nonnegative(),
+    outputTokens: z.number().int().nonnegative(),
+    totalTokens: z.number().int().nonnegative(),
+    totalCost: z.number().nonnegative(),
+    entries: z.array(usageEntrySchema),
+    legacy: z.boolean().optional(),
+  })
+  .refine((v) => v.totalTokens === v.inputTokens + v.outputTokens, {
+    message: "totalTokens MUST equal inputTokens + outputTokens",
+    path: ["totalTokens"],
+  });
 
 export type UsageRecord = z.infer<typeof usageRecordSchema>;

--- a/scripts/check-changeset-config.test.mjs
+++ b/scripts/check-changeset-config.test.mjs
@@ -1,0 +1,63 @@
+// Invariant: both bridge extension packages must be versioned via changesets
+// alongside the rest of the monorepo. The cws-auto-publish spec requires
+// `@kaiord/garmin-bridge` and `@kaiord/train2go-bridge` to participate in the
+// primary `linked` group so they move in lockstep on every release.
+//
+// This mechanical check replaces reviewer-dependent drift.
+
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = resolve(__dirname, "..", ".changeset", "config.json");
+
+function loadConfig() {
+  return JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+}
+
+test("linked[0] includes @kaiord/garmin-bridge", () => {
+  const cfg = loadConfig();
+
+  assert.ok(Array.isArray(cfg.linked), "linked must be an array");
+  assert.ok(
+    Array.isArray(cfg.linked[0]),
+    "linked[0] must be an array (the primary linked group)"
+  );
+  assert.ok(
+    cfg.linked[0].includes("@kaiord/garmin-bridge"),
+    `linked[0] missing @kaiord/garmin-bridge; got ${JSON.stringify(cfg.linked[0])}`
+  );
+});
+
+test("linked[0] includes @kaiord/train2go-bridge", () => {
+  const cfg = loadConfig();
+
+  assert.ok(
+    cfg.linked[0].includes("@kaiord/train2go-bridge"),
+    `linked[0] missing @kaiord/train2go-bridge; got ${JSON.stringify(cfg.linked[0])}`
+  );
+});
+
+test("linked[0] still includes the existing core publishables", () => {
+  const cfg = loadConfig();
+
+  for (const required of [
+    "@kaiord/core",
+    "@kaiord/fit",
+    "@kaiord/tcx",
+    "@kaiord/zwo",
+    "@kaiord/garmin",
+    "@kaiord/garmin-connect",
+    "@kaiord/cli",
+    "@kaiord/mcp",
+    "@kaiord/ai",
+  ]) {
+    assert.ok(
+      cfg.linked[0].includes(required),
+      `linked[0] regressed — missing ${required}`
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Closes the eight spec-vs-code drift gaps that the 2026-04-20 `/opsx-sync` audit surfaced. Each gap is implementation-only — the spec was already correct, so this PR brings the code up to spec rather than rewriting the specs. No public API breaks; the SPA changes are internal to `@kaiord/workout-spa-editor`. Dexie ships additive schema bumps (v2 for `bridges`, v3 for the `UsageRecord` split) with backfills.

Follows the plan in `openspec/changes/fix-spec-code-drift/` (see `proposal.md`, `design.md`, `tasks.md`). One task group per commit, TDD throughout.

## What changed

- **§1 Changesets config** — add `@kaiord/garmin-bridge` and `@kaiord/train2go-bridge` to `linked[0]`; mechanical guard in `scripts/check-changeset-config.test.mjs`.
- **§2 Docs theme-color** — VitePress head now emits `<meta name="theme-color">` with the value parsed at config-load time from `--brand-bg-primary` in `styles/brand-tokens.css`. CI invariant blocks re-introducing a hex literal under `packages/docs/`.
- **§3 Storage-unavailable banner** — new `storage-store` + `StorageAvailabilityBanner` mounted once in `MainLayout`. Renders the spec-exact string `Storage unavailable — changes in this session won't be saved` when `probeStorage()` reports failure.
- **§4 Bridge REMOVED state + persistence** — `BridgeStatus` grows `"removed"`; `pruneStale` transitions `unavailable → removed` after 24h (with notification) and deletes the row 24h after that. Registry persists to a new Dexie v2 `bridges` store so the 24h timers survive browser restarts. Wall-clock caveat documented in `packages/workout-spa-editor/src/adapters/bridge/README.md`. Non-regression test pins the Dexie-vs-Zustand boundary.
- **§5 Train2Go 30s detection cache** — the guard was already wired; this PR adds the missing tests (cached+stale, never-detected, cached-not-installed, no-rolling-window) and an integration test for the Settings > Extensions flow.
- **§6 modifiedAt on every KRD edit** — new `onWorkoutMutation(draft, { nextState?, krd?, timestamp? })` central chokepoint. `useEditorActions.acceptWorkout` / `pushWorkout` now read the edited KRD from the workout-store and route through the helper, so edits in STRUCTURED / READY bump `modifiedAt` (not only PUSHED → MODIFIED).
- **§7 BatchProgress per-workout status** — `BatchProgress` gains `counts: { queued, processing, succeeded, failed }` and `byId: Record<id, WorkoutBatchStatus>`. The banner renders the four-bucket breakdown via a new `ProcessingStatus` subcomponent.
- **§8 UsageRecord input/output split** — schema gains `inputTokens` / `outputTokens` (plus optional `legacy` for migrated rows); Zod `.refine` invariant pins `totalTokens === inputTokens + outputTokens`. Dexie v3 migration backfills legacy rows (`inputTokens = totalTokens`, `outputTokens = 0`, `legacy: true`) end-to-end-tested via fake-indexeddb; `UsageTable` shows `—` for `outputTokens` on legacy rows.

## Test plan

- [x] `pnpm -r test` (14 packages, ~4,650 tests) — all green
- [x] `pnpm -r build` — no warnings
- [x] `pnpm lint` — zero ESLint / TS / prettier / spec / archive errors
- [x] `pnpm exec changeset status` — `@kaiord/workout-spa-editor: minor`, `@kaiord/docs: patch`
- [x] Manual: run `pnpm build` on `packages/docs` — rendered `dist/index.html` carries `<meta name="theme-color" content="#0f172a">`, matching `--brand-bg-primary`

## Related

- Audit: `/opsx-sync` pass on 2026-04-20 (commit 1114bd87)
- Change artifacts: `openspec/changes/fix-spec-code-drift/`
- Follow-up: group-B spec-wording alignments ship separately per the proposal's non-goals