### PR TITLE
feat(spa-editor): focus components wiring (§8.1–§8.5)

### DIFF
--- a/.changeset/focus-components.md
+++ b/.changeset/focus-components.md
@@ -1,0 +1,39 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Focus management: wire `FocusRegistryProvider` + `useFocusAfterAction`
+into the editor component tree (§8.1–§8.5 of the
+`spa-editor-focus-management` proposal). After this PR every workout
+mutation that writes `pendingFocusTarget` actually moves DOM focus.
+
+- `WorkoutSection` wraps `FocusRegistryProvider` around the editor
+  subtree and mounts `useFocusAfterAction` via a thin
+  `useWorkoutSectionFocus` hook. Three fallback refs are wired in:
+  the editor root (`<div data-testid="editor-root">`), the Add Step
+  button (§7.5 empty-state target), and the workout title `<h2>`
+  (§7.5 last-resort heading).
+- `WorkoutTitle` adds `tabIndex={-1}` to the `<h2>` and forwards a
+  new `titleRef` prop, with a `:focus-visible` outline so the
+  programmatic focus is visible.
+- `WorkoutStepsList` accepts `editorRootRef` and
+  `addStepButtonRef`, attaching them to the outer `<div>` and the
+  "Add Step" button. The outer `<div>` now carries
+  `data-testid="editor-root"` for tests.
+- `WorkoutStepsListActions` forwards `addStepButtonRef` to the
+  `<Button>` (which already supported ref forwarding).
+- `StepCard` and `RepetitionBlockCard` self-register with the
+  registry under their own `step.id` / `block.id` via a shared
+  `useFocusRegistration` hook. A `mergeRefs` utility combines the
+  forwarded `ref` (DnD, tests) with the internal registration ref.
+
+Integration tests in
+`WorkoutSection.focus-integration.test.tsx` drive real store
+mutations through the full render tree and assert
+`document.activeElement` after each `setTimeout(0)`:
+
+- next sibling after `deleteStep(0)` on two-step workout
+- focus on new step card after `createStep()`
+- Add Step button focused when the list becomes empty
+- focus does NOT move while an `<input>` inside the editor root is
+  focused (form-field guard from §7.3)

--- a/packages/workout-spa-editor/src/components/molecules/RepetitionBlockCard/RepetitionBlockCard.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/RepetitionBlockCard/RepetitionBlockCard.tsx
@@ -1,5 +1,7 @@
 import { forwardRef } from "react";
 
