### PR TITLE
chore(prettier): ignore pnpm-lock.yaml

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 # Dependencies
 node_modules/
+pnpm-lock.yaml
 
 # Build outputs
 dist/


### PR DESCRIPTION
Fixes the release-bot push failure on run [24905115684](https://github.com/pablo-albaladejo/kaiord/actions/runs/24905115684): changesets/action pushed the "Version Packages" commit → the pre-push hook ran `lint:fix` → prettier reformatted `pnpm-lock.yaml` → husky blocked the push.

`pnpm-lock.yaml` is a machine-generated file with pnpm's own deterministic serialization. Prettier-formatting it produces purely cosmetic diffs that break the pre-push hook. Adding it to `.prettierignore` fixes the root cause.

Also eliminates the recurring `chore: apply prettier to pnpm-lock.yaml` commits that appeared on #342, #347, #350, #351, #352 today.

## Test plan

- [x] `pnpm lint:fix` locally → only `.prettierignore` itself shows as modified (not `pnpm-lock.yaml`)
- [ ] CI green
- [ ] Re-trigger release workflow after merge → PR #325 updates cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code formatting configuration to exclude lock files from formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->