### PR TITLE
feat(spa-editor): focus intent wiring + selection invariant + store README (§6, §8.8, §10)

### DIFF
--- a/.changeset/focus-mgmt-action-wiring.md
+++ b/.changeset/focus-mgmt-action-wiring.md
@@ -1,0 +1,46 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Focus management: wire store actions to focus-rule helpers (§6),
+enforce single-parent multi-selection invariant (§8.8), and document
+the store in `src/store/README.md` (§10).
+
+**§6 — action wiring.** Every state-mutating action now writes a
+`pendingFocusTarget` alongside the new workout snapshot:
+
+- **Delete** (`deleteStep`, `deleteRepetitionBlock`) →
+  `nextAfterDelete({ workout, deletedIndex })` — next-sibling /
+  previous-sibling / empty-state.
+- **Creation** (`createStep`, `duplicateStep`,
+  `createEmptyRepetitionBlock`, `addStepToRepetitionBlock`,
+  `duplicateStepInRepetitionBlock`, `createRepetitionBlock`,
+  `pasteStep`) → `createdItemTarget(newId)`. `pasteStep` focuses the
+  freshly-regenerated id, never the clipboard-supplied one.
+- **Ungroup** → focus the first extracted child.
+- **Clear** → `null`.
+- **Undo delete** → `restoredAfterUndoTarget(workout, restoredId)`.
+- **Undo/redo** → `preservedSelectionTarget(snapshot, priorSelection,
+index)`, reading the parallel `selectionHistory` slice.
+- **Reorder** (`reorderStep`, `reorderStepsInBlock`) →
+  `createdItemTarget(movedId)` to keep focus on the dragged item.
+
+`PasteStepResult` exposes a `pastedItemId` field so the store reducer
+can set focus without re-walking the workout.
+
+**§8.8 — single-parent multi-selection invariant.** A selection cannot
+span the main list and the inside of a repetition block, nor span two
+different blocks. `toggleStepSelection` now _replaces_ the selection
+(rather than extending it) when a toggle would violate that invariant;
+`selectAllSteps` filters to the subset that shares the first id's
+parent. Covered by 7 new tests in `selection-invariant.test.ts`.
+
+**§10 — store README.** `packages/workout-spa-editor/src/store/README.md`
+documents the runtime state slices (workout / history / focus /
+clipboard / selection), the action surface, the `pushHistorySnapshot`
+and `stripIds` chokepoints, the pure focus-rule helpers, and the
+narrow-selector discipline consumers must follow to avoid coupling to
+full `WorkoutStore` shape.
+
+Deferred to follow-up PRs: §7 focus hook + registry + overlay
+observer, and §8.1–§8.5 component integration that depends on §7.

--- a/packages/workout-spa-editor/e2e/step-selection.spec.ts
+++ b/packages/workout-spa-editor/e2e/step-selection.spec.ts
@@ -223,10 +223,15 @@ test.describe("Step Selection - Unique IDs", () => {
     await expect(selectedIndicators).toHaveCount(1);
   });
 
