### PR TITLE
chore(release): changeset for 7.1.1 patch — TS6 + CI hardening

### DIFF
--- a/.changeset/release-post-ts6-migration.md
+++ b/.changeset/release-post-ts6-migration.md
@@ -1,0 +1,21 @@
+---
+"@kaiord/core": patch
+"@kaiord/cli": patch
+"@kaiord/fit": patch
+"@kaiord/tcx": patch
+"@kaiord/zwo": patch
+"@kaiord/garmin": patch
+"@kaiord/garmin-connect": patch
+"@kaiord/mcp": patch
+"@kaiord/ai": patch
+---
+
+Internal build + CI hardening release. No public API changes, no runtime behavior changes.
+
+- **TypeScript 6.0.3**: toolchain migrated from TS 5.9.3 across all packages. Consumers can now opt into TS 6 without hitting `baseUrl` deprecation warnings in shipped type declarations.
+- **Dedupe vite to 8.x**: removed the dual-vite-major state in the lockfile (vite 7.3 was coming in via vitepress alpha). `pnpm.overrides` forces a single major.
+- **Dependabot sweep**: @garmin/fitsdk 21.200→21.201, vitest 4.1.4→4.1.5, tailwindcss 4.2.2→4.2.4, lucide-react 1.8→1.11, vue 3.5.32→3.5.33, ora 9.3→9.4, @codecov/vite-plugin 1.9→2.0, @fission-ai/openspec 1.3.0→1.3.1, plus 3 GitHub Actions version bumps.
+- **CI hardening**: Link-checker is now a required status check + lychee pinned to v0.24; `enforce_admins` enabled on main branch protection; CHANGELOG.md excluded from cspell; `pnpm-lock.yaml` excluded from prettier (eliminates a recurring push-time reformat loop).
+- **Build watchdog**: `scripts/check-tsup-ignoredeprecations.mjs` auto-fails lint the day tsup fixes [egoist/tsup#1388](https://github.com/egoist/tsup/issues/1388), so the repo self-heals to drop the last remaining `ignoreDeprecations` silencer without manual tracking.
+
+No API additions, removals, or behavioral changes. Published packages consume the same surface as 7.0.0.


### PR DESCRIPTION
## Summary

Adds a patch-level changeset covering all 9 public `@kaiord` packages. On merge, the release workflow will regenerate the "Version Packages" PR with the linked group normalizing to **7.1.1** across the 9 public packages + 2 extensions (extensions already at 7.1.0 from today's earlier release).

## What ships in 7.1.1

No public API changes. The release content is internal tooling + CI hardening accumulated across today's session:

- **TypeScript 6.0.3** migration (from 5.9.3) — type declarations ship without `baseUrl` deprecation warnings
- **Vite dedup to 8.x** — single vite major in the lockfile (vite 7.3 was dragged in by vitepress alpha)
- **Dependabot sweep**: @garmin/fitsdk 21.200→21.201, vitest 4.1.4→4.1.5 (+ coverage-v8, ui), tailwindcss 4.2.2→4.2.4, lucide-react 1.8→1.11, vue 3.5.32→3.5.33, ora 9.3→9.4, @codecov/vite-plugin 1.9→2.0, @fission-ai/openspec 1.3.0→1.3.1, 3 GitHub Actions bumps
- **CI hardening**: Link-checker promoted to required status check, lychee pinned to v0.24, `enforce_admins: true` on main
- **Build watchdog**: `scripts/check-tsup-ignoredeprecations.mjs` auto-fails lint when upstream tsup fixes its forced-baseUrl bug
- **Fixed recurring release-workflow push loop**: `pnpm-lock.yaml` excluded from prettier + `CHANGELOG.md` from cspell

## Next steps after merge

1. Release workflow triggers (pushes to `.changeset/**` match the path filter)
2. "Version Packages" PR opens with the 7.1.1 bump
3. Approve + merge that PR → publish step runs → 9 public packages reach npm as 7.1.1

## Test plan

- [x] `pnpm exec changeset status --verbose` confirms all 9 packages bump as patch to 7.1.1
- [ ] CI green on this PR
- [ ] Release workflow regenerates "Version Packages" PR after merge
- [ ] Final publish step succeeds (npm OIDC wiring from the previous 7.0.0 release is intact)
- [ ] `gh release list` shows 9 new `@kaiord/*@7.1.1` entries

## Out of scope

- **Chrome Web Store publish is known-broken** (`CWS_REFRESH_TOKEN` expired, seen on today's release run 24907901891). This changeset's linked group will bump the extensions to 7.1.1 as well, but the CWS upload will fail until the token is manually refreshed. That is orthogonal and unblocks separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded TypeScript to version 6 across packages.
  * Updated dependencies via Dependabot sweep.
  * Enhanced CI/CD reliability with stricter checks and pinned tools.
  * Improved build validation with automated deprecation detection.

**Note:** No public API or runtime behavior changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->