### PR TITLE
feat(spa-editor): pure focus-rule helpers (§5)

### DIFF
--- a/.changeset/focus-rule-helpers.md
+++ b/.changeset/focus-rule-helpers.md
@@ -1,0 +1,28 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Internal refactor: pure focus-rule helpers (§5 of the
+`spa-editor-focus-management` proposal).
+
+Five pure functions, one per file in `src/store/focus-rules/`, each
+taking a `Workout` + mutation ids and returning a `FocusTarget`:
+
+- `createdItemTarget(id)` — newly-created items.
+- `nextAfterDelete({ workout, deletedIndex, parentBlockId? })` —
+  next-sibling / previous-sibling / empty-state rules for single
+  deletes (covers main-list and block-child branches, including the
+  "block becomes empty → anchor to parent block" cascade).
+- `nextAfterMultiDelete({ workout, deletedIndices })` — multi-select
+  delete (contiguous, non-contiguous, delete-all).
+- `restoredAfterUndoTarget(workout, id)` — focus restored item if still
+  present, else empty-state.
+- `preservedSelectionTarget(workout, priorSelection, fallbackIndex)` —
+  prior selection present / same-index fallback / empty-state.
+
+The rules read `Workout` state only; `findById` does the lookup. No
+React, no DOM, no store imports — a new CI focus-invariant grep in
+`.github/workflows/ci.yml` rejects any `from 'react'` / `document.` /
+`window.` / `HTMLElement` under `src/store/focus-rules/`.
+
+Consumers (§6 action wiring) land in a follow-up PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,11 +238,27 @@ jobs:
         # touches `document` / `window` / `HTMLElement`, focus dispatch
         # (§7) would end up testing DOM behaviour inside what should be
         # pure reducer logic. Test files are exempt.
+        #
+        # Fail closed on any grep error (missing dir, permissions, etc.)
+        # rather than silently passing via `! grep …` which treats exit
+        # code 2 (error) the same as 1 (no match).
         run: |
-          ! grep -RnE "from ['\"]react|from ['\"]react-dom|from ['\"]@testing-library|document\\.|window\\.|HTMLElement" \
+          set +e
+          grep -RnE "from ['\"]react|from ['\"]react-dom|from ['\"]@testing-library|document\\.|window\\.|HTMLElement" \
             --include="*.ts" --include="*.tsx" \
             --exclude="*.test.ts" --exclude="*.test.tsx" \
             packages/workout-spa-editor/src/store/focus-rules/
+          status=$?
+          set -e
+          if [ "$status" = "0" ]; then
+            echo "focus-rules purity violation: grep found forbidden imports above"
+            exit 1
+          elif [ "$status" = "1" ]; then
+            exit 0
+          else
+            echo "focus-rules purity check: grep exited with status $status (error)"
+            exit 2
+          fi
 
       - name: Focus-invariants — workoutHistory push only inside pushHistorySnapshot
         # `selectionHistory` must stay exactly parallel to `workoutHistory`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,19 @@ jobs:
       - name: Check architecture boundaries
         run: pnpm arch:check
 
+      - name: Focus-invariants — focus-rules stay pure (no React/DOM imports)
+        # §5 rule helpers are pure: they take a Workout + ids and return a
+        # FocusTarget. If any file under `src/store/focus-rules/` ever
+        # imports from `react` / `react-dom` / `@testing-library/*` or
+        # touches `document` / `window` / `HTMLElement`, focus dispatch
+        # (§7) would end up testing DOM behaviour inside what should be
+        # pure reducer logic. Test files are exempt.
+        run: |
+          ! grep -RnE "from ['\"]react|from ['\"]react-dom|from ['\"]@testing-library|document\\.|window\\.|HTMLElement" \
+            --include="*.ts" --include="*.tsx" \
+            --exclude="*.test.ts" --exclude="*.test.tsx" \
+            packages/workout-spa-editor/src/store/focus-rules/
+
       - name: Focus-invariants — workoutHistory push only inside pushHistorySnapshot
         # `selectionHistory` must stay exactly parallel to `workoutHistory`
         # for the undo / redo fallback rules to work (§4). The single

