### PR TITLE
feat(spa-editor): focus state, rules, and action wiring

### DIFF
--- a/.changeset/focus-mgmt-core.md
+++ b/.changeset/focus-mgmt-core.md
@@ -1,0 +1,23 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Internal refactor: focus state, rules, and action wiring (focus-management core).
+
+- Add `pendingFocusTarget: FocusTarget | null` to the workout store via a
+  composable `FocusSlice` (state + `setPendingFocusTarget` action).
+- Track a `selectionHistory` parallel to `workoutHistory`, routed through a
+  single `pushHistorySnapshot(uiWorkout, selection, state)` chokepoint so
+  snapshot length invariants stay enforceable.
+- Ship pure per-action focus-rule helpers under `src/store/focus-rules/`
+  (one function per file, no React/DOM dependencies): `nextAfterDelete`,
+  `nextAfterMultiDelete`, `createdItemTarget`, `restoredAfterUndoTarget`,
+  `preservedSelectionTarget`.
+- Wire every mutating store action (delete, paste, create, duplicate,
+  group, ungroup, undo, redo, undo-delete, reorder) to set
+  `pendingFocusTarget` using the rule helpers.
+- Add two CI invariants in `.github/workflows/ci.yml`: focus-rules purity
+  grep, and `workoutHistory.push` confined to `workout-store-history.ts`.
+
+No user-visible behavior change yet: the context/hook that consumes
+`pendingFocusTarget` and drives DOM focus lands in a follow-up PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,35 @@ jobs:
       - name: Check architecture boundaries
         run: pnpm arch:check
 
+  focus-invariants:
+    name: Focus invariants
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: always() && needs.detect-changes.outputs.should-test == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Focus-rules purity (no React/DOM imports)
+        run: |
+          if grep -R -E "from ['\"]react|document\.|window\.|HTMLElement" packages/workout-spa-editor/src/store/focus-rules/; then
+            echo "::error::packages/workout-spa-editor/src/store/focus-rules/ must be pure (no React/DOM imports)"
+            exit 1
+          fi
+
+      - name: workoutHistory.push confined to pushHistorySnapshot
+        run: |
+          # Only `packages/workout-spa-editor/src/store/workout-store-history.ts`
+          # is allowed to call `workoutHistory.push`. This invariant is
+          # removed by the hardening change once the pushHistorySnapshot
+          # refactor is complete across the codebase.
+          matches=$(grep -R "workoutHistory\.push" packages/workout-spa-editor/src --include="*.ts" --include="*.tsx" | grep -v "workout-store-history.ts" || true)
+          if [ -n "$matches" ]; then
+            echo "::error::workoutHistory.push is only allowed inside workout-store-history.ts"
+            echo "$matches"
+            exit 1
+          fi
+
   check-links:
     name: Link checker
     runs-on: ubuntu-latest

--- a/packages/workout-spa-editor/src/store/actions/add-step-to-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/add-step-to-repetition-block-action.ts
@@ -9,6 +9,7 @@
  */
 
 import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
@@ -79,5 +80,8 @@ export const addStepToRepetitionBlockAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: createdItemTarget(newStep.id),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/create-empty-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/create-empty-repetition-block-action.ts
@@ -16,7 +16,9 @@ import type {
 } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
 import { generateBlockId } from "../../utils/id-generation";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
