### PR TITLE
feat(spa-editor): focus-visible + reduced-motion + narrow-selector CI (§8.6, §8.7, §10.3)

### DIFF
--- a/.changeset/focus-styles.md
+++ b/.changeset/focus-styles.md
@@ -1,0 +1,35 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Focus management: hardening pass — consistent `:focus-visible` outline
+on every focusable item target, reduced-motion support, and a CI-grep
+invariant that enforces narrow Zustand subscriptions
+(§8.6–§8.7 + §10.3 of the `spa-editor-focus-management` proposal).
+
+**§8.6–§8.7 — styling + tab-order.**
+
+- `StepCard`, `RepetitionBlockCard`, and the workout title `<h2>`
+  render the same `focus-visible:ring-2 focus-visible:ring-blue-500
+focus-visible:ring-offset-2` outline (dark variants included), so a
+  programmatic focus move from `useFocusAfterAction` produces the
+  same visual signal on every item type.
+- `motion-reduce:transition-none` disables the color transition on
+  the cards when `prefers-reduced-motion: reduce` is set, sparing
+  users with vestibular sensitivity a flash on focus.
+- Step cards keep `tabIndex={0}` so the programmatic focus target
+  stays in the normal sequential Tab order.
+
+**§10.3 — narrow-selector CI invariant.**
+
+- Added a Python-based focus-invariant check in `.github/workflows/ci.yml`
+  that rejects `useWorkoutStore()` (no-arg) and identity selectors
+  like `useWorkoutStore((s) => s)` under
+  `packages/workout-spa-editor/src/components/**` and `src/hooks/**`.
+  Consumers must subscribe via narrow selectors or pre-baked hooks
+  from `workout-store-selectors.ts` so a `setPendingFocusTarget`
+  write does not re-render every consumer.
+- Migrated the three pre-existing wide-selector consumers
+  (`useGarminPush`, `useAiGeneration`, `LayoutHeader`) to narrow
+  hooks (`useCurrentWorkout`, `useLoadWorkout`). Test mocks updated
+  to match the new import paths.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,6 +357,54 @@ jobs:
               sys.exit(1)
           PY
 
+      - name: Focus-invariants — narrow-selector discipline for useWorkoutStore
+        # Every consumer of the workout store under src/components/** or
+        # src/hooks/** MUST subscribe via a narrow selector so that a
+        # `setPendingFocusTarget` write (which produces a fresh object
+        # reference) does not re-render every consumer. The forbidden
+        # patterns are: no-arg `useWorkoutStore()` (subscribes to the
+        # whole state), and `useWorkoutStore((s) => s)` (same effect).
+        # Pre-baked narrow hooks live in `workout-store-selectors.ts`;
+        # prefer those or pass an explicit `(s) => s.specificField`.
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+
+          roots = [
+              Path("packages/workout-spa-editor/src/components"),
+              Path("packages/workout-spa-editor/src/hooks"),
+          ]
+          # `useWorkoutStore()` with no selector, or `useWorkoutStore((s) => s)`
+          # / `useWorkoutStore(s => s)` with the identity selector.
+          wide_call = re.compile(r"\buseWorkoutStore\s*\(\s*\)")
+          identity = re.compile(
+              r"\buseWorkoutStore\s*\(\s*\(?\s*(\w+)\s*\)?\s*=>\s*\1\s*\)"
+          )
+          violations = []
+          for root in roots:
+              for path in root.rglob("*"):
+                  if path.suffix not in {".ts", ".tsx"}:
+                      continue
+                  if ".test." in path.name:
+                      continue
+                  text = path.read_text()
+                  if wide_call.search(text) or identity.search(text):
+                      violations.append(str(path))
+
+          if violations:
+              print(
+                  "Wide useWorkoutStore() subscriptions under "
+                  "components/ or hooks/ are forbidden (§10.3). Use a "
+                  "narrow selector or a pre-baked hook from "
+                  "workout-store-selectors.ts:"
+              )
+              for v in violations:
+                  print(f"  {v}")
+              sys.exit(1)
+          PY
+
   check-links:
     name: Link checker
     runs-on: ubuntu-latest

--- a/packages/workout-spa-editor/src/components/molecules/GarminPushButton/useGarminPush.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/GarminPushButton/useGarminPush.test.ts
@@ -23,8 +23,8 @@ const workoutState: { currentWorkout: unknown } = {
   currentWorkout: { name: "test workout" },
 };
 