+import { useFocusRegistration } from "../../../hooks/focus/use-focus-registration";
+import { mergeRefs } from "../../../lib/merge-refs";
 import {
   buildBlockClasses,
   createBlockClickHandler,
@@ -40,9 +42,13 @@ export const RepetitionBlockCard = forwardRef<
   const handleBlockClick = createBlockClickHandler(block.id, onBlockSelect);
   const handleKeyDown = createBlockKeyDownHandler(onDelete, s.isEditingCount);
 
+  // Self-register with the focus registry (§8.3). Nested steps
+  // register under their own ids separately via StepCard.
+  const registration = useFocusRegistration<HTMLDivElement>(block.id);
+
   return (
     <div
-      ref={ref}
+      ref={mergeRefs(ref, registration.ref)}
       className={buildBlockClasses(isDragging, className)}
       data-testid="repetition-block-card"
       tabIndex={0}

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/StepCard.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/StepCard.tsx
@@ -1,5 +1,7 @@
 import { forwardRef, type HTMLAttributes } from "react";
 
+import { useFocusRegistration } from "../../../hooks/focus/use-focus-registration";
+import { mergeRefs } from "../../../lib/merge-refs";
 import { SelectionIndicator } from "../SelectionIndicator";
 import type { DragHandleProps, StepCardProps } from "./StepCard.types";
 import { useStepCardData } from "./use-step-card-data";
@@ -41,9 +43,15 @@ export const StepCard = forwardRef<HTMLDivElement, StepCardProps>(
       onToggleMultiSelect,
     });
 
+    // Self-register with the focus registry (§8.2) so the post-commit
+    // `useFocusAfterAction` hook can resolve `step.id → HTMLElement`.
+    const registration = useFocusRegistration<HTMLDivElement>(
+      (step as { id?: string }).id
+    );
+
     return (
       <div
-        ref={ref}
+        ref={mergeRefs(ref, registration.ref)}
         className={classes}
         onClick={handlers.handleClick}
         onMouseDown={handlers.handleMouseDown}

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutHeader.tsx
@@ -1,3 +1,4 @@
+import type { RefObject } from "react";
 import { useState } from "react";
 
 import {
@@ -16,9 +17,11 @@ import { WorkoutTitle } from "./WorkoutTitle";
 type WorkoutHeaderProps = {
   readonly workout: Workout;
   readonly krd: KRD;
+  /** Ref to the `<h2>` title for §7.5 heading-fallback focus. */
+  readonly titleRef?: RefObject<HTMLHeadingElement | null>;
 };
 
-export function WorkoutHeader({ workout, krd }: WorkoutHeaderProps) {
+export function WorkoutHeader({ workout, krd, titleRef }: WorkoutHeaderProps) {
   const updateWorkout = useUpdateWorkout();
   const canUndo = useCanUndo();
   const canRedo = useCanRedo();
@@ -53,7 +56,11 @@ export function WorkoutHeader({ workout, krd }: WorkoutHeaderProps) {
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <div className="flex flex-col gap-4">
-        <WorkoutTitle workout={workout} onEdit={handleEditMetadata} />
+        <WorkoutTitle
+          workout={workout}
+          onEdit={handleEditMetadata}
+          titleRef={titleRef}
+        />
         <WorkoutActions
           krd={krd}
           canUndo={canUndo}

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutSection.focus-integration.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutSection.focus-integration.test.tsx
@@ -1,0 +1,206 @@
+/**
+ * Focus integration tests (§8.1–§8.5).
+ *
+ * Rendering `<WorkoutSection>` wires `FocusRegistryProvider` +
+ * `useFocusAfterAction` + the three fallback refs (editor root,
+ * Add Step button, `<h2>` title). These tests exercise the real
+ * store mutations and assert `document.activeElement` after the
+ * focus-apply pipeline runs (setTimeout 0).
+ *
+ * Timing: focus moves happen inside `setTimeout(fn, 0)` per §7.6;
+ * tests install `vi.useFakeTimers()` and call `vi.runAllTimers()`
+ * to push past that boundary.
+ */
+
+import { act } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { __resetOverlayObserverForTests } from "../../../lib/focus/overlay-observer";
+import { useWorkoutStore } from "../../../store/workout-store";
+import { renderWithProviders } from "../../../test-utils";
+import type { KRD } from "../../../types/krd";
+import { WorkoutSection } from "./WorkoutSection";
+
+// Mock WorkoutStats and WorkoutPreview to skip heavy chart rendering
+// that is irrelevant to focus — they just need to not crash.
+vi.mock("../../organisms/WorkoutStats/WorkoutStats", () => ({
+  WorkoutStats: () => <div data-testid="workout-stats-mock" />,
+}));
+vi.mock("../../molecules/WorkoutPreview", () => ({
+  WorkoutPreview: () => <div data-testid="workout-preview-mock" />,
+}));
+
+const step = (stepIndex: number) => ({
+  stepIndex,
+  durationType: "time" as const,
+  duration: { type: "time" as const, seconds: 300 },
+  targetType: "power" as const,
+  target: {
+    type: "power" as const,
+    value: { unit: "watts" as const, value: 150 },
+  },
+});
+
+const buildKrd = (steps: Array<unknown>): KRD =>
+  ({
+    version: "1.0",
+    type: "structured_workout",
+    metadata: { created: "2025-01-01T00:00:00Z", sport: "cycling" },
+    extensions: {
+      structured_workout: { sport: "cycling", steps, name: "Focus Test" },
+    },
+  }) as unknown as KRD;
+
+const resetStore = () => {
+  useWorkoutStore.setState({
+    currentWorkout: null,
+    workoutHistory: [],
+    historyIndex: -1,
+    selectionHistory: [],
+    selectedStepId: null,
+    selectedStepIds: [],
+    isEditing: false,
+    deletedSteps: [],
+    pendingFocusTarget: null,
+  });
+};
+
+const readInner = () =>
+  useWorkoutStore.getState().currentWorkout!.extensions!.structured_workout as {
+    steps: Array<{ id: string }>;
+  };
+
+// Reactive wrapper: reads `currentWorkout` from the store so that a
+// mutation in the store triggers a re-render with the new workout.
+const ReactiveSection = () => {
+  const krd = useWorkoutStore((s) => s.currentWorkout);
+  const selectedStepId = useWorkoutStore((s) => s.selectedStepId);
+  if (!krd) return null;
+  const workout = krd.extensions!.structured_workout!;
+  return (
+    <WorkoutSection
+      workout={workout as never}
+      krd={krd}
+      selectedStepId={selectedStepId}
+      onStepSelect={() => {}}
+    />
+  );
+};
+
+const renderSection = (krd: KRD) => {
+  useWorkoutStore.getState().loadWorkout(krd);
+  return renderWithProviders(<ReactiveSection />);
+};
+
+describe("WorkoutSection focus integration (§8.1–§8.5)", () => {
+  beforeEach(() => {
+    resetStore();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    __resetOverlayObserverForTests();
+    resetStore();
+    document.body.innerHTML = "";
+  });
+
+  it("focuses the next sibling after deleting a step", () => {
+    // Arrange — two steps; delete the first.
+    renderSection(buildKrd([step(0), step(1)]));
+    const initialSecondId = readInner().steps[1].id;
+
+    // Act
+    act(() => {
+      useWorkoutStore.getState().deleteStep(0);
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    // Assert — focus landed on what was the second step (now index 0).
+    const activeId = (
+      document.activeElement as HTMLElement | null
+    )?.getAttribute("data-testid");
+    expect(activeId).toBe("step-card");
+    // And it is the same DOM node as the original second step's card.
+    const stepCards = document.querySelectorAll(
+      '[data-testid="step-card"]'
+    ) as NodeListOf<HTMLElement>;
+    expect(stepCards.length).toBe(1);
+    // The surviving card carries the original second step's id in the
+    // registry; we cannot read the id directly off the card (no data
+    // attribute for it), but the fact that it was focused is the
+    // assertion we care about.
+    expect(initialSecondId).toBeDefined();
+  });
+
+  it("focuses the new step after createStep", () => {
+    // Arrange
+    renderSection(buildKrd([step(0)]));
+
+    // Act
+    act(() => {
+      useWorkoutStore.getState().createStep();
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    // Assert — a second step exists and focus lives on a step card.
+    const stepCards = document.querySelectorAll('[data-testid="step-card"]');
+    expect(stepCards.length).toBe(2);
+    expect(
+      (document.activeElement as HTMLElement | null)?.getAttribute(
+        "data-testid"
+      )
+    ).toBe("step-card");
+  });
+
+  it("focuses the Add Step button when the list becomes empty", () => {
+    // Arrange — one step; delete it.
+    renderSection(buildKrd([step(0)]));
+
+    // Act
+    act(() => {
+      useWorkoutStore.getState().deleteStep(0);
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    // Assert — focus on the Add Step button (the empty-state target).
+    // Capture AFTER the mutation so we compare against the live
+    // post-re-render DOM node, not a stale pre-mutation reference.
+    const addStepButton = document.querySelector(
+      '[data-testid="add-step-button"]'
+    );
+    expect(document.activeElement).toBe(addStepButton);
+  });
+
+  it("does not move focus while an input inside the editor is focused", () => {
+    // Arrange
+    renderSection(buildKrd([step(0), step(1)]));
+    // Inject an input inside the editor root; focus it; then trigger
+    // a mutation that would normally move focus.
+    const editorRoot = document.querySelector(
+      '[data-testid="editor-root"]'
+    ) as HTMLElement;
+    const input = document.createElement("input");
+    input.type = "text";
+    editorRoot.appendChild(input);
+    input.focus();
+
+    // Act
+    act(() => {
+      useWorkoutStore.getState().deleteStep(0);
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    // Assert — focus stayed on the input; pendingFocusTarget cleared.
+    expect(document.activeElement).toBe(input);
+    expect(useWorkoutStore.getState().pendingFocusTarget).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutSection.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutSection.tsx
@@ -1,12 +1,14 @@
+import { FocusRegistryProvider } from "../../../contexts/focus-registry-context";
 import type { KRD, Workout } from "../../../types/krd";
 import { StoreConfirmationModal } from "../../molecules/ConfirmationModal";
 import { CreateRepetitionBlockDialog } from "../../molecules/CreateRepetitionBlockDialog/CreateRepetitionBlockDialog";
 import { WorkoutPreview } from "../../molecules/WorkoutPreview";
 import { WorkoutStats } from "../../organisms/WorkoutStats/WorkoutStats";
+import { useWorkoutSectionFocus } from "./use-workout-section-focus";
 import { useWorkoutSectionState } from "./useWorkoutSectionState";
 import { WorkoutHeader } from "./WorkoutHeader";
 import { WorkoutSectionEditor } from "./WorkoutSectionEditor";
-import { WorkoutStepsList } from "./WorkoutStepsList";
+import { WorkoutStepsListBinding } from "./WorkoutStepsListBinding";
 
 export type WorkoutSectionProps = {
   workout: Workout;
@@ -21,7 +23,7 @@ export type WorkoutSectionProps = {
   ) => void;
 };
 
-export function WorkoutSection(props: WorkoutSectionProps) {
+function WorkoutSectionInner(props: WorkoutSectionProps) {
   const state = useWorkoutSectionState(
     props.workout,
     props.krd,
@@ -30,9 +32,17 @@ export function WorkoutSection(props: WorkoutSectionProps) {
     props.onStepReorder,
     props.onReorderStepsInBlock
   );
+
+  const { editorRootRef, addStepButtonRef, titleRef } =
+    useWorkoutSectionFocus();
+
   return (
     <div className="space-y-6" data-testid="workout-section">
-      <WorkoutHeader workout={props.workout} krd={props.krd} />
+      <WorkoutHeader
+        workout={props.workout}
+        krd={props.krd}
+        titleRef={titleRef}
+      />
       <WorkoutStats workout={props.workout} />
       <WorkoutPreview
         workout={props.workout}
@@ -45,29 +55,12 @@ export function WorkoutSection(props: WorkoutSectionProps) {
         onSave={state.handleSave}
         onCancel={state.handleCancel}
       />
-      <WorkoutStepsList
+      <WorkoutStepsListBinding
         workout={props.workout}
         selectedStepId={props.selectedStepId}
-        selectedStepIds={state.selectedStepIds}
-        onStepSelect={state.handleStepSelect}
-        onBlockSelect={state.handleBlockSelect}
-        onToggleStepSelection={state.handleToggleStepSelection}
-        onStepDelete={state.deleteStep}
-        onStepDuplicate={state.duplicateStep}
-        onStepCopy={state.copyStep}
-        onStepPaste={state.pasteStep}
-        onStepReorder={state.reorderStep}
-        onReorderStepsInBlock={state.reorderStepsInBlock}
-        onAddStep={state.createStep}
-        onCreateRepetitionBlock={state.handleCreateRepetitionBlock}
-        onCreateEmptyRepetitionBlock={state.handleCreateEmptyRepetitionBlock}
-        onEditRepetitionBlock={state.handleEditRepetitionBlock}
-        onAddStepToRepetitionBlock={state.handleAddStepToRepetitionBlock}
-        onUngroupRepetitionBlock={state.handleUngroupRepetitionBlock}
-        onDeleteRepetitionBlock={state.handleDeleteRepetitionBlock}
-        onDuplicateStepInRepetitionBlock={
-          state.handleDuplicateStepInRepetitionBlock
-        }
+        state={state}
+        editorRootRef={editorRootRef}
+        addStepButtonRef={addStepButtonRef}
       />
       <CreateRepetitionBlockDialog
         stepCount={state.blockStepCount}
@@ -77,5 +70,16 @@ export function WorkoutSection(props: WorkoutSectionProps) {
       />
       <StoreConfirmationModal />
     </div>
+  );
+}
+
+export function WorkoutSection(props: WorkoutSectionProps) {
+  // `FocusRegistryProvider` must wrap every consumer of
+  // `FocusRegistryContext` (StepCard, RepetitionBlockCard, and the
+  // hook itself), so it sits at the WorkoutSection boundary.
+  return (
+    <FocusRegistryProvider>
+      <WorkoutSectionInner {...props} />
+    </FocusRegistryProvider>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutStepsList.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutStepsList.tsx
@@ -1,3 +1,5 @@
+import type { RefObject } from "react";
+
 import type { Workout } from "../../../types/krd";
 import { EditorContextMenu } from "../../organisms/EditorContextMenu";
 import { WorkoutList } from "../../organisms/WorkoutList/WorkoutList";
@@ -34,62 +36,45 @@ type WorkoutStepsListProps = {
     blockId: string,
     stepIndex: number
   ) => void;
+  /**
+   * Ref to the outer editor root. `useFocusAfterAction` (§7.4) scopes
+   * its overlay MutationObserver to this element, and `isFormFieldFocused`
+   * (§7.3) uses it to decide whether `document.activeElement` is
+   * "inside the editor" for the form-field guard.
+   */
+  readonly editorRootRef?: RefObject<HTMLDivElement | null>;
+  /** Ref to the Add Step button — §7.5 empty-state focus target. */
+  readonly addStepButtonRef?: RefObject<HTMLButtonElement | null>;
 };
 
-export function WorkoutStepsList({
-  workout,
-  selectedStepId,
-  selectedStepIds,
-  onStepSelect,
-  onBlockSelect,
-  onToggleStepSelection,
-  onStepDelete,
-  onStepDuplicate,
-  onStepCopy,
-  onStepPaste,
-  onStepReorder,
-  onReorderStepsInBlock,
-  onAddStep,
-  onCreateRepetitionBlock,
-  onCreateEmptyRepetitionBlock,
-  onEditRepetitionBlock,
-  onAddStepToRepetitionBlock,
-  onUngroupRepetitionBlock,
-  onDeleteRepetitionBlock,
-  onDuplicateStepInRepetitionBlock,
-}: WorkoutStepsListProps) {
+export function WorkoutStepsList(props: WorkoutStepsListProps) {
+  const {
+    selectedStepIds,
+    onStepPaste,
+    editorRootRef,
+    addStepButtonRef,
+    onCreateRepetitionBlock,
+    onCreateEmptyRepetitionBlock,
+    ...workoutListProps
+  } = props;
   const hasMultipleSelection = selectedStepIds.length >= 2;
 
   return (
     <EditorContextMenu>
-      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
-        <WorkoutList
-          workout={workout}
-          selectedStepId={selectedStepId}
-          selectedStepIds={selectedStepIds}
-          onStepSelect={onStepSelect}
-          onBlockSelect={onBlockSelect}
-          onToggleStepSelection={onToggleStepSelection}
-          onStepDelete={onStepDelete}
-          onStepDuplicate={onStepDuplicate}
-          onStepCopy={onStepCopy}
-          onStepReorder={onStepReorder}
-          onReorderStepsInBlock={onReorderStepsInBlock}
-          onDuplicateStepInRepetitionBlock={onDuplicateStepInRepetitionBlock}
-          onEditRepetitionBlock={onEditRepetitionBlock}
-          onAddStepToRepetitionBlock={onAddStepToRepetitionBlock}
-          onUngroupRepetitionBlock={onUngroupRepetitionBlock}
-          onDeleteRepetitionBlock={onDeleteRepetitionBlock}
-          onAddStep={onAddStep}
-        />
-
+      <div
+        ref={editorRootRef}
+        data-testid="editor-root"
+        className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800"
+      >
+        <WorkoutList {...workoutListProps} selectedStepIds={selectedStepIds} />
         <WorkoutStepsListActions
           hasMultipleSelection={hasMultipleSelection}
           selectedStepCount={selectedStepIds.length}
           onCreateRepetitionBlock={onCreateRepetitionBlock}
           onCreateEmptyRepetitionBlock={onCreateEmptyRepetitionBlock}
-          onAddStep={onAddStep}
+          onAddStep={props.onAddStep}
           onPasteStep={onStepPaste}
+          addStepButtonRef={addStepButtonRef}
         />
       </div>
     </EditorContextMenu>

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutStepsListActions.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutStepsListActions.tsx
@@ -1,4 +1,5 @@
 import { Plus, Repeat } from "lucide-react";
+import type { RefObject } from "react";
 
 import { Button } from "../../atoms/Button/Button";
 import { PasteButton } from "../../molecules/PasteButton";
@@ -11,6 +12,13 @@ type WorkoutStepsListActionsProps = {
   readonly onCreateEmptyRepetitionBlock: () => void;
   readonly onAddStep: () => void;
   readonly onPasteStep?: () => void;
+  /**
+   * Ref to the Add Step button — this is the empty-state focus
+   * target for `useFocusAfterAction` (§7.5). The button is always
+   * mounted, so the hook can land focus on it whether or not the
+   * workout currently has steps.
+   */
+  readonly addStepButtonRef?: RefObject<HTMLButtonElement | null>;
 };
 
 export function WorkoutStepsListActions({
@@ -20,6 +28,7 @@ export function WorkoutStepsListActions({
   onCreateEmptyRepetitionBlock,
   onAddStep,
   onPasteStep,
+  addStepButtonRef,
 }: WorkoutStepsListActionsProps) {
   const hasSingleSelection = selectedStepCount === 1;
 
@@ -44,6 +53,7 @@ export function WorkoutStepsListActions({
           Add Repetition
         </Button>
         <Button
+          ref={addStepButtonRef}
           variant="secondary"
           onClick={onAddStep}
           aria-label="Add new step to workout"

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutStepsListBinding.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutStepsListBinding.tsx
@@ -1,0 +1,58 @@
+/**
+ * Thin adapter between the `useWorkoutSectionState` action bundle and
+ * the prop-heavy `WorkoutStepsList`. Lives in its own file so
+ * `WorkoutSectionInner` stays under the 60-line function limit.
+ */
+
+import type { RefObject } from "react";
+
+import type { Workout } from "../../../types/krd";
+import type { useWorkoutSectionState } from "./useWorkoutSectionState";
+import { WorkoutStepsList } from "./WorkoutStepsList";
+
+type State = ReturnType<typeof useWorkoutSectionState>;
+
+type WorkoutStepsListBindingProps = {
+  workout: Workout;
+  selectedStepId: string | null;
+  state: State;
+  editorRootRef: RefObject<HTMLDivElement | null>;
+  addStepButtonRef: RefObject<HTMLButtonElement | null>;
+};
+
+export function WorkoutStepsListBinding({
+  workout,
+  selectedStepId,
+  state,
+  editorRootRef,
+  addStepButtonRef,
+}: WorkoutStepsListBindingProps) {
+  return (
+    <WorkoutStepsList
+      workout={workout}
+      selectedStepId={selectedStepId}
+      selectedStepIds={state.selectedStepIds}
+      onStepSelect={state.handleStepSelect}
+      onBlockSelect={state.handleBlockSelect}
+      onToggleStepSelection={state.handleToggleStepSelection}
+      onStepDelete={state.deleteStep}
+      onStepDuplicate={state.duplicateStep}
+      onStepCopy={state.copyStep}
+      onStepPaste={state.pasteStep}
+      onStepReorder={state.reorderStep}
+      onReorderStepsInBlock={state.reorderStepsInBlock}
+      onAddStep={state.createStep}
+      onCreateRepetitionBlock={state.handleCreateRepetitionBlock}
+      onCreateEmptyRepetitionBlock={state.handleCreateEmptyRepetitionBlock}
+      onEditRepetitionBlock={state.handleEditRepetitionBlock}
+      onAddStepToRepetitionBlock={state.handleAddStepToRepetitionBlock}
+      onUngroupRepetitionBlock={state.handleUngroupRepetitionBlock}
+      onDeleteRepetitionBlock={state.handleDeleteRepetitionBlock}
+      onDuplicateStepInRepetitionBlock={
+        state.handleDuplicateStepInRepetitionBlock
+      }
+      editorRootRef={editorRootRef}
+      addStepButtonRef={addStepButtonRef}
+    />
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutTitle.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutTitle.tsx
@@ -1,4 +1,5 @@
 import { Edit2 } from "lucide-react";
+import type { RefObject } from "react";
 
 import type { Workout } from "../../../types/krd";
 import { Button } from "../../atoms/Button/Button";
@@ -6,13 +7,23 @@ import { Button } from "../../atoms/Button/Button";
 type WorkoutTitleProps = {
   workout: Workout;
   onEdit: () => void;
+  /**
+   * Ref to the `<h2>` — `useFocusAfterAction` (§7.5 fallback chain)
+   * lands focus here as the last-resort fallback when nothing else
+   * in the registry resolves.
+   */
+  titleRef?: RefObject<HTMLHeadingElement | null>;
 };
 
-export function WorkoutTitle({ workout, onEdit }: WorkoutTitleProps) {
+export function WorkoutTitle({ workout, onEdit, titleRef }: WorkoutTitleProps) {
   return (
     <div className="min-w-0 flex-1 text-left">
       <div className="flex items-center gap-2">
-        <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+        <h2
+          ref={titleRef}
+          tabIndex={-1}
+          className="text-2xl font-bold text-gray-900 focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:text-white dark:focus-visible:ring-offset-gray-800"
+        >
           {workout.name || "Untitled Workout"}
         </h2>
         <Button

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-workout-section-focus.ts
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-workout-section-focus.ts
@@ -1,0 +1,24 @@
+/**
+ * `useWorkoutSectionFocus` — creates the three fallback refs wired
+ * into `useFocusAfterAction` (§7) and mounts the hook. Kept separate
+ * from `WorkoutSection` so the component file stays under the 80-line
+ * limit.
+ */
+
+import { useRef } from "react";
+
+import { useFocusAfterAction } from "../../../hooks/focus/use-focus-after-action";
+
+export const useWorkoutSectionFocus = () => {
+  const editorRootRef = useRef<HTMLDivElement | null>(null);
+  const addStepButtonRef = useRef<HTMLButtonElement | null>(null);
+  const titleRef = useRef<HTMLHeadingElement | null>(null);
+
+  useFocusAfterAction({
+    editorRootRef,
+    emptyStateButtonRef: addStepButtonRef,
+    editorHeadingRef: titleRef,
+  });
+
+  return { editorRootRef, addStepButtonRef, titleRef };
+};

--- a/packages/workout-spa-editor/src/hooks/focus/use-focus-registration.ts
+++ b/packages/workout-spa-editor/src/hooks/focus/use-focus-registration.ts
@@ -1,0 +1,40 @@
+/**
+ * `useFocusRegistration` — small wrapper around
+ * `FocusRegistryContext.registerItem` / `unregisterItem` so every
+ * card component can self-register with a one-liner.
+ *
+ * Returns a callback ref that the consumer installs on its root
+ * element. The hook handles the StrictMode double-mount dance (the
+ * registry's own unregister is identity-gated) and the missing-id
+ * case (no-op).
+ */
+
+import type { RefCallback } from "react";
+import { useCallback, useContext, useEffect, useRef } from "react";
+
+import { FocusRegistryContext } from "../../contexts/focus-registry-context";
+import type { ItemId } from "../../store/providers/item-id";
+
+export const useFocusRegistration = <T extends HTMLElement>(
+  id: string | undefined
+): {
+  ref: RefCallback<T>;
+  current: T | null;
+} => {
+  const registry = useContext(FocusRegistryContext);
+  const internalRef = useRef<T | null>(null);
+
+  useEffect(() => {
+    const el = internalRef.current;
+    if (!el || !id) return;
+    const itemId = id as ItemId;
+    registry.registerItem(itemId, el);
+    return () => registry.unregisterItem(itemId, el);
+  }, [id, registry]);
+
+  const ref = useCallback<RefCallback<T>>((node) => {
+    internalRef.current = node;
+  }, []);
+
+  return { ref, current: internalRef.current };
+};

--- a/packages/workout-spa-editor/src/lib/merge-refs.ts
+++ b/packages/workout-spa-editor/src/lib/merge-refs.ts
@@ -1,0 +1,20 @@
+/**
+ * Merge multiple React refs (callback or object) into a single
+ * callback ref. Useful when a component both `forwardRef`s to a
+ * parent AND needs its own internal ref.
+ */
+
+import type { MutableRefObject, Ref } from "react";
+
+export const mergeRefs =
+  <T>(...refs: Array<Ref<T> | undefined>) =>
+  (node: T | null): void => {
+    refs.forEach((r) => {
+      if (!r) return;
+      if (typeof r === "function") {
+        r(node);
+        return;
+      }
+      (r as MutableRefObject<T | null>).current = node;
+    });
+  };


### PR DESCRIPTION
## Summary

Sixth PR in the `spa-editor-focus-management` series (after #323, #336, #337, #338, #339, #340). This is the PR that actually **turns the lights on**: every store action that writes `pendingFocusTarget` (via §6 in #339) now moves DOM focus, because the hook from #340 is finally wired into the editor tree.

Scope per the split plan: **§8.1–§8.5 only**. §8.6–§8.7 (`:focus-visible` styling + tab-order) and §10.3 (narrow-selector CI grep) are follow-up PRs.

### Component changes

- **`WorkoutSection`** wraps the editor subtree in `FocusRegistryProvider` and mounts `useFocusAfterAction` via a new `useWorkoutSectionFocus` hook. The hook creates three fallback refs: editor root (overlay-observer scope + form-field guard), Add Step button (§7.5 empty-state target), and the workout title `<h2>` (§7.5 last-resort heading).
- **`WorkoutTitle`** adds `tabIndex={-1}` to the `<h2>` and accepts a new `titleRef` prop, with a `:focus-visible` outline so the programmatic focus move is visible.
- **`WorkoutStepsList`** threads `editorRootRef` + `addStepButtonRef`. The outer `<div>` now carries `data-testid="editor-root"` for tests.
- **`WorkoutStepsListActions`** forwards `addStepButtonRef` to the Add Step `<Button>` (which already supported ref forwarding).
- **`StepCard`** and **`RepetitionBlockCard`** self-register with the focus registry under their own `step.id` / `block.id` via a shared `useFocusRegistration` hook. A new `mergeRefs` utility merges the forwarded `ref` (DnD, tests) with the internal registration ref.

### New integration tests

`WorkoutSection.focus-integration.test.tsx` drives real store mutations through the full render tree and asserts `document.activeElement` after each `setTimeout(0)`:

- **Delete → next sibling**: `deleteStep(0)` on a two-step workout focuses the surviving card.
- **Create → new item**: `createStep()` focuses the fresh card.
- **Delete last → empty-state**: `deleteStep(0)` on a single-step workout focuses the Add Step button.
- **Form-field guard (§7.3)**: focus does NOT move while an `<input>` inside the editor root is focused; `pendingFocusTarget` is cleared instead.

### File additions / changes

- **New files (4)**: `use-focus-registration.ts`, `merge-refs.ts`, `use-workout-section-focus.ts`, `WorkoutStepsListBinding.tsx`, `WorkoutSection.focus-integration.test.tsx`
- **Modified (6)**: `WorkoutSection.tsx`, `WorkoutTitle.tsx`, `WorkoutHeader.tsx`, `WorkoutStepsList.tsx`, `WorkoutStepsListActions.tsx`, `StepCard.tsx`, `RepetitionBlockCard.tsx`

All files stay within the 80-line lint cap; all functions within 60 lines.

## Test plan

- [x] `pnpm --filter @kaiord/workout-spa-editor test` — 2593 passed, 4 skipped (4 new integration tests)
- [x] `pnpm --filter @kaiord/workout-spa-editor lint` — clean
- [x] `pnpm --filter @kaiord/workout-spa-editor build` — clean
- [x] Integration tests cover: delete → next, create → new, delete-last → empty-state, form-field guard
- [ ] Manual UI smoke — deferred to §8.6 PR where the focus-visible ring styling lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)