### PR TITLE
fix(ci): lychee v0.24 dropped the boolean form of include_fragments

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -17,7 +17,10 @@
 # problem we're solving today.
 
 offline = true
-include_fragments = false
+# lychee v0.24+ changed the type of `include_fragments` (boolean →
+# string/table); its purpose — skipping anchor fragments — is not
+# load-bearing for this repo's internal-link check, so we drop it
+# and rely on the default behavior.
 max_retries = 1
 timeout = 10
 format = "compact"


### PR DESCRIPTION
## Summary

After Dependabot bumped lychee via #342, the Link-checker CI job fails on every PR with:

\`\`\`
TOML parse error at line 20, column 21
   include_fragments = false
                       ^^^^^
   wanted string or table
\`\`\`

Lychee v0.24.0 changed the type of \`include_fragments\` — the boolean form used here is no longer valid. The setting is not load-bearing for this repo's internal-link check (we already pass \`offline = true\`; anchor fragments are not critical), so the simplest correct fix is to drop the line and rely on the default.

Unblocks Link-checker CI on all open PRs (#343, #344, and any future PR).

## Test plan

- [x] \`bash scripts/lint-links.sh\` locally (lychee 0.23) — 135 OK, 0 errors, 188 excluded
- [ ] CI will verify on lychee 0.24

🤖 Generated with [Claude Code](https://claude.com/claude-code)