+import { asItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 
@@ -109,5 +111,10 @@ export const createEmptyRepetitionBlockAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: repetitionBlock.id
+      ? createdItemTarget(asItemId(repetitionBlock.id))
+      : null,
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/create-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/create-repetition-block-action.ts
@@ -9,6 +9,8 @@
 
 import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
 import { generateBlockId } from "../../utils/id-generation";
+import { createdItemTarget } from "../focus-rules";
+import { asItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 import {
@@ -71,5 +73,10 @@ export const createRepetitionBlockAction = (
     extensions: { ...krd.extensions, structured_workout: updatedWorkout },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: repetitionBlock.id
+      ? createdItemTarget(asItemId(repetitionBlock.id))
+      : null,
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/create-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/create-step-action.ts
@@ -5,6 +5,7 @@
  */
 
 import type { KRD, Workout } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
@@ -43,5 +44,8 @@ export const createStepAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: createdItemTarget(newStep.id),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/delete-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-repetition-block-action.ts
@@ -13,7 +13,9 @@
 
 import type { KRD, Workout } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
-import type { UIWorkoutItem } from "../../types/krd-ui";
+import type { UIWorkout, UIWorkoutItem } from "../../types/krd-ui";
+import { nextAfterDelete } from "../focus-rules";
+import { asItemId } from "../providers/item-id";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
@@ -125,5 +127,8 @@ export const deleteRepetitionBlockAction = (
     selectedStepId: null,
     selectedStepIds: [],
     deletedSteps: newDeletedBlocks,
+    pendingFocusTarget: block.id
+      ? nextAfterDelete(krd as UIWorkout, asItemId(block.id))
+      : null,
   };
 };

--- a/packages/workout-spa-editor/src/store/actions/delete-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-step-action.ts
@@ -12,7 +12,9 @@ import type {
   WorkoutStep,
 } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
-import type { UIWorkoutItem } from "../../types/krd-ui";
+import type { UIWorkout, UIWorkoutItem } from "../../types/krd-ui";
+import { nextAfterDelete } from "../focus-rules";
+import { asItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 
@@ -75,20 +77,22 @@ export const deleteStepAction = (
   // Runtime invariant: `state.currentWorkout` is a UIWorkout, so the
   // deleted item already carries its stable ItemId. The `as Workout` cast
   // above erased that at the type level — re-assert it here so the undo
-  // trail stays on the UIWorkoutItem contract (CodeRabbit feedback).
-  const newDeletedSteps = deletedStep
+  // trail stays on the UIWorkoutItem contract.
+  const deletedUiItem = deletedStep as UIWorkoutItem | null;
+  const newDeletedSteps = deletedUiItem
     ? [
         ...deletedSteps,
-        {
-          step: deletedStep as UIWorkoutItem,
-          index: stepIndex,
-          timestamp: Date.now(),
-        },
+        { step: deletedUiItem, index: stepIndex, timestamp: Date.now() },
       ]
     : deletedSteps;
+
+  const focusTarget = deletedUiItem
+    ? nextAfterDelete(krd as UIWorkout, asItemId(deletedUiItem.id))
+    : null;
 
   return {
     ...createUpdateWorkoutAction(updatedKrd, state),
     deletedSteps: newDeletedSteps,
+    pendingFocusTarget: focusTarget,
   };
 };

--- a/packages/workout-spa-editor/src/store/actions/duplicate-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/duplicate-step-action.ts
@@ -11,6 +11,7 @@ import type {
   WorkoutStep,
 } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
 import type { ItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
@@ -74,5 +75,8 @@ export const duplicateStepAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: createdItemTarget(duplicatedStep.id),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/duplicate-step-in-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/duplicate-step-in-repetition-block-action.ts
@@ -5,7 +5,9 @@
  */
 
 import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
+import type { ItemId } from "../providers/item-id";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
@@ -84,5 +86,8 @@ export const duplicateStepInRepetitionBlockAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: createdItemTarget(duplicatedStep.id as ItemId),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/error-recovery-actions.ts
+++ b/packages/workout-spa-editor/src/store/actions/error-recovery-actions.ts
@@ -41,6 +41,8 @@ export const restoreFromBackupAction = (
     currentWorkout: restoredWorkout,
     workoutHistory: [restoredWorkout],
     historyIndex: 0,
+    selectionHistory: [null],
+    pendingFocusTarget: null,
     success: true,
   };
 };

--- a/packages/workout-spa-editor/src/store/actions/focus-wiring.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/focus-wiring.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { UIWorkout } from "../../types/krd-ui";
+import { asItemId } from "../providers/item-id";
+import type { WorkoutState } from "../workout-state.types";
+import { addStepToRepetitionBlockAction } from "./add-step-to-repetition-block-action";
+import { createEmptyRepetitionBlockAction } from "./create-empty-repetition-block-action";
+import { createRepetitionBlockAction } from "./create-repetition-block-action";
+import { createStepAction } from "./create-step-action";
+import { deleteRepetitionBlockAction } from "./delete-repetition-block-action";
+import { deleteStepAction } from "./delete-step-action";
+import { duplicateStepAction } from "./duplicate-step-action";
+import { duplicateStepInRepetitionBlockAction } from "./duplicate-step-in-repetition-block-action";
+import { editRepetitionBlockAction } from "./edit-repetition-block-action";
+import { createRedoAction, createUndoAction } from "./history-actions";
+import { reorderStepAction } from "./reorder-step-action";
+import { reorderStepsInBlockAction } from "./reorder-steps-in-block-action";
+import { undoDeleteAction } from "./undo-delete-action";
+import { ungroupRepetitionBlockAction } from "./ungroup-repetition-block-action";
+
+const step = (id: string, stepIndex = 0) => ({
+  id,
+  stepIndex,
+  durationType: "open" as const,
+  duration: { type: "open" as const },
+  targetType: "open" as const,
+  target: { type: "open" as const },
+});
+
+const block = (id: string, steps: Array<ReturnType<typeof step>>) => ({
+  id,
+  repeatCount: 2,
+  steps,
+});
+
+const makeWorkout = (items: Array<unknown>): UIWorkout =>
+  ({
+    version: "1.0",
+    type: "structured_workout",
+    metadata: { sport: "cycling" },
+    extensions: {
+      structured_workout: {
+        name: "w",
+        sport: "cycling",
+        steps: items,
+      },
+    },
+  }) as unknown as UIWorkout;
+
+const makeState = (workout: UIWorkout): WorkoutState => ({
+  currentWorkout: workout,
+  workoutHistory: [workout],
+  historyIndex: 0,
+  selectedStepId: null,
+  selectedStepIds: [],
+  isEditing: false,
+  selectionHistory: [null],
+});
+
+describe("focus wiring on mutating actions", () => {
+  it("deleteStep → nextAfterDelete (next sibling)", () => {
+    const w = makeWorkout([step("a", 0), step("b", 1), step("c", 2)]);
+
+    const out = deleteStepAction(w, 1, makeState(w));
+
+    expect(out.pendingFocusTarget).toEqual({
+      kind: "item",
+      id: asItemId("c"),
+    });
+  });
+
+  it("deleteStep → nextAfterDelete (previous sibling when last)", () => {
+    const w = makeWorkout([step("a", 0), step("b", 1)]);
+
+    const out = deleteStepAction(w, 1, makeState(w));
+
+    expect(out.pendingFocusTarget).toEqual({
+      kind: "item",
+      id: asItemId("a"),
+    });
+  });
+
+  it("deleteStep → empty-state when list becomes empty", () => {
+    const w = makeWorkout([step("only", 0)]);
+
+    const out = deleteStepAction(w, 0, makeState(w));
+
+    expect(out.pendingFocusTarget).toEqual({ kind: "empty-state" });
+  });
+
+  it("deleteRepetitionBlock → nextAfterDelete", () => {
+    const blk = block("blk", [step("b1", 0)]);
+    const w = makeWorkout([step("a", 0), blk, step("c", 2)]);
+
+    const out = deleteRepetitionBlockAction(w, "blk", makeState(w));
+
+    expect(out.pendingFocusTarget).toEqual({
+      kind: "item",
+      id: asItemId("c"),
+    });
+  });
+
+  it("createStep → pendingFocusTarget = new step id", () => {
+    const w = makeWorkout([]);
+
+    const out = createStepAction(w, makeState(w));
+
+    expect(out.pendingFocusTarget?.kind).toBe("item");
+    if (out.pendingFocusTarget?.kind === "item") {
+      expect(typeof out.pendingFocusTarget.id).toBe("string");
+      expect(out.pendingFocusTarget.id.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("createEmptyRepetitionBlock → pendingFocusTarget = new block id", () => {
+    const w = makeWorkout([]);
+
+    const out = createEmptyRepetitionBlockAction(w, 2, makeState(w));
+
+    expect(out.pendingFocusTarget?.kind).toBe("item");
+  });
+
+  it("createRepetitionBlock → pendingFocusTarget = new block id", () => {
+    const w = makeWorkout([step("a", 0), step("b", 1)]);
+
+    const out = createRepetitionBlockAction(w, [0, 1], 3, makeState(w));
+
+    expect(out.pendingFocusTarget?.kind).toBe("item");
+  });
+
+  it("addStepToRepetitionBlock → pendingFocusTarget = new step id", () => {
+    const blk = block("blk", [step("b1", 0)]);
+    const w = makeWorkout([blk]);
+
+    const out = addStepToRepetitionBlockAction(w, "blk", makeState(w));
+
+    expect(out.pendingFocusTarget?.kind).toBe("item");
+  });
+
+  it("duplicateStep → pendingFocusTarget = duplicated step id", () => {
+    const w = makeWorkout([step("a", 0)]);
+
+    const out = duplicateStepAction(w, 0, makeState(w));
+
+    expect(out.pendingFocusTarget?.kind).toBe("item");
+  });
+
+  it("duplicateStepInRepetitionBlock → pendingFocusTarget = duplicate id", () => {
+    const blk = block("blk", [step("b1", 0)]);
+    const w = makeWorkout([blk]);
+
+    const out = duplicateStepInRepetitionBlockAction(w, "blk", 0, makeState(w));
+
+    expect(out.pendingFocusTarget?.kind).toBe("item");
+  });
+
+  it("ungroupRepetitionBlock → first formerly-child step id", () => {
+    const blk = block("blk", [step("b1", 0), step("b2", 1)]);
+    const w = makeWorkout([blk]);
+
+    const out = ungroupRepetitionBlockAction(w, "blk", makeState(w));
+
+    expect(out.pendingFocusTarget).toEqual({
+      kind: "item",
+      id: asItemId("b1"),
+    });
+  });
+
+  it("editRepetitionBlock leaves pendingFocusTarget untouched", () => {
+    const blk = block("blk", [step("b1", 0)]);
+    const w = makeWorkout([blk]);
+
+    const out = editRepetitionBlockAction(w, "blk", 5, makeState(w));
+
+    expect("pendingFocusTarget" in out).toBe(false);
+  });
+
+  it("reorderStep → pendingFocusTarget = moved step id", () => {
+    const w = makeWorkout([step("a", 0), step("b", 1), step("c", 2)]);
+
+    const out = reorderStepAction(w, 0, 2, makeState(w));
+
+    expect(out.pendingFocusTarget).toEqual({
+      kind: "item",
+      id: asItemId("a"),
+    });
+  });
+
+  it("reorderStepsInBlock → pendingFocusTarget = moved step id", () => {
+    const blk = block("blk", [step("b1", 0), step("b2", 1)]);
+    const w = makeWorkout([blk]);
+
+    const out = reorderStepsInBlockAction(w, "blk", 0, 1, makeState(w));
+
+    expect(out.pendingFocusTarget).toEqual({
+      kind: "item",
+      id: asItemId("b1"),
+    });
+  });
+
+  it("undoDelete → pendingFocusTarget = restored step id", () => {
+    const restoredStep = step("restored", 0);
+    const w = makeWorkout([step("a", 0)]);
+    const stamp = 42;
+    const state: WorkoutState = {
+      ...makeState(w),
+      deletedSteps: [
+        { step: restoredStep as never, index: 1, timestamp: stamp },
+      ],
+    };
+
+    const out = undoDeleteAction(w, stamp, state);
+
+    expect(out.pendingFocusTarget).toEqual({
+      kind: "item",
+      id: asItemId("restored"),
+    });
+  });
+
+  it("undo → preservedSelectionTarget using the captured prior selection", () => {
+    const w0 = makeWorkout([step("a", 0)]);
+    const w1 = makeWorkout([step("a", 0), step("b", 1)]);
+    const state: WorkoutState = {
+      currentWorkout: w1,
+      workoutHistory: [w0, w1],
+      historyIndex: 1,
+      selectedStepId: "b",
+      selectedStepIds: [],
+      isEditing: false,
+      selectionHistory: [null, asItemId("a")],
+    };
+
+    const out = createUndoAction(state);
+
+    expect(out.pendingFocusTarget).toEqual({
+      kind: "item",
+      id: asItemId("a"),
+    });
+  });
+
+  it("redo → preservedSelectionTarget on the restored snapshot", () => {
+    const w0 = makeWorkout([step("a", 0)]);
+    const w1 = makeWorkout([step("a", 0), step("b", 1)]);
+    const state: WorkoutState = {
+      currentWorkout: w0,
+      workoutHistory: [w0, w1],
+      historyIndex: 0,
+      selectedStepId: "a",
+      selectedStepIds: [],
+      isEditing: false,
+      selectionHistory: [null, asItemId("a")],
+    };
+
+    const out = createRedoAction(state);
+
+    expect(out.pendingFocusTarget?.kind).toBe("item");
+  });
+
+  it("pasteStep → pendingFocusTarget = newly-generated pasted id", async () => {
+    const clipboardMock = vi.fn().mockResolvedValue(
+      JSON.stringify({
+        stepIndex: 0,
+        durationType: "open",
+        duration: { type: "open" },
+        targetType: "open",
+        target: { type: "open" },
+      })
+    );
+    vi.stubGlobal("navigator", {
+      clipboard: { readText: clipboardMock },
+    });
+
+    const { pasteStepAction } = await import("./paste-step-action");
+    const w = makeWorkout([step("a", 0)]);
+
+    const out = await pasteStepAction(w);
+
+    expect(out.success).toBe(true);
+    expect(typeof out.newItemId).toBe("string");
+    expect(out.newItemId?.length).toBeGreaterThan(0);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/workout-spa-editor/src/store/actions/history-actions.ts
+++ b/packages/workout-spa-editor/src/store/actions/history-actions.ts
@@ -4,30 +4,40 @@
  * Action creators for undo/redo functionality.
  */
 
+import { preservedSelectionTarget } from "../focus-rules";
+import { asItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
+
+const asId = (s: string | null) => (s ? asItemId(s) : null);
 
 export const createUndoAction = (
   state: WorkoutState
 ): Partial<WorkoutState> => {
-  if (state.historyIndex > 0) {
-    const newIndex = state.historyIndex - 1;
-    return {
-      currentWorkout: state.workoutHistory[newIndex],
-      historyIndex: newIndex,
-    };
-  }
-  return {};
+  if (state.historyIndex <= 0) return {};
+  const newIndex = state.historyIndex - 1;
+  const restored = state.workoutHistory[newIndex];
+  // On undo, the focus target is the selection captured for the snapshot
+  // we are undoing (i.e. the selection the user had right before the
+  // mutation that we are rolling back).
+  const prevSelection =
+    state.selectionHistory?.[state.historyIndex] ?? asId(state.selectedStepId);
+  return {
+    currentWorkout: restored,
+    historyIndex: newIndex,
+    pendingFocusTarget: preservedSelectionTarget(restored, prevSelection, 0),
+  };
 };
 
 export const createRedoAction = (
   state: WorkoutState
 ): Partial<WorkoutState> => {
-  if (state.historyIndex < state.workoutHistory.length - 1) {
-    const newIndex = state.historyIndex + 1;
-    return {
-      currentWorkout: state.workoutHistory[newIndex],
-      historyIndex: newIndex,
-    };
-  }
-  return {};
+  if (state.historyIndex >= state.workoutHistory.length - 1) return {};
+  const newIndex = state.historyIndex + 1;
+  const restored = state.workoutHistory[newIndex];
+  const selection = asId(state.selectedStepId);
+  return {
+    currentWorkout: restored,
+    historyIndex: newIndex,
+    pendingFocusTarget: preservedSelectionTarget(restored, selection, 0),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/paste-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/paste-step-action.ts
@@ -4,6 +4,8 @@ import type {
   Workout,
   WorkoutStep,
 } from "../../types/krd";
+import type { ItemId } from "../providers/item-id";
+import { asItemId } from "../providers/item-id";
 import {
   createUpdatedKrd,
   getSuccessMessage,
@@ -20,6 +22,7 @@ export type PasteStepResult = {
   success: boolean;
   message: string;
   updatedKrd?: KRD;
+  newItemId?: ItemId;
 };
 
 export const pasteStepAction = async (
@@ -58,8 +61,9 @@ export const pasteStepAction = async (
 
     const updatedKrd = createUpdatedKrd(krd, updatedWorkout);
     const message = getSuccessMessage(freshPayload);
+    const newItemId = asItemId((freshPayload as { id: string }).id);
 
-    return { success: true, message, updatedKrd };
+    return { success: true, message, updatedKrd, newItemId };
   } catch {
     return { success: false, message: "Failed to paste from clipboard" };
   }

--- a/packages/workout-spa-editor/src/store/actions/reorder-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/reorder-step-action.ts
@@ -11,6 +11,8 @@ import type {
   Workout,
   WorkoutStep,
 } from "../../types/krd";
+import type { FocusTarget } from "../focus/focus-target.types";
+import { asItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 
@@ -84,5 +86,13 @@ export const reorderStepAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  const movedId = (movedStep as { id?: string } | undefined)?.id;
+  const focusTarget: FocusTarget | null = movedId
+    ? { kind: "item", id: asItemId(movedId) }
+    : null;
+
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: focusTarget,
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/reorder-steps-in-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/reorder-steps-in-block-action.ts
@@ -6,6 +6,8 @@
  */
 
 import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
+import type { FocusTarget } from "../focus/focus-target.types";
+import { asItemId } from "../providers/item-id";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
@@ -86,5 +88,13 @@ export const reorderStepsInBlockAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  const movedId = (movedStep as { id?: string } | undefined)?.id;
+  const focusTarget: FocusTarget | null = movedId
+    ? { kind: "item", id: asItemId(movedId) }
+    : null;
+
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: focusTarget,
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/undo-delete-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/undo-delete-action.ts
@@ -11,6 +11,8 @@ import type {
   WorkoutStep,
 } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
+import type { FocusTarget } from "../focus/focus-target.types";
+import { asItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 
@@ -66,8 +68,14 @@ export const undoDeleteAction = (
   // Remove the deleted step from tracking
   const newDeletedSteps = deletedSteps.filter((d) => d.timestamp !== timestamp);
 
+  const restoredId = (step as { id?: string }).id;
+  const focusTarget: FocusTarget | null = restoredId
+    ? { kind: "item", id: asItemId(restoredId) }
+    : null;
+
   return {
     ...createUpdateWorkoutAction(updatedKrd, state),
     deletedSteps: newDeletedSteps,
+    pendingFocusTarget: focusTarget,
   };
 };

--- a/packages/workout-spa-editor/src/store/actions/ungroup-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/ungroup-repetition-block-action.ts
@@ -9,6 +9,8 @@
  */
 
 import type { KRD, Workout } from "../../types/krd";
+import type { FocusTarget } from "../focus/focus-target.types";
+import { asItemId } from "../providers/item-id";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
@@ -68,5 +70,13 @@ export const ungroupRepetitionBlockAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  const firstChild = extractedSteps[0] as { id?: string } | undefined;
+  const focusTarget: FocusTarget | null = firstChild?.id
+    ? { kind: "item", id: asItemId(firstChild.id) }
+    : null;
+
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: focusTarget,
+  };
 };

--- a/packages/workout-spa-editor/src/store/create-workout-method-helpers-basic.ts
+++ b/packages/workout-spa-editor/src/store/create-workout-method-helpers-basic.ts
@@ -2,6 +2,7 @@ import type { StoreApi } from "zustand";
 
 import { copyStepAction } from "./actions/copy-step-action";
 import { pasteStepAction } from "./actions/paste-step-action";
+import { createdItemTarget } from "./focus-rules";
 import type { createWorkoutStoreActions } from "./workout-store-actions";
 import type { WorkoutStore } from "./workout-store-types";
 
@@ -46,7 +47,13 @@ export const createClipboardMethods = (
     }
     const result = await pasteStepAction(state.currentWorkout, insertIndex);
     if (result.success && result.updatedKrd) {
-      set((state) => actions.updateWorkout(result.updatedKrd!, state));
+      const focusTarget = result.newItemId
+        ? createdItemTarget(result.newItemId)
+        : null;
+      set((s) => ({
+        ...actions.updateWorkout(result.updatedKrd!, s),
+        pendingFocusTarget: focusTarget,
+      }));
     }
     return { success: result.success, message: result.message };
   },

--- a/packages/workout-spa-editor/src/store/focus-rules/_fixtures.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/_fixtures.ts
@@ -1,0 +1,45 @@
+import type {
+  UIRepetitionBlock,
+  UIWorkout,
+  UIWorkoutItem,
+  UIWorkoutStep,
+} from "../../types/krd-ui";
+import type { ItemId } from "../providers/item-id";
+import { asItemId } from "../providers/item-id";
+
+export const step = (id: string, stepIndex = 0): UIWorkoutStep =>
+  ({
+    id: asItemId(id),
+    stepIndex,
+    durationType: "open",
+    duration: { type: "open" },
+    targetType: "open",
+    target: { type: "open" },
+  }) as unknown as UIWorkoutStep;
+
+export const block = (
+  id: string,
+  steps: Array<UIWorkoutStep>,
+  repeatCount = 2
+): UIRepetitionBlock =>
+  ({
+    id: asItemId(id),
+    repeatCount,
+    steps,
+  }) as unknown as UIRepetitionBlock;
+
+export const workout = (items: Array<UIWorkoutItem>): UIWorkout =>
+  ({
+    version: "1.0",
+    type: "structured_workout",
+    metadata: { sport: "cycling" },
+    extensions: {
+      structured_workout: {
+        name: "fixture",
+        sport: "cycling",
+        steps: items,
+      },
+    },
+  }) as unknown as UIWorkout;
+
+export const id = (s: string): ItemId => asItemId(s);

--- a/packages/workout-spa-editor/src/store/focus-rules/created-item.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/created-item.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { createdItemTarget } from "./created-item";
+import { id } from "./_fixtures";
+
+describe("createdItemTarget", () => {
+  it("returns { kind: 'item', id } for the new item", () => {
+    expect(createdItemTarget(id("new-1"))).toEqual({
+      kind: "item",
+      id: id("new-1"),
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/created-item.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/created-item.ts
@@ -1,0 +1,7 @@
+import type { FocusTarget } from "../focus/focus-target.types";
+import type { ItemId } from "../providers/item-id";
+
+export const createdItemTarget = (newItemId: ItemId): FocusTarget => ({
+  kind: "item",
+  id: newItemId,
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/index.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/index.ts
@@ -1,0 +1,5 @@
+export { createdItemTarget } from "./created-item";
+export { nextAfterDelete } from "./next-after-delete";
+export { nextAfterMultiDelete } from "./next-after-multi-delete";
+export { preservedSelectionTarget } from "./preserved-selection";
+export { restoredAfterUndoTarget } from "./restored-after-undo";

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-delete.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-delete.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { block, id, step, workout } from "./_fixtures";
+import { nextAfterDelete } from "./next-after-delete";
+
+describe("nextAfterDelete", () => {
+  it("main-list next sibling when item is not last", () => {
+    const w = workout([step("a"), step("b"), step("c")]);
+
+    expect(nextAfterDelete(w, id("b"))).toEqual({
+      kind: "item",
+      id: id("c"),
+    });
+  });
+
+  it("main-list previous sibling when deleted item is last", () => {
+    const w = workout([step("a"), step("b"), step("c")]);
+
+    expect(nextAfterDelete(w, id("c"))).toEqual({
+      kind: "item",
+      id: id("b"),
+    });
+  });
+
+  it("main-list empty-state when deleting the only remaining item", () => {
+    const w = workout([step("a")]);
+
+    expect(nextAfterDelete(w, id("a"))).toEqual({ kind: "empty-state" });
+  });
+
+  it("block-child next sibling when not last", () => {
+    const blk = block("blk", [step("b1"), step("b2"), step("b3")]);
+    const w = workout([step("a"), blk, step("c")]);
+
+    expect(nextAfterDelete(w, id("b1"), id("blk"))).toEqual({
+      kind: "item",
+      id: id("b2"),
+    });
+  });
+
+  it("block-child previous sibling when deleting last step in block", () => {
+    const blk = block("blk", [step("b1"), step("b2")]);
+    const w = workout([blk]);
+
+    expect(nextAfterDelete(w, id("b2"), id("blk"))).toEqual({
+      kind: "item",
+      id: id("b1"),
+    });
+  });
+
+  it("block-child last-remaining cascades to main-list next sibling", () => {
+    const blk = block("blk", [step("b1")]);
+    const w = workout([step("a"), blk, step("c")]);
+
+    expect(nextAfterDelete(w, id("b1"), id("blk"))).toEqual({
+      kind: "item",
+      id: id("c"),
+    });
+  });
+
+  it("block-child last-remaining cascades to empty-state when block was the only item", () => {
+    const blk = block("blk", [step("b1")]);
+    const w = workout([blk]);
+
+    expect(nextAfterDelete(w, id("b1"), id("blk"))).toEqual({
+      kind: "empty-state",
+    });
+  });
+
+  it("returns empty-state when deleted id is not present", () => {
+    const w = workout([step("a")]);
+
+    expect(nextAfterDelete(w, id("zzz"))).toEqual({ kind: "empty-state" });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-delete.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-delete.ts
@@ -1,0 +1,44 @@
+import type { UIWorkout } from "../../types/krd-ui";
+import type { FocusTarget } from "../focus/focus-target.types";
+import type { ItemId } from "../providers/item-id";
+import { findBlockInMainList, getMainListItems } from "./shared-lookups";
+
+const fromMainList = (workout: UIWorkout, deletedId: ItemId): FocusTarget => {
+  const items = getMainListItems(workout);
+  const idx = items.findIndex((item) => item.id === deletedId);
+  if (idx === -1) return { kind: "empty-state" };
+  const next = items[idx + 1];
+  if (next) return { kind: "item", id: next.id };
+  const prev = items[idx - 1];
+  if (prev) return { kind: "item", id: prev.id };
+  return { kind: "empty-state" };
+};
+
+/**
+ * Pure focus rule for a single-item delete.
+ *
+ * - Main list: next sibling → previous sibling → empty-state.
+ * - Block child: next step in block → previous step in block → cascade to
+ *   main-list rule keyed by the now-empty parent block (the block itself
+ *   will be removed by the action handler).
+ */
+export const nextAfterDelete = (
+  workout: UIWorkout,
+  deletedItemId: ItemId,
+  parentBlockId?: ItemId
+): FocusTarget => {
+  if (!parentBlockId) return fromMainList(workout, deletedItemId);
+
+  const parent = findBlockInMainList(workout, parentBlockId);
+  if (!parent) return fromMainList(workout, deletedItemId);
+
+  const stepIdx = parent.block.steps.findIndex((s) => s.id === deletedItemId);
+  if (stepIdx === -1) return fromMainList(workout, parentBlockId);
+
+  const nextStep = parent.block.steps[stepIdx + 1];
+  if (nextStep) return { kind: "item", id: nextStep.id };
+  const prevStep = parent.block.steps[stepIdx - 1];
+  if (prevStep) return { kind: "item", id: prevStep.id };
+
+  return fromMainList(workout, parentBlockId);
+};

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { block, id, step, workout } from "./_fixtures";
+import { nextAfterMultiDelete } from "./next-after-multi-delete";
+
+describe("nextAfterMultiDelete", () => {
+  it("picks the first remaining item after the last deleted position", () => {
+    const w = workout([step("a"), step("b"), step("c"), step("d")]);
+
+    expect(nextAfterMultiDelete(w, [id("a"), id("b")])).toEqual({
+      kind: "item",
+      id: id("c"),
+    });
+  });
+
+  it("falls back to the previous-sibling of the first deleted when nothing remains after", () => {
+    const w = workout([step("a"), step("b"), step("c"), step("d")]);
+
+    expect(nextAfterMultiDelete(w, [id("c"), id("d")])).toEqual({
+      kind: "item",
+      id: id("b"),
+    });
+  });
+
+  it("returns empty-state when every item is deleted", () => {
+    const w = workout([step("a"), step("b")]);
+
+    expect(nextAfterMultiDelete(w, [id("a"), id("b")])).toEqual({
+      kind: "empty-state",
+    });
+  });
+
+  it("handles non-contiguous selection by skipping deleted ids", () => {
+    const w = workout([step("a"), step("b"), step("c"), step("d"), step("e")]);
+
+    expect(nextAfterMultiDelete(w, [id("b"), id("d")])).toEqual({
+      kind: "item",
+      id: id("e"),
+    });
+  });
+
+  it("operates inside a parent block when parentBlockId is provided", () => {
+    const blk = block("blk", [step("b1"), step("b2"), step("b3")]);
+    const w = workout([blk]);
+
+    expect(nextAfterMultiDelete(w, [id("b1"), id("b2")], id("blk"))).toEqual({
+      kind: "item",
+      id: id("b3"),
+    });
+  });
+
+  it("returns empty-state if deletedIds is empty", () => {
+    const w = workout([step("a")]);
+
+    expect(nextAfterMultiDelete(w, [])).toEqual({ kind: "empty-state" });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.ts
@@ -1,0 +1,58 @@
+import type { UIWorkout, UIWorkoutItem } from "../../types/krd-ui";
+import type { FocusTarget } from "../focus/focus-target.types";
+import type { ItemId } from "../providers/item-id";
+import { findBlockInMainList, getMainListItems } from "./shared-lookups";
+
+const pickAfterLast = (
+  items: ReadonlyArray<{ id: ItemId }>,
+  deleted: ReadonlySet<ItemId>,
+  lastDeletedIdx: number
+): FocusTarget | null => {
+  for (let i = lastDeletedIdx + 1; i < items.length; i++) {
+    if (!deleted.has(items[i].id)) return { kind: "item", id: items[i].id };
+  }
+  return null;
+};
+
+const pickBeforeFirst = (
+  items: ReadonlyArray<{ id: ItemId }>,
+  deleted: ReadonlySet<ItemId>,
+  firstDeletedIdx: number
+): FocusTarget | null => {
+  for (let i = firstDeletedIdx - 1; i >= 0; i--) {
+    if (!deleted.has(items[i].id)) return { kind: "item", id: items[i].id };
+  }
+  return null;
+};
+
+const computeTarget = (
+  items: ReadonlyArray<{ id: ItemId }>,
+  deleted: ReadonlySet<ItemId>
+): FocusTarget => {
+  const deletedIdxs: Array<number> = [];
+  for (let i = 0; i < items.length; i++) {
+    if (deleted.has(items[i].id)) deletedIdxs.push(i);
+  }
+  if (deletedIdxs.length === 0) return { kind: "empty-state" };
+  const first = deletedIdxs[0];
+  const last = deletedIdxs[deletedIdxs.length - 1];
+  return (
+    pickAfterLast(items, deleted, last) ??
+    pickBeforeFirst(items, deleted, first) ?? { kind: "empty-state" }
+  );
+};
+
+export const nextAfterMultiDelete = (
+  workout: UIWorkout,
+  deletedIds: ReadonlyArray<ItemId>,
+  parentBlockId?: ItemId
+): FocusTarget => {
+  const deleted: ReadonlySet<ItemId> = new Set(deletedIds);
+  if (parentBlockId) {
+    const parent = findBlockInMainList(workout, parentBlockId);
+    if (!parent) return { kind: "empty-state" };
+    return computeTarget(parent.block.steps, deleted);
+  }
+  const mainItems = getMainListItems(workout) as ReadonlyArray<UIWorkoutItem>;
+  return computeTarget(mainItems, deleted);
+};

--- a/packages/workout-spa-editor/src/store/focus-rules/preserved-selection.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/preserved-selection.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { id, step, workout } from "./_fixtures";
+import { preservedSelectionTarget } from "./preserved-selection";
+
+describe("preservedSelectionTarget", () => {
+  it("keeps the prior selection when it still exists", () => {
+    const w = workout([step("a"), step("b")]);
+
+    expect(preservedSelectionTarget(w, id("a"), 0)).toEqual({
+      kind: "item",
+      id: id("a"),
+    });
+  });
+
+  it("falls back to the same-index item when the prior selection is gone", () => {
+    const w = workout([step("a"), step("b")]);
+
+    expect(preservedSelectionTarget(w, id("gone"), 1)).toEqual({
+      kind: "item",
+      id: id("b"),
+    });
+  });
+
+  it("returns empty-state when index is out of range and prior selection is gone", () => {
+    const w = workout([step("a")]);
+
+    expect(preservedSelectionTarget(w, id("gone"), 5)).toEqual({
+      kind: "empty-state",
+    });
+  });
+
+  it("returns empty-state when previous selection is null and index is out of range", () => {
+    const w = workout([]);
+
+    expect(preservedSelectionTarget(w, null, 0)).toEqual({
+      kind: "empty-state",
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/preserved-selection.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/preserved-selection.ts
@@ -1,0 +1,18 @@
+import type { UIWorkout } from "../../types/krd-ui";
+import type { FocusTarget } from "../focus/focus-target.types";
+import type { ItemId } from "../providers/item-id";
+import { containsItemId, getMainListItems } from "./shared-lookups";
+
+export const preservedSelectionTarget = (
+  workout: UIWorkout,
+  previouslySelectedId: ItemId | null,
+  fallbackIndex: number
+): FocusTarget => {
+  if (previouslySelectedId && containsItemId(workout, previouslySelectedId)) {
+    return { kind: "item", id: previouslySelectedId };
+  }
+  const items = getMainListItems(workout);
+  const candidate = items[fallbackIndex];
+  if (candidate) return { kind: "item", id: candidate.id };
+  return { kind: "empty-state" };
+};

--- a/packages/workout-spa-editor/src/store/focus-rules/restored-after-undo.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/restored-after-undo.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { block, id, step, workout } from "./_fixtures";
+import { restoredAfterUndoTarget } from "./restored-after-undo";
+
+describe("restoredAfterUndoTarget", () => {
+  it("returns the restored item id when present in the workout", () => {
+    const w = workout([step("a"), step("b")]);
+
+    expect(restoredAfterUndoTarget(w, id("b"))).toEqual({
+      kind: "item",
+      id: id("b"),
+    });
+  });
+
+  it("returns empty-state when the id is not present", () => {
+    const w = workout([step("a")]);
+
+    expect(restoredAfterUndoTarget(w, id("missing"))).toEqual({
+      kind: "empty-state",
+    });
+  });
+
+  it("finds items nested inside a repetition block", () => {
+    const blk = block("blk", [step("b1")]);
+    const w = workout([blk]);
+
+    expect(restoredAfterUndoTarget(w, id("b1"))).toEqual({
+      kind: "item",
+      id: id("b1"),
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/restored-after-undo.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/restored-after-undo.ts
@@ -1,0 +1,12 @@
+import type { UIWorkout } from "../../types/krd-ui";
+import type { FocusTarget } from "../focus/focus-target.types";
+import type { ItemId } from "../providers/item-id";
+import { containsItemId } from "./shared-lookups";
+
+export const restoredAfterUndoTarget = (
+  workout: UIWorkout,
+  restoredItemId: ItemId
+): FocusTarget =>
+  containsItemId(workout, restoredItemId)
+    ? { kind: "item", id: restoredItemId }
+    : { kind: "empty-state" };

--- a/packages/workout-spa-editor/src/store/focus-rules/shared-lookups.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/shared-lookups.ts
@@ -1,0 +1,61 @@
+import { isRepetitionBlock, isWorkoutStep } from "../../types/krd";
+import type {
+  UIRepetitionBlock,
+  UIWorkout,
+  UIWorkoutItem,
+  UIWorkoutStep,
+} from "../../types/krd-ui";
+import type { ItemId } from "../providers/item-id";
+
+export const getMainListItems = (
+  workout: UIWorkout
+): ReadonlyArray<UIWorkoutItem> =>
+  (workout.extensions?.structured_workout?.steps ??
+    []) as ReadonlyArray<UIWorkoutItem>;
+
+export const findMainListIndex = (workout: UIWorkout, id: ItemId): number =>
+  getMainListItems(workout).findIndex((item) => item.id === id);
+
+export const findBlockInMainList = (
+  workout: UIWorkout,
+  blockId: ItemId
+): { block: UIRepetitionBlock; index: number } | null => {
+  const items = getMainListItems(workout);
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (isRepetitionBlock(item) && item.id === blockId) {
+      return { block: item as UIRepetitionBlock, index: i };
+    }
+  }
+  return null;
+};
+
+export const findBlockContainingStepId = (
+  workout: UIWorkout,
+  stepId: ItemId
+): {
+  block: UIRepetitionBlock;
+  blockIndex: number;
+  stepIndex: number;
+} | null => {
+  const items = getMainListItems(workout);
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (!isRepetitionBlock(item)) continue;
+    const block = item as UIRepetitionBlock;
+    const idx = block.steps.findIndex((s) => s.id === stepId);
+    if (idx !== -1) return { block, blockIndex: i, stepIndex: idx };
+  }
+  return null;
+};
+
+export const containsItemId = (workout: UIWorkout, id: ItemId): boolean => {
+  for (const item of getMainListItems(workout)) {
+    if (item.id === id) return true;
+    if (!isWorkoutStep(item)) {
+      const block = item as UIRepetitionBlock;
+      if (block.steps.some((s: UIWorkoutStep) => s.id === id)) return true;
+    }
+  }
+  return false;
+};

--- a/packages/workout-spa-editor/src/store/focus/focus-slice.test.ts
+++ b/packages/workout-spa-editor/src/store/focus/focus-slice.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { create } from "zustand";
+
+import { asItemId } from "../providers/item-id";
+import { createFocusSlice } from "./focus-slice";
+import type { FocusSlice } from "./focus-slice.types";
+
+const makeStore = () => create<FocusSlice>()((set) => createFocusSlice(set));
+
+describe("FocusSlice", () => {
+  it("initialises pendingFocusTarget to null and selectionHistory to []", () => {
+    const store = makeStore();
+
+    expect(store.getState().pendingFocusTarget).toBeNull();
+    expect(store.getState().selectionHistory).toEqual([]);
+  });
+
+  it("setPendingFocusTarget(null) clears the target", () => {
+    const store = makeStore();
+
+    store.getState().setPendingFocusTarget({
+      kind: "item",
+      id: asItemId("a"),
+    });
+    store.getState().setPendingFocusTarget(null);
+
+    expect(store.getState().pendingFocusTarget).toBeNull();
+  });
+
+  it("writes the latest target on repeated sets", () => {
+    const store = makeStore();
+
+    store.getState().setPendingFocusTarget({
+      kind: "item",
+      id: asItemId("first"),
+    });
+    store.getState().setPendingFocusTarget({
+      kind: "item",
+      id: asItemId("second"),
+    });
+
+    expect(store.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: "second",
+    });
+  });
+
+  it("accepts an id that does not match any item without throwing", () => {
+    const store = makeStore();
+
+    expect(() =>
+      store.getState().setPendingFocusTarget({
+        kind: "item",
+        id: asItemId("unresolved"),
+      })
+    ).not.toThrow();
+    expect(store.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: "unresolved",
+    });
+  });
+
+  it("accepts empty-state kind", () => {
+    const store = makeStore();
+
+    store.getState().setPendingFocusTarget({ kind: "empty-state" });
+
+    expect(store.getState().pendingFocusTarget).toEqual({
+      kind: "empty-state",
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus/focus-slice.ts
+++ b/packages/workout-spa-editor/src/store/focus/focus-slice.ts
@@ -1,0 +1,17 @@
+import type { StoreApi } from "zustand";
+
+import type { FocusSlice, FocusSliceState } from "./focus-slice.types";
+import type { FocusTarget } from "./focus-target.types";
+
+export const initialFocusSliceState: FocusSliceState = {
+  pendingFocusTarget: null,
+  selectionHistory: [],
+};
+
+export const createFocusSlice = <T extends FocusSlice>(
+  set: StoreApi<T>["setState"]
+): FocusSlice => ({
+  ...initialFocusSliceState,
+  setPendingFocusTarget: (target: FocusTarget | null) =>
+    set({ pendingFocusTarget: target } as Partial<T>),
+});

--- a/packages/workout-spa-editor/src/store/focus/focus-slice.types.ts
+++ b/packages/workout-spa-editor/src/store/focus/focus-slice.types.ts
@@ -1,0 +1,13 @@
+import type { ItemId } from "../providers/item-id";
+import type { FocusTarget } from "./focus-target.types";
+
+export type FocusSliceState = {
+  pendingFocusTarget: FocusTarget | null;
+  selectionHistory: Array<ItemId | null>;
+};
+
+export type FocusSliceActions = {
+  setPendingFocusTarget: (target: FocusTarget | null) => void;
+};
+
+export type FocusSlice = FocusSliceState & FocusSliceActions;

--- a/packages/workout-spa-editor/src/store/focus/focus-target.types.test.ts
+++ b/packages/workout-spa-editor/src/store/focus/focus-target.types.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { asItemId } from "../providers/item-id";
+import type { FocusTarget } from "./focus-target.types";
+
+describe("FocusTarget discriminated union", () => {
+  it("narrows to { id } on kind === 'item'", () => {
+    const target: FocusTarget = { kind: "item", id: asItemId("abc") };
+
+    if (target.kind === "item") {
+      expect(target.id).toBe("abc");
+    } else {
+      throw new Error("expected item narrowing");
+    }
+  });
+
+  it("narrows to empty-state without id", () => {
+    const target: FocusTarget = { kind: "empty-state" };
+
+    if (target.kind === "empty-state") {
+      expect("id" in target).toBe(false);
+    } else {
+      throw new Error("expected empty-state narrowing");
+    }
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus/focus-target.types.ts
+++ b/packages/workout-spa-editor/src/store/focus/focus-target.types.ts
@@ -1,0 +1,6 @@
+import type { ItemId } from "../providers/item-id";
+
+export type FocusTargetItem = { kind: "item"; id: ItemId };
+export type FocusTargetEmptyState = { kind: "empty-state" };
+
+export type FocusTarget = FocusTargetItem | FocusTargetEmptyState;

--- a/packages/workout-spa-editor/src/store/workout-actions.ts
+++ b/packages/workout-spa-editor/src/store/workout-actions.ts
@@ -3,11 +3,12 @@ import type { Sport } from "../types/krd-core";
 import type { UIWorkout } from "../types/krd-ui";
 import { migrateRepetitionBlocks } from "../utils/workout-migration";
 import { hydrateUIWorkout } from "./hydrate-ui-workout";
+import type { ItemId } from "./providers/item-id";
+import { asItemId } from "./providers/item-id";
 import type { WorkoutState } from "./workout-state.types";
+import { pushHistorySnapshot } from "./workout-store-history";
 
 export type { WorkoutState };
-
-const MAX_HISTORY_SIZE = 50;
 
 export const createLoadWorkoutAction = (krd: KRD): Partial<WorkoutState> => {
   const workout = krd.extensions?.structured_workout as Workout | undefined;
@@ -25,38 +26,34 @@ export const createLoadWorkoutAction = (krd: KRD): Partial<WorkoutState> => {
     currentWorkout: uiWorkout,
     workoutHistory: [uiWorkout],
     historyIndex: 0,
+    selectionHistory: [null],
     selectedStepId: null,
     selectedStepIds: [],
     isEditing: false,
+    pendingFocusTarget: null,
   };
 };
+
+const selectionAsItemId = (state: WorkoutState): ItemId | null =>
+  state.selectedStepId ? asItemId(state.selectedStepId) : null;
 
 export const createUpdateWorkoutAction = (
   uiWorkout: UIWorkout,
   state: WorkoutState
-): Partial<WorkoutState> => {
-  const newHistory = [
-    ...state.workoutHistory.slice(0, state.historyIndex + 1),
-    uiWorkout,
-  ];
-  const trimmedHistory =
-    newHistory.length > MAX_HISTORY_SIZE
-      ? newHistory.slice(newHistory.length - MAX_HISTORY_SIZE)
-      : newHistory;
-  return {
-    currentWorkout: uiWorkout,
-    workoutHistory: trimmedHistory,
-    historyIndex: trimmedHistory.length - 1,
-  };
-};
+): Partial<WorkoutState> => ({
+  currentWorkout: uiWorkout,
+  ...pushHistorySnapshot(uiWorkout, selectionAsItemId(state), state),
+});
 
 export const createClearWorkoutAction = (): Partial<WorkoutState> => ({
   currentWorkout: null,
   workoutHistory: [],
   historyIndex: -1,
+  selectionHistory: [],
   selectedStepId: null,
   selectedStepIds: [],
   isEditing: false,
+  pendingFocusTarget: null,
 });
 
 export const createEmptyWorkoutAction = (
@@ -73,9 +70,11 @@ export const createEmptyWorkoutAction = (
     currentWorkout: emptyWorkout,
     workoutHistory: [emptyWorkout],
     historyIndex: 0,
+    selectionHistory: [null],
     selectedStepId: null,
     selectedStepIds: [],
     isEditing: false,
+    pendingFocusTarget: null,
   };
 };
 

--- a/packages/workout-spa-editor/src/store/workout-state.types.ts
+++ b/packages/workout-spa-editor/src/store/workout-state.types.ts
@@ -1,4 +1,6 @@
 import type { UIWorkout, UIWorkoutItem } from "../types/krd-ui";
+import type { FocusTarget } from "./focus/focus-target.types";
+import type { ItemId } from "./providers/item-id";
 
 export type {
   UIRepetitionBlock,
@@ -22,4 +24,6 @@ export type WorkoutState = {
     index: number;
     timestamp: number;
   }>;
+  selectionHistory?: Array<ItemId | null>;
+  pendingFocusTarget?: FocusTarget | null;
 };

--- a/packages/workout-spa-editor/src/store/workout-store-actions.types.ts
+++ b/packages/workout-spa-editor/src/store/workout-store-actions.types.ts
@@ -1,0 +1,58 @@
+import type { KRD } from "../types/krd";
+import type { Sport } from "../types/krd-core";
+import type { ModalConfig } from "./workout-store-state.types";
+
+export type WorkoutStoreActions = {
+  loadWorkout: (krd: KRD) => void;
+  createEmptyWorkout: (name: string, sport: Sport) => void;
+  updateWorkout: (krd: KRD) => void;
+  createStep: () => void;
+  deleteStep: (stepIndex: number) => void;
+  undoDelete: (timestamp: number) => void;
+  clearExpiredDeletes: () => void;
+  duplicateStep: (stepIndex: number) => void;
+  copyStep: (
+    stepIndex: number
+  ) => Promise<{ success: boolean; message: string }>;
+  pasteStep: (
+    insertIndex?: number
+  ) => Promise<{ success: boolean; message: string }>;
+  reorderStep: (activeIndex: number, overIndex: number) => void;
+  reorderStepsInBlock: (
+    blockId: string,
+    activeIndex: number,
+    overIndex: number
+  ) => void;
+  createRepetitionBlock: (
+    stepIndices: Array<number>,
+    repeatCount: number
+  ) => void;
+  createEmptyRepetitionBlock: (repeatCount: number) => void;
+  editRepetitionBlock: (blockId: string, repeatCount: number) => void;
+  addStepToRepetitionBlock: (blockId: string) => void;
+  duplicateStepInRepetitionBlock: (blockId: string, stepIndex: number) => void;
+  ungroupRepetitionBlock: (blockId: string) => void;
+  deleteRepetitionBlock: (blockId: string) => void;
+  selectStep: (id: string | null) => void;
+  toggleStepSelection: (id: string) => void;
+  clearStepSelection: () => void;
+  selectAllSteps: (ids: Array<string>) => void;
+  setEditing: (editing: boolean) => void;
+  clearWorkout: () => void;
+  undo: () => void;
+  redo: () => void;
+
+  createBackup: () => void;
+  restoreFromBackup: () => boolean;
+  enableSafeMode: () => void;
+  disableSafeMode: () => void;
+
+  showConfirmationModal: (config: ModalConfig) => void;
+  hideConfirmationModal: () => void;
+  openCreateBlockDialog: () => void;
+  closeCreateBlockDialog: () => void;
+
+  canUndo: () => boolean;
+  canRedo: () => boolean;
+  hasBackup: () => boolean;
+};

--- a/packages/workout-spa-editor/src/store/workout-store-history.test.ts
+++ b/packages/workout-spa-editor/src/store/workout-store-history.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { asItemId } from "./providers/item-id";
+import type { UIWorkout } from "./workout-state.types";
+import { pushHistorySnapshot } from "./workout-store-history";
+
+const makeWorkout = (version: string): UIWorkout =>
+  ({
+    version,
+    type: "structured_workout",
+    metadata: { sport: "cycling" },
+    extensions: {
+      structured_workout: {
+        name: "w",
+        sport: "cycling",
+        steps: [],
+      },
+    },
+  }) as unknown as UIWorkout;
+
+describe("pushHistorySnapshot", () => {
+  const baseState = {
+    workoutHistory: [] as Array<UIWorkout>,
+    historyIndex: -1,
+    selectionHistory: [] as Array<ReturnType<typeof asItemId> | null>,
+  };
+
+  it("appends workout + selection and bumps historyIndex", () => {
+    const a = makeWorkout("a");
+
+    const result = pushHistorySnapshot(a, asItemId("s1"), baseState);
+
+    expect(result.workoutHistory).toEqual([a]);
+    expect(result.selectionHistory).toEqual([asItemId("s1")]);
+    expect(result.historyIndex).toBe(0);
+  });
+
+  it("keeps workoutHistory.length === selectionHistory.length across pushes", () => {
+    const a = makeWorkout("a");
+    const b = makeWorkout("b");
+
+    const first = pushHistorySnapshot(a, null, baseState);
+    const second = pushHistorySnapshot(b, asItemId("s1"), first);
+
+    expect(second.workoutHistory).toHaveLength(second.selectionHistory.length);
+  });
+
+  it("captures the pre-mutation selection as the last selection entry", () => {
+    const a = makeWorkout("a");
+    const b = makeWorkout("b");
+
+    const first = pushHistorySnapshot(a, asItemId("before"), baseState);
+    const second = pushHistorySnapshot(b, asItemId("after"), first);
+
+    expect(second.selectionHistory[0]).toBe(asItemId("before"));
+    expect(second.selectionHistory[1]).toBe(asItemId("after"));
+  });
+
+  it("drops redo-future entries when pushing past the current historyIndex", () => {
+    const a = makeWorkout("a");
+    const b = makeWorkout("b");
+    const c = makeWorkout("c");
+
+    const afterB = pushHistorySnapshot(
+      b,
+      asItemId("sb"),
+      pushHistorySnapshot(a, asItemId("sa"), baseState)
+    );
+    // Simulate undo by rewinding historyIndex, then push c.
+    const rewound = {
+      ...afterB,
+      historyIndex: 0,
+    };
+
+    const result = pushHistorySnapshot(c, asItemId("sc"), rewound);
+
+    expect(result.workoutHistory).toEqual([a, c]);
+    expect(result.selectionHistory).toEqual([asItemId("sa"), asItemId("sc")]);
+    expect(result.historyIndex).toBe(1);
+  });
+
+  it("caps history at MAX_HISTORY_SIZE preserving parallel lengths", () => {
+    let state = { ...baseState };
+    for (let i = 0; i < 60; i++) {
+      state = pushHistorySnapshot(
+        makeWorkout(`v${i}`),
+        asItemId(`s${i}`),
+        state
+      );
+    }
+
+    expect(state.workoutHistory).toHaveLength(50);
+    expect(state.selectionHistory).toHaveLength(50);
+    expect(state.workoutHistory[0].version).toBe("v10");
+    expect(state.selectionHistory[0]).toBe(asItemId("s10"));
+  });
+
+  it("defaults selectionHistory to [] if the caller state omits it", () => {
+    const a = makeWorkout("a");
+    const loose = { workoutHistory: [] as Array<UIWorkout>, historyIndex: -1 };
+
+    const result = pushHistorySnapshot(a, null, loose);
+
+    expect(result.selectionHistory).toEqual([null]);
+  });
+
+  describe("dev-mode invariant assertion", () => {
+    it("logs when a malformed caller desynchronises the arrays", () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.stubEnv("NODE_ENV", "test");
+      const a = makeWorkout("a");
+      const desync = {
+        workoutHistory: [a, a, a],
+        historyIndex: 2,
+        selectionHistory: [null], // shorter than workoutHistory
+      };
+
+      pushHistorySnapshot(a, null, desync);
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      errorSpy.mockRestore();
+      vi.unstubAllEnvs();
+    });
+
+    it("is silent in production", () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.stubEnv("NODE_ENV", "production");
+      const a = makeWorkout("a");
+      const desync = {
+        workoutHistory: [a, a, a],
+        historyIndex: 2,
+        selectionHistory: [null],
+      };
+
+      pushHistorySnapshot(a, null, desync);
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      errorSpy.mockRestore();
+      vi.unstubAllEnvs();
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/store/workout-store-history.ts
+++ b/packages/workout-spa-editor/src/store/workout-store-history.ts
@@ -1,0 +1,80 @@
+import type { ItemId } from "./providers/item-id";
+import type { UIWorkout } from "./workout-state.types";
+
+export const MAX_HISTORY_SIZE = 50;
+
+// DO NOT capture pendingFocusTarget here — undo/redo compute focus targets
+// at dispatch time via focus-rule helpers.
+type HistorySource = {
+  workoutHistory: Array<UIWorkout>;
+  historyIndex: number;
+  selectionHistory?: Array<ItemId | null>;
+};
+
+export type HistorySnapshotUpdate = {
+  workoutHistory: Array<UIWorkout>;
+  historyIndex: number;
+  selectionHistory: Array<ItemId | null>;
+};
+
+const isDevMode = (): boolean => {
+  const g = globalThis as { process?: { env?: { NODE_ENV?: string } } };
+  const nodeEnv = g.process?.env?.NODE_ENV;
+  if (nodeEnv !== undefined) return nodeEnv !== "production";
+  const mode = (import.meta as { env?: { MODE?: string } }).env?.MODE;
+  return mode !== "production";
+};
+
+const assertParallel = (
+  history: ReadonlyArray<UIWorkout>,
+  selection: ReadonlyArray<ItemId | null>
+): void => {
+  if (isDevMode() && history.length !== selection.length) {
+    console.error(
+      `[kaiord] History invariant violation: workoutHistory.length=${history.length}, selectionHistory.length=${selection.length}`
+    );
+  }
+};
+
+const trimToHistoryIndex = <T>(arr: Array<T>, index: number): Array<T> =>
+  arr.slice(0, index + 1);
+
+/**
+ * Centralised chokepoint for appending a snapshot to the workout history
+ * and its parallel selection-history array.
+ *
+ * Every mutating action MUST call this helper instead of pushing to
+ * `workoutHistory` directly — a CI grep enforces that `workoutHistory.push`
+ * appears nowhere else in the SPA.
+ */
+export const pushHistorySnapshot = (
+  uiWorkout: UIWorkout,
+  selection: ItemId | null,
+  state: HistorySource
+): HistorySnapshotUpdate => {
+  const trimmedHistory = trimToHistoryIndex(
+    state.workoutHistory,
+    state.historyIndex
+  );
+  const trimmedSelection = trimToHistoryIndex(
+    state.selectionHistory ?? [],
+    state.historyIndex
+  );
+
+  trimmedHistory.push(uiWorkout);
+  trimmedSelection.push(selection);
+
+  const overflow = trimmedHistory.length - MAX_HISTORY_SIZE;
+  const cappedHistory =
+    overflow > 0 ? trimmedHistory.slice(overflow) : trimmedHistory;
+  const cappedSelection =
+    overflow > 0 ? trimmedSelection.slice(overflow) : trimmedSelection;
+
+  assertParallel(cappedHistory, cappedSelection);
+
+  return {
+    workoutHistory: cappedHistory,
+    historyIndex: cappedHistory.length - 1,
+    selectionHistory: cappedSelection,
+  };
+};

--- a/packages/workout-spa-editor/src/store/workout-store-state.types.ts
+++ b/packages/workout-spa-editor/src/store/workout-store-state.types.ts
@@ -1,0 +1,39 @@
+/**
+ * State-only fields of the workout store. Keep this file small — the
+ * single-responsibility split lets `workout-store-types.ts` stay under
+ * the max-lines budget and keeps composed slices (focus, future ones)
+ * trivial to inspect.
+ */
+
+import type { UIWorkout, UIWorkoutItem } from "../types/krd-ui";
+
+export type DeletedStep = {
+  step: UIWorkoutItem;
+  index: number;
+  timestamp: number;
+};
+
+export type ModalConfig = {
+  title: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  onConfirm: () => void;
+  onCancel?: () => void;
+  variant: "default" | "destructive";
+};
+
+export type WorkoutStoreState = {
+  currentWorkout: UIWorkout | null;
+  workoutHistory: Array<UIWorkout>;
+  historyIndex: number;
+  selectedStepId: string | null;
+  selectedStepIds: Array<string>;
+  isEditing: boolean;
+  safeMode: boolean;
+  lastBackup: UIWorkout | null;
+  deletedSteps: Array<DeletedStep>;
+  isModalOpen: boolean;
+  modalConfig: ModalConfig | null;
+  createBlockDialogOpen: boolean;
+};

--- a/packages/workout-spa-editor/src/store/workout-store-types.ts
+++ b/packages/workout-spa-editor/src/store/workout-store-types.ts
@@ -1,98 +1,15 @@
 /**
  * Workout Store Types
  *
- * Type definitions for the workout store.
+ * Composition of the store's state, action, and focus-slice type files.
+ * Each constituent file lives next to this one to respect the file-size
+ * invariant.
  */
 
-import type { KRD } from "../types/krd";
-import type { Sport } from "../types/krd-core";
-import type { UIWorkout, UIWorkoutItem } from "../types/krd-ui";
+import type { FocusSlice } from "./focus/focus-slice.types";
+import type { WorkoutStoreActions } from "./workout-store-actions.types";
+import type { WorkoutStoreState } from "./workout-store-state.types";
 
-export type DeletedStep = {
-  step: UIWorkoutItem;
-  index: number;
-  timestamp: number;
-};
+export type { DeletedStep, ModalConfig } from "./workout-store-state.types";
 
-export type ModalConfig = {
-  title: string;
-  message: string;
-  confirmLabel: string;
-  cancelLabel: string;
-  onConfirm: () => void;
-  onCancel?: () => void;
-  variant: "default" | "destructive";
-};
-
-export type WorkoutStore = {
-  // State
-  currentWorkout: UIWorkout | null;
-  workoutHistory: Array<UIWorkout>;
-  historyIndex: number;
-  selectedStepId: string | null;
-  selectedStepIds: Array<string>;
-  isEditing: boolean;
-  safeMode: boolean;
-  lastBackup: UIWorkout | null;
-  deletedSteps: Array<DeletedStep>;
-  isModalOpen: boolean;
-  modalConfig: ModalConfig | null;
-  createBlockDialogOpen: boolean;
-
-  // Actions
-  loadWorkout: (krd: KRD) => void;
-  createEmptyWorkout: (name: string, sport: Sport) => void;
-  updateWorkout: (krd: KRD) => void;
-  createStep: () => void;
-  deleteStep: (stepIndex: number) => void;
-  undoDelete: (timestamp: number) => void;
-  clearExpiredDeletes: () => void;
-  duplicateStep: (stepIndex: number) => void;
-  copyStep: (
-    stepIndex: number
-  ) => Promise<{ success: boolean; message: string }>;
-  pasteStep: (
-    insertIndex?: number
-  ) => Promise<{ success: boolean; message: string }>;
-  reorderStep: (activeIndex: number, overIndex: number) => void;
-  reorderStepsInBlock: (
-    blockId: string,
-    activeIndex: number,
-    overIndex: number
-  ) => void;
-  createRepetitionBlock: (
-    stepIndices: Array<number>,
-    repeatCount: number
-  ) => void;
-  createEmptyRepetitionBlock: (repeatCount: number) => void;
-  editRepetitionBlock: (blockId: string, repeatCount: number) => void;
-  addStepToRepetitionBlock: (blockId: string) => void;
-  duplicateStepInRepetitionBlock: (blockId: string, stepIndex: number) => void;
-  ungroupRepetitionBlock: (blockId: string) => void;
-  deleteRepetitionBlock: (blockId: string) => void;
-  selectStep: (id: string | null) => void;
-  toggleStepSelection: (id: string) => void;
-  clearStepSelection: () => void;
-  selectAllSteps: (ids: Array<string>) => void;
-  setEditing: (editing: boolean) => void;
-  clearWorkout: () => void;
-  undo: () => void;
-  redo: () => void;
-
-  // Error Recovery Actions
-  createBackup: () => void;
-  restoreFromBackup: () => boolean;
-  enableSafeMode: () => void;
-  disableSafeMode: () => void;
-
-  // Modal Actions
-  showConfirmationModal: (config: ModalConfig) => void;
-  hideConfirmationModal: () => void;
-  openCreateBlockDialog: () => void;
-  closeCreateBlockDialog: () => void;
-
-  // Computed
-  canUndo: () => boolean;
-  canRedo: () => boolean;
-  hasBackup: () => boolean;
-};
+export type WorkoutStore = WorkoutStoreState & WorkoutStoreActions & FocusSlice;

--- a/packages/workout-spa-editor/src/store/workout-store.ts
+++ b/packages/workout-spa-editor/src/store/workout-store.ts
@@ -3,6 +3,7 @@ import { create } from "zustand";
 import { createHistoryMethods } from "./create-history-methods";
 import { createRecoveryMethods } from "./create-recovery-methods";
 import { createWorkoutMethods } from "./create-workout-methods";
+import { createFocusSlice } from "./focus/focus-slice";
 import { createWorkoutStoreActions } from "./workout-store-actions";
 import { createModalActions } from "./workout-store-modal-actions";
 import { createSelectionActions } from "./workout-store-selection-actions";
@@ -24,6 +25,7 @@ export const useWorkoutStore = create<WorkoutStore>((set, get) => {
     isModalOpen: false,
     modalConfig: null,
     createBlockDialogOpen: false,
+    ...createFocusSlice<WorkoutStore>(set),
     ...createWorkoutMethods(actions, set, get),
     ...createSelectionActions(set),
     setEditing: (editing) => set({ isEditing: editing }),


### PR DESCRIPTION
## Summary

Second PR in the focus-management series. Builds directly on #323 (stable `ItemId` + `stripIds` foundations). Implements the **in-memory half** of the focus-management design — the DOM consumer (FocusRegistryContext + `useFocusAfterAction`) is intentionally deferred to a follow-up PR.

- Compose a `FocusSlice` onto the workout store: `pendingFocusTarget: FocusTarget | null`, `selectionHistory: Array<ItemId | null>`, and `setPendingFocusTarget`.
- Centralise every history append through a new `pushHistorySnapshot(uiWorkout, selection, state)` helper in `src/store/workout-store-history.ts`. The helper is the only caller of `workoutHistory.push` in the SPA — a new CI invariant enforces this and will be removed by the hardening change later.
- Ship pure per-action focus-rule helpers under `src/store/focus-rules/` (one function per file, no `react` / DOM imports, ≤100 LOC per file): `nextAfterDelete`, `nextAfterMultiDelete`, `createdItemTarget`, `restoredAfterUndoTarget`, `preservedSelectionTarget`. A second CI invariant enforces the purity constraint via grep.
- Wire every mutating store action to set `pendingFocusTarget` alongside its state update: delete (step + block), create (step + block + grouped + nested), duplicate (step + nested), ungroup, paste, reorder (main + block), undo/redo, undo-delete. `editRepetitionBlock` leaves `pendingFocusTarget` untouched per spec.

Scope boundaries respected: bridge, persistence, batch, usage code are untouched. Task §7 onward (FocusRegistryContext + `useFocusAfterAction`) is intentionally out of scope.

## Scope for this PR

- ✅ Task §4 — Focus target state + selection history (focus slice, `pushHistorySnapshot`, dev-mode invariant, CI grep)
- ✅ Task §5 — Pure focus-rule helpers (one function per file, CI purity grep)
- ✅ Task §6 — Wire focus rules into every mutating action
- ❌ Task §7 onward — Deferred to follow-up PR (`FocusRegistryContext`, `useFocusAfterAction`, component integration)

## CI invariants added

Two new checks live in a `focus-invariants` job in `.github/workflows/ci.yml`:

1. **Focus-rules purity** — `grep -R -E "from ['\"]react|document\.|window\.|HTMLElement" packages/workout-spa-editor/src/store/focus-rules/` returns zero matches.
2. **workoutHistory.push confinement** — `workoutHistory.push` appears only inside `workout-store-history.ts`. (Removed by the hardening change once the refactor has settled.)

## Test plan

- [x] `pnpm -r test` — all green (2549+ passing, incl. 40 new tests for focus types, slice, history helper, pure rules, and action wiring)
- [x] `pnpm -r build` — clean
- [x] `pnpm lint` — zero errors, zero warnings
- [x] Focus-rules purity grep returns no matches
- [x] `workoutHistory.push` grep returns no matches outside `workout-store-history.ts`
- [ ] Manual DOM focus behaviour — N/A (DOM consumer lands in follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal focus state management infrastructure in the workout editor. Added centralized focus-rule computation and selection history tracking to support improved focus handling in future updates. No visible behavior changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->