### PR TITLE
feat(bridge-runtime-discovery): runtime extension ID discovery via content-script announcements

### DIFF
--- a/.changeset/bridge-runtime-discovery.md
+++ b/.changeset/bridge-runtime-discovery.md
@@ -1,0 +1,54 @@
+---
+"@kaiord/garmin-bridge": minor
+"@kaiord/train2go-bridge": minor
+"@kaiord/workout-spa-editor": minor
+---
+
+Replace build-time `VITE_*_EXTENSION_ID` env vars with runtime bridge
+discovery via content script announcements.
+
+**Why**: the old flow baked extension IDs into the SPA bundle at build
+time, which coupled each build to a specific install and required new
+developers to edit `.env.local` before extensions could be detected
+(Twelve-Factor III / V violation). The new flow is zero-config for
+users and developers — install the extension and it announces itself
+to the SPA on every navigation.
+
+**`@kaiord/garmin-bridge` & `@kaiord/train2go-bridge` (minor — user-visible
+discovery change requiring extension reload):**
+
+- New `kaiord-announce.js` content script injected at
+  `document_start` on `https://*.kaiord.com/*` (and
+  `http://localhost/*` in dev) posts `KAIORD_BRIDGE_ANNOUNCE` with
+  `chrome.runtime.id`, version, and declared capabilities
+- Listens for `KAIORD_BRIDGE_DISCOVER` from the SPA and re-announces
+  to handle the service-worker cold-start race
+- Manifest (`manifest.json` + `manifest.prod.json`) adds a second
+  `content_scripts` entry for the announce-only script. Existing
+  host-scoped scripts (`connect.garmin.com` / `app.train2go.com`)
+  are unchanged
+
+**`@kaiord/workout-spa-editor` (minor — runtime discovery replaces env-var
+coupling):**
+
+- New `bridge-discovery` adapter listens for announcements on
+  `window.message`, verifies each via a ping against the announced
+  `extensionId` (manifest schema + `data.id` match + supported
+  protocol version), and exposes `getExtensionId(bridgeId)` to the
+  rest of the app. Rejects spoofed announcements
+- `useGarminBridgeActions` and the `train2go-store` actions no longer
+  read `import.meta.env.VITE_*_EXTENSION_ID`; they call the
+  discovery singleton at call time, so the ID updates reactively
+  on announcement
+- `useStoreHydration` starts the discovery listener on app boot
+- `VITE_GARMIN_EXTENSION_ID` and `VITE_TRAIN2GO_EXTENSION_ID` are
+  removed from `.env.example` — no extension ID env vars required
+- Privacy policy discloses the new announce-only content script
+  (and its localhost-dev variant stripped from the production
+  manifest); the `check-privacy-policy` lint now allows the
+  announce match set and flags missing disclosure
+
+**Migration note**: users must reload/update both Chrome extensions
+after this release so the new `kaiord-announce.js` content script is
+picked up. After the reload, the SPA auto-detects the extension with
+no additional configuration.

--- a/docs/garmin-bridge-migration.md
+++ b/docs/garmin-bridge-migration.md
@@ -50,4 +50,5 @@ Confirm the destruction when prompted. This removes:
 - The `VITE_GARMIN_LAMBDA_URL` environment variable has been removed
 - Garmin credentials (username/password) are no longer stored
 - The Settings panel now shows extension status instead of Lambda URL and credentials
-- Set `VITE_GARMIN_EXTENSION_ID` if you need a specific extension ID
+- Extension IDs are discovered at runtime via a content script announcement; no
+  `VITE_GARMIN_EXTENSION_ID` env var is required

--- a/openspec/changes/bridge-runtime-discovery/tasks.md
+++ b/openspec/changes/bridge-runtime-discovery/tasks.md
@@ -1,27 +1,27 @@
 ## 1. Extension content scripts
 
-- [ ] 1.1 Create `packages/garmin-bridge/kaiord-announce.js` — content script that posts `KAIORD_BRIDGE_ANNOUNCE` and listens for `KAIORD_BRIDGE_DISCOVER`
-- [ ] 1.2 Update `packages/garmin-bridge/manifest.json` — add content script entry for `*.kaiord.com` and `localhost:*`
-- [ ] 1.3 Create `packages/train2go-bridge/kaiord-announce.js` — same pattern as garmin
-- [ ] 1.4 Update `packages/train2go-bridge/manifest.json` — add content script entry
+- [x] 1.1 Create `packages/garmin-bridge/kaiord-announce.js` — content script that posts `KAIORD_BRIDGE_ANNOUNCE` and listens for `KAIORD_BRIDGE_DISCOVER`
+- [x] 1.2 Update `packages/garmin-bridge/manifest.json` — add content script entry for `*.kaiord.com` and `localhost:*`
+- [x] 1.3 Create `packages/train2go-bridge/kaiord-announce.js` — same pattern as garmin
+- [x] 1.4 Update `packages/train2go-bridge/manifest.json` — add content script entry
 
 ## 2. SPA bridge discovery adapter
 
-- [ ] 2.1 Create `adapters/bridge/bridge-discovery.ts` — listens for `KAIORD_BRIDGE_ANNOUNCE`, validates, exposes discovered bridges
-- [ ] 2.2 Add tests for `bridge-discovery.ts` (announce, re-discover, timeout, spoofed message)
-- [ ] 2.3 Wire discovery into app bootstrap (listen on mount, cleanup on unmount)
+- [x] 2.1 Create `adapters/bridge/bridge-discovery.ts` — listens for `KAIORD_BRIDGE_ANNOUNCE`, validates, exposes discovered bridges
+- [x] 2.2 Add tests for `bridge-discovery.ts` (announce, re-discover, timeout, spoofed message)
+- [x] 2.3 Wire discovery into app bootstrap (listen on mount, cleanup on unmount)
 
 ## 3. Remove VITE env var coupling
 
-- [ ] 3.1 Update `use-garmin-bridge-actions.ts` — get extensionId from discovery instead of `import.meta.env`
-- [ ] 3.2 Update `train2go-store.ts` / `train2go-store-actions.ts` — get extensionId from discovery
-- [ ] 3.3 Remove `VITE_GARMIN_EXTENSION_ID` and `VITE_TRAIN2GO_EXTENSION_ID` from `.env.example`
-- [ ] 3.4 Update tests for hooks/stores that mocked env vars
+- [x] 3.1 Update `use-garmin-bridge-actions.ts` — get extensionId from discovery instead of `import.meta.env`
+- [x] 3.2 Update `train2go-store.ts` / `train2go-store-actions.ts` — get extensionId from discovery
+- [x] 3.3 Remove `VITE_GARMIN_EXTENSION_ID` and `VITE_TRAIN2GO_EXTENSION_ID` from `.env.example`
+- [x] 3.4 Update tests for hooks/stores that mocked env vars
 
 ## 4. Integration and verification
 
-- [ ] 4.1 Run full test suite, fix any broken tests
-- [ ] 4.2 Run lint and type check
+- [x] 4.1 Run full test suite, fix any broken tests
+- [x] 4.2 Run lint and type check
 - [ ] 4.3 Manual verification: install both extensions locally, confirm discovery works on localhost
-- [ ] 4.4 Update `deploy-site.yml` — remove any VITE extension ID env vars (currently none, confirm)
-- [ ] 4.5 Create changeset
+- [x] 4.4 Update `deploy-site.yml` — remove any VITE extension ID env vars (currently none, confirm)
+- [x] 4.5 Create changeset

--- a/openspec/specs/privacy-policy/spec.md
+++ b/openspec/specs/privacy-policy/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-20 (bridge-runtime-discovery)
 
 # Privacy Policy
 
@@ -31,7 +31,8 @@ The privacy policy SHALL cover the following topics:
 - **No credentials storage**: No extension reads, stores, or transmits user passwords or OAuth tokens
 - **No third-party sharing**: No data is shared with third parties beyond the user-configured LLM provider disclosed above
 - **Communication scope**: Each extension only communicates with its declared host (`connect.garmin.com` / `app.train2go.com`) and allowed Kaiord origins. The Kaiord-origin channel (`externally_connectable`) SHALL be described as one-way inbound (editor → extension)
