### PR TITLE
chore(ci): harden link-checker (always-run, pin lychee@0.24, required + enforce_admins)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,11 +405,12 @@ jobs:
               sys.exit(1)
           PY
 
+  # Always runs (no `if:` gate) and lychee is pinned to a MAJOR.MINOR —
+  # both are spec-locked under `doc-drift-prevention`. See
+  # `openspec/specs/doc-drift-prevention/spec.md`.
   check-links:
     name: Link checker
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: always() && needs.detect-changes.outputs.should-test == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -417,7 +418,7 @@ jobs:
       - name: Install lychee
         uses: taiki-e/install-action@v2
         with:
-          tool: lychee
+          tool: lychee@0.24
 
       - name: Run link checker
         run: bash scripts/lint-links.sh

--- a/openspec/changes/harden-link-checker/proposal.md
+++ b/openspec/changes/harden-link-checker/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The CI "Link checker" job broke silently on 2026-04-24 when the `taiki-e/install-action@v2` action started installing `lychee@0.24.0`, which changed `include_fragments` from a boolean to a string enum. Because the check is NOT in the required-status-check set and the repo's `enforce_admins` is `false`, the regression (a) did not block any PR merge and (b) hid in the "other checks" section of the GitHub UI where it is easy to miss. PR #342 was admin-bypassed past it.
+
+Two structural weaknesses let this happen:
+
+1. The lychee CLI version floats — every CI run installs the latest lychee, so any new lychee release can break internal-link checking without a PR.
+2. "Link checker" is an optional check. A broken link checker does not block merge, so documentation can drift silently when the guard itself is silenced.
+
+The doc-drift-prevention spec already states "Broken links SHALL fail the build" but does not say that the check itself is a required gate, nor that the tool is pinned. That loophole is what this change closes.
+
+## What Changes
+
+- **Pin lychee to a MAJOR.MINOR** in `.github/workflows/ci.yml` via `taiki-e/install-action`'s version-specifier form (`tool: lychee@0.24`). Bumps arrive as PRs (via dependabot on github-actions), not as surprise CI failures.
+- **Always run Link checker**, not only when `detect-changes.should-test == 'true'`. Lychee is offline and runs in ~10 s — there is no meaningful cost to always running it, and a docs-only PR (where `should-test` may be `false`) is exactly when link-checking matters most.
+- **Promote "Link checker" to a required status check** on `main` via branch protection.
+- **Enable `enforce_admins`** on `main` so that a regression in any required check cannot be admin-bypassed. The repo is a one-maintainer repo; emergency reverts can temporarily disable protection for the ~30 seconds they need.
+- **Update `doc-drift-prevention/spec.md`** to capture the three new invariants (pinned lychee, always-runs, required check).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `doc-drift-prevention`: extended with three new requirements (pinned lychee version, always-run Link checker, required-status-check gate) and a modified existing requirement ("CI link checker" becomes a required gate rather than an informational check).
+
+## Impact
+
+- **Package**: none (CI / branch protection only)
+- **Layer**: CI infrastructure + OpenSpec
+- **Files**:
+  - `.github/workflows/ci.yml` — remove the `if:` gate on `check-links`, pin lychee version
+  - `lychee.toml` — add a clarifying comment about `include_fragments` being omitted intentionally (value type changed in 0.24; default is fine here)
+  - `openspec/specs/doc-drift-prevention/spec.md` — update via delta
+  - Branch protection — administrative `gh api` calls after merge (documented in tasks)
+- **No runtime impact**, no public API changes, no changeset required.
+
+## Risks & rollback
+
+- Making Link checker required means any lychee misconfig blocks merges. Mitigation: the version is pinned (0.24) so the only way it breaks is a config change in-repo, which is reviewable in the same PR.
+- `enforce_admins: true` blocks the one-maintainer workflow in emergencies. Rollback: `gh api -X DELETE repos/.../branches/main/protection/enforce_admins` restores current behavior in one command.
+- If dependabot is not already updating github-actions, a new lychee release would not be auto-proposed. Verify `.github/dependabot.yml` has `package-ecosystem: github-actions`; if not, this change adds it.