-  test("should support multi-selection across different blocks", async ({
+  test("enforces the single-parent invariant when toggling across different blocks", async ({
     page,
   }) => {
-    // Requirement 4.3: Test multi-selection across blocks
+    // spa-editor-focus-management §8.8: a multi-selection cannot span
+    // the main list and the inside of a repetition block, nor two
+    // different blocks. Cross-parent toggles REPLACE the selection
+    // (rather than extend it) so `selectedStepIds` always shares one
+    // parent. This test previously asserted the old (extend) behavior;
+    // it now asserts the new (replace) behavior.
     await page.goto("/workout/new");
 
     // Load a workout with multiple repetition blocks
@@ -368,24 +373,26 @@ test.describe("Step Selection - Unique IDs", () => {
     });
     await page.waitForTimeout(300);
 
-    // Verify all three clicked steps are selected
-    await expect(mainStep).toHaveAttribute("data-selected", "true", {
+    // The three toggles crossed parents twice (main→block1, block1→block2),
+    // so the selection was replaced each time. Only the last-toggled step
+    // (block2Step) remains selected.
+    await expect(block2Step).toHaveAttribute("data-selected", "true", {
       timeout: 2000,
     });
-    await expect(block1Step).toHaveAttribute("data-selected", "true");
-    await expect(block2Step).toHaveAttribute("data-selected", "true");
+    await expect(mainStep).toHaveAttribute("data-selected", "false");
+    await expect(block1Step).toHaveAttribute("data-selected", "false");
 
-    // Verify other steps are NOT selected
+    // And no other steps are selected either.
     const block1Step2 = allStepCards.nth(2);
     const block2Step2 = allStepCards.nth(4);
     await expect(block1Step2).toHaveAttribute("data-selected", "false");
     await expect(block2Step2).toHaveAttribute("data-selected", "false");
 
-    // Verify exactly 3 steps are selected
+    // Exactly 1 step selected (the last-toggled block2 child).
     const selectedIndicators = page.locator(
       '[data-testid="step-card"][data-selected="true"]'
     );
-    await expect(selectedIndicators).toHaveCount(3);
+    await expect(selectedIndicators).toHaveCount(1);
   });
 
   test("should independently select steps with same stepIndex in different contexts", async ({

--- a/packages/workout-spa-editor/src/store/README.md
+++ b/packages/workout-spa-editor/src/store/README.md
@@ -1,68 +1,114 @@
 # Store
 
-This directory contains Zustand stores for global state management.
+Zustand stores for global state management.
 
 ## Workout Store
 
-The workout store (`workout-store.ts`) manages the current workout state, selection, and editing mode.
+`workout-store.ts` is the central store. It owns the current workout,
+selection, history (undo/redo), and the focus-intent slice.
 
 ### State
 
-- `currentWorkout: KRD | null` - The currently loaded workout
-- `selectedStepId: string | null` - ID of the currently selected step
-- `isEditing: boolean` - Whether the user is in editing mode
+- `currentWorkout: UIWorkout | null` — the in-memory workout. A
+  `UIWorkout` is structurally a `KRD` plus a stable `ItemId` on every
+  step and block. See `../types/ui-workout.ts`.
+- `workoutHistory: Array<UIWorkout>` — undo/redo snapshots.
+- `historyIndex: number` — current position in `workoutHistory`.
+- `selectionHistory: Array<string | null>` — parallel to
+  `workoutHistory`; each entry is the `selectedStepId` at the moment
+  the matching snapshot was pushed. Used by undo-of-add/paste/duplicate
+  to restore focus to the item that was selected just before the undone
+  mutation.
+- `selectedStepId: string | null`, `selectedStepIds: Array<string>` —
+  single- and multi-selection.
+- `pendingFocusTarget: FocusTarget | null` — focus intent written by
+  mutating actions. A hook (`useFocusAfterAction`, §7) reads it after
+  each React commit and moves DOM focus accordingly.
+- `isEditing`, `safeMode`, `lastBackup`, `deletedSteps`, `isModalOpen`,
+  `modalConfig`, `createBlockDialogOpen` — misc UI slots.
 
 ### Actions
 
-- `loadWorkout(krd: KRD)` - Load a workout into the store (resets selection and editing state)
-- `updateWorkout(krd: KRD)` - Update the current workout (preserves selection and editing state)
-- `selectStep(id: string | null)` - Select a step by ID or deselect with null
-- `setEditing(editing: boolean)` - Toggle editing mode
-- `clearWorkout()` - Clear the current workout and reset all state
+- `loadWorkout(krd)` / `createEmptyWorkout(name, sport)` / `clearWorkout()`
+  — reset the store. Hydrate assigns fresh `ItemId`s on every load.
+- `updateWorkout(uiWorkout)` — mid-session mutation push (preserves ids).
+- `setPendingFocusTarget(target)` — dumb setter for the focus slice.
+- `createStep` / `duplicateStep` / `pasteStep` / `addStepToRepetitionBlock`
+  / `duplicateStepInRepetitionBlock` / `createRepetitionBlock`
+  / `createEmptyRepetitionBlock` — produce new items with fresh
+  `ItemId`s, set `pendingFocusTarget = createdItemTarget(newId)`.
+- `deleteStep` / `deleteRepetitionBlock` — set `pendingFocusTarget` via
+  `nextAfterDelete` (next sibling, previous sibling, empty-state, or
+  block-cascade anchor).
+- `undoDelete` — set `pendingFocusTarget` via `restoredAfterUndoTarget`.
+- `undo` / `redo` — set `pendingFocusTarget` via
+  `preservedSelectionTarget`, reading the parallel `selectionHistory`.
+- `reorderStep` / `reorderStepsInBlock` — set `pendingFocusTarget` to
+  the moved item's own id (stable across the reorder).
+- `editRepetitionBlock` — leaves `pendingFocusTarget` untouched.
+- `toggleStepSelection` / `selectAllSteps` — enforce the single-parent
+  invariant: a multi-selection cannot span the main list and the
+  inside of a block (cross-parent toggles replace rather than extend).
 
-### Selector Hooks
+### History chokepoint
 
-Convenience hooks for accessing specific parts of the store:
+Every append to `workoutHistory` goes through
+`pushHistorySnapshot(state, uiWorkout, selection)` in
+`workout-store-history.ts`. The helper keeps `workoutHistory` and
+`selectionHistory` parallel by construction (drift is structurally
+impossible). A CI focus-invariant grep rejects any
+`workoutHistory.push` / `.unshift` / `.splice` / `...slice, x` outside
+that helper.
 
-- `useCurrentWorkout()` - Get the current workout
-- `useSelectedStepId()` - Get the selected step ID
-- `useIsEditing()` - Get the editing state
-- `useWorkoutActions()` - Get all action functions
+### Outbound ID chokepoint
 
-### Usage Example
+`stripIds(uiWorkout): KRD` in `strip-ids.ts` removes `id` fields from
+every step and block before the workout crosses a boundary. Every
+Dexie write path, `saveWorkout`, and `exportWorkout` pass through it.
+Direct calls to `@kaiord/core` conversion ports do the same.
 
-```typescript
-import { useWorkoutStore, useCurrentWorkout, useWorkoutActions } from "@/store";
+### Focus-rule helpers
 
-function WorkoutEditor() {
-  // Access state
-  const workout = useCurrentWorkout();
+`focus-rules/` holds five pure functions (one per file) that compute
+what `pendingFocusTarget` should be after each mutation:
 
-  // Access actions
-  const { loadWorkout, selectStep } = useWorkoutActions();
+- `createdItemTarget(id)` — newly-created items.
+- `nextAfterDelete({ workout, deletedIndex, parentBlockId? })` —
+  single-delete rules (main-list + block-child, cascade anchor).
+- `nextAfterMultiDelete({ workout, deletedIndices })` — multi-select.
+- `restoredAfterUndoTarget(workout, id)` — undo of delete.
+- `preservedSelectionTarget(workout, priorSelection, fallbackIndex)` —
+  undo of add/paste/duplicate and redo traversal.
 
-  // Or use the store directly
-  const isEditing = useWorkoutStore((state) => state.isEditing);
+Purity is CI-enforced: no `react`, `react-dom`, `@testing-library`,
+`document.`, `window.`, or `HTMLElement` references allowed under
+`focus-rules/`.
 
-  return (
-    <div>
-      {workout && <WorkoutDisplay workout={workout} />}
-    </div>
-  );
-}
+### Narrow-selector discipline
+
+Every `setPendingFocusTarget({ kind: 'item', id })` produces a fresh
+object reference, so any consumer subscribed with a wide selector
+(`useWorkoutStore()` / `useWorkoutStore(s => s)`) would re-render on
+every focus-intent write. Subscribe narrowly:
+
+```ts
+const target = useWorkoutStore((s) => s.pendingFocusTarget);
 ```
 
-## Requirements Mapping
+A CI grep check in §10.3.a will pin this discipline once the hook
+consumer (§7) lands.
 
-- **Requirement 1**: Display workout structure
-  - `loadWorkout` loads KRD files for visualization
-  - `currentWorkout` provides the workout data to display
+## AI Store
 
-- **Requirement 2**: Create new workouts
-  - `updateWorkout` updates workout metadata and steps
-  - `loadWorkout` initializes new workout structures
+`ai-store.ts` holds AI-provider config. It's independent from the
+workout store and is persisted to Dexie via `ai-store-persistence`.
 
-- **Requirement 3**: Edit existing steps
-  - `selectStep` selects steps for editing
-  - `isEditing` tracks editing mode
-  - `updateWorkout` saves step modifications
+## Library Store
+
+`library-store/` holds the saved-workouts library with Dexie
+persistence. `stripIds` runs on every write path.
+
+## Profile Store
+
+`profile-store/` holds the active sport profile and its sport-zone
+overrides.

--- a/packages/workout-spa-editor/src/store/actions/add-step-to-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/add-step-to-repetition-block-action.ts
@@ -9,6 +9,7 @@
  */
 
 import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
@@ -79,5 +80,8 @@ export const addStepToRepetitionBlockAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: createdItemTarget(newStep.id),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/create-empty-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/create-empty-repetition-block-action.ts
@@ -15,7 +15,9 @@ import type {
   WorkoutStep,
 } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
+import type { ItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 
@@ -106,5 +108,10 @@ export const createEmptyRepetitionBlockAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    // Focus lands on the newly-created block card so the user can
+    // immediately edit its repeat count or add more steps.
+    pendingFocusTarget: createdItemTarget(repetitionBlock.id as ItemId),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/create-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/create-repetition-block-action.ts
@@ -8,7 +8,9 @@
  */
 
 import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
+import type { ItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 import {
@@ -73,5 +75,8 @@ export const createRepetitionBlockAction = (
     extensions: { ...krd.extensions, structured_workout: updatedWorkout },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: createdItemTarget(repetitionBlock.id as ItemId),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/create-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/create-step-action.ts
@@ -5,6 +5,7 @@
  */
 
 import type { KRD, Workout } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
@@ -43,5 +44,8 @@ export const createStepAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: createdItemTarget(newStep.id),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/creation-focus-intent.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/creation-focus-intent.test.ts
@@ -183,10 +183,12 @@ describe("creation-action focus intent (§6.3–6.6)", () => {
     // Assert — focus lands on the regenerated id, never the attacker id.
     const inner = readInner();
     const target = useWorkoutStore.getState().pendingFocusTarget;
-    expect(target).not.toBeNull();
-    if (target && target.kind === "item") {
-      expect(target.id).not.toBe("attacker-supplied-id");
-      expect(inner.steps.some((s) => s.id === target.id)).toBe(true);
+    // Must be an item target (empty-state would skip the id assertions).
+    expect(target?.kind).toBe("item");
+    if (!target || target.kind !== "item") {
+      throw new Error("Expected pasteStep to focus the regenerated item");
     }
+    expect(target.id).not.toBe("attacker-supplied-id");
+    expect(inner.steps.some((s) => s.id === target.id)).toBe(true);
   });
 });

--- a/packages/workout-spa-editor/src/store/actions/creation-focus-intent.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/creation-focus-intent.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Focus-intent tests for creation actions (§6.3–6.6).
+ *
+ * Every action that produces a new UIWorkoutItem sets
+ * `pendingFocusTarget` to `createdItemTarget(newId)` so the new card
+ * receives focus immediately after the commit.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
+import { isRepetitionBlock } from "../../types/krd";
+import { useWorkoutStore } from "../workout-store";
+
+const step = (stepIndex: number) => ({
+  stepIndex,
+  durationType: "time" as const,
+  duration: { type: "time" as const, seconds: 300 },
+  targetType: "power" as const,
+  target: {
+    type: "power" as const,
+    value: { unit: "watts" as const, value: 150 },
+  },
+});
+
+const buildKrd = (steps: Array<unknown>): KRD =>
+  ({
+    version: "1.0",
+    type: "structured_workout",
+    metadata: { created: "2025-01-01T00:00:00Z", sport: "cycling" },
+    extensions: {
+      structured_workout: { sport: "cycling", steps },
+    },
+  }) as unknown as KRD;
+
+const resetStore = () => {
+  useWorkoutStore.setState({
+    currentWorkout: null,
+    workoutHistory: [],
+    historyIndex: -1,
+    selectionHistory: [],
+    selectedStepId: null,
+    selectedStepIds: [],
+    isEditing: false,
+    deletedSteps: [],
+    pendingFocusTarget: null,
+  });
+};
+
+const readInner = () =>
+  useWorkoutStore.getState().currentWorkout!.extensions!.structured_workout as {
+    steps: Array<{ id: string }>;
+  };
+
+describe("creation-action focus intent (§6.3–6.6)", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetStore();
+  });
+
+  it("createStep focuses the new step", () => {
+    // Arrange
+    useWorkoutStore.getState().loadWorkout(buildKrd([step(0)]));
+
+    // Act
+    useWorkoutStore.getState().createStep();
+
+    // Assert
+    const newId = readInner().steps[1].id;
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: newId,
+    });
+  });
+
+  it("duplicateStep focuses the fresh duplicate", () => {
+    // Arrange
+    useWorkoutStore.getState().loadWorkout(buildKrd([step(0)]));
+    const originalId = readInner().steps[0].id;
+
+    // Act
+    useWorkoutStore.getState().duplicateStep(0);
+
+    // Assert
+    const dupId = readInner().steps[1].id;
+    expect(dupId).not.toBe(originalId);
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: dupId,
+    });
+  });
+
+  it("createEmptyRepetitionBlock focuses the new block card", () => {
+    // Arrange
+    useWorkoutStore.getState().loadWorkout(buildKrd([step(0)]));
+
+    // Act
+    useWorkoutStore.getState().createEmptyRepetitionBlock(2);
+
+    // Assert — the new block is the last item.
+    const lastItem = readInner().steps.at(-1) as unknown as RepetitionBlock;
+    expect(isRepetitionBlock(lastItem)).toBe(true);
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: lastItem.id,
+    });
+  });
+
+  it("addStepToRepetitionBlock focuses the new nested step", () => {
+    // Arrange — workout with one block containing a single step.
+    useWorkoutStore
+      .getState()
+      .loadWorkout(buildKrd([{ repeatCount: 2, steps: [step(0)] }]));
+    const blockId = readInner().steps[0].id;
+
+    // Act
+    useWorkoutStore.getState().addStepToRepetitionBlock(blockId);
+
+    // Assert — focus target is the new nested step (not the block).
+    const block = readInner().steps[0] as unknown as RepetitionBlock;
+    const newNested = (block.steps[1] as { id: string }).id;
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: newNested,
+    });
+  });
+
+  it("duplicateStepInRepetitionBlock focuses the duplicate", () => {
+    // Arrange
+    useWorkoutStore
+      .getState()
+      .loadWorkout(buildKrd([{ repeatCount: 2, steps: [step(0)] }]));
+    const blockId = readInner().steps[0].id;
+
+    // Act
+    useWorkoutStore.getState().duplicateStepInRepetitionBlock(blockId, 0);
+
+    // Assert
+    const block = readInner().steps[0] as unknown as RepetitionBlock;
+    const dupId = (block.steps[1] as { id: string }).id;
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: dupId,
+    });
+  });
+
+  it("createRepetitionBlock focuses the newly-wrapped block", () => {
+    // Arrange — three top-level steps, select the first two to wrap.
+    useWorkoutStore
+      .getState()
+      .loadWorkout(buildKrd([step(0), step(1), step(2)]));
+
+    // Act — wrap stepIndices [0, 1] into a block (min 2 for wrap).
+    useWorkoutStore.getState().createRepetitionBlock([0, 1], 2);
+
+    // Assert — the new block is at position 0.
+    const block = readInner().steps[0] as unknown as RepetitionBlock;
+    expect(isRepetitionBlock(block)).toBe(true);
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: block.id,
+    });
+  });
+
+  it("pasteStep focuses the freshly-regenerated paste id, not the clipboard id", async () => {
+    // Arrange — clipboard carries an attacker-supplied id.
+    const clipboardStep = {
+      id: "attacker-supplied-id",
+      stepIndex: 99,
+      durationType: "time",
+      duration: { type: "time", seconds: 60 },
+      targetType: "power",
+      target: { type: "power", value: { unit: "watts", value: 150 } },
+    };
+    const readText = vi.fn(async () => JSON.stringify(clipboardStep));
+    vi.stubGlobal("navigator", { clipboard: { readText } });
+
+    useWorkoutStore.getState().loadWorkout(buildKrd([step(0)]));
+
+    // Act
+    await useWorkoutStore.getState().pasteStep();
+
+    // Assert — focus lands on the regenerated id, never the attacker id.
+    const inner = readInner();
+    const target = useWorkoutStore.getState().pendingFocusTarget;
+    expect(target).not.toBeNull();
+    if (target && target.kind === "item") {
+      expect(target.id).not.toBe("attacker-supplied-id");
+      expect(inner.steps.some((s) => s.id === target.id)).toBe(true);
+    }
+  });
+});

--- a/packages/workout-spa-editor/src/store/actions/delete-focus-intent.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-focus-intent.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Focus-intent tests for delete actions (§6.1).
+ *
+ * Covers the four branches of the `nextAfterDelete` rule for
+ * `deleteStepAction` and `deleteRepetitionBlockAction`: next sibling,
+ * previous sibling, empty-state, and block-cascade (block deletion
+ * going through the same rule as a main-list delete).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { KRD } from "../../types/krd";
+import { useWorkoutStore } from "../workout-store";
+
+const step = (stepIndex: number) => ({
+  stepIndex,
+  durationType: "time" as const,
+  duration: { type: "time" as const, seconds: 300 },
+  targetType: "power" as const,
+  target: {
+    type: "power" as const,
+    value: { unit: "watts" as const, value: 150 },
+  },
+});
+
+const buildKrd = (steps: Array<unknown>): KRD =>
+  ({
+    version: "1.0",
+    type: "structured_workout",
+    metadata: { created: "2025-01-01T00:00:00Z", sport: "cycling" },
+    extensions: {
+      structured_workout: { sport: "cycling", steps },
+    },
+  }) as unknown as KRD;
+
+const resetStore = () => {
+  useWorkoutStore.setState({
+    currentWorkout: null,
+    workoutHistory: [],
+    historyIndex: -1,
+    selectionHistory: [],
+    selectedStepId: null,
+    selectedStepIds: [],
+    isEditing: false,
+    deletedSteps: [],
+    pendingFocusTarget: null,
+  });
+};
+
+describe("deleteStepAction focus intent", () => {
+  afterEach(resetStore);
+
+  it("focuses the next sibling when one exists", () => {
+    // Arrange — three steps; delete the middle one.
+    useWorkoutStore
+      .getState()
+      .loadWorkout(buildKrd([step(0), step(1), step(2)]));
+    const after = useWorkoutStore.getState().currentWorkout!.extensions!
+      .structured_workout as { steps: Array<{ id: string }> };
+    const thirdId = after.steps[2].id;
+
+    // Act
+    useWorkoutStore.getState().deleteStep(1);
+
+    // Assert
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: thirdId,
+    });
+  });
+
+  it("falls back to the previous sibling when the tail was deleted", () => {
+    // Arrange
+    useWorkoutStore.getState().loadWorkout(buildKrd([step(0), step(1)]));
+    const firstId = (
+      useWorkoutStore.getState().currentWorkout!.extensions!
+        .structured_workout as { steps: Array<{ id: string }> }
+    ).steps[0].id;
+
+    // Act — delete the last step.
+    useWorkoutStore.getState().deleteStep(1);
+
+    // Assert
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: firstId,
+    });
+  });
+
+  it("falls back to empty-state when the list becomes empty", () => {
+    // Arrange
+    useWorkoutStore.getState().loadWorkout(buildKrd([step(0)]));
+
+    // Act
+    useWorkoutStore.getState().deleteStep(0);
+
+    // Assert
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "empty-state",
+    });
+  });
+});
+
+describe("deleteRepetitionBlockAction focus intent", () => {
+  afterEach(resetStore);
+
+  it("focuses the next main-list sibling after a block delete", () => {
+    // Arrange — a block followed by a top-level step.
+    useWorkoutStore
+      .getState()
+      .loadWorkout(buildKrd([{ repeatCount: 2, steps: [step(0)] }, step(1)]));
+    const workout = useWorkoutStore.getState().currentWorkout!.extensions!
+      .structured_workout as { steps: Array<{ id: string }> };
+    const blockId = workout.steps[0].id;
+    const nextId = workout.steps[1].id;
+
+    // Act
+    useWorkoutStore.getState().deleteRepetitionBlock(blockId);
+
+    // Assert
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "item",
+      id: nextId,
+    });
+  });
+
+  it("falls back to empty-state when the block was the only item", () => {
+    // Arrange
+    useWorkoutStore
+      .getState()
+      .loadWorkout(buildKrd([{ repeatCount: 2, steps: [step(0)] }]));
+    const blockId = (
+      useWorkoutStore.getState().currentWorkout!.extensions!
+        .structured_workout as { steps: Array<{ id: string }> }
+    ).steps[0].id;
+
+    // Act
+    useWorkoutStore.getState().deleteRepetitionBlock(blockId);
+
+    // Assert
+    expect(useWorkoutStore.getState().pendingFocusTarget).toEqual({
+      kind: "empty-state",
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/store/actions/delete-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-repetition-block-action.ts
@@ -14,6 +14,7 @@
 import type { KRD, Workout } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
 import type { UIWorkoutItem } from "../../types/krd-ui";
+import { nextAfterDelete } from "../focus-rules";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
@@ -120,10 +121,19 @@ export const deleteRepetitionBlockAction = (
     },
   ];
 
+  // Focus intent: the block took a main-list slot, so the same
+  // nextAfterDelete rule applies — next sibling in the main list,
+  // previous sibling, or empty-state.
+  const pendingFocusTarget = nextAfterDelete({
+    workout: { ...workout, steps: reindexedSteps },
+    deletedIndex: position,
+  });
+
   return {
     ...createUpdateWorkoutAction(updatedKrd, state),
     selectedStepId: null,
     selectedStepIds: [],
     deletedSteps: newDeletedBlocks,
+    pendingFocusTarget,
   };
 };

--- a/packages/workout-spa-editor/src/store/actions/delete-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-step-action.ts
@@ -5,51 +5,16 @@
  * Tracks deleted steps for undo functionality.
  */
 
-import type {
-  KRD,
-  RepetitionBlock,
-  Workout,
-  WorkoutStep,
-} from "../../types/krd";
-import { isWorkoutStep } from "../../types/krd";
+import type { KRD, Workout } from "../../types/krd";
 import type { UIWorkoutItem } from "../../types/krd-ui";
+import { nextAfterDelete } from "../focus-rules";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
-
-const findStepToDelete = (
-  workout: Workout,
-  stepIndex: number
-): WorkoutStep | RepetitionBlock | null => {
-  for (const step of workout.steps) {
-    if (isWorkoutStep(step) && step.stepIndex === stepIndex) {
-      return step;
-    }
-  }
-  return null;
-};
-
-const filterSteps = (
-  steps: Array<WorkoutStep | RepetitionBlock>,
-  stepIndex: number
-): Array<WorkoutStep | RepetitionBlock> => {
-  return steps.filter((step: WorkoutStep | RepetitionBlock) => {
-    if (isWorkoutStep(step)) {
-      return step.stepIndex !== stepIndex;
-    }
-    return true;
-  });
-};
-
-const reindexSteps = (
-  steps: Array<WorkoutStep | RepetitionBlock>
-): Array<WorkoutStep | RepetitionBlock> => {
-  return steps.map((step: WorkoutStep | RepetitionBlock, index: number) => {
-    if (isWorkoutStep(step)) {
-      return { ...step, stepIndex: index };
-    }
-    return step;
-  });
-};
+import {
+  filterSteps,
+  findStepToDelete,
+  reindexSteps,
+} from "./delete-step-helpers";
 
 export const deleteStepAction = (
   krd: KRD,
@@ -61,7 +26,7 @@ export const deleteStepAction = (
   }
 
   const workout = krd.extensions.structured_workout as Workout;
-  const deletedStep = findStepToDelete(workout, stepIndex);
+  const found = findStepToDelete(workout, stepIndex);
   const updatedSteps = filterSteps(workout.steps, stepIndex);
   const reindexedSteps = reindexSteps(updatedSteps);
 
@@ -75,20 +40,29 @@ export const deleteStepAction = (
   // Runtime invariant: `state.currentWorkout` is a UIWorkout, so the
   // deleted item already carries its stable ItemId. The `as Workout` cast
   // above erased that at the type level — re-assert it here so the undo
-  // trail stays on the UIWorkoutItem contract (CodeRabbit feedback).
-  const newDeletedSteps = deletedStep
+  // trail stays on the UIWorkoutItem contract.
+  const newDeletedSteps = found
     ? [
         ...deletedSteps,
         {
-          step: deletedStep as UIWorkoutItem,
+          step: found.step as UIWorkoutItem,
           index: stepIndex,
           timestamp: Date.now(),
         },
       ]
     : deletedSteps;
 
+  // Compute focus intent: where should the user's focus land post-delete?
+  const pendingFocusTarget = found
+    ? nextAfterDelete({
+        workout: updatedWorkout,
+        deletedIndex: found.arrayIndex,
+      })
+    : state.pendingFocusTarget;
+
   return {
     ...createUpdateWorkoutAction(updatedKrd, state),
     deletedSteps: newDeletedSteps,
+    pendingFocusTarget,
   };
 };

--- a/packages/workout-spa-editor/src/store/actions/delete-step-helpers.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-step-helpers.ts
@@ -1,0 +1,40 @@
+/**
+ * Helpers for `deleteStepAction` — split to keep the action file under
+ * the ≤80-line ESLint max-lines rule.
+ */
+
+import type { RepetitionBlock, Workout, WorkoutStep } from "../../types/krd";
+import { isWorkoutStep } from "../../types/krd";
+
+export type FoundStep = {
+  step: WorkoutStep | RepetitionBlock;
+  arrayIndex: number;
+};
+
+export const findStepToDelete = (
+  workout: Workout,
+  stepIndex: number
+): FoundStep | null => {
+  for (let i = 0; i < workout.steps.length; i++) {
+    const step = workout.steps[i];
+    if (isWorkoutStep(step) && step.stepIndex === stepIndex) {
+      return { step, arrayIndex: i };
+    }
+  }
+  return null;
+};
+
+export const filterSteps = (
+  steps: Array<WorkoutStep | RepetitionBlock>,
+  stepIndex: number
+): Array<WorkoutStep | RepetitionBlock> =>
+  steps.filter((step) =>
+    isWorkoutStep(step) ? step.stepIndex !== stepIndex : true
+  );
+
+export const reindexSteps = (
+  steps: Array<WorkoutStep | RepetitionBlock>
+): Array<WorkoutStep | RepetitionBlock> =>
+  steps.map((step, index) =>
+    isWorkoutStep(step) ? { ...step, stepIndex: index } : step
+  );

--- a/packages/workout-spa-editor/src/store/actions/duplicate-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/duplicate-step-action.ts
@@ -11,6 +11,7 @@ import type {
   WorkoutStep,
 } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
 import type { ItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
@@ -74,5 +75,8 @@ export const duplicateStepAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: createdItemTarget(duplicatedStep.id),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/duplicate-step-in-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/duplicate-step-in-repetition-block-action.ts
@@ -5,7 +5,9 @@
  */
 
 import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
+import type { ItemId } from "../providers/item-id";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
@@ -84,5 +86,8 @@ export const duplicateStepInRepetitionBlockAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget: createdItemTarget(duplicatedStep.id as ItemId),
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/history-actions.ts
+++ b/packages/workout-spa-editor/src/store/actions/history-actions.ts
@@ -4,7 +4,36 @@
  * Action creators for undo/redo functionality.
  */
 
+import type { Workout } from "../../types/krd";
+import { preservedSelectionTarget } from "../focus-rules";
+import type { ItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
+
+/**
+ * Compute the focus target for an undo/redo traversal.
+ *
+ * Reads the `selectionHistory` entry aligned with the new `historyIndex`
+ * and delegates to `preservedSelectionTarget`, which falls back to the
+ * same-index item or empty-state when the prior selection is gone.
+ */
+const focusForHistoryIndex = (
+  state: WorkoutState,
+  newIndex: number
+): ReturnType<typeof preservedSelectionTarget> => {
+  const snapshot = state.workoutHistory[newIndex];
+  const workout = snapshot?.extensions?.structured_workout as
+    | Workout
+    | undefined;
+  // `selectionHistory` is guaranteed parallel to `workoutHistory` by
+  // `pushHistorySnapshot`, but legacy test fixtures may omit it
+  // entirely. Fall back to `null` for a missing slot.
+  const priorSelection =
+    (state.selectionHistory?.[newIndex] as ItemId | null | undefined) ?? null;
+  // Fallback index: try the prior selection's index in the destination
+  // snapshot. Starting at 0 is the simplest safe choice — the rule
+  // walks the list to find something focusable anyway.
+  return preservedSelectionTarget(workout, priorSelection, 0);
+};
 
 export const createUndoAction = (
   state: WorkoutState
@@ -14,6 +43,7 @@ export const createUndoAction = (
     return {
       currentWorkout: state.workoutHistory[newIndex],
       historyIndex: newIndex,
+      pendingFocusTarget: focusForHistoryIndex(state, newIndex),
     };
   }
   return {};
@@ -27,6 +57,7 @@ export const createRedoAction = (
     return {
       currentWorkout: state.workoutHistory[newIndex],
       historyIndex: newIndex,
+      pendingFocusTarget: focusForHistoryIndex(state, newIndex),
     };
   }
   return {};

--- a/packages/workout-spa-editor/src/store/actions/history-actions.ts
+++ b/packages/workout-spa-editor/src/store/actions/history-actions.ts
@@ -13,9 +13,24 @@ import type { WorkoutState } from "../workout-actions";
  * Compute the focus target for an undo/redo traversal.
  *
  * Reads the `selectionHistory` entry aligned with the new `historyIndex`
- * and delegates to `preservedSelectionTarget`, which falls back to the
- * same-index item or empty-state when the prior selection is gone.
+ * and delegates to `preservedSelectionTarget`. When the prior selection
+ * is gone from the destination snapshot, the rule uses the *current*
+ * selection's position in the workout we're leaving as the fallback
+ * index, so focus lands near the same logical position rather than
+ * jumping to slot 0.
  */
+const currentSelectionMainListIndex = (state: WorkoutState): number => {
+  const currentWorkout = state.currentWorkout?.extensions
+    ?.structured_workout as Workout | undefined;
+  const steps = currentWorkout?.steps ?? [];
+  const currentId = state.selectedStepId;
+  if (!currentId) return 0;
+  const idx = steps.findIndex(
+    (item) => (item as { id?: string }).id === currentId
+  );
+  return idx >= 0 ? idx : 0;
+};
+
 const focusForHistoryIndex = (
   state: WorkoutState,
   newIndex: number
@@ -29,10 +44,8 @@ const focusForHistoryIndex = (
   // entirely. Fall back to `null` for a missing slot.
   const priorSelection =
     (state.selectionHistory?.[newIndex] as ItemId | null | undefined) ?? null;
-  // Fallback index: try the prior selection's index in the destination
-  // snapshot. Starting at 0 is the simplest safe choice — the rule
-  // walks the list to find something focusable anyway.
-  return preservedSelectionTarget(workout, priorSelection, 0);
+  const fallbackIndex = currentSelectionMainListIndex(state);
+  return preservedSelectionTarget(workout, priorSelection, fallbackIndex);
 };
 
 export const createUndoAction = (

--- a/packages/workout-spa-editor/src/store/actions/paste-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/paste-step-action.ts
@@ -20,6 +20,14 @@ export type PasteStepResult = {
   success: boolean;
   message: string;
   updatedKrd?: KRD;
+  /**
+   * Stable id of the just-pasted item (step or block). Exposed so the
+   * store caller can set `pendingFocusTarget` to `createdItemTarget(id)`
+   * after the `updateWorkout` commit. Always a fresh UUID produced by
+   * `regeneratePasteIds` — never the clipboard-supplied id (paste-path
+   * trust boundary, design decision 1).
+   */
+  pastedItemId?: string;
 };
 
 export const pasteStepAction = async (
@@ -58,8 +66,9 @@ export const pasteStepAction = async (
 
     const updatedKrd = createUpdatedKrd(krd, updatedWorkout);
     const message = getSuccessMessage(freshPayload);
+    const pastedItemId = (freshPayload as { id?: string }).id;
 
-    return { success: true, message, updatedKrd };
+    return { success: true, message, updatedKrd, pastedItemId };
   } catch {
     return { success: false, message: "Failed to paste from clipboard" };
   }

--- a/packages/workout-spa-editor/src/store/actions/reorder-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/reorder-step-action.ts
@@ -11,6 +11,8 @@ import type {
   Workout,
   WorkoutStep,
 } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
+import type { ItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 
@@ -84,5 +86,16 @@ export const reorderStepAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  // Focus follows the moved item to its new position. Its id is stable
+  // across the reorder (ItemId doesn't change on array moves), so the
+  // hook re-resolves the same item and scrolls to its new DOM node.
+  const movedId = (movedStep as { id?: string }).id;
+  const pendingFocusTarget = movedId
+    ? createdItemTarget(movedId as ItemId)
+    : state.pendingFocusTarget;
+
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget,
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/reorder-steps-in-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/reorder-steps-in-block-action.ts
@@ -6,6 +6,8 @@
  */
 
 import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
+import type { ItemId } from "../providers/item-id";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
@@ -86,5 +88,16 @@ export const reorderStepsInBlockAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  // Focus follows the moved nested step — its id is stable across the
+  // intra-block reorder, so the hook re-resolves the same item at its
+  // new DOM position.
+  const movedId = (movedStep as { id?: string }).id;
+  const pendingFocusTarget = movedId
+    ? createdItemTarget(movedId as ItemId)
+    : state.pendingFocusTarget;
+
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget,
+  };
 };

--- a/packages/workout-spa-editor/src/store/actions/undo-delete-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/undo-delete-action.ts
@@ -11,6 +11,8 @@ import type {
   WorkoutStep,
 } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
+import { restoredAfterUndoTarget } from "../focus-rules";
+import type { ItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 
@@ -66,8 +68,16 @@ export const undoDeleteAction = (
   // Remove the deleted step from tracking
   const newDeletedSteps = deletedSteps.filter((d) => d.timestamp !== timestamp);
 
+  // Focus lands on the restored item so the user can immediately
+  // continue editing what they just undid.
+  const restoredId = (step as { id?: string }).id;
+  const pendingFocusTarget = restoredId
+    ? restoredAfterUndoTarget(updatedWorkout, restoredId as ItemId)
+    : state.pendingFocusTarget;
+
   return {
     ...createUpdateWorkoutAction(updatedKrd, state),
     deletedSteps: newDeletedSteps,
+    pendingFocusTarget,
   };
 };

--- a/packages/workout-spa-editor/src/store/actions/ungroup-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/ungroup-repetition-block-action.ts
@@ -9,6 +9,8 @@
  */
 
 import type { KRD, Workout } from "../../types/krd";
+import { createdItemTarget } from "../focus-rules";
+import type { ItemId } from "../providers/item-id";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
@@ -68,5 +70,17 @@ export const ungroupRepetitionBlockAction = (
     },
   };
 
-  return createUpdateWorkoutAction(updatedKrd, state);
+  // Focus lands on the first formerly-child step at its new top-level
+  // position (the same `position` the block occupied). Falls back to
+  // the existing focus target if the block had no steps (shouldn't
+  // happen — empty blocks cascade-delete before they can be ungrouped).
+  const firstChildId = (extractedSteps[0] as { id?: string } | undefined)?.id;
+  const pendingFocusTarget = firstChildId
+    ? createdItemTarget(firstChildId as ItemId)
+    : state.pendingFocusTarget;
+
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    pendingFocusTarget,
+  };
 };

--- a/packages/workout-spa-editor/src/store/create-workout-method-helpers-basic.ts
+++ b/packages/workout-spa-editor/src/store/create-workout-method-helpers-basic.ts
@@ -2,6 +2,8 @@ import type { StoreApi } from "zustand";
 
 import { copyStepAction } from "./actions/copy-step-action";
 import { pasteStepAction } from "./actions/paste-step-action";
+import { createdItemTarget } from "./focus-rules";
+import type { ItemId } from "./providers/item-id";
 import type { createWorkoutStoreActions } from "./workout-store-actions";
 import type { WorkoutStore } from "./workout-store-types";
 
@@ -53,10 +55,18 @@ export const createClipboardMethods = (
       // that no longer exist (the selection before paste may have come
       // from a step that was reordered or whose id got regenerated in
       // a prior mutation).
+      //
+      // Focus lands on the freshly-pasted item — `pastedItemId` is the
+      // regenerated UUID, never the clipboard-supplied id (paste-path
+      // trust boundary, design decision 1).
+      const pendingFocusTarget = result.pastedItemId
+        ? createdItemTarget(result.pastedItemId as ItemId)
+        : null;
       set((state) => ({
         ...actions.updateWorkout(result.updatedKrd!, state),
         selectedStepId: null,
         selectedStepIds: [],
+        pendingFocusTarget,
       }));
     }
     return { success: result.success, message: result.message };

--- a/packages/workout-spa-editor/src/store/selection-invariant.test.ts
+++ b/packages/workout-spa-editor/src/store/selection-invariant.test.ts
@@ -1,0 +1,169 @@
+/**
+ * §8.8 single-parent selection invariant:
+ * multi-selection cannot span the main list and the inside of a
+ * repetition block, nor can it span two different blocks. Violating
+ * toggles replace the selection rather than extend it.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { KRD, RepetitionBlock, Workout } from "../types/krd";
+import { useWorkoutStore } from "./workout-store";
+
+const step = (stepIndex: number) => ({
+  stepIndex,
+  durationType: "time" as const,
+  duration: { type: "time" as const, seconds: 300 },
+  targetType: "power" as const,
+  target: {
+    type: "power" as const,
+    value: { unit: "watts" as const, value: 150 },
+  },
+});
+
+const buildKrd = (steps: Array<unknown>): KRD =>
+  ({
+    version: "1.0",
+    type: "structured_workout",
+    metadata: { created: "2025-01-01T00:00:00Z", sport: "cycling" },
+    extensions: {
+      structured_workout: { sport: "cycling", steps },
+    },
+  }) as unknown as KRD;
+
+const readInner = () =>
+  useWorkoutStore.getState().currentWorkout!.extensions!.structured_workout as {
+    steps: Array<{ id: string }>;
+  };
+
+const resetStore = () => {
+  useWorkoutStore.setState({
+    currentWorkout: null,
+    workoutHistory: [],
+    historyIndex: -1,
+    selectionHistory: [],
+    selectedStepId: null,
+    selectedStepIds: [],
+    isEditing: false,
+    deletedSteps: [],
+    pendingFocusTarget: null,
+  });
+};
+
+describe("toggleStepSelection single-parent invariant", () => {
+  afterEach(resetStore);
+
+  it("extends the selection when toggling two main-list steps", () => {
+    // Arrange — two top-level steps, no blocks.
+    useWorkoutStore.getState().loadWorkout(buildKrd([step(0), step(1)]));
+    const [a, b] = readInner().steps;
+
+    // Act
+    useWorkoutStore.getState().toggleStepSelection(a.id);
+    useWorkoutStore.getState().toggleStepSelection(b.id);
+
+    // Assert — same-parent (main list) → extend.
+    expect(useWorkoutStore.getState().selectedStepIds).toEqual([a.id, b.id]);
+  });
+
+  it("extends the selection when toggling two nested steps in the same block", () => {
+    // Arrange
+    useWorkoutStore
+      .getState()
+      .loadWorkout(buildKrd([{ repeatCount: 2, steps: [step(0), step(1)] }]));
+    const block = readInner().steps[0] as unknown as RepetitionBlock;
+    const [n0, n1] = block.steps as Array<{ id: string }>;
+
+    // Act
+    useWorkoutStore.getState().toggleStepSelection(n0.id);
+    useWorkoutStore.getState().toggleStepSelection(n1.id);
+
+    // Assert
+    expect(useWorkoutStore.getState().selectedStepIds).toEqual([n0.id, n1.id]);
+  });
+
+  it("replaces the selection when toggling mixes main-list + nested-step", () => {
+    // Arrange — a top-level step plus a block with one nested step.
+    useWorkoutStore
+      .getState()
+      .loadWorkout(buildKrd([step(0), { repeatCount: 2, steps: [step(0)] }]));
+    const top = readInner().steps[0];
+    const block = readInner().steps[1] as unknown as RepetitionBlock;
+    const nested = block.steps[0] as { id: string };
+
+    // Act — select the top-level first, then a nested step.
+    useWorkoutStore.getState().toggleStepSelection(top.id);
+    useWorkoutStore.getState().toggleStepSelection(nested.id);
+
+    // Assert — the previous selection is dropped; only the nested id
+    // remains (cross-parent toggle replaced rather than extended).
+    expect(useWorkoutStore.getState().selectedStepIds).toEqual([nested.id]);
+  });
+
+  it("replaces the selection when toggling mixes two different blocks", () => {
+    // Arrange — two blocks, each with one nested step.
+    useWorkoutStore.getState().loadWorkout(
+      buildKrd([
+        { repeatCount: 2, steps: [step(0)] },
+        { repeatCount: 2, steps: [step(0)] },
+      ])
+    );
+    const blockA = readInner().steps[0] as unknown as RepetitionBlock;
+    const blockB = readInner().steps[1] as unknown as RepetitionBlock;
+    const nestedA = (blockA.steps[0] as { id: string }).id;
+    const nestedB = (blockB.steps[0] as { id: string }).id;
+
+    // Act
+    useWorkoutStore.getState().toggleStepSelection(nestedA);
+    useWorkoutStore.getState().toggleStepSelection(nestedB);
+
+    // Assert — cross-block toggle replaces.
+    expect(useWorkoutStore.getState().selectedStepIds).toEqual([nestedB]);
+  });
+
+  it("removes an already-selected id without triggering the replace branch", () => {
+    // Arrange
+    useWorkoutStore.getState().loadWorkout(buildKrd([step(0), step(1)]));
+    const [a, b] = readInner().steps;
+    useWorkoutStore.getState().toggleStepSelection(a.id);
+    useWorkoutStore.getState().toggleStepSelection(b.id);
+
+    // Act — deselect `a`.
+    useWorkoutStore.getState().toggleStepSelection(a.id);
+
+    // Assert
+    expect(useWorkoutStore.getState().selectedStepIds).toEqual([b.id]);
+  });
+});
+
+describe("selectAllSteps single-parent invariant", () => {
+  afterEach(resetStore);
+
+  it("accepts a homogeneous set of main-list ids", () => {
+    // Arrange
+    useWorkoutStore.getState().loadWorkout(buildKrd([step(0), step(1)]));
+    const ids = readInner().steps.map((s) => s.id);
+
+    // Act
+    useWorkoutStore.getState().selectAllSteps(ids);
+
+    // Assert
+    expect(useWorkoutStore.getState().selectedStepIds).toEqual(ids);
+  });
+
+  it("filters out cross-parent ids, keeping only those sharing the first id's parent", () => {
+    // Arrange — a top-level step and a nested step.
+    useWorkoutStore
+      .getState()
+      .loadWorkout(buildKrd([step(0), { repeatCount: 2, steps: [step(0)] }]));
+    const topId = readInner().steps[0].id;
+    const block = readInner().steps[1] as unknown as RepetitionBlock;
+    const nestedId = (block.steps[0] as { id: string }).id;
+
+    // Act — first id is the top-level, so we keep main-list ids only.
+    useWorkoutStore.getState().selectAllSteps([topId, nestedId]);
+
+    // Assert — nested id is dropped.
+    expect(useWorkoutStore.getState().selectedStepIds).toEqual([topId]);
+  });
+});

--- a/packages/workout-spa-editor/src/store/workout-actions.ts
+++ b/packages/workout-spa-editor/src/store/workout-actions.ts
@@ -51,6 +51,10 @@ export const createClearWorkoutAction = (): Partial<WorkoutState> => ({
   selectedStepIds: [],
   selectionHistory: [],
   isEditing: false,
+  // No workout means there is nothing to focus — explicit null so the
+  // hook (§7) sees a fresh state rather than leftover intent from the
+  // previous session.
+  pendingFocusTarget: null,
 });
 
 export const createEmptyWorkoutAction = (

--- a/packages/workout-spa-editor/src/store/workout-state.types.ts
+++ b/packages/workout-spa-editor/src/store/workout-state.types.ts
@@ -1,4 +1,5 @@
 import type { UIWorkout, UIWorkoutItem } from "../types/krd-ui";
+import type { FocusTarget } from "./focus/focus-target.types";
 
 export type {
   UIRepetitionBlock,
@@ -12,6 +13,11 @@ export type WorkoutState = {
   currentWorkout: UIWorkout | null;
   workoutHistory: Array<UIWorkout>;
   historyIndex: number;
+  /**
+   * Focus intent written by mutating actions (§6). `useFocusAfterAction`
+   * (§7) reads it after each commit and moves DOM focus.
+   */
+  pendingFocusTarget: FocusTarget | null;
   // `selectionHistory` is kept parallel to `workoutHistory`: each entry
   // is the `selectedStepId` that was active the moment the matching
   // workout snapshot was pushed. Undo of add/paste/duplicate restores

--- a/packages/workout-spa-editor/src/store/workout-store-selection-actions.ts
+++ b/packages/workout-spa-editor/src/store/workout-store-selection-actions.ts
@@ -1,24 +1,88 @@
 /**
- * Creates selection-related action handlers for the workout store
+ * Creates selection-related action handlers for the workout store.
+ *
+ * Multi-selection invariant (§8.8): a selection cannot span the main
+ * list and the inside of a repetition block. When a toggle would
+ * violate that invariant, the selection is *replaced* rather than
+ * extended — we drop the previous selection and start a new one
+ * rooted at the newly-toggled item's parent.
  */
+
+import type { Workout } from "../types/krd";
+import { findById } from "./find-by-id";
+
+type MinimalState = {
+  selectedStepIds: Array<string>;
+  currentWorkout?: { extensions?: { structured_workout?: Workout } } | null;
+};
+
+/** Returns the parent block id (or `null` for main-list) of an item id. */
+const parentOf = (workout: Workout | undefined, id: string): string | null => {
+  const found = findById(workout, id);
+  if (!found) return null;
+  if (found.kind === "nested-step") return found.block.id as string;
+  // Top-level step or block card → main list (represented as `null`).
+  return null;
+};
+
 export function createSelectionActions(
   set: (partial: Partial<unknown>) => void
 ) {
   return {
     selectStep: (id: string | null) =>
       set({ selectedStepId: id, selectedStepIds: [] }),
+
     toggleStepSelection: (id: string) =>
-      set((state: { selectedStepIds: Array<string> }) => {
+      set((state: MinimalState) => {
+        const workout = state.currentWorkout?.extensions?.structured_workout as
+          | Workout
+          | undefined;
         const isSelected = state.selectedStepIds.includes(id);
+        if (isSelected) {
+          return {
+            selectedStepIds: state.selectedStepIds.filter((s) => s !== id),
+            selectedStepId: null,
+          };
+        }
+
+        // Replace — not extend — if the toggle would mix a main-list
+        // item and a nested-step from a block (or steps from two
+        // different blocks).
+        const incomingParent = parentOf(workout, id);
+        const sameParent = state.selectedStepIds.every(
+          (existing) => parentOf(workout, existing) === incomingParent
+        );
+        const nextSelection = sameParent
+          ? [...state.selectedStepIds, id]
+          : [id];
+
         return {
-          selectedStepIds: isSelected
-            ? state.selectedStepIds.filter((stepId) => stepId !== id)
-            : [...state.selectedStepIds, id],
+          selectedStepIds: nextSelection,
           selectedStepId: null,
         };
       }),
+
     clearStepSelection: () => set({ selectedStepIds: [] }),
+
     selectAllSteps: (ids: Array<string>) =>
-      set({ selectedStepIds: ids, selectedStepId: null }),
+      set((state: MinimalState) => {
+        const workout = state.currentWorkout?.extensions?.structured_workout as
+          | Workout
+          | undefined;
+        if (ids.length === 0) {
+          return { selectedStepIds: [], selectedStepId: null };
+        }
+        // Same invariant: every id must share a parent; otherwise we
+        // drop everything but the items that share the first id's
+        // parent.
+        const firstParent = parentOf(workout, ids[0]);
+        const filtered = ids.filter(
+          (id) => parentOf(workout, id) === firstParent
+        );
+        return {
+          selectedStepIds: filtered,
+          selectedStepId: null,
+        };
+      }),
   };
 }


### PR DESCRIPTION
## Summary

This is the fourth PR in the `spa-editor-focus-management` series (after #323 foundations, #336 consumer migration, #337 focus target state, #338 focus-rule helpers). It wires every state-mutating store action to the pure helpers from #338, enforces a multi-selection invariant, and documents the store runtime.

Scoped per the split plan agreed upstream: **§6 action wiring + §8.8 selection invariant + §10 store README**. §7 (focus hook + registry + overlay observer) and §8.1–§8.5 (component integration that depends on §7) land in follow-up PRs.

### §6 — action wiring

Every mutation now writes `pendingFocusTarget` alongside the workout snapshot:

| Action group | Helper | Rule |
|---|---|---|
| `deleteStep`, `deleteRepetitionBlock` | `nextAfterDelete` | next sibling → previous sibling → empty-state |
| `createStep`, `duplicateStep`, `createEmptyRepetitionBlock`, `addStepToRepetitionBlock`, `duplicateStepInRepetitionBlock`, `createRepetitionBlock`, `pasteStep` | `createdItemTarget(newId)` | focus the new item |
| `ungroupRepetitionBlock` | `createdItemTarget(firstChildId)` | focus first extracted child |
| `clearWorkout` | `null` | focus cleared |
| `undoDelete` | `restoredAfterUndoTarget(workout, restoredId)` | focus restored item if present, else empty-state |
| `undo`, `redo` | `preservedSelectionTarget(snapshot, priorSelection, index)` | read parallel `selectionHistory` slice |
| `reorderStep`, `reorderStepsInBlock` | `createdItemTarget(movedId)` | keep focus on dragged item |

`PasteStepResult` exposes a new `pastedItemId` field so the store reducer can set focus without re-walking the workout — and crucially, focus lands on the regenerated id, never on any attacker-supplied clipboard id.

### §8.8 — single-parent multi-selection invariant

A selection cannot span the main list and the inside of a repetition block, nor span two different blocks. `toggleStepSelection` now **replaces** (rather than extends) the selection when a toggle would violate that invariant; `selectAllSteps` filters to the subset that shares the first id's parent. Covered by 7 new tests in `selection-invariant.test.ts`.

### §10 — store README

`packages/workout-spa-editor/src/store/README.md` documents:
- state slices (workout / history / focus / clipboard / selection)
- action surface
- `pushHistorySnapshot` and `stripIds` chokepoints
- pure focus-rule helpers
- narrow-selector discipline

### File breakdown

- **Action wiring (§6):** 14 files under `src/store/actions/` plus `create-workout-method-helpers-basic.ts`, `workout-actions.ts`, `workout-state.types.ts`. `delete-step-helpers.ts` extracted to keep `delete-step-action.ts` under the 80-line limit.
- **Selection invariant (§8.8):** `workout-store-selection-actions.ts` rewrite + new `selection-invariant.test.ts`.
- **Tests:** 12 new tests total (7 selection + 5 delete-focus-intent) on top of the 7 creation-focus-intent tests already in this branch.
- **Docs:** `src/store/README.md` rewrite.

## Test plan

- [x] `pnpm -r test` — 2539 passed, 4 skipped
- [x] `pnpm lint` — clean (max-lines, import-sort, prettier, tsc, openspec)
- [x] `pnpm -r build`
- [x] Focus-intent assertions cover every branch: next/prev/empty-state for delete, created-item for every creation path, paste uses regenerated id not clipboard id
- [x] Selection invariant: same-parent extend, cross-parent replace (main↔block, block↔block), deselect does not trigger replace branch
- [ ] Manual UI pass — deferred to the §7 PR where focus is actually applied to the DOM (this PR only sets intent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Focus now updates predictably after create/duplicate/paste/delete/ungroup/undo/redo/reorder actions and when clearing workouts.
  * Reordering preserves focus on the moved item; paste focuses the regenerated item ID.

* **Behavior Changes (Multi-selection)**
  * Multi-selection enforces a single-parent invariant; toggles replace selection when joining different parent scopes; select-all filters to the first item's parent.

* **Documentation**
  * Store README expanded with focus/selection and history guidance.

* **Tests**
  * Added tests for creation/delete/undo-focus, selection invariant, and a paste clipboard regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->