-- **Localhost dev disclosure**: The policy SHALL disclose that local-development manifests additionally accept messages from `http://localhost:5173` / `http://localhost:5174`, and SHALL state that these origins are stripped from the production manifest before CWS submission
+- **Runtime discovery disclosure**: The policy SHALL disclose the announce-only content script injected into SPA origins (`https://*.kaiord.com/*` in production, additionally `http://localhost/*` in development) and SHALL state that the script only posts a fixed announcement object via `window.postMessage`, does not read SPA DOM / cookies / storage / network, and does not modify the page
+- **Localhost dev disclosure**: The policy SHALL disclose that local-development manifests additionally accept messages from `http://localhost:5173` / `http://localhost:5174` via `externally_connectable`, that the announce content script injects on `http://localhost/*`, and SHALL state that these development-only matches are stripped from the production manifest before CWS submission
 - **Regulatory compliance**: Statement of compliance with applicable data protection regulations (GDPR, CCPA) — specifically that because no personal data is collected server-side, there is no personal data held by Kaiord to protect, share, or delete
 - **Data-subject rights**: The policy SHALL explicitly enumerate GDPR/CCPA rights (access, rectification, erasure, portability) and state that, because Kaiord holds no records, such requests have no data to act upon
 - **Retention guidance**: The policy SHALL describe how the user can remove local data — at minimum the editor's API-key clear action, per-workout delete, and the browser-level "clear site data" path

--- a/packages/docs/legal/privacy-policy.md
+++ b/packages/docs/legal/privacy-policy.md
@@ -7,7 +7,7 @@ description: Kaiord privacy policy covering the website, documentation, Chrome e
 
 # Privacy Policy
 
-**Last updated:** 2026-04-17
+**Last updated:** 2026-04-20
 
 This privacy policy describes how the Kaiord project ("we", "us") handles data across all its products: the website (kaiord.com), documentation (kaiord.com/docs), the Kaiord workout editor, the Kaiord Garmin Bridge Chrome extension, and the Kaiord Train2Go Bridge Chrome extension.
 
@@ -51,9 +51,11 @@ The extensions only communicate with the following domains:
 - `https://app.train2go.com/*` — Train2Go Bridge content script (runs on that domain) reads the coaching plan from the page
 - `https://*.kaiord.com/*` — the Kaiord editor (running on kaiord.com) sends messages **to** each extension via Chrome's `externally_connectable` channel. This is a one-way inbound channel: the extensions do not read the editor's DOM or cookies.
 
+Each extension also injects a minimal **announce-only** content script (`kaiord-announce.js`) into `https://*.kaiord.com/*` so the editor can discover which extension IDs are installed at runtime. This content script only calls `window.postMessage` to publish a fixed announcement object (bridge id, extension id, version, declared capabilities) and re-announces on request. It does **not** read the editor's DOM, cookies, storage, or network traffic, does **not** modify the page, and does **not** enable any inbound data path from kaiord.com into the extension beyond what `externally_connectable` already allows.
+
 Each extension declares `host_permissions` limited to the single host listed above — no wildcard or `<all_urls>` access.
 
-No other domains are contacted in production builds. During local development, both extensions additionally accept messages from `http://localhost:5173` and `http://localhost:5174` (Vite dev server). These origins are stripped from the production manifests (`manifest.prod.json`) before publishing to the Chrome Web Store.
+No other domains are contacted in production builds. During local development, both extensions additionally accept messages from `http://localhost:5173` and `http://localhost:5174` (Vite dev server), and the announce-only content script is also injected on `http://localhost/*` so locally-served editor builds can discover the extensions. These development-only matches are stripped from the production manifests (`manifest.prod.json`) before publishing to the Chrome Web Store.
 
 ## Regulatory Compliance
 

--- a/packages/docs/scripts/check-privacy-policy.mjs
+++ b/packages/docs/scripts/check-privacy-policy.mjs
@@ -49,6 +49,14 @@ const ALLOWED_EXTERNALLY_CONNECTABLE = new Set([
   "http://localhost:5173/*",
   "http://localhost:5174/*",
 ]);