--- a/openspec/changes/harden-link-checker/specs/doc-drift-prevention/spec.md
+++ b/openspec/changes/harden-link-checker/specs/doc-drift-prevention/spec.md
@@ -1,0 +1,44 @@
+## MODIFIED Requirements
+
+### Requirement: CI link checker
+
+The CI pipeline SHALL check all internal links in documentation pages on every pull request and every push to `main`. Broken links SHALL fail the build. The link-checker job SHALL run unconditionally — it SHALL NOT be gated by `detect-changes` or any other pre-filter, because docs-only changes (where the pre-filter may mark tests as unnecessary) are exactly the changes where broken internal links matter most.
+
+#### Scenario: Broken link detected
+
+- **WHEN** a documentation page references a non-existent internal path
+- **THEN** the CI link check SHALL fail and report the broken link
+
+#### Scenario: Docs-only PR
+
+- **WHEN** a pull request modifies only Markdown files under `packages/docs/` and does not touch source code
+- **THEN** the CI link checker SHALL still run and validate internal links
+
+## ADDED Requirements
+
+### Requirement: Link checker is a required status check
+
+The `Link checker` job SHALL be listed among the required status checks on the `main` branch's protection rule. A pull request SHALL NOT be eligible for merge (including admin merge) while this check is failing, absent an explicit branch-protection override.
+
+#### Scenario: PR with a broken link
+
+- **WHEN** a pull request introduces a broken internal link and the Link checker fails
+- **THEN** the GitHub merge box SHALL mark the PR as "Required status check is failing" and disable the merge button
+
+### Requirement: Pinned lychee version in CI
+
+The lychee CLI used by the link-checker job SHALL be pinned to an explicit MAJOR.MINOR version in `.github/workflows/ci.yml` via `taiki-e/install-action`'s `tool: lychee@<version>` form. New lychee releases SHALL reach CI only through a version-bump PR, never through a silent install of whatever is latest.
+
+#### Scenario: New lychee release
+
+- **WHEN** upstream lychee publishes a new minor or major version
+- **THEN** CI SHALL continue to install the pinned version; bumping is a code change reviewable in a PR, not a CI runtime surprise
+
+### Requirement: Admin bypass of failing required checks is disabled
+
+Branch protection on `main` SHALL set `enforce_admins: true`. A repository admin SHALL NOT be able to merge a pull request while a required status check is failing, without first editing the protection rule.
+
+#### Scenario: Admin attempts to merge with failing required check
+
+- **WHEN** a repository admin tries to merge a pull request while the `Link checker` (or any other required) check is failing
+- **THEN** the GitHub API SHALL reject the merge with a protection-policy error and require the admin to explicitly disable protection first