--- a/packages/workout-spa-editor/src/store/focus-rules/created-item.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/created-item.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { asItemId } from "../providers/item-id";
+import { createdItemTarget } from "./created-item";
+
+describe("createdItemTarget", () => {
+  it("returns a { kind: 'item', id } target for the new id", () => {
+    // Arrange
+    const newId = asItemId("new-item-id");
+
+    // Act
+    const target = createdItemTarget(newId);
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "new-item-id" });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/created-item.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/created-item.ts
@@ -1,0 +1,16 @@
+/**
+ * Rule: focus the item that was just created.
+ *
+ * Trivial wrapper around `focusItem(id)`, kept as its own file so the
+ * surface of rules is uniform (one function per file) and so consumers
+ * read intent at the call site: `setPendingFocusTarget(createdItemTarget(id))`.
+ *
+ * Purity: no React, no DOM, no store reads. See CI invariant.
+ */
+
+import type { FocusTarget } from "../focus/focus-target.types";
+import { focusItem } from "../focus/focus-target.types";
+import type { ItemId } from "../providers/item-id";
+
+export const createdItemTarget = (newItemId: ItemId): FocusTarget =>
+  focusItem(newItemId);

--- a/packages/workout-spa-editor/src/store/focus-rules/index.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Pure focus-rule helpers.
+ *
+ * Each rule is a single pure function: it takes a `Workout` + the ids
+ * touched by a mutation and returns a `FocusTarget`. No React, no DOM,
+ * no store reads — a CI grep enforces the purity constraint.
+ *
+ * Consumers (§6 action wiring) call these to compute what to put in
+ * `pendingFocusTarget` after each mutation.
+ */
+
+export { createdItemTarget } from "./created-item";
+export { nextAfterDelete } from "./next-after-delete";
+export { nextAfterMultiDelete } from "./next-after-multi-delete";
+export { preservedSelectionTarget } from "./preserved-selection";
+export { restoredAfterUndoTarget } from "./restored-after-undo";

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-delete.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-delete.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import type { Workout } from "../../types/krd";
+import { asItemId } from "../providers/item-id";
+import { nextAfterDelete } from "./next-after-delete";
+
+const step = (id: string, stepIndex: number) => ({
+  id: asItemId(id),
+  stepIndex,
+  durationType: "time" as const,
+  duration: { type: "time" as const, seconds: 60 },
+  targetType: "open" as const,
+  target: { type: "open" as const },
+});
+
+const block = (id: string, innerIds: Array<string>) => ({
+  id: asItemId(id),
+  repeatCount: 2,
+  steps: innerIds.map((iid, i) => step(iid, i)),
+});
+
+describe("nextAfterDelete (main list)", () => {
+  it("focuses the next sibling when one exists", () => {
+    // Arrange — deleted was at index 1; post-delete, step "c" now sits there.
+    const workout = {
+      sport: "cycling",
+      steps: [step("a", 0), step("c", 2)],
+    } as unknown as Workout;
+
+    // Act
+    const target = nextAfterDelete({ workout, deletedIndex: 1 });
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "c" });
+  });
+
+  it("focuses the previous sibling when the deleted item was the tail", () => {
+    // Arrange — deleted was last; post-delete, only "a" and "b" remain.
+    const workout = {
+      sport: "cycling",
+      steps: [step("a", 0), step("b", 1)],
+    } as unknown as Workout;
+
+    // Act — deletedIndex = 2 (past the end of the post-delete array).
+    const target = nextAfterDelete({ workout, deletedIndex: 2 });
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "b" });
+  });
+
+  it("falls back to empty-state when the main list becomes empty", () => {
+    // Arrange
+    const workout = { sport: "cycling", steps: [] } as unknown as Workout;
+
+    // Act
+    const target = nextAfterDelete({ workout, deletedIndex: 0 });
+
+    // Assert
+    expect(target).toEqual({ kind: "empty-state" });
+  });
+
+  it("falls back to empty-state when the workout is undefined", () => {
+    // Act
+    const target = nextAfterDelete({ workout: undefined, deletedIndex: 0 });
+
+    // Assert
+    expect(target).toEqual({ kind: "empty-state" });
+  });
+});
+
+describe("nextAfterDelete (inside a repetition block)", () => {
+  it("focuses the next sibling inside the same block", () => {
+    // Arrange — block had [x, y, z]; y was deleted; now [x, z] and z sits at index 1.
+    const workout = {
+      sport: "cycling",
+      steps: [block("blk-1", ["x", "z"])],
+    } as unknown as Workout;
+
+    // Act
+    const target = nextAfterDelete({
+      workout,
+      deletedIndex: 1,
+      parentBlockId: asItemId("blk-1"),
+    });
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "z" });
+  });
+
+  it("focuses the previous sibling when the deleted item was the tail of the block", () => {
+    // Arrange — deleted was tail; post-delete the block has [x, y].
+    const workout = {
+      sport: "cycling",
+      steps: [block("blk-1", ["x", "y"])],
+    } as unknown as Workout;
+
+    // Act — deletedIndex = 2 (past end of block after delete).
+    const target = nextAfterDelete({
+      workout,
+      deletedIndex: 2,
+      parentBlockId: asItemId("blk-1"),
+    });
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "y" });
+  });
+
+  it("anchors focus to the parent block card when the block became empty", () => {
+    // Arrange — the block lost its last inner step. The consumer is
+    // expected to cascade into deleteRepetitionBlock next; the rule
+    // parks focus on the parent in the meantime.
+    const workout = {
+      sport: "cycling",
+      steps: [block("blk-1", [])],
+    } as unknown as Workout;
+
+    // Act
+    const target = nextAfterDelete({
+      workout,
+      deletedIndex: 0,
+      parentBlockId: asItemId("blk-1"),
+    });
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "blk-1" });
+  });
+
+  it("falls back to main-list rules when the parent block is gone", () => {
+    // Arrange — caller passed a block id that no longer exists.
+    const workout = {
+      sport: "cycling",
+      steps: [step("a", 0)],
+    } as unknown as Workout;
+
+    // Act
+    const target = nextAfterDelete({
+      workout,
+      deletedIndex: 0,
+      parentBlockId: asItemId("ghost-block"),
+    });
+
+    // Assert — falls through to "next in main list" which picks "a".
+    expect(target).toEqual({ kind: "item", id: "a" });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-delete.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-delete.ts
@@ -1,0 +1,95 @@
+/**
+ * Rule: focus the "next logical item" after a single delete.
+ *
+ * Branches (from the proposal Goals section):
+ *   - Main-list delete, next sibling exists → next sibling.
+ *   - Main-list delete, no next → previous sibling.
+ *   - Main-list delete, list becomes empty → main-list empty-state.
+ *   - Block-child delete, next sibling in the same block → that sibling.
+ *   - Block-child delete, no next in block → previous sibling in block.
+ *   - Block-child delete, the block is now empty (cascade) → the parent
+ *     block card stays selected. The block-deletion itself is the next
+ *     action the store dispatches; this rule just anchors focus to the
+ *     parent until that cascade lands.
+ *
+ * Inputs are the post-delete workout (the item is already gone),
+ * the deleted item's original position context, and the parent block
+ * id when the deletion happened inside a repetition block.
+ *
+ * Purity: no React, no DOM, no store reads.
+ */
+
+import type { Workout } from "../../types/krd";
+import { findById } from "../find-by-id";
+import type { FocusTarget } from "../focus/focus-target.types";
+import { focusEmptyState, focusItem } from "../focus/focus-target.types";
+import type { ItemId } from "../providers/item-id";
+
+type NextAfterDeleteInput = {
+  workout: Workout | undefined;
+  /** Flat index the deleted item occupied before the mutation. */
+  deletedIndex: number;
+  /** Block the item lived inside, if any. */
+  parentBlockId?: ItemId;
+};
+
+export const nextAfterDelete = (input: NextAfterDeleteInput): FocusTarget => {
+  const { workout, deletedIndex, parentBlockId } = input;
+  if (!workout) return focusEmptyState;
+
+  if (parentBlockId) {
+    return nextInsideBlock(workout, parentBlockId, deletedIndex);
+  }
+  return nextInMainList(workout, deletedIndex);
+};
+
+const nextInMainList = (
+  workout: Workout,
+  deletedIndex: number
+): FocusTarget => {
+  const steps = workout.steps;
+  if (steps.length === 0) return focusEmptyState;
+
+  // Try the same index first (the old next-sibling slid up into this slot).
+  const next = steps[deletedIndex] as { id?: string } | undefined;
+  if (next?.id) return focusItem(next.id as ItemId);
+
+  // No next → previous sibling.
+  if (deletedIndex > 0) {
+    const prev = steps[deletedIndex - 1] as { id?: string } | undefined;
+    if (prev?.id) return focusItem(prev.id as ItemId);
+  }
+
+  return focusEmptyState;
+};
+
+const nextInsideBlock = (
+  workout: Workout,
+  parentBlockId: ItemId,
+  deletedIndex: number
+): FocusTarget => {
+  const found = findById(workout, parentBlockId);
+  if (!found || found.kind !== "block") {
+    // Block was cascaded away (or the caller passed a bad id). The
+    // parent-block handle is gone — fall back to main-list rules.
+    return nextInMainList(workout, 0);
+  }
+
+  const blockSteps = found.block.steps;
+  if (blockSteps.length === 0) {
+    // Block is now empty; anchor focus to the parent block card. The
+    // consumer (§6 `deleteStep` wiring) is expected to cascade into
+    // `deleteRepetitionBlock` next.
+    return focusItem(parentBlockId);
+  }
+
+  const next = blockSteps[deletedIndex] as { id?: string } | undefined;
+  if (next?.id) return focusItem(next.id as ItemId);
+
+  if (deletedIndex > 0) {
+    const prev = blockSteps[deletedIndex - 1] as { id?: string } | undefined;
+    if (prev?.id) return focusItem(prev.id as ItemId);
+  }
+
+  return focusItem(parentBlockId);
+};

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-delete.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-delete.ts
@@ -71,8 +71,11 @@ const nextInsideBlock = (
   const found = findById(workout, parentBlockId);
   if (!found || found.kind !== "block") {
     // Block was cascaded away (or the caller passed a bad id). The
-    // parent-block handle is gone — fall back to main-list rules.
-    return nextInMainList(workout, 0);
+    // parent-block handle is gone — fall back to main-list rules at
+    // the position the item originally occupied so focus lands as
+    // close as possible to where the user was acting, rather than
+    // resetting to the top of the list.
+    return nextInMainList(workout, deletedIndex);
   }
 
   const blockSteps = found.block.steps;

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import type { Workout } from "../../types/krd";
+import { asItemId } from "../providers/item-id";
+import { nextAfterMultiDelete } from "./next-after-multi-delete";
+
+const step = (id: string, stepIndex: number) => ({
+  id: asItemId(id),
+  stepIndex,
+  durationType: "time" as const,
+  duration: { type: "time" as const, seconds: 60 },
+  targetType: "open" as const,
+  target: { type: "open" as const },
+});
+
+const workoutWith = (ids: Array<string>): Workout =>
+  ({
+    sport: "cycling",
+    steps: ids.map((id, i) => step(id, i)),
+  }) as unknown as Workout;
+
+describe("nextAfterMultiDelete", () => {
+  it("focuses the first remaining item after the last-deleted position (contiguous)", () => {
+    // Arrange — original [a, b, c, d, e]; deleted [b, c] at indices [1, 2];
+    // post-delete workout = [a, d, e]; the item "after last-deleted" is d
+    // at post-delete position (2 - 1) = 1.
+    const workout = workoutWith(["a", "d", "e"]);
+
+    // Act
+    const target = nextAfterMultiDelete({
+      workout,
+      deletedIndices: [1, 2],
+    });
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "d" });
+  });
+
+  it("handles non-contiguous deletions the same way", () => {
+    // Arrange — original [a, b, c, d, e]; deleted [a, c] at indices [0, 2];
+    // post-delete workout = [b, d, e]. lastDeleted=2, removedCount=2 →
+    // position 2-1=1 → "d".
+    const workout = workoutWith(["b", "d", "e"]);
+
+    // Act
+    const target = nextAfterMultiDelete({
+      workout,
+      deletedIndices: [0, 2],
+    });
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "d" });
+  });
+
+  it("falls back to the previous-sibling when nothing sits after the deletion", () => {
+    // Arrange — original [a, b, c]; deleted the tail [b, c] at [1, 2];
+    // post-delete workout = [a]; no item after last-deleted; fallback
+    // to previous-sibling of first-deleted (index 0) → "a".
+    const workout = workoutWith(["a"]);
+
+    // Act
+    const target = nextAfterMultiDelete({
+      workout,
+      deletedIndices: [1, 2],
+    });
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "a" });
+  });
+
+  it("returns empty-state when every item was deleted", () => {
+    // Arrange — list is empty post-delete.
+    const workout = workoutWith([]);
+
+    // Act
+    const target = nextAfterMultiDelete({
+      workout,
+      deletedIndices: [0, 1, 2],
+    });
+
+    // Assert
+    expect(target).toEqual({ kind: "empty-state" });
+  });
+
+  it("returns empty-state when workout is undefined", () => {
+    // Act
+    const target = nextAfterMultiDelete({
+      workout: undefined,
+      deletedIndices: [0],
+    });
+
+    // Assert
+    expect(target).toEqual({ kind: "empty-state" });
+  });
+
+  it("returns empty-state when no indices were passed", () => {
+    // Arrange
+    const workout = workoutWith(["a"]);
+
+    // Act
+    const target = nextAfterMultiDelete({ workout, deletedIndices: [] });
+
+    // Assert
+    expect(target).toEqual({ kind: "empty-state" });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.test.ts
@@ -68,6 +68,24 @@ describe("nextAfterMultiDelete", () => {
     expect(target).toEqual({ kind: "item", id: "a" });
   });
 
+  it("anchors on a surviving item when both after-last and before-first checks miss", () => {
+    // Arrange — original [a, b, c]; deleted [0, 2]; post-delete [b].
+    // `afterLast` position = 2 - 1 = 1 → undefined (only 1 item now).
+    // `firstDeleted` = 0, so no previous-sibling check applies. Without
+    // the "anchor to surviving" fallback this would collapse to
+    // empty-state even though "b" is still in the list.
+    const workout = workoutWith(["b"]);
+
+    // Act
+    const target = nextAfterMultiDelete({
+      workout,
+      deletedIndices: [0, 2],
+    });
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "b" });
+  });
+
   it("returns empty-state when every item was deleted", () => {
     // Arrange — list is empty post-delete.
     const workout = workoutWith([]);

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.ts
@@ -1,0 +1,64 @@
+/**
+ * Rule: focus the "next logical item" after a multi-select delete.
+ *
+ * Branches (from the proposal Goals section):
+ *   - First remaining item after the last-deleted position, if any.
+ *   - Otherwise previous-sibling rule applied to the first-deleted
+ *     position (i.e. the item now sitting just before the earliest
+ *     original deletion).
+ *   - Empty list → main-list empty-state.
+ *
+ * Non-contiguous selections are handled by "last-deleted / first-deleted"
+ * referring to the max / min of the original positions regardless of
+ * gaps between them.
+ *
+ * Purity: no React, no DOM, no store reads.
+ */
+
+import type { Workout } from "../../types/krd";
+import type { FocusTarget } from "../focus/focus-target.types";
+import { focusEmptyState, focusItem } from "../focus/focus-target.types";
+import type { ItemId } from "../providers/item-id";
+
+type NextAfterMultiDeleteInput = {
+  workout: Workout | undefined;
+  /**
+   * Flat indices the deleted items occupied before the mutation. Need
+   * not be sorted or contiguous. Empty → empty-state.
+   */
+  deletedIndices: ReadonlyArray<number>;
+};
+
+export const nextAfterMultiDelete = (
+  input: NextAfterMultiDeleteInput
+): FocusTarget => {
+  const { workout, deletedIndices } = input;
+  if (!workout) return focusEmptyState;
+
+  const steps = workout.steps;
+  if (steps.length === 0 || deletedIndices.length === 0) {
+    return focusEmptyState;
+  }
+
+  const indices = [...deletedIndices].sort((a, b) => a - b);
+  const firstDeleted = indices[0];
+  const lastDeleted = indices[indices.length - 1];
+  const removedCount = indices.length;
+
+  // The "first remaining item after the last-deleted original position"
+  // sits at `lastDeleted - (removedCount - 1)` in the post-delete list,
+  // because every earlier deletion shifted things left by one.
+  const afterLastPosition = lastDeleted - (removedCount - 1);
+  const afterLast = steps[afterLastPosition] as { id?: string } | undefined;
+  if (afterLast?.id) return focusItem(afterLast.id as ItemId);
+
+  // No item sits after the deletion range. Apply the previous-sibling
+  // rule to the first-deleted original position: the item now at
+  // `firstDeleted - 1` is the one just before the earliest deletion.
+  if (firstDeleted > 0) {
+    const prev = steps[firstDeleted - 1] as { id?: string } | undefined;
+    if (prev?.id) return focusItem(prev.id as ItemId);
+  }
+
+  return focusEmptyState;
+};

--- a/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/next-after-multi-delete.ts
@@ -60,5 +60,16 @@ export const nextAfterMultiDelete = (
     if (prev?.id) return focusItem(prev.id as ItemId);
   }
 
+  // Items still remain somewhere in the list (e.g. a non-contiguous
+  // delete that took [0, 2] out of [a, b, c] leaves [b] at index 0,
+  // where both "after last" and "before first" checks miss). Anchor
+  // focus on whatever survives nearest the original first-deleted
+  // position rather than collapsing to empty-state when the list is
+  // not actually empty.
+  const candidate = steps[Math.min(firstDeleted, steps.length - 1)] as
+    | { id?: string }
+    | undefined;
+  if (candidate?.id) return focusItem(candidate.id as ItemId);
+
   return focusEmptyState;
 };

--- a/packages/workout-spa-editor/src/store/focus-rules/preserved-selection.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/preserved-selection.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import type { Workout } from "../../types/krd";
+import { asItemId } from "../providers/item-id";
+import { preservedSelectionTarget } from "./preserved-selection";
+
+const makeStep = (id: string, stepIndex: number) => ({
+  id: asItemId(id),
+  stepIndex,
+  durationType: "time" as const,
+  duration: { type: "time" as const, seconds: 60 },
+  targetType: "open" as const,
+  target: { type: "open" as const },
+});
+
+const workoutWith = (ids: Array<string>): Workout =>
+  ({
+    sport: "cycling",
+    steps: ids.map((id, i) => makeStep(id, i)),
+  }) as unknown as Workout;
+
+describe("preservedSelectionTarget", () => {
+  it("returns the prior selection when it is still present", () => {
+    // Arrange
+    const workout = workoutWith(["a", "b", "c"]);
+
+    // Act
+    const target = preservedSelectionTarget(workout, asItemId("b"), 1);
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "b" });
+  });
+
+  it("falls back to the item now at the same-index when the prior id is gone", () => {
+    // Arrange — "b" was deleted; position 1 is now "c".
+    const workout = workoutWith(["a", "c"]);
+
+    // Act
+    const target = preservedSelectionTarget(workout, asItemId("b"), 1);
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "c" });
+  });
+
+  it("falls back to the same-index item when the prior selection is null", () => {
+    // Arrange
+    const workout = workoutWith(["a", "b"]);
+
+    // Act
+    const target = preservedSelectionTarget(workout, null, 0);
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "a" });
+  });
+
+  it("falls back to empty-state when no item sits at the fallback index", () => {
+    // Arrange
+    const workout = workoutWith(["a"]);
+
+    // Act — fallbackIndex out of range.
+    const target = preservedSelectionTarget(workout, asItemId("ghost"), 5);
+
+    // Assert
+    expect(target).toEqual({ kind: "empty-state" });
+  });
+
+  it("falls back to empty-state when the workout is undefined", () => {
+    // Act
+    const target = preservedSelectionTarget(undefined, asItemId("x"), 0);
+
+    // Assert
+    expect(target).toEqual({ kind: "empty-state" });
+  });
+
+  it("falls back to empty-state when the workout has no steps at all", () => {
+    // Arrange
+    const workout = workoutWith([]);
+
+    // Act
+    const target = preservedSelectionTarget(workout, null, 0);
+
+    // Assert
+    expect(target).toEqual({ kind: "empty-state" });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/preserved-selection.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/preserved-selection.ts
@@ -1,0 +1,37 @@
+/**
+ * Rule: focus the "previously selected" item after a mutation that did
+ * not explicitly create or delete anything the user was acting on
+ * (undo of add / paste / duplicate, redo, …).
+ *
+ * Order of preference:
+ *   1. The prior selection id is still present in the workout → focus it.
+ *   2. Some other item now sits at the prior selection's main-list
+ *      position (`fallbackIndex`) → focus that item.
+ *   3. The list is empty → focus the main-list empty-state.
+ *
+ * Purity: no React, no DOM, no store reads.
+ */
+
+import type { Workout } from "../../types/krd";
+import { findById } from "../find-by-id";
+import type { FocusTarget } from "../focus/focus-target.types";
+import { focusEmptyState, focusItem } from "../focus/focus-target.types";
+import type { ItemId } from "../providers/item-id";
+
+export const preservedSelectionTarget = (
+  workout: Workout | undefined,
+  previouslySelectedId: ItemId | null,
+  fallbackIndex: number
+): FocusTarget => {
+  if (previouslySelectedId && findById(workout, previouslySelectedId)) {
+    return focusItem(previouslySelectedId);
+  }
+
+  const steps = workout?.steps ?? [];
+  const itemAtFallback = steps[fallbackIndex] as { id?: string } | undefined;
+  if (itemAtFallback?.id) {
+    return focusItem(itemAtFallback.id as ItemId);
+  }
+
+  return focusEmptyState;
+};

--- a/packages/workout-spa-editor/src/store/focus-rules/restored-after-undo.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/restored-after-undo.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { Workout } from "../../types/krd";
+import { asItemId } from "../providers/item-id";
+import { restoredAfterUndoTarget } from "./restored-after-undo";
+
+const makeStep = (id: string, stepIndex: number) => ({
+  id: asItemId(id),
+  stepIndex,
+  durationType: "time" as const,
+  duration: { type: "time" as const, seconds: 60 },
+  targetType: "open" as const,
+  target: { type: "open" as const },
+});
+
+const workoutWith = (ids: Array<string>): Workout =>
+  ({
+    sport: "cycling",
+    steps: ids.map((id, i) => makeStep(id, i)),
+  }) as unknown as Workout;
+
+describe("restoredAfterUndoTarget", () => {
+  it("focuses the restored item when it exists in the post-undo workout", () => {
+    // Arrange
+    const workout = workoutWith(["a", "b", "c"]);
+
+    // Act
+    const target = restoredAfterUndoTarget(workout, asItemId("b"));
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "b" });
+  });
+
+  it("falls back to empty-state when the workout is undefined", () => {
+    // Act
+    const target = restoredAfterUndoTarget(undefined, asItemId("ghost"));
+
+    // Assert
+    expect(target).toEqual({ kind: "empty-state" });
+  });
+
+  it("falls back to empty-state when the restored id is not present", () => {
+    // Arrange
+    const workout = workoutWith(["a", "b"]);
+
+    // Act
+    const target = restoredAfterUndoTarget(workout, asItemId("ghost"));
+
+    // Assert
+    expect(target).toEqual({ kind: "empty-state" });
+  });
+
+  it("also resolves restored nested-step ids inside a repetition block", () => {
+    // Arrange
+    const workout = {
+      sport: "cycling",
+      steps: [
+        makeStep("top-0", 0),
+        {
+          id: asItemId("block-1"),
+          repeatCount: 2,
+          steps: [makeStep("nested-0", 0), makeStep("nested-1", 1)],
+        },
+      ],
+    } as unknown as Workout;
+
+    // Act
+    const target = restoredAfterUndoTarget(workout, asItemId("nested-1"));
+
+    // Assert
+    expect(target).toEqual({ kind: "item", id: "nested-1" });
+  });
+});