+// content_scripts.matches entries allowed for the announce-only script
+// that injects into SPA origins so the editor can discover installed
+// extensions at runtime. Chrome match patterns do not accept a port in
+// the host, so localhost is expressed as `http://localhost/*`.
+const ALLOWED_ANNOUNCE_CONTENT_SCRIPT_MATCHES = new Set([
+  "https://*.kaiord.com/*",
+  "http://localhost/*",
+]);
 // No extension may declare these: cookies (credential access),
 // webRequestBlocking / declarativeNetRequest* (request mutation).
 const FORBIDDEN_PERMISSIONS = new Set([
@@ -126,6 +134,10 @@ const REQUIRED_RULES = [
     re: /externally_connectable/,
   },
   {
+    label: "Announce-only content-script disclosure present",
+    re: /announce-only/i,
+  },
+  {
     label: "Localhost dev origins disclosed",
     re: /localhost:5173/,
   },
@@ -193,14 +205,21 @@ export function checkManifestPermissions(
     }
   }
 
-  // content_scripts matches must be inside the disclosed host.
+  // content_scripts matches must be inside the disclosed host, OR
+  // must be the announce-only injection set disclosed alongside
+  // externally_connectable (the SPA-origin match used for runtime
+  // extension discovery).
   for (const cs of manifest.content_scripts ?? []) {
     for (const m of cs.matches ?? []) {
-      if (!allowedHosts.has(m)) {
-        violations.push(
-          `${extensionName}: undisclosed content_scripts match "${m}" — policy restricts DOM access to ${[...allowedHosts].join(", ")}`
-        );
+      if (
+        allowedHosts.has(m) ||
+        ALLOWED_ANNOUNCE_CONTENT_SCRIPT_MATCHES.has(m)
+      ) {
+        continue;
       }
+      violations.push(
+        `${extensionName}: undisclosed content_scripts match "${m}" — policy restricts DOM access to ${[...allowedHosts].join(", ")} or the announce-only matches ${[...ALLOWED_ANNOUNCE_CONTENT_SCRIPT_MATCHES].join(", ")}`
+      );
     }
   }
 

--- a/packages/docs/scripts/check-privacy-policy.test.mjs
+++ b/packages/docs/scripts/check-privacy-policy.test.mjs
@@ -46,6 +46,8 @@ provider (Anthropic, OpenAI, or Google).
 ## Communication Scope
 
 \`externally_connectable\` is a one-way inbound channel.
+An announce-only content script injects into SPA origins so the
+editor can discover installed extensions at runtime.
 Local dev origins: http://localhost:5173 and http://localhost:5174.
 Each extension declares \`host_permissions\` limited to the single
 host listed above — no wildcard or \`<all_urls>\` access.
@@ -110,6 +112,77 @@ test("missing localhost dev disclosure is flagged", () => {
   const src = FULL.replace(/localhost:5173/g, "");
   const v = checkPolicy(src);
   assert.ok(v.some((r) => r.includes("Localhost")));
+});
+
+test("missing announce-only content-script disclosure is flagged", () => {
+  const src = FULL.replace(/announce-only/gi, "different-wording");
+  const v = checkPolicy(src);
+  assert.ok(v.some((r) => r.includes("Announce-only")));
+});
+
+test("manifest with announce-only content script match on kaiord.com passes", () => {
+  const dir = mkdtempSync(join(tmpdir(), "kaiord-priv-announce-"));
+  try {
+    const path = join(dir, "manifest.json");
+    writeFileSync(
+      path,
+      JSON.stringify(
+        {
+          permissions: ["tabs"],
+          host_permissions: ["https://app.train2go.com/*"],
+          content_scripts: [
+            {
+              matches: ["https://app.train2go.com/*"],
+              js: ["content.js"],
+            },
+            {
+              matches: ["https://*.kaiord.com/*", "http://localhost/*"],
+              js: ["kaiord-announce.js"],
+            },
+          ],
+        },
+        null,
+        2
+      )
+    );
+    const v = checkManifestPermissions(
+      path,
+      "train2go-bridge",
+      new Set(["https://app.train2go.com/*"])
+    );
+    assert.deepEqual(v, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("manifest with undisclosed content_scripts match is still rejected", () => {
+  const dir = mkdtempSync(join(tmpdir(), "kaiord-priv-undisclosed-"));
+  try {
+    const path = join(dir, "manifest.json");
+    writeFileSync(
+      path,
+      JSON.stringify(
+        {
+          permissions: ["tabs"],
+          host_permissions: ["https://app.train2go.com/*"],
+          content_scripts: [
+            { matches: ["https://evil.example.com/*"], js: ["x.js"] },
+          ],
+        },
+        null,
+        2
+      )
+    );
+    const v = checkManifestPermissions(
+      path,
+      "train2go-bridge",
+      new Set(["https://app.train2go.com/*"])
+    );
+    assert.ok(v.some((r) => r.includes("undisclosed content_scripts match")));
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // ---------- checkManifestPermissions ----------

--- a/packages/garmin-bridge/kaiord-announce.js
+++ b/packages/garmin-bridge/kaiord-announce.js
@@ -1,0 +1,39 @@
+/**
+ * Kaiord Garmin Bridge — Announce Content Script
+ *
+ * Injected at document_start on SPA origins (*.kaiord.com, localhost).
+ * Posts KAIORD_BRIDGE_ANNOUNCE to the page so the SPA can discover the
+ * extension ID at runtime. Re-announces on KAIORD_BRIDGE_DISCOVER.
+ */
+
+const BRIDGE_ID = "garmin-bridge";
+const BRIDGE_NAME = "Garmin Connect";
+const PROTOCOL_VERSION = 1;
+const CAPABILITIES = ["write:workouts"];
+
+const buildAnnouncement = () => ({
+  type: "KAIORD_BRIDGE_ANNOUNCE",
+  bridgeId: BRIDGE_ID,
+  extensionId: chrome.runtime.id,
+  name: BRIDGE_NAME,
+  version: chrome.runtime.getManifest().version,
+  protocolVersion: PROTOCOL_VERSION,
+  capabilities: CAPABILITIES,
+});
+
+const announce = () => {
+  window.postMessage(buildAnnouncement(), window.location.origin);
+};
+
+const onDiscoverRequest = (event) => {
+  if (event.source !== window) return;
+  if (!event.data || event.data.type !== "KAIORD_BRIDGE_DISCOVER") return;
+  announce();
+};
+
+window.addEventListener("message", onDiscoverRequest);
+announce();
+
+if (typeof module !== "undefined") {
+  module.exports = { buildAnnouncement, announce, onDiscoverRequest };
+}

--- a/packages/garmin-bridge/manifest.json
+++ b/packages/garmin-bridge/manifest.json
@@ -31,6 +31,11 @@
       "matches": ["https://connect.garmin.com/*"],
       "js": ["content.js"],
       "run_at": "document_start"
+    },
+    {
+      "matches": ["https://*.kaiord.com/*", "http://localhost/*"],
+      "js": ["kaiord-announce.js"],
+      "run_at": "document_start"
     }
   ],
 

--- a/packages/garmin-bridge/manifest.prod.json
+++ b/packages/garmin-bridge/manifest.prod.json
@@ -31,6 +31,11 @@
       "matches": ["https://connect.garmin.com/*"],
       "js": ["content.js"],
       "run_at": "document_start"
+    },
+    {
+      "matches": ["https://*.kaiord.com/*"],
+      "js": ["kaiord-announce.js"],
+      "run_at": "document_start"
     }
   ],
 

--- a/packages/garmin-bridge/test/chrome-mock.js
+++ b/packages/garmin-bridge/test/chrome-mock.js
@@ -6,7 +6,9 @@ const sessionStore = {};
 
 const chromeMock = {
   runtime: {
+    id: "garmin-test-extension-id",
     lastError: null,
+    getManifest: vi.fn(() => ({ version: "0.2.0" })),
     onMessage: {
       addListener: vi.fn(),
     },
@@ -41,6 +43,14 @@ const chromeMock = {
 
 globalThis.chrome = chromeMock;
 globalThis.fetch = vi.fn();
+
+const windowMock = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  postMessage: vi.fn(),
+  location: { origin: "https://kaiord.com" },
+};
+globalThis.window = windowMock;
 
 // Helper to reset state between tests
 globalThis.__resetChromeMock = () => {

--- a/packages/garmin-bridge/test/kaiord-announce.test.js
+++ b/packages/garmin-bridge/test/kaiord-announce.test.js
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-const { buildAnnouncement, onDiscoverRequest, announce } =
-  require("../kaiord-announce.js");
+const {
+  buildAnnouncement,
+  onDiscoverRequest,
+  announce,
+} = require("../kaiord-announce.js");
 
 describe("kaiord-announce.js (garmin-bridge)", () => {
   beforeEach(() => {

--- a/packages/garmin-bridge/test/kaiord-announce.test.js
+++ b/packages/garmin-bridge/test/kaiord-announce.test.js
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+const { buildAnnouncement, onDiscoverRequest, announce } =
+  require("../kaiord-announce.js");
+
+describe("kaiord-announce.js (garmin-bridge)", () => {
+  beforeEach(() => {
+    __resetChromeMock();
+  });
+
+  describe("buildAnnouncement", () => {
+    it("returns a well-formed announcement with bridge metadata", () => {
+      const ann = buildAnnouncement();
+
+      expect(ann).toEqual({
+        type: "KAIORD_BRIDGE_ANNOUNCE",
+        bridgeId: "garmin-bridge",
+        extensionId: "garmin-test-extension-id",
+        name: "Garmin Connect",
+        version: "0.2.0",
+        protocolVersion: 1,
+        capabilities: ["write:workouts"],
+      });
+    });
+
+    it("uses chrome.runtime.id for the extension identifier", () => {
+      chrome.runtime.id = "another-id";
+
+      const ann = buildAnnouncement();
+
+      expect(ann.extensionId).toBe("another-id");
+
+      chrome.runtime.id = "garmin-test-extension-id";
+    });
+  });
+
+  describe("onDiscoverRequest", () => {
+    it("re-announces when a KAIORD_BRIDGE_DISCOVER from window arrives", () => {
+      onDiscoverRequest({
+        source: window,
+        data: { type: "KAIORD_BRIDGE_DISCOVER" },
+      });
+
+      expect(window.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "KAIORD_BRIDGE_ANNOUNCE",
+          bridgeId: "garmin-bridge",
+        }),
+        "https://kaiord.com"
+      );
+    });
+
+    it("ignores messages from other sources", () => {
+      onDiscoverRequest({
+        source: { fake: true },
+        data: { type: "KAIORD_BRIDGE_DISCOVER" },
+      });
+
+      expect(window.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("ignores unrelated message types", () => {
+      onDiscoverRequest({
+        source: window,
+        data: { type: "SOMETHING_ELSE" },
+      });
+
+      expect(window.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("ignores events without data", () => {
+      onDiscoverRequest({ source: window });
+
+      expect(window.postMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("announce", () => {
+    it("posts the announcement to the current origin", () => {
+      announce();
+
+      expect(window.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "KAIORD_BRIDGE_ANNOUNCE",
+          bridgeId: "garmin-bridge",
+        }),
+        "https://kaiord.com"
+      );
+    });
+  });
+});

--- a/packages/garmin-bridge/vitest.config.js
+++ b/packages/garmin-bridge/vitest.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./test/chrome-mock.js"],
     coverage: {
-      include: ["background.js", "content.js"],
+      include: ["background.js", "content.js", "kaiord-announce.js"],
       exclude: ["popup.js"],
     },
   },

--- a/packages/train2go-bridge/TESTING.md
+++ b/packages/train2go-bridge/TESTING.md
@@ -27,13 +27,10 @@
 
 ## Test with SPA
 
-1. Copy the extension ID from `chrome://extensions/`
-2. Create `.env` in `packages/workout-spa-editor/`:
-   ```
-   VITE_TRAIN2GO_EXTENSION_ID=your-extension-id-here
-   ```
-3. Start the SPA: `cd packages/workout-spa-editor && pnpm dev`
-4. The SPA detects the extension on boot via `useTrain2GoStore`
+1. Start the SPA: `cd packages/workout-spa-editor && pnpm dev`
+2. Open the SPA — the extension's content script auto-announces to
+   the page and the SPA discovers the extension ID at runtime.
+3. No `.env` entry is required.
 
 ## Troubleshooting
 

--- a/packages/train2go-bridge/kaiord-announce.js
+++ b/packages/train2go-bridge/kaiord-announce.js
@@ -1,0 +1,39 @@
+/**
+ * Kaiord Train2Go Bridge — Announce Content Script
+ *
+ * Injected at document_start on SPA origins (*.kaiord.com, localhost).
+ * Posts KAIORD_BRIDGE_ANNOUNCE to the page so the SPA can discover the
+ * extension ID at runtime. Re-announces on KAIORD_BRIDGE_DISCOVER.
+ */
+
+const BRIDGE_ID = "train2go-bridge";
+const BRIDGE_NAME = "Train2Go";
+const PROTOCOL_VERSION = 1;
+const CAPABILITIES = ["read:training-plan"];
+
+const buildAnnouncement = () => ({
+  type: "KAIORD_BRIDGE_ANNOUNCE",
+  bridgeId: BRIDGE_ID,
+  extensionId: chrome.runtime.id,
+  name: BRIDGE_NAME,
+  version: chrome.runtime.getManifest().version,
+  protocolVersion: PROTOCOL_VERSION,
+  capabilities: CAPABILITIES,
+});
+
+const announce = () => {
+  window.postMessage(buildAnnouncement(), window.location.origin);
+};
+
+const onDiscoverRequest = (event) => {
+  if (event.source !== window) return;
+  if (!event.data || event.data.type !== "KAIORD_BRIDGE_DISCOVER") return;
+  announce();
+};
+
+window.addEventListener("message", onDiscoverRequest);
+announce();
+
+if (typeof module !== "undefined") {
+  module.exports = { buildAnnouncement, announce, onDiscoverRequest };
+}

--- a/packages/train2go-bridge/manifest.json
+++ b/packages/train2go-bridge/manifest.json
@@ -31,6 +31,11 @@
       "matches": ["https://app.train2go.com/*"],
       "js": ["content.js"],
       "run_at": "document_start"
+    },
+    {
+      "matches": ["https://*.kaiord.com/*", "http://localhost/*"],
+      "js": ["kaiord-announce.js"],
+      "run_at": "document_start"
     }
   ],
 