--- a/openspec/changes/harden-link-checker/tasks.md
+++ b/openspec/changes/harden-link-checker/tasks.md
@@ -1,0 +1,51 @@
+# Tasks — harden-link-checker
+
+## 1. CI workflow changes
+
+- [x] 1.1 Remove the `if: always() && needs.detect-changes.outputs.should-test == 'true'` conditional on `check-links` in `.github/workflows/ci.yml` so the job always runs (takes ~10 s, offline, zero marginal cost).
+- [x] 1.2 Pin lychee to `0.24` via `taiki-e/install-action` in the same workflow: `tool: lychee@0.24`.
+- [ ] 1.3 Add an explanatory comment above the `check-links` job noting why it is always on and why lychee is pinned.
+
+## 2. Config hygiene
+
+- [ ] 2.1 Add a comment to `lychee.toml` explaining that `include_fragments` is intentionally omitted — the setting changed from boolean to string enum in lychee 0.24 and the default (no fragment validation) is correct for this repo's offline/internal link check.
+
+## 3. OpenSpec delta
+
+- [x] 3.1 Write `openspec/changes/harden-link-checker/specs/doc-drift-prevention/spec.md` with the modified `CI link checker` requirement and three new requirements (pinned lychee version, always-run, required status check, admin-bypass protection).
+- [ ] 3.2 Run `pnpm lint:specs` locally; fix any structural-lint findings.
+- [ ] 3.3 Run `npx openspec validate changes/harden-link-checker` if available.
+
+## 4. Post-merge administrative steps (manual, via `gh api`)
+
+These run **after** the PR merges — the PR itself needs to land with the check STILL optional so CI on the PR does not require itself.
+
+- [ ] 4.1 Add `Link checker` to required status checks:
+  ```sh
+  gh api -X PATCH repos/pablo-albaladejo/kaiord/branches/main/protection/required_status_checks \
+    --input - <<'JSON'
+  {
+    "strict": true,
+    "contexts": [
+      "detect-changes","lint","typecheck","test","build","round-trip",
+      "Check for Changeset","Link checker"
+    ]
+  }
+  JSON
+  ```
+- [ ] 4.2 Enable `enforce_admins`:
+  ```sh
+  gh api -X POST repos/pablo-albaladejo/kaiord/branches/main/protection/enforce_admins
+  ```
+- [ ] 4.3 Verify with:
+  ```sh
+  gh api repos/pablo-albaladejo/kaiord/branches/main/protection \
+    --jq '{required: .required_status_checks.contexts, enforce_admins: .enforce_admins.enabled}'
+  ```
+  Expected output contains `Link checker` in `required` and `enforce_admins: true`.
+
+## 5. Verification
+
+- [ ] 5.1 Confirm Link checker runs on the PR itself (it will, since removing the `if:` means it always runs).
+- [ ] 5.2 Confirm the PR passes CI (all required + Link checker).
+- [ ] 5.3 After post-merge steps, open a trivial follow-up test PR and confirm `Link checker` appears under "Required" in the merge box.


### PR DESCRIPTION
## Summary

Closes the loophole surfaced on 2026-04-24 when lychee 0.24 silently broke the internal-link check, which in turn led to admin-bypassing PR #342 past the failing "Link checker". Three structural fixes:

1. **`check-links` always runs** — drops the `if: always() && needs.detect-changes.outputs.should-test == 'true'` gate. Lychee is offline and takes ~10 s; docs-only PRs are exactly when link-checking matters, and those are the ones the pre-filter would skip.
2. **Lychee pinned to `0.24`** via `taiki-e/install-action`'s `tool: lychee@0.24` form. Future lychee releases arrive via PRs, not as CI surprises.
3. **OpenSpec change** `harden-link-checker` codifies the three invariants — always-run, pinned version, required status check + `enforce_admins` — as a delta to the `doc-drift-prevention` spec.

Administrative follow-up (cannot be done in a PR): after merge, run the `gh api` commands in `tasks.md` §4 to promote Link checker to required and enable `enforce_admins`. Intentionally not done in this PR because the PR itself would then be unable to merge — a newly-required check must first exist on `main`.

## Files

- `.github/workflows/ci.yml` — conditional removed, lychee pinned, explanatory comment referencing the spec.
- `openspec/changes/harden-link-checker/proposal.md`
- `openspec/changes/harden-link-checker/tasks.md`
- `openspec/changes/harden-link-checker/specs/doc-drift-prevention/spec.md` — delta: modified `CI link checker` requirement + three new requirements.

## Test plan

- [x] `pnpm lint:specs` ✓
- [x] `npx openspec validate harden-link-checker` → "Change 'harden-link-checker' is valid"
- [ ] CI passes (Link checker green under pinned 0.24)
- [ ] Post-merge: `gh api` commands in tasks.md §4
- [ ] Post-merge verification: `gh api repos/.../branches/main/protection --jq '{required: .required_status_checks.contexts, enforce_admins: .enforce_admins.enabled}'`

## Risks & rollback

- Making Link checker required means any future lychee-config drift blocks merges. Mitigation: version is pinned, bumps are explicit.
- `enforce_admins: true` blocks the one-maintainer workflow in emergencies. Rollback: `gh api -X DELETE repos/.../branches/main/protection/enforce_admins`.