-vi.mock("../../../store/workout-store", () => ({
-  useWorkoutStore: vi.fn(() => ({ ...workoutState })),
+vi.mock("../../../store/workout-store-selectors", () => ({
+  useCurrentWorkout: vi.fn(() => workoutState.currentWorkout),
 }));
 
 const mockExportGcnWorkout = vi.fn();

--- a/packages/workout-spa-editor/src/components/molecules/GarminPushButton/useGarminPush.ts
+++ b/packages/workout-spa-editor/src/components/molecules/GarminPushButton/useGarminPush.ts
@@ -1,12 +1,12 @@
 import { useCallback } from "react";
 
 import { useGarminBridge } from "../../../contexts";
-import { useWorkoutStore } from "../../../store/workout-store";
+import { useCurrentWorkout } from "../../../store/workout-store-selectors";
 import { exportGcnWorkout } from "../../../utils/export-workout-formats";
 
 export const useGarminPush = () => {
   const { pushWorkout, setPushing, sessionActive } = useGarminBridge();
-  const { currentWorkout } = useWorkoutStore();
+  const currentWorkout = useCurrentWorkout();
 
   const push = useCallback(async () => {
     if (!currentWorkout || !sessionActive) return;

--- a/packages/workout-spa-editor/src/components/molecules/RepetitionBlockCard/repetition-block-card.helpers.ts
+++ b/packages/workout-spa-editor/src/components/molecules/RepetitionBlockCard/repetition-block-card.helpers.ts
@@ -5,8 +5,12 @@ export function buildBlockClasses(
   isDragging: boolean,
   className: string
 ): string {
+  // `focus-visible:` ring matches StepCard so programmatic focus moves
+  // (§7/§8) are visually consistent across item types.
+  // `motion-reduce:` disables the color transition when the user has
+  // `prefers-reduced-motion: reduce` set.
   const baseClasses =
-    "rounded-lg border-2 border-dashed border-primary-300 dark:border-primary-700 bg-primary-50/50 dark:bg-primary-950/20 p-4 transition-colors";
+    "rounded-lg border-2 border-dashed border-primary-300 dark:border-primary-700 bg-primary-50/50 dark:bg-primary-950/20 p-4 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 motion-reduce:transition-none";
   const draggingClasses = isDragging ? "cursor-grabbing" : "";
   return [baseClasses, draggingClasses, className].filter(Boolean).join(" ");
 }

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/use-step-card-classes.ts
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/use-step-card-classes.ts
@@ -4,8 +4,12 @@ export function getStepCardClasses(
   hasDragHandle: boolean,
   className: string
 ): string {
+  // `focus-visible:` ring is the visual signal for programmatic focus
+  // moves set by `useFocusAfterAction` (§7/§8). `motion-reduce:` kills
+  // the color transition when `prefers-reduced-motion: reduce` is on,
+  // avoiding a flash for users with vestibular sensitivity.
   const baseClasses =
-    "rounded-lg border-2 transition-colors duration-200 cursor-pointer hover:shadow-md relative";
+    "rounded-lg border-2 transition-colors duration-200 cursor-pointer hover:shadow-md relative focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-900 motion-reduce:transition-none";
   const selectedClasses = isSelected
     ? "border-primary-500 bg-primary-50 ring-2 ring-primary-200 dark:bg-primary-900/30 dark:ring-primary-800"
     : "border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800";

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/useAiGeneration.ts
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/useAiGeneration.ts
@@ -4,14 +4,14 @@ import { useCallback } from "react";
 import { generateWorkoutKrd } from "../../../lib/generate-workout";
 import { useAiStore } from "../../../store/ai-store";
 import { useProfileStore } from "../../../store/profile-store";
-import { useWorkoutStore } from "../../../store/workout-store";
+import { useLoadWorkout } from "../../../store/workout-store-selectors";
 import type { SportKey } from "../../../types/sport-zones";
 import { formatZonesContext } from "./zones-formatter";
 
 export const useAiGeneration = () => {
   const { getSelectedProvider, customPrompt, setGeneration } = useAiStore();
   const { getActiveProfile } = useProfileStore();
-  const { loadWorkout } = useWorkoutStore();
+  const loadWorkout = useLoadWorkout();
 
   const generate = useCallback(
     async (text: string, sport?: Sport) => {

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutSection.focus-integration.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutSection.focus-integration.test.tsx
@@ -203,4 +203,47 @@ describe("WorkoutSection focus integration (§8.1–§8.5)", () => {
     expect(document.activeElement).toBe(input);
     expect(useWorkoutStore.getState().pendingFocusTarget).toBeNull();
   });
+
+  // §8.6 — focus-visible styling contract. jsdom does not apply CSS
+  // pseudo-classes, so we assert the marker classes are present in the
+  // className string — verifying the ring is wired even if we cannot
+  // measure the pixel outline.
+  it("applies focus-visible ring classes to every focusable item target", () => {
+    // Arrange
+    renderSection(buildKrd([step(0), { repeatCount: 2, steps: [step(0)] }]));
+
+    // Assert — both a step card and the block card carry the ring class.
+    const stepCard = document.querySelector(
+      '[data-testid="step-card"]'
+    ) as HTMLElement;
+    const blockCard = document.querySelector(
+      '[data-testid="repetition-block-card"]'
+    ) as HTMLElement;
+    expect(stepCard.className).toContain("focus-visible:ring-2");
+    expect(blockCard.className).toContain("focus-visible:ring-2");
+
+    // And the classes respect prefers-reduced-motion via motion-reduce:.
+    expect(stepCard.className).toContain("motion-reduce:transition-none");
+    expect(blockCard.className).toContain("motion-reduce:transition-none");
+  });
+
+  // §8.7 — tab-order: Tab from a programmatically focused step card
+  // should move focus forward; Shift+Tab should move it back. jsdom
+  // does not implement the sequential focus navigation algorithm, so
+  // we cannot dispatch a literal Tab keypress and observe focus
+  // moving. Instead we assert the preconditions: the step card has
+  // `tabIndex={0}` (not -1), i.e. it participates in the normal
+  // sequential order.
+  it("step cards participate in normal sequential focus order (tabIndex=0)", () => {
+    // Arrange
+    renderSection(buildKrd([step(0)]));
+    const stepCard = document.querySelector(
+      '[data-testid="step-card"]'
+    ) as HTMLElement;
+
+    // Assert — tabIndex 0 means the user can Tab onto it; a focus move
+    // by the hook lands on a normally-tabbable target, not a roving
+    // -1 trap.
+    expect(stepCard.tabIndex).toBe(0);
+  });
 });

--- a/packages/workout-spa-editor/src/components/templates/MainLayout/LayoutHeader.tsx
+++ b/packages/workout-spa-editor/src/components/templates/MainLayout/LayoutHeader.tsx
@@ -2,7 +2,10 @@ import { useSettingsDialog } from "../../../contexts";
 import { useLazyDialog } from "../../../hooks/use-lazy-dialog";
 import { useLibrary } from "../../../hooks/use-library";
 import { useProfileStore } from "../../../store/profile-store";
-import { useWorkoutStore } from "../../../store/workout-store";
+import {
+  useCurrentWorkout,
+  useLoadWorkout,
+} from "../../../store/workout-store-selectors";
 import { HeaderLogo } from "./components/HeaderLogo";
 import { HeaderNav } from "./components/HeaderNav";
 import { LayoutHeaderDialogs } from "./components/LayoutHeaderDialogs";
@@ -23,7 +26,8 @@ export const LayoutHeader = ({ onReplayTutorial }: LayoutHeaderProps) => {
   const { getActiveProfile } = useProfileStore();
   const activeProfile = getActiveProfile();
   const { templates } = useLibrary();
-  const { currentWorkout, loadWorkout } = useWorkoutStore();
+  const currentWorkout = useCurrentWorkout();
+  const loadWorkout = useLoadWorkout();
 
   return (
     <header className="sticky top-0 z-50 border-b border-gray-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">


### PR DESCRIPTION
## Summary

Seventh PR in the `spa-editor-focus-management` series. Hardening pass after #341 wired the hook into the tree: consistent visual focus signal on every item, respect for `prefers-reduced-motion`, and a CI invariant that locks down narrow Zustand subscriptions so `setPendingFocusTarget` writes do not cascade re-renders.

Scoped per the plan: **§8.6 + §8.7 + §10.3**. The last remaining step is `/opsx-archive` for the proposal itself — a separate PR.

### §8.6 — `:focus-visible` styling

`StepCard`, `RepetitionBlockCard`, and the workout title `<h2>` render the same focus ring:

```
focus-visible:outline-none
focus-visible:ring-2
focus-visible:ring-blue-500
focus-visible:ring-offset-2
dark:focus-visible:ring-offset-gray-900
```

When `useFocusAfterAction` moves focus onto any item type, the user sees the same visual signal — no surprise from differently-styled targets.

### §8.7 — reduced-motion + tab-order

- `motion-reduce:transition-none` on both card roots kills the color transition when `prefers-reduced-motion: reduce` is set, sparing users with vestibular sensitivity a flash when focus lands.
- Step cards keep `tabIndex={0}` so the hook's programmatic focus target also sits in the normal sequential Tab order — no roving `-1` trap.

### §10.3 — narrow-selector CI invariant

- Python-based invariant in `.github/workflows/ci.yml` rejects `useWorkoutStore()` (no-arg) and identity selectors (`useWorkoutStore((s) => s)`) under `packages/workout-spa-editor/src/components/**` and `src/hooks/**`. Test files excluded.
- Migrated three pre-existing wide-selector consumers:
  - `useGarminPush` → `useCurrentWorkout()`
  - `useAiGeneration` → `useLoadWorkout()`
  - `LayoutHeader` → `useCurrentWorkout()` + `useLoadWorkout()`
- Test mock path updated for `useGarminPush.test.ts`.

### Tests added

Three assertions in `WorkoutSection.focus-integration.test.tsx`:

- every focusable item carries `focus-visible:ring-2`
- every focusable item carries `motion-reduce:transition-none`
- step cards have `tabIndex === 0`

## Test plan

- [x] `pnpm -r test` — 2595 passed, 4 skipped (3 new styling/tab tests)
- [x] `pnpm --filter @kaiord/workout-spa-editor lint` — clean
- [x] Local python invocation of the new CI check — reports no violations on this branch
- [ ] Manual UI pass — the ring is visible only through CSS; Playwright E2E verification is deferred since the hook-driven focus is covered by integration tests already

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent focus-visible ring styling across step and repetition cards to improve visual feedback during keyboard navigation
  * Implemented support for user's reduced-motion preferences by disabling unnecessary transitions when motion reduction is enabled
  * Enhanced keyboard accessibility with proper sequential tab order for improved navigability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->