--- a/packages/train2go-bridge/manifest.prod.json
+++ b/packages/train2go-bridge/manifest.prod.json
@@ -31,6 +31,11 @@
       "matches": ["https://app.train2go.com/*"],
       "js": ["content.js"],
       "run_at": "document_start"
+    },
+    {
+      "matches": ["https://*.kaiord.com/*"],
+      "js": ["kaiord-announce.js"],
+      "run_at": "document_start"
     }
   ],
 

--- a/packages/train2go-bridge/test/chrome-mock.js
+++ b/packages/train2go-bridge/test/chrome-mock.js
@@ -4,7 +4,9 @@
 
 const chromeMock = {
   runtime: {
+    id: "train2go-test-extension-id",
     lastError: null,
+    getManifest: vi.fn(() => ({ version: "0.1.1" })),
     onMessage: {
       addListener: vi.fn(),
     },
@@ -22,6 +24,14 @@ const chromeMock = {
 
 globalThis.chrome = chromeMock;
 globalThis.fetch = vi.fn();
+
+const windowMock = {
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  postMessage: vi.fn(),
+  location: { origin: "https://kaiord.com" },
+};
+globalThis.window = windowMock;
 
 // Helper to reset state between tests
 globalThis.__resetChromeMock = () => {

--- a/packages/train2go-bridge/test/kaiord-announce.test.js
+++ b/packages/train2go-bridge/test/kaiord-announce.test.js
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
-const { buildAnnouncement, onDiscoverRequest, announce } =
-  require("../kaiord-announce.js");
+const {
+  buildAnnouncement,
+  onDiscoverRequest,
+  announce,
+} = require("../kaiord-announce.js");
 
 describe("kaiord-announce.js (train2go-bridge)", () => {
   beforeEach(() => {

--- a/packages/train2go-bridge/test/kaiord-announce.test.js
+++ b/packages/train2go-bridge/test/kaiord-announce.test.js
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+const { buildAnnouncement, onDiscoverRequest, announce } =
+  require("../kaiord-announce.js");
+
+describe("kaiord-announce.js (train2go-bridge)", () => {
+  beforeEach(() => {
+    __resetChromeMock();
+  });
+
+  describe("buildAnnouncement", () => {
+    it("returns a well-formed announcement with bridge metadata", () => {
+      const ann = buildAnnouncement();
+
+      expect(ann).toEqual({
+        type: "KAIORD_BRIDGE_ANNOUNCE",
+        bridgeId: "train2go-bridge",
+        extensionId: "train2go-test-extension-id",
+        name: "Train2Go",
+        version: "0.1.1",
+        protocolVersion: 1,
+        capabilities: ["read:training-plan"],
+      });
+    });
+  });
+
+  describe("onDiscoverRequest", () => {
+    it("re-announces when a KAIORD_BRIDGE_DISCOVER from window arrives", () => {
+      onDiscoverRequest({
+        source: window,
+        data: { type: "KAIORD_BRIDGE_DISCOVER" },
+      });
+
+      expect(window.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "KAIORD_BRIDGE_ANNOUNCE",
+          bridgeId: "train2go-bridge",
+        }),
+        "https://kaiord.com"
+      );
+    });
+
+    it("ignores messages from other sources", () => {
+      onDiscoverRequest({
+        source: { fake: true },
+        data: { type: "KAIORD_BRIDGE_DISCOVER" },
+      });
+
+      expect(window.postMessage).not.toHaveBeenCalled();
+    });
+
+    it("ignores unrelated message types", () => {
+      onDiscoverRequest({
+        source: window,
+        data: { type: "SOMETHING_ELSE" },
+      });
+
+      expect(window.postMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("announce", () => {
+    it("posts the announcement to the current origin", () => {
+      announce();
+
+      expect(window.postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "KAIORD_BRIDGE_ANNOUNCE",
+          bridgeId: "train2go-bridge",
+        }),
+        "https://kaiord.com"
+      );
+    });
+  });
+});

--- a/packages/train2go-bridge/vitest.config.js
+++ b/packages/train2go-bridge/vitest.config.js
@@ -5,7 +5,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./test/chrome-mock.js"],
     coverage: {
-      include: ["background.js", "content.js", "parser.js"],
+      include: ["background.js", "content.js", "kaiord-announce.js", "parser.js"],
       exclude: ["popup.js"],
     },
   },

--- a/packages/train2go-bridge/vitest.config.js
+++ b/packages/train2go-bridge/vitest.config.js
@@ -5,7 +5,12 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./test/chrome-mock.js"],
     coverage: {
-      include: ["background.js", "content.js", "kaiord-announce.js", "parser.js"],
+      include: [
+        "background.js",
+        "content.js",
+        "kaiord-announce.js",
+        "parser.js",
+      ],
       exclude: ["popup.js"],
     },
   },

--- a/packages/workout-spa-editor/.env.example
+++ b/packages/workout-spa-editor/.env.example
@@ -3,8 +3,6 @@
 # Base path for deployment (e.g., GitHub Pages)
 # VITE_BASE_PATH=/workout-spa-editor
 
-# Garmin Bridge extension ID (Chrome unpacked or Web Store ID)
-# VITE_GARMIN_EXTENSION_ID=your-extension-id-here
-
-# Train2Go Bridge extension ID (Chrome unpacked ID)
-# VITE_TRAIN2GO_EXTENSION_ID=your-train2go-extension-id-here
+# Bridge extensions (Garmin, Train2Go) are discovered at runtime via
+# content script announcements. No extension IDs are required at build
+# time; install the extension and the SPA will pick it up automatically.

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery-types.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery-types.ts
@@ -1,0 +1,37 @@
+/**
+ * Bridge Discovery Types
+ *
+ * Runtime announcement protocol between bridge extensions and the SPA.
+ */
+
+export type BridgeAnnouncement = {
+  type: "KAIORD_BRIDGE_ANNOUNCE";
+  bridgeId: string;
+  extensionId: string;
+  name: string;
+  version: string;
+  protocolVersion: number;
+  capabilities: string[];
+};
+
+export type DiscoveryListener = () => void;
+
+export type BridgeDiscovery = {
+  start: () => void;
+  stop: () => void;
+  getExtensionId: (bridgeId: string) => string | null;
+  subscribe: (listener: DiscoveryListener) => () => void;
+};
+
+export function isAnnouncement(data: unknown): data is BridgeAnnouncement {
+  if (!data || typeof data !== "object") return false;
+  const a = data as Record<string, unknown>;
+  return (
+    a.type === "KAIORD_BRIDGE_ANNOUNCE" &&
+    typeof a.bridgeId === "string" &&
+    a.bridgeId.length > 0 &&
+    typeof a.extensionId === "string" &&
+    a.extensionId.length > 0 &&
+    typeof a.protocolVersion === "number"
+  );
+}

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery-verify.test.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery-verify.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { verifyAnnouncement } from "./bridge-discovery-verify";
+import type { BridgeAnnouncement } from "./bridge-discovery-types";
+
+vi.mock("./bridge-transport", () => ({
+  sendBridgeMessage: vi.fn(),
+}));
+
+import { sendBridgeMessage } from "./bridge-transport";
+
+const mockSend = vi.mocked(sendBridgeMessage);
+
+const ann: BridgeAnnouncement = {
+  type: "KAIORD_BRIDGE_ANNOUNCE",
+  bridgeId: "garmin-bridge",
+  extensionId: "ext-1",
+  name: "Garmin",
+  version: "1.0.0",
+  protocolVersion: 1,
+  capabilities: ["write:workouts"],
+};
+
+const validManifest = {
+  ok: true,
+  protocolVersion: 1,
+  data: {
+    id: "garmin-bridge",
+    name: "Garmin",
+    version: "1.0.0",
+    protocolVersion: 1,
+    capabilities: ["write:workouts" as const],
+  },
+};
+
+describe("verifyAnnouncement", () => {
+  it("returns true for a matching ping manifest", async () => {
+    mockSend.mockResolvedValue(validManifest);
+
+    await expect(verifyAnnouncement(ann)).resolves.toBe(true);
+  });
+
+  it("returns false when the ping fails", async () => {
+    mockSend.mockResolvedValue({ ok: false, error: "no" });
+
+    await expect(verifyAnnouncement(ann)).resolves.toBe(false);
+  });
+
+  it("returns false when the manifest fails schema validation", async () => {
+    mockSend.mockResolvedValue({
+      ok: true,
+      data: { id: "garmin-bridge", name: "x" },
+    });
+
+    await expect(verifyAnnouncement(ann)).resolves.toBe(false);
+  });
+
+  it("returns false when manifest.id does not match the announced bridgeId", async () => {
+    mockSend.mockResolvedValue({
+      ok: true,
+      data: {
+        ...validManifest.data,
+        id: "different-bridge",
+      },
+    });
+
+    await expect(verifyAnnouncement(ann)).resolves.toBe(false);
+  });
+
+  it("returns false when the protocol version is unsupported", async () => {
+    mockSend.mockResolvedValue({
+      ok: true,
+      data: {
+        ...validManifest.data,
+        protocolVersion: 99,
+      },
+    });
+
+    await expect(verifyAnnouncement(ann)).resolves.toBe(false);
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery-verify.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery-verify.ts
@@ -1,0 +1,31 @@
+/**
+ * Bridge Discovery Verification
+ *
+ * Confirms a bridge announcement is legitimate by pinging the announced
+ * extensionId and checking that the returned manifest matches the
+ * declared bridgeId and schema. Rejects spoofed announcements.
+ */
+
+import { bridgeManifestSchema } from "../../types/bridge-schemas";
+import type { BridgeAnnouncement } from "./bridge-discovery-types";
+import { sendBridgeMessage } from "./bridge-transport";
+
+const SUPPORTED_PROTOCOLS = [1] as const;
+
+export async function verifyAnnouncement(
+  announcement: BridgeAnnouncement
+): Promise<boolean> {
+  const response = await sendBridgeMessage(announcement.extensionId, {
+    action: "ping",
+  });
+  if (!response.ok || !response.data) return false;
+
+  const manifest = bridgeManifestSchema.safeParse(response.data);
+  if (!manifest.success) return false;
+
+  if (manifest.data.id !== announcement.bridgeId) return false;
+  if (!SUPPORTED_PROTOCOLS.includes(manifest.data.protocolVersion as 1)) {
+    return false;
+  }
+  return true;
+}

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery.test.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createBridgeDiscovery } from "./bridge-discovery";
+import type { BridgeAnnouncement } from "./bridge-discovery-types";
+
+const ANNOUNCE_GARMIN: BridgeAnnouncement = {
+  type: "KAIORD_BRIDGE_ANNOUNCE",
+  bridgeId: "garmin-bridge",
+  extensionId: "garmin-ext-id",
+  name: "Garmin",
+  version: "0.2.0",
+  protocolVersion: 1,
+  capabilities: ["write:workouts"],
+};
+
+const ANNOUNCE_TRAIN2GO: BridgeAnnouncement = {
+  type: "KAIORD_BRIDGE_ANNOUNCE",
+  bridgeId: "train2go-bridge",
+  extensionId: "train2go-ext-id",
+  name: "Train2Go",
+  version: "0.1.1",
+  protocolVersion: 1,
+  capabilities: ["read:training-plan"],
+};
+
+function emit(data: unknown): void {
+  window.dispatchEvent(new MessageEvent("message", { data, source: window }));
+}
+
+describe("createBridgeDiscovery", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("registers extension id after a verified announcement", async () => {
+    const verify = vi.fn().mockResolvedValue(true);
+    const discovery = createBridgeDiscovery({ verify });
+    discovery.start();
+
+    emit(ANNOUNCE_GARMIN);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(verify).toHaveBeenCalledWith(ANNOUNCE_GARMIN);
+    expect(discovery.getExtensionId("garmin-bridge")).toBe("garmin-ext-id");
+    discovery.stop();
+  });
+
+  it("rejects announcements that fail verification (spoof)", async () => {
+    const verify = vi.fn().mockResolvedValue(false);
+    const discovery = createBridgeDiscovery({ verify });
+    discovery.start();
+
+    emit(ANNOUNCE_GARMIN);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(discovery.getExtensionId("garmin-bridge")).toBeNull();
+    discovery.stop();
+  });
+
+  it("registers multiple bridges independently", async () => {
+    const verify = vi.fn().mockResolvedValue(true);
+    const discovery = createBridgeDiscovery({ verify });
+    discovery.start();
+
+    emit(ANNOUNCE_GARMIN);
+    emit(ANNOUNCE_TRAIN2GO);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(discovery.getExtensionId("garmin-bridge")).toBe("garmin-ext-id");
+    expect(discovery.getExtensionId("train2go-bridge")).toBe("train2go-ext-id");
+    discovery.stop();
+  });
+
+  it("ignores announcements with invalid shape", async () => {
+    const verify = vi.fn().mockResolvedValue(true);
+    const discovery = createBridgeDiscovery({ verify });
+    discovery.start();
+
+    emit({ type: "KAIORD_BRIDGE_ANNOUNCE" });
+    emit({ foo: "bar" });
+    emit(null);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(verify).not.toHaveBeenCalled();
+    expect(discovery.getExtensionId("garmin-bridge")).toBeNull();
+    discovery.stop();
+  });
+
+  it("posts KAIORD_BRIDGE_DISCOVER after 3s when no bridges announced", () => {
+    const postSpy = vi.spyOn(window, "postMessage");
+    const discovery = createBridgeDiscovery({
+      verify: vi.fn().mockResolvedValue(true),
+    });
+    discovery.start();
+
+    vi.advanceTimersByTime(3_000);
+
+    expect(postSpy).toHaveBeenCalledWith(
+      { type: "KAIORD_BRIDGE_DISCOVER" },
+      "*"
+    );
+    discovery.stop();
+  });
+
+  it("does not post KAIORD_BRIDGE_DISCOVER when a bridge has already announced", async () => {
+    const postSpy = vi.spyOn(window, "postMessage");
+    const discovery = createBridgeDiscovery({
+      verify: vi.fn().mockResolvedValue(true),
+    });
+    discovery.start();
+
+    emit(ANNOUNCE_GARMIN);
+    await vi.runOnlyPendingTimersAsync();
+    postSpy.mockClear();
+
+    vi.advanceTimersByTime(3_000);
+
+    expect(postSpy).not.toHaveBeenCalled();
+    discovery.stop();
+  });
+
+  it("notifies subscribers when a bridge is registered", async () => {
+    const listener = vi.fn();
+    const discovery = createBridgeDiscovery({
+      verify: vi.fn().mockResolvedValue(true),
+    });
+    discovery.start();
+    discovery.subscribe(listener);
+
+    emit(ANNOUNCE_GARMIN);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    discovery.stop();
+  });
+
+  it("unsubscribes cleanly", async () => {
+    const listener = vi.fn();
+    const discovery = createBridgeDiscovery({
+      verify: vi.fn().mockResolvedValue(true),
+    });
+    discovery.start();
+    const unsubscribe = discovery.subscribe(listener);
+
+    unsubscribe();
+    emit(ANNOUNCE_GARMIN);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(listener).not.toHaveBeenCalled();
+    discovery.stop();
+  });
+
+  it("skips verification when the same announcement is received twice", async () => {
+    const verify = vi.fn().mockResolvedValue(true);
+    const discovery = createBridgeDiscovery({ verify });
+    discovery.start();
+
+    emit(ANNOUNCE_GARMIN);
+    await vi.runOnlyPendingTimersAsync();
+    emit(ANNOUNCE_GARMIN);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(verify).toHaveBeenCalledTimes(1);
+    discovery.stop();
+  });
+
+  it("removes window listeners on stop()", async () => {
+    const verify = vi.fn().mockResolvedValue(true);
+    const discovery = createBridgeDiscovery({ verify });
+    discovery.start();
+    discovery.stop();
+
+    emit(ANNOUNCE_GARMIN);
+    await vi.runOnlyPendingTimersAsync();
+
+    expect(verify).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery.ts
@@ -1,0 +1,84 @@
+/**
+ * Bridge Discovery
+ *
+ * Listens for KAIORD_BRIDGE_ANNOUNCE messages on `window`, verifies each
+ * announcement via a ping against the announced extensionId, and exposes
+ * the verified `bridgeId → extensionId` mapping at runtime. Replaces
+ * build-time `VITE_*_EXTENSION_ID` env var coupling.
+ */
+
+import {
+  type BridgeAnnouncement,
+  type BridgeDiscovery,
+  type DiscoveryListener,
+  isAnnouncement,
+} from "./bridge-discovery-types";
+import { verifyAnnouncement } from "./bridge-discovery-verify";
+
+const DISCOVER_REQUEST_DELAY_MS = 3_000;
+
+type VerifyFn = (ann: BridgeAnnouncement) => Promise<boolean>;
+
+export type CreateBridgeDiscoveryOptions = {
+  verify?: VerifyFn;
+  discoverDelayMs?: number;
+};
+
+export function createBridgeDiscovery(
+  options: CreateBridgeDiscoveryOptions = {}
+): BridgeDiscovery {
+  const verify = options.verify ?? verifyAnnouncement;
+  const discoverDelayMs = options.discoverDelayMs ?? DISCOVER_REQUEST_DELAY_MS;
+  const ids = new Map<string, string>();
+  const listeners = new Set<DiscoveryListener>();
+  let handler: ((event: MessageEvent) => void) | null = null;
+  let discoverTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const notify = () => listeners.forEach((l) => l());
+
+  async function handleAnnouncement(ann: BridgeAnnouncement): Promise<void> {
+    if (ids.get(ann.bridgeId) === ann.extensionId) return;
+    const ok = await verify(ann);
+    if (!ok) return;
+    ids.set(ann.bridgeId, ann.extensionId);
+    notify();
+  }
+
+  function onMessage(event: MessageEvent): void {
+    if (event.source !== window) return;
+    if (!isAnnouncement(event.data)) return;
+    void handleAnnouncement(event.data);
+  }
+
+  function start(): void {
+    if (handler) return;
+    handler = onMessage;
+    window.addEventListener("message", handler);
+    discoverTimer = setTimeout(() => {
+      if (ids.size === 0) {
+        window.postMessage({ type: "KAIORD_BRIDGE_DISCOVER" }, "*");
+      }
+    }, discoverDelayMs);
+  }
+
+  function stop(): void {
+    if (handler) window.removeEventListener("message", handler);
+    if (discoverTimer) clearTimeout(discoverTimer);
+    handler = null;
+    discoverTimer = null;
+  }
+
+  return {
+    start,
+    stop,
+    getExtensionId: (id) => ids.get(id) ?? null,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}
+
+export const bridgeDiscovery = createBridgeDiscovery();

--- a/packages/workout-spa-editor/src/hooks/use-bridge-discovery-bootstrap.ts
+++ b/packages/workout-spa-editor/src/hooks/use-bridge-discovery-bootstrap.ts
@@ -1,0 +1,20 @@
+/**
+ * useBridgeDiscoveryBootstrap
+ *
+ * Starts the bridge discovery listener on mount and stops it on unmount.
+ * The singleton `bridgeDiscovery` is started exactly once per app boot —
+ * repeated calls to start() are no-ops.
+ */
+
+import { useEffect } from "react";
+
+import { bridgeDiscovery } from "../adapters/bridge/bridge-discovery";
+
+export const useBridgeDiscoveryBootstrap = () => {
+  useEffect(() => {
+    bridgeDiscovery.start();
+    return () => {
+      bridgeDiscovery.stop();
+    };
+  }, []);
+};

--- a/packages/workout-spa-editor/src/hooks/use-discovered-extension-id.ts
+++ b/packages/workout-spa-editor/src/hooks/use-discovered-extension-id.ts
@@ -1,0 +1,18 @@
+/**
+ * useDiscoveredExtensionId
+ *
+ * React hook that subscribes to the bridge discovery singleton and
+ * returns the currently announced extension id for a given bridge
+ * (or `null` before any verified announcement arrives).
+ */
+
+import { useSyncExternalStore } from "react";
+
+import { bridgeDiscovery } from "../adapters/bridge/bridge-discovery";
+
+export const useDiscoveredExtensionId = (bridgeId: string): string | null =>
+  useSyncExternalStore(
+    (listener) => bridgeDiscovery.subscribe(listener),
+    () => bridgeDiscovery.getExtensionId(bridgeId),
+    () => null
+  );

--- a/packages/workout-spa-editor/src/hooks/use-garmin-bridge-action-helpers.ts
+++ b/packages/workout-spa-editor/src/hooks/use-garmin-bridge-action-helpers.ts
@@ -1,0 +1,61 @@
+/**
+ * Helpers for `useGarminBridgeActions` — detection + push flows factored
+ * out of the hook so the hook body stays within the file-size budget.
+ * Extension IDs come from the bridge discovery singleton at call time.
+ */
+
+import { bridgeDiscovery } from "../adapters/bridge/bridge-discovery";
+import type { PushState } from "../contexts/garmin-bridge-types";
+import { ping } from "../store/garmin-extension-transport";
+import { evaluatePingResult, executePush } from "./garmin-bridge-operations";
+
+export const getGarminExtensionId = (): string =>
+  bridgeDiscovery.getExtensionId("garmin-bridge") ?? "";
+
+export type DetectSetters = {
+  setExtensionInstalled: (v: boolean) => void;
+  setSessionActive: (v: boolean) => void;
+  setLastError: (v: string | null) => void;
+};
+
+export const runDetect = async ({
+  setExtensionInstalled,
+  setSessionActive,
+  setLastError,
+}: DetectSetters): Promise<void> => {
+  const extensionId = getGarminExtensionId();
+  if (!extensionId) {
+    setExtensionInstalled(false);
+    setSessionActive(false);
+    setLastError(null);
+    return;
+  }
+  const res = await ping(extensionId);
+  const result = evaluatePingResult(res);
+  setExtensionInstalled(result.installed);
+  setSessionActive(result.installed && result.session);
+  setLastError(result.installed ? result.error : null);
+};
+
+export const runPush = async (
+  gcn: unknown,
+  setPushing: (s: PushState) => void,
+  redetect: () => Promise<void>
+): Promise<void> => {
+  setPushing({ status: "loading" });
+  const result = await executePush(getGarminExtensionId(), gcn);
+  if (result.status === "invalidated") {
+    await redetect();
+    setPushing({
+      status: "error",
+      message: "Extension was updated. Please try again.",
+    });
+    return;
+  }
+  if (result.status === "error") {
+    if (result.redetect) await redetect();
+    setPushing({ status: "error", message: result.message });
+    return;
+  }
+  setPushing({ status: "success" });
+};

--- a/packages/workout-spa-editor/src/hooks/use-garmin-bridge-actions.ts
+++ b/packages/workout-spa-editor/src/hooks/use-garmin-bridge-actions.ts
@@ -1,15 +1,12 @@
 import { useCallback, useState } from "react";
 
 import type { PushState } from "../contexts/garmin-bridge-types";
-import { ping } from "../store/garmin-extension-transport";
+import { executeList, INITIAL_PUSH_STATE } from "./garmin-bridge-operations";
 import {
-  evaluatePingResult,
-  executeList,
-  executePush,
-  INITIAL_PUSH_STATE,
-} from "./garmin-bridge-operations";
-
-const EXTENSION_ID: string = import.meta.env.VITE_GARMIN_EXTENSION_ID || "";
+  getGarminExtensionId,
+  runDetect,
+  runPush,
+} from "./use-garmin-bridge-action-helpers";
 
 export const useGarminBridgeActions = () => {
   const [extensionInstalled, setExtensionInstalled] = useState(false);
@@ -17,41 +14,21 @@ export const useGarminBridgeActions = () => {
   const [pushing, setPushing] = useState<PushState>(INITIAL_PUSH_STATE);
   const [lastError, setLastError] = useState<string | null>(null);
 
-  const detectExtension = useCallback(async () => {
-    const res = await ping(EXTENSION_ID);
-    const result = evaluatePingResult(res);
-    setExtensionInstalled(result.installed);
-    setSessionActive(result.installed && result.session);
-    setLastError(result.installed ? result.error : null);
-  }, []);
+  const detectExtension = useCallback(
+    () => runDetect({ setExtensionInstalled, setSessionActive, setLastError }),
+    []
+  );
 
-  const redetect = useCallback(async () => {
-    await detectExtension();
-  }, [detectExtension]);
+  const redetect = useCallback(() => detectExtension(), [detectExtension]);
 
   const pushWorkout = useCallback(
-    async (gcn: unknown) => {
-      setPushing({ status: "loading" });
-      const result = await executePush(EXTENSION_ID, gcn);
-      if (result.status === "invalidated") {
-        await redetect();
-        setPushing({
-          status: "error",
-          message: "Extension was updated. Please try again.",
-        });
-      } else if (result.status === "error") {
-        if (result.redetect) await redetect();
-        setPushing({ status: "error", message: result.message });
-      } else {
-        setPushing({ status: "success" });
-      }
-    },
+    (gcn: unknown) => runPush(gcn, setPushing, redetect),
     [redetect]
   );
 
   const listWorkouts = useCallback(async (): Promise<unknown[]> => {
     try {
-      const { data } = await executeList(EXTENSION_ID);
+      const { data } = await executeList(getGarminExtensionId());
       return data;
     } catch (err: unknown) {
       if (err instanceof Error && "redetect" in err) await redetect();

--- a/packages/workout-spa-editor/src/hooks/use-garmin-detection.test.ts
+++ b/packages/workout-spa-editor/src/hooks/use-garmin-detection.test.ts
@@ -9,10 +9,14 @@ vi.mock("../contexts", () => ({
   })),
 }));
 
+vi.mock("./use-discovered-extension-id", () => ({
+  useDiscoveredExtensionId: vi.fn(() => null),
+}));
+
 import { useGarminDetection } from "./use-garmin-detection";
 
 describe("useGarminDetection", () => {
-  it("should call detectExtension on garmin bridge context", () => {
+  it("calls detectExtension on mount even without a discovered id", () => {
     renderHook(() => useGarminDetection());
 
     expect(mockDetectExtension).toHaveBeenCalledTimes(1);

--- a/packages/workout-spa-editor/src/hooks/use-garmin-detection.ts
+++ b/packages/workout-spa-editor/src/hooks/use-garmin-detection.ts
@@ -1,11 +1,13 @@
 import { useEffect } from "react";
 
 import { useGarminBridge } from "../contexts";
+import { useDiscoveredExtensionId } from "./use-discovered-extension-id";
 
 export const useGarminDetection = () => {
   const { detectExtension } = useGarminBridge();
+  const extensionId = useDiscoveredExtensionId("garmin-bridge");
 
   useEffect(() => {
     detectExtension();
-  }, [detectExtension]);
+  }, [detectExtension, extensionId]);
 };

--- a/packages/workout-spa-editor/src/hooks/use-store-hydration.ts
+++ b/packages/workout-spa-editor/src/hooks/use-store-hydration.ts
@@ -1,4 +1,5 @@
 import { useAiHydration } from "./use-ai-hydration";
+import { useBridgeDiscoveryBootstrap } from "./use-bridge-discovery-bootstrap";
 import { useGarminDetection } from "./use-garmin-detection";
 import { useStorageProbe } from "./use-storage-probe";
 import { useTrain2GoDetection } from "./use-train2go-detection";
@@ -6,6 +7,7 @@ import { useTrain2GoDetection } from "./use-train2go-detection";
 export const useStoreHydration = () => {
   useStorageProbe();
   useAiHydration();
+  useBridgeDiscoveryBootstrap();
   useGarminDetection();
   useTrain2GoDetection();
 };

--- a/packages/workout-spa-editor/src/hooks/use-train2go-detection.ts
+++ b/packages/workout-spa-editor/src/hooks/use-train2go-detection.ts
@@ -1,11 +1,13 @@
 import { useEffect } from "react";
 
 import { useTrain2GoStore } from "../store/train2go-store";
+import { useDiscoveredExtensionId } from "./use-discovered-extension-id";
 
 export const useTrain2GoDetection = () => {
   const detectExtension = useTrain2GoStore((s) => s.detectExtension);
+  const extensionId = useDiscoveredExtensionId("train2go-bridge");
 
   useEffect(() => {
     detectExtension();
-  }, [detectExtension]);
+  }, [detectExtension, extensionId]);
 };

--- a/packages/workout-spa-editor/src/store/train2go-detect-integration.test.ts
+++ b/packages/workout-spa-editor/src/store/train2go-detect-integration.test.ts
@@ -43,7 +43,11 @@ describe("Train2Go detection cache — integration", () => {
     };
     const set = (p: Partial<State>) => Object.assign(state, p);
     const get = () => state;
-    detect = createDetectAction(set as never, get as never, "train2go-ext-id");
+    detect = createDetectAction(
+      set as never,
+      get as never,
+      () => "train2go-ext-id"
+    );
     vi.mocked(ping).mockResolvedValue({
       ok: true,
       protocolVersion: 1,

--- a/packages/workout-spa-editor/src/store/train2go-detect.test.ts
+++ b/packages/workout-spa-editor/src/store/train2go-detect.test.ts
@@ -27,7 +27,11 @@ describe("createDetectAction", () => {
     };
     set = (partial) => Object.assign(state, partial);
     get = () => state;
-    detect = createDetectAction(set as never, get as never, "test-ext-id");
+    detect = createDetectAction(
+      set as never,
+      get as never,
+      () => "test-ext-id"
+    );
     vi.clearAllMocks();
   });
 
@@ -80,7 +84,11 @@ describe("createDetectAction", () => {
   });
 
   it("skips detection when extension ID is empty", async () => {
-    const detectEmpty = createDetectAction(set as never, get as never, "");
+    const detectEmpty = createDetectAction(
+      set as never,
+      get as never,
+      () => ""
+    );
 
     await detectEmpty();
 

--- a/packages/workout-spa-editor/src/store/train2go-detect.ts
+++ b/packages/workout-spa-editor/src/store/train2go-detect.ts
@@ -14,7 +14,8 @@ const DETECTION_CACHE_MS = 30_000;
 const SUPPORTED_PROTOCOLS = [1];
 
 export const createDetectAction =
-  (set: Set, get: Get, extensionId: string) => async () => {
+  (set: Set, get: Get, getExtensionId: () => string) => async () => {
+    const extensionId = getExtensionId();
     if (!extensionId) return;
 
     const { lastDetectionTimestamp, extensionInstalled } = get();

--- a/packages/workout-spa-editor/src/store/train2go-store-actions.test.ts
+++ b/packages/workout-spa-editor/src/store/train2go-store-actions.test.ts
@@ -62,7 +62,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.fetchWeek("2026-04-13");
@@ -77,7 +77,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.fetchWeek("2026-04-13");
@@ -91,7 +91,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.fetchWeek("2026-04-13");
@@ -106,7 +106,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.fetchWeek("2026-04-13");
@@ -120,7 +120,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.fetchWeek("2026-04-13");
@@ -133,7 +133,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.fetchWeek("2026-04-13");
@@ -185,7 +185,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.fetchDay("2026-04-13");
@@ -201,7 +201,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.fetchDay("2026-04-13");
@@ -215,7 +215,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.fetchDay("2026-04-13");
@@ -230,7 +230,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.fetchDay("2026-04-13");
@@ -246,7 +246,7 @@ describe("train2go-store-actions", () => {
       const actions = createTrain2GoActions(
         set as never,
         get as never,
-        "ext-id"
+        () => "ext-id"
       );
 
       await actions.openTrain2Go();

--- a/packages/workout-spa-editor/src/store/train2go-store-actions.ts
+++ b/packages/workout-spa-editor/src/store/train2go-store-actions.ts
@@ -15,8 +15,11 @@ import type { Train2GoStore } from "./train2go-store";
 type Set = (fn: Partial<Train2GoStore>) => void;
 type Get = () => Train2GoStore;
 
+type GetExtensionId = () => string;
+
 const createReadWeekAction =
-  (set: Set, get: Get, extensionId: string) => async (date: string) => {
+  (set: Set, get: Get, getExtensionId: GetExtensionId) =>
+  async (date: string) => {
     const { userId } = get();
     if (!userId) {
       set({ lastError: "Not connected to Train2Go" });
@@ -25,7 +28,7 @@ const createReadWeekAction =
 
     set({ loading: true, lastError: null });
 
-    const res = await readWeek(extensionId, date, userId);
+    const res = await readWeek(getExtensionId(), date, userId);
 
     if (!res.ok) {
       if (res.error === "Session expired") {
@@ -40,11 +43,12 @@ const createReadWeekAction =
   };
 
 const createReadDayAction =
-  (set: Set, get: Get, extensionId: string) => async (date: string) => {
+  (set: Set, get: Get, getExtensionId: GetExtensionId) =>
+  async (date: string) => {
     const { userId } = get();
     if (!userId) return;
 
-    const res = await readDay(extensionId, date, userId);
+    const res = await readDay(getExtensionId(), date, userId);
 
     if (!res.ok) {
       set({ lastError: res.error ?? "Read day failed" });
@@ -69,17 +73,17 @@ const createReadDayAction =
   };
 
 const createOpenAction =
-  (_set: Set, _get: Get, extensionId: string) => async () => {
-    await openTrain2Go(extensionId);
+  (_set: Set, _get: Get, getExtensionId: GetExtensionId) => async () => {
+    await openTrain2Go(getExtensionId());
   };
 
 export const createTrain2GoActions = (
   set: Set,
   get: Get,
-  extensionId: string
+  getExtensionId: GetExtensionId
 ) => ({
-  detectExtension: createDetectAction(set, get, extensionId),
-  fetchWeek: createReadWeekAction(set, get, extensionId),
-  fetchDay: createReadDayAction(set, get, extensionId),
-  openTrain2Go: createOpenAction(set, get, extensionId),
+  detectExtension: createDetectAction(set, get, getExtensionId),
+  fetchWeek: createReadWeekAction(set, get, getExtensionId),
+  fetchDay: createReadDayAction(set, get, getExtensionId),
+  openTrain2Go: createOpenAction(set, get, getExtensionId),
 });

--- a/packages/workout-spa-editor/src/store/train2go-store.ts
+++ b/packages/workout-spa-editor/src/store/train2go-store.ts
@@ -7,9 +7,11 @@
 
 import { create } from "zustand";
 
+import { bridgeDiscovery } from "../adapters/bridge/bridge-discovery";
 import { createTrain2GoActions } from "./train2go-store-actions";
 
-const EXTENSION_ID: string = import.meta.env.VITE_TRAIN2GO_EXTENSION_ID || "";
+const getTrain2GoExtensionId = (): string =>
+  bridgeDiscovery.getExtensionId("train2go-bridge") ?? "";
 
 export type Train2GoActivity = {
   id: number;
@@ -48,5 +50,5 @@ export const useTrain2GoStore = create<Train2GoStore>((set, get) => ({
   lastDetectionTimestamp: null,
   activities: [],
 
-  ...createTrain2GoActions(set, get, EXTENSION_ID),
+  ...createTrain2GoActions(set, get, getTrain2GoExtensionId),
 }));


### PR DESCRIPTION
## Summary

- Replace build-time `VITE_GARMIN_EXTENSION_ID` / `VITE_TRAIN2GO_EXTENSION_ID` coupling with a runtime content-script announcement protocol: bridge extensions inject a minimal `kaiord-announce.js` into SPA origins and post `KAIORD_BRIDGE_ANNOUNCE` with `chrome.runtime.id`; the SPA listens, verifies each announcement via ping + `manifest.id` match + protocol version, and uses the discovered ID for all subsequent `chrome.runtime.sendMessage` calls.
- SPA gains a new `bridge-discovery` adapter (`adapters/bridge/bridge-discovery*`), a React bootstrap hook (`useBridgeDiscoveryBootstrap`), and a reactive `useDiscoveredExtensionId(bridgeId)` hook. `useGarminBridgeActions` and the `train2go-store` actions now read IDs from the discovery singleton at call time, replacing `import.meta.env.VITE_*_EXTENSION_ID`.
- Extensions add a second `content_scripts` entry (`https://*.kaiord.com/*` in prod, additionally `http://localhost/*` in dev) running at `document_start`. The privacy policy and its lint checker are updated to disclose the announce-only script; the `check-privacy-policy` test suite grows rules covering the new match set.

## Migration

**Users must reload/update both the Kaiord Garmin Bridge and Kaiord Train2Go Bridge Chrome extensions after this PR merges.** Without reloading, the new `kaiord-announce.js` content script is not injected and the SPA will not discover the extension ID. After the reload the SPA auto-detects the extension — no `.env` configuration is required.

## Test plan

- [x] `pnpm -r test` — all 227 test files / 2475 SPA tests / full monorepo suite pass
- [x] `pnpm -r build` — full build green
- [x] `pnpm lint` — ESLint + TypeScript + prettier + specs + archive + privacy-policy lint all green
- [x] `pnpm test:scripts` — privacy-policy checker + archive scripts
- [x] New unit tests for `bridge-discovery.ts` (announce registered, spoofed rejected, multiple bridges, invalid shape, 3s `KAIORD_BRIDGE_DISCOVER` fallback, subscribe/unsubscribe, stop cleanup)
- [x] New unit tests for `bridge-discovery-verify.ts` (matching manifest, failed ping, bad schema, `manifest.id` mismatch, unsupported protocol)
- [x] New unit tests for `kaiord-announce.js` (both extensions)
- [ ] Manual: install both extensions locally, confirm discovery on `http://localhost:5173`

🤖 Generated with [Claude Code](https://claude.com/claude-code)