--- a/packages/workout-spa-editor/src/store/focus-rules/restored-after-undo.test.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/restored-after-undo.test.ts
@@ -57,7 +57,9 @@ describe("restoredAfterUndoTarget", () => {
       steps: [
         makeStep("top-0", 0),
         {
-          id: asItemId("block-1"),
+          // RepetitionBlock ids are plain strings (not branded `ItemId`);
+          // the selection/focus brand applies to WorkoutStep ids only.
+          id: "block-1",
           repeatCount: 2,
           steps: [makeStep("nested-0", 0), makeStep("nested-1", 1)],
         },

--- a/packages/workout-spa-editor/src/store/focus-rules/restored-after-undo.ts
+++ b/packages/workout-spa-editor/src/store/focus-rules/restored-after-undo.ts
@@ -1,0 +1,27 @@
+/**
+ * Rule: focus the item restored by an `undoDelete` mutation.
+ *
+ * Input is the item's stable `ItemId` as captured in `deletedSteps`.
+ * If the restored item is actually present in the post-undo workout,
+ * focus it. Otherwise fall back to the main-list empty-state — that
+ * only happens when the caller hands us an id that never made it back
+ * in (a caller bug), but the rule stays defensive so a mis-wired
+ * consumer cannot crash focus dispatch.
+ *
+ * Purity: no React, no DOM, no store reads.
+ */
+
+import type { Workout } from "../../types/krd";
+import { findById } from "../find-by-id";
+import type { FocusTarget } from "../focus/focus-target.types";
+import { focusEmptyState, focusItem } from "../focus/focus-target.types";
+import type { ItemId } from "../providers/item-id";
+
+export const restoredAfterUndoTarget = (
+  workout: Workout | undefined,
+  restoredItemId: ItemId
+): FocusTarget => {
+  const found = findById(workout, restoredItemId);
+  if (found) return focusItem(restoredItemId);
+  return focusEmptyState;
+};


### PR DESCRIPTION
## Summary

§5 of the `spa-editor-focus-management` proposal. Five pure functions, one per file under `src/store/focus-rules/`, each taking a `Workout` + mutation ids and returning a `FocusTarget`. No React, no DOM, no store reads — a new CI focus-invariant grep enforces the purity constraint.

| File | Rule |
|---|---|
| `created-item.ts` | `createdItemTarget(id)` |
| `next-after-delete.ts` | `nextAfterDelete({ workout, deletedIndex, parentBlockId? })` — main-list next/prev/empty, block-child next/prev, block-empty cascade anchoring to parent block |
| `next-after-multi-delete.ts` | `nextAfterMultiDelete({ workout, deletedIndices })` — contiguous, non-contiguous, delete-all |
| `restored-after-undo.ts` | `restoredAfterUndoTarget(workout, id)` |
| `preserved-selection.ts` | `preservedSelectionTarget(workout, priorSelection, fallbackIndex)` — prior still present / same-index fallback / empty-state |

Barrel at `focus-rules/index.ts` re-exports all five.

## Purity invariant (CI)

New grep in `.github/workflows/ci.yml` rejects any `from 'react'` / `from 'react-dom'` / `from '@testing-library/*'` / `document.` / `window.` / `HTMLElement` under `src/store/focus-rules/` (test files exempt). Verified locally — zero matches.

## Test plan

- [x] `pnpm -r test` — **2519 SPA tests** pass (+25 new cases across the five rules).
- [x] `pnpm -r build` — clean.
- [x] `pnpm lint` — 0 errors, 0 warnings.
- [x] Every rule file ≤100 LOC; every function <40 LOC.

## Out-of-scope (follow-up PRs)

- §6 Wire focus rules into every mutating action (delete/multi-delete/paste/add/duplicate/group/ungroup/undo/redo/reorder).
- §7 `useFocusAfterAction` hook + `FocusRegistryContext` + overlay observer.
- §8 Component integration.
- §10/§11 Spec deltas + remaining CI invariants.

Changeset: `@kaiord/workout-spa-editor: patch` — internal refactor, no consumer yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for focus-management utilities across item creation, deletion, undo, and selection operations.

* **Chores**
  * Introduced CI validation to enforce code purity standards in focus-management utilities.
  * Updated package versioning documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->