### PR TITLE
feat(analytics): add Analytics port/adapter with Cloudflare Web Analytics

### DIFF
--- a/.changeset/analytics-port-adapter.md
+++ b/.changeset/analytics-port-adapter.md
@@ -1,0 +1,7 @@
+---
+"@kaiord/core": patch
+---
+
+Add Analytics port and noop adapter.
+
+Introduces `Analytics` type and `AnalyticsEvent` alias as a new port in `@kaiord/core`, alongside `createNoopAnalytics()` as the default do-nothing adapter. OSS consumers receive a zero-dependency, zero-tracking default; private deployments can inject their own adapter (e.g. Cloudflare Web Analytics) without any code changes to the framework.

--- a/openspec/changes/analytics-port-adapter/.openspec.yaml
+++ b/openspec/changes/analytics-port-adapter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/analytics-port-adapter/design.md
+++ b/openspec/changes/analytics-port-adapter/design.md
@@ -2,7 +2,7 @@
 
 Kaiord currently has zero analytics on kaiord.com (landing) and `/editor/`. The project follows hexagonal architecture strictly — the existing `Logger` port (`packages/core/src/ports/logger.ts`) is the reference pattern for cross-cutting infrastructure. Analytics must follow the same pattern: a port in `core`, a noop adapter as default, and provider-specific adapters in consumer packages.
 
-The chosen provider is **Cloudflare Web Analytics**: free tier, cookieless, GDPR-compliant by default, no consent banner required — coherent with the project's "your data never leaves your device" messaging. DNS is on AWS Route53; Cloudflare is used only as an analytics beacon (no proxy required).
+The chosen provider is **Cloudflare Web Analytics**: free tier, cookieless, GDPR-compliant by default, no consent banner required — coherent with the project's "your data never leaves your device" messaging. DNS is on AWS Route 53; Cloudflare is used only as an analytics beacon (no proxy required).
 
 ## Goals / Non-Goals
 
@@ -45,7 +45,7 @@ type Analytics = {
 
 ### 2. Noop adapter in core, Cloudflare adapter in consumer packages (Option A)
 
-```
+```text
 core/adapters/analytics/noop-analytics.ts     ← published with @kaiord/core
 landing/src/adapters/analytics/               ← private
 workout-spa-editor/src/adapters/analytics/    ← private
@@ -57,7 +57,7 @@ workout-spa-editor/src/adapters/analytics/    ← private
 
 ### 3. Editor injection via React Context
 
-```
+```text
 AnalyticsContext (React.createContext)
   └── AnalyticsProvider (wraps app in main.tsx)
         └── useAnalytics() hook (consumed by components)

--- a/openspec/changes/analytics-port-adapter/design.md
+++ b/openspec/changes/analytics-port-adapter/design.md
@@ -7,6 +7,7 @@ The chosen provider is **Cloudflare Web Analytics**: free tier, cookieless, GDPR
 ## Goals / Non-Goals
 
 **Goals:**
+
 - Define `Analytics` port in `@kaiord/core` mirroring the `Logger` type
 - Provide `createNoopAnalytics()` as the default adapter (no tracking unless injected)
 - Wire Cloudflare Web Analytics in `@kaiord/landing` (vanilla TS) and `@kaiord/workout-spa-editor` (React)
@@ -14,6 +15,7 @@ The chosen provider is **Cloudflare Web Analytics**: free tier, cookieless, GDPR
 - Export port and noop adapter from `@kaiord/core` public API for OSS consumers
 
 **Non-Goals:**
+
 - A new published `@kaiord/analytics-cloudflare` package (YAGNI — adapters stay private)
 - Session recording, heatmaps, or product analytics (Cloudflare free tier: page views + custom events only)
 - Any consent banner or cookie management (Cloudflare Analytics is cookieless)
@@ -25,12 +27,12 @@ The chosen provider is **Cloudflare Web Analytics**: free tier, cookieless, GDPR
 
 ```typescript
 // packages/core/src/ports/analytics.ts
-type AnalyticsEvent = Record<string, string | number | boolean>
+type AnalyticsEvent = Record<string, string | number | boolean>;
 
 type Analytics = {
-  pageView: (path: string) => void
-  event: (name: string, props?: AnalyticsEvent) => void
-}
+  pageView: (path: string) => void;
+  event: (name: string, props?: AnalyticsEvent) => void;
+};
 ```
 
 **Why**: Mirrors the Cloudflare Web Analytics JS API surface (`window.cfBeacon.pushEvent`). Keeping it minimal avoids over-engineering for a single provider. Properties are typed strictly (`string | number | boolean`, not `unknown`) so adapters can safely serialize them without runtime guards.
@@ -76,8 +78,10 @@ const analytics = createCloudflareAnalytics(import.meta.env.VITE_CF_ANALYTICS_TO
 
 ```typescript
 // landing/src/analytics.ts
-import { createCloudflareAnalytics } from './adapters/analytics/cloudflare-analytics'
-export const analytics = createCloudflareAnalytics(import.meta.env.VITE_CF_ANALYTICS_TOKEN)
+import { createCloudflareAnalytics } from "./adapters/analytics/cloudflare-analytics";
+export const analytics = createCloudflareAnalytics(
+  import.meta.env.VITE_CF_ANALYTICS_TOKEN
+);
 ```
 
 **Why**: The landing is vanilla TS with no framework. A singleton module is idiomatic and simple. The token is injected at build time via Vite env vars.
@@ -90,14 +94,14 @@ The adapter guards against the beacon not being available (e.g., blocked by ad b
 
 ```typescript
 const push = (name: string, props?: AnalyticsEvent) => {
-  if (typeof window !== 'undefined' && window.cfBeacon) {
+  if (typeof window !== "undefined" && window.cfBeacon) {
     try {
-      window.cfBeacon.pushEvent(name, props)
+      window.cfBeacon.pushEvent(name, props);
     } catch {
       // beacon errors must not surface to the application
     }
   }
-}
+};
 ```
 
 A `window.cfBeacon` TypeScript ambient declaration is required in each consumer package for strict-mode compilation (`src/types/cf-beacon.d.ts`).
@@ -114,32 +118,34 @@ The beacon `<script>` tag is conditionally emitted only when `VITE_CF_ANALYTICS_
 Concretely, the adapter factory treats an empty/undefined token as a signal to return a noop:
 
 ```typescript
-export const createCloudflareAnalytics = (token: string | undefined): Analytics => {
-  if (!token) return createNoopAnalytics()
+export const createCloudflareAnalytics = (
+  token: string | undefined
+): Analytics => {
+  if (!token) return createNoopAnalytics();
   // ... wire up beacon
-}
+};
 ```
 
 **Local dev behavior (explicit)**:
 
-| Environment              | Token set? | Behavior                              |
-|--------------------------|------------|---------------------------------------|
-| Local dev (`pnpm dev`)   | No         | Noop — no beacon, no console errors   |
-| CI/CD build              | Yes        | Cloudflare adapter active             |
-| Production               | Yes        | Same artifact as CI/CD build          |
+| Environment            | Token set? | Behavior                            |
+| ---------------------- | ---------- | ----------------------------------- |
+| Local dev (`pnpm dev`) | No         | Noop — no beacon, no console errors |
+| CI/CD build            | Yes        | Cloudflare adapter active           |
+| Production             | Yes        | Same artifact as CI/CD build        |
 
 ### 6. Events to track
 
-| Surface  | Event name          | Props                              | Trigger                          |
-|----------|---------------------|------------------------------------|----------------------------------|
-| Landing  | (page view)         | —                                  | automatic via beacon             |
-| Landing  | `editor-opened`     | —                                  | click on "Try the Editor" CTA    |
-| Landing  | `github-opened`     | —                                  | click on "Star on GitHub" link   |
-| Landing  | `docs-opened`       | —                                  | click on "Read the Docs" link    |
-| Editor   | `editor-loaded`     | —                                  | app mount in main.tsx            |
-| Editor   | `workout-generated` | `{ provider, sport }`              | AI generation completes          |
-| Editor   | `workout-exported`  | `{ format }`                       | export to FIT/TCX/ZWO/GCN        |
-| Editor   | `garmin-synced`     | `{ result: 'success' \| 'failure' }`| Garmin Connect push completes   |
+| Surface | Event name          | Props                                | Trigger                        |
+| ------- | ------------------- | ------------------------------------ | ------------------------------ |
+| Landing | (page view)         | —                                    | automatic via beacon           |
+| Landing | `editor-opened`     | —                                    | click on "Try the Editor" CTA  |
+| Landing | `github-opened`     | —                                    | click on "Star on GitHub" link |
+| Landing | `docs-opened`       | —                                    | click on "Read the Docs" link  |
+| Editor  | `editor-loaded`     | —                                    | app mount in main.tsx          |
+| Editor  | `workout-generated` | `{ provider, sport }`                | AI generation completes        |
+| Editor  | `workout-exported`  | `{ format }`                         | export to FIT/TCX/ZWO/GCN      |
+| Editor  | `garmin-synced`     | `{ result: 'success' \| 'failure' }` | Garmin Connect push completes  |
 
 `garmin-synced` is fired on both success and failure — the `result` dimension allows computing the sync conversion rate. `workout-generated` includes `provider` (e.g., `claude`, `gpt`, `gemini`) and `sport` for segmentation. No props carry PII.
 

--- a/openspec/changes/analytics-port-adapter/design.md
+++ b/openspec/changes/analytics-port-adapter/design.md
@@ -1,0 +1,155 @@
+## Context
+
+Kaiord currently has zero analytics on kaiord.com (landing) and `/editor/`. The project follows hexagonal architecture strictly — the existing `Logger` port (`packages/core/src/ports/logger.ts`) is the reference pattern for cross-cutting infrastructure. Analytics must follow the same pattern: a port in `core`, a noop adapter as default, and provider-specific adapters in consumer packages.
+
+The chosen provider is **Cloudflare Web Analytics**: free tier, cookieless, GDPR-compliant by default, no consent banner required — coherent with the project's "your data never leaves your device" messaging. DNS is on AWS Route53; Cloudflare is used only as an analytics beacon (no proxy required).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define `Analytics` port in `@kaiord/core` mirroring the `Logger` type
+- Provide `createNoopAnalytics()` as the default adapter (no tracking unless injected)
+- Wire Cloudflare Web Analytics in `@kaiord/landing` (vanilla TS) and `@kaiord/workout-spa-editor` (React)
+- Track key funnel events: page views, CTA clicks, editor interactions
+- Export port and noop adapter from `@kaiord/core` public API for OSS consumers
+
+**Non-Goals:**
+- A new published `@kaiord/analytics-cloudflare` package (YAGNI — adapters stay private)
+- Session recording, heatmaps, or product analytics (Cloudflare free tier: page views + custom events only)
+- Any consent banner or cookie management (Cloudflare Analytics is cookieless)
+- Tracking inside the core conversion pipeline (`fromBinary`, `toText`, etc.)
+
+## Decisions
+
+### 1. Port shape: two methods only
+
+```typescript
+// packages/core/src/ports/analytics.ts
+type AnalyticsEvent = Record<string, string | number | boolean>
+
+type Analytics = {
+  pageView: (path: string) => void
+  event: (name: string, props?: AnalyticsEvent) => void
+}
+```
+
+**Why**: Mirrors the Cloudflare Web Analytics JS API surface (`window.cfBeacon.pushEvent`). Keeping it minimal avoids over-engineering for a single provider. Properties are typed strictly (`string | number | boolean`, not `unknown`) so adapters can safely serialize them without runtime guards.
+
+**Deliberate divergence from Logger**: The `Logger` port uses `Record<string, unknown>` for context. `Analytics` uses the stricter `Record<string, string | number | boolean>`. This is intentional — log context stays local and never serialized externally, whereas analytics props are shipped to a third-party service. The tighter type prevents callers from accidentally passing complex objects or, critically, PII-containing structures that would pass type-checking but leak data to Cloudflare. **Event properties MUST NOT contain personally identifiable information** (user IDs, emails, file contents, workout names). This constraint is enforced by convention, not the type system alone.
+
+**`pageView(path)` semantics**: The beacon auto-tracks the initial page load for each `index.html`. `pageView` is reserved for manual invocation on SPA route changes. In the current scope (single route per package), `pageView` is called once on landing page load for completeness but is primarily a forward-compatibility hook — if the editor introduces sub-routes, `pageView` enables manual route tracking without changing the port contract.
+
+**Alternative considered**: A single `track(event)` method. Rejected — separating `pageView` from `event` matches how Cloudflare distinguishes page views (automatic) from custom events (manual).
+
+### 2. Noop adapter in core, Cloudflare adapter in consumer packages (Option A)
+
+```
+core/adapters/analytics/noop-analytics.ts     ← published with @kaiord/core
+landing/src/adapters/analytics/               ← private
+workout-spa-editor/src/adapters/analytics/    ← private
+```
+
+**Why**: A published `@kaiord/analytics-cloudflare` package would require CI/CD wiring, changesets, and a semantic versioning contract for a single 15-line file. Option A is proportionate to the current scale. If other consumers request the Cloudflare adapter, extract then.
+
+**Alternative considered**: Option B (published package). Rejected as premature.
+
+### 3. Editor injection via React Context
+
+```
+AnalyticsContext (React.createContext)
+  └── AnalyticsProvider (wraps app in main.tsx)
+        └── useAnalytics() hook (consumed by components)
+```
+
+**Why**: Consistent with how other ports are injected in the SPA. Existing contexts live in `packages/workout-spa-editor/src/contexts/` (e.g., `garmin-bridge-context.tsx`, `settings-dialog-context.tsx`). `analytics-context.tsx` follows the same convention. Avoids prop-drilling. The provider accepts an `Analytics` value — tests inject a spy, production injects Cloudflare.
+
+```tsx
+// main.tsx — production wiring
+const analytics = createCloudflareAnalytics(import.meta.env.VITE_CF_ANALYTICS_TOKEN)
+<AnalyticsProvider value={analytics}><App /></AnalyticsProvider>
+
+// any test — spy injection
+<AnalyticsProvider value={createNoopAnalytics()}><ComponentUnderTest /></AnalyticsProvider>
+```
+
+### 4. Landing injection via module-level singleton
+
+```typescript
+// landing/src/analytics.ts
+import { createCloudflareAnalytics } from './adapters/analytics/cloudflare-analytics'
+export const analytics = createCloudflareAnalytics(import.meta.env.VITE_CF_ANALYTICS_TOKEN)
+```
+
+**Why**: The landing is vanilla TS with no framework. A singleton module is idiomatic and simple. The token is injected at build time via Vite env vars.
+
+### 5. Cloudflare beacon script in index.html (both packages)
+
+Cloudflare Web Analytics requires a `<script>` tag in the HTML to load its beacon. The TS adapter calls `window.cfBeacon.pushEvent()` for custom events — this API is only available after the beacon loads.
+
+The adapter guards against the beacon not being available (e.g., blocked by ad blockers or missing token), and wraps `pushEvent` in a `try/catch` to prevent any future beacon SDK regression from propagating into application code:
+
+```typescript
+const push = (name: string, props?: AnalyticsEvent) => {
+  if (typeof window !== 'undefined' && window.cfBeacon) {
+    try {
+      window.cfBeacon.pushEvent(name, props)
+    } catch {
+      // beacon errors must not surface to the application
+    }
+  }
+}
+```
+
+A `window.cfBeacon` TypeScript ambient declaration is required in each consumer package for strict-mode compilation (`src/types/cf-beacon.d.ts`).
+
+**Why the adapter does NOT accept a `Logger` parameter**: The noop-or-forward design is intentional. Analytics are best-effort telemetry — silently dropping events is the correct production behavior. Adding a `Logger` dependency would couple the adapter to another port, increase the API surface, and risk debug noise leaking into production logs. If troubleshooting is needed, the Cloudflare dashboard is the authoritative source. The catch block remains silent by design.
+
+The beacon `<script>` tag is conditionally emitted only when `VITE_CF_ANALYTICS_TOKEN` is non-empty at build time. This ensures local development without a token produces no beacon load, no console errors, and no invalid-token network requests — the noop adapter is used instead:
+
+```html
+<!-- Only injected when VITE_CF_ANALYTICS_TOKEN is set at build time -->
+<!-- Vite HTML env replacement: if token is empty string, script tag is omitted -->
+```
+
+Concretely, the adapter factory treats an empty/undefined token as a signal to return a noop:
+
+```typescript
+export const createCloudflareAnalytics = (token: string | undefined): Analytics => {
+  if (!token) return createNoopAnalytics()
+  // ... wire up beacon
+}
+```
+
+**Local dev behavior (explicit)**:
+
+| Environment              | Token set? | Behavior                              |
+|--------------------------|------------|---------------------------------------|
+| Local dev (`pnpm dev`)   | No         | Noop — no beacon, no console errors   |
+| CI/CD build              | Yes        | Cloudflare adapter active             |
+| Production               | Yes        | Same artifact as CI/CD build          |
+
+### 6. Events to track
+
+| Surface  | Event name          | Props                              | Trigger                          |
+|----------|---------------------|------------------------------------|----------------------------------|
+| Landing  | (page view)         | —                                  | automatic via beacon             |
+| Landing  | `editor-opened`     | —                                  | click on "Try the Editor" CTA    |
+| Landing  | `github-opened`     | —                                  | click on "Star on GitHub" link   |
+| Landing  | `docs-opened`       | —                                  | click on "Read the Docs" link    |
+| Editor   | `editor-loaded`     | —                                  | app mount in main.tsx            |
+| Editor   | `workout-generated` | `{ provider, sport }`              | AI generation completes          |
+| Editor   | `workout-exported`  | `{ format }`                       | export to FIT/TCX/ZWO/GCN        |
+| Editor   | `garmin-synced`     | `{ result: 'success' \| 'failure' }`| Garmin Connect push completes   |
+
+`garmin-synced` is fired on both success and failure — the `result` dimension allows computing the sync conversion rate. `workout-generated` includes `provider` (e.g., `claude`, `gpt`, `gemini`) and `sport` for segmentation. No props carry PII.
+
+## Risks / Trade-offs
+
+- **Ad blockers**: Cloudflare beacon may be blocked. The adapter silently no-ops. Acceptable — analytics are directional, not mission-critical.
+- **Token exposure**: `VITE_CF_ANALYTICS_TOKEN` is a public beacon token (not a secret API key). Cloudflare Web Analytics tokens are designed to be public — they only allow sending events to your dashboard, not reading data. Baking it into the bundle at build time is a justified deviation from 12-factor III/V: the token is not a secret, GitHub Pages has no runtime config injection, and there is a single deployment environment. If a staging environment is ever added, the token can be a different value per CI job.
+- **Empty token in local dev**: When `VITE_CF_ANALYTICS_TOKEN` is not set, `createCloudflareAnalytics` returns a noop and the beacon `<script>` tag is not emitted. This prevents console errors and invalid-token network requests during local development.
+- **SPA route changes**: The editor is a single-page app. Cloudflare's beacon auto-tracks the initial page load; route changes within the SPA require manual `pageView` calls if sub-routes are introduced. Current scope: single route, so this is not needed yet.
+- **`window.cfBeacon` timing**: The beacon script loads asynchronously. Custom events called before the beacon loads are dropped. Mitigation: `editor-loaded` event is fired on app mount, which is after the beacon script has had time to initialize.
+- **PII in event props**: The `AnalyticsEvent` type (`Record<string, string | number | boolean>`) does not prevent PII by type alone. Callers MUST NOT pass user IDs, emails, file contents, or workout names as prop values. This is enforced by convention and code review, not the type system.
+- **CSP implications**: The Cloudflare beacon loads from `https://static.cloudflareinsights.com` and connects to `https://cloudflareinsights.com`. If a `Content-Security-Policy` header or `<meta>` CSP is ever added to the site, both origins must be allowlisted in `script-src` and `connect-src`. Currently GitHub Pages does not set CSP headers, so this is not an immediate concern.
+- **SRI not applicable**: Cloudflare's beacon URL (`beacon.min.js`) is a mutable, versioned endpoint. Cloudflare does not publish SRI hashes for it, so `integrity` attributes cannot be applied to the `<script>` tag. This is an accepted limitation of using a third-party beacon.

--- a/openspec/changes/analytics-port-adapter/proposal.md
+++ b/openspec/changes/analytics-port-adapter/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Kaiord has no visibility into who visits kaiord.com or uses the editor. Adding analytics following the existing Logger port/adapter pattern makes tracking opt-in by design: OSS consumers inject nothing (or a noop), while Kaiord's own deployments inject a Cloudflare Web Analytics adapter — consistent with the "your data never leaves your device" privacy message.
+
+## What Changes
+
+- New `Analytics` port in `@kaiord/core` (`pageView`, `event`) mirroring the existing `Logger` port
+- New `noopAnalytics` adapter in `@kaiord/core` (default: no tracking)
+- New `cloudflareAnalytics` adapter in `@kaiord/landing` (vanilla TS, wraps `window.cfBeacon`)
+- New `cloudflareAnalytics` adapter in `@kaiord/workout-spa-editor` (React, wraps `window.cfBeacon`)
+- `AnalyticsProvider` + `useAnalytics()` React hook in the editor for context-based injection
+- Cloudflare beacon `<script>` tag added to `landing/index.html` and `workout-spa-editor/index.html`
+- Token/site ID sourced from env vars (`VITE_CF_ANALYTICS_TOKEN` for editor, build-time substitution for landing)
+- Landing tracks: page view on load, `editor-opened` on CTA click, `github-opened` on GitHub link click
+- Editor tracks: `editor-loaded`, `workout-generated`, `workout-exported`, `garmin-synced`
+
+## Capabilities
+
+### New Capabilities
+
+- `analytics-port`: Analytics port and noop adapter in `@kaiord/core` — the contract any analytics implementation must satisfy
+
+### Modified Capabilities
+
+<!-- No existing spec-level behaviors change. This is purely additive infrastructure. -->
+
+## Impact
+
+- **Packages touched**: `@kaiord/core` (port + noop adapter), `@kaiord/landing` (adapter + wiring), `@kaiord/workout-spa-editor` (adapter + provider + hook + wiring)
+- **Hexagonal layers**: ports (new `Analytics` type), adapters (cloudflare implementations), application (no change)
+- **Public API**: `Analytics` type and `createNoopAnalytics` exported from `@kaiord/core` — additive, no breaking changes
+- **No new published packages**: Cloudflare adapters are private to each consumer package (YAGNI)
+- **No cookies, no consent banner**: Cloudflare Web Analytics is cookieless and GDPR-compliant by default

--- a/openspec/changes/analytics-port-adapter/specs/analytics-port/spec.md
+++ b/openspec/changes/analytics-port-adapter/specs/analytics-port/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+### Requirement: Analytics port is defined in core
+
+The system SHALL expose an `Analytics` type in `@kaiord/core/ports` with two methods: `pageView(path: string): void` and `event(name: string, props?: Record<string, string | number | boolean>): void`. The port MUST NOT depend on any external library or browser API.
+
+#### Scenario: Port is importable from core
+
+- **WHEN** a consumer imports `Analytics` from `@kaiord/core`
+- **THEN** the type is available with `pageView` and `event` signatures
+
+### Requirement: Noop adapter is provided as default
+
+The system SHALL provide `createNoopAnalytics(): Analytics` in `@kaiord/core/adapters/analytics`. Calling any method on the noop adapter MUST produce no side effects and MUST NOT throw.
+
+#### Scenario: Noop adapter silently discards all calls
+
+- **WHEN** `pageView` or `event` is called on the noop adapter
+- **THEN** no network request is made, no error is thrown, and no output is produced
+
+### Requirement: Cloudflare adapter wraps the beacon API
+
+The system SHALL provide `createCloudflareAnalytics(token: string | undefined): Analytics` in both `@kaiord/landing` and `@kaiord/workout-spa-editor`. The adapter MUST return a noop when the token is falsy (empty string or undefined), and MUST guard against `window.cfBeacon` being unavailable (e.g., blocked by an ad blocker) when the token is present.
+
+#### Scenario: pageView is forwarded to beacon when available
+
+- **WHEN** `pageView('/editor/')` is called and `window.cfBeacon` is present
+- **THEN** the adapter forwards the path to the beacon API without throwing
+
+#### Scenario: Event is sent when beacon is available
+
+- **WHEN** `event('workout-generated', { sport: 'cycling' })` is called and `window.cfBeacon` is present
+- **THEN** the adapter calls `window.cfBeacon.pushEvent` with the event name and properties
+
+#### Scenario: pageView is silently dropped when beacon is blocked
+
+- **WHEN** `pageView` is called and `window.cfBeacon` is undefined
+- **THEN** no error is thrown and execution continues normally
+
+#### Scenario: Event is silently dropped when beacon is blocked
+
+- **WHEN** `event` is called and `window.cfBeacon` is undefined
+- **THEN** no error is thrown and execution continues normally
+
+#### Scenario: Event called before beacon initializes is silently dropped
+
+- **WHEN** `event` is called synchronously before the async beacon script has loaded (`window.cfBeacon` not yet set)
+- **THEN** no error is thrown and execution continues normally
+
+#### Scenario: pushEvent error is silently swallowed
+
+- **WHEN** `event` is called and `window.cfBeacon.pushEvent` throws
+- **THEN** the error is caught internally and execution continues normally without propagating to the caller
+
+#### Scenario: Adapter is noop when token is not set
+
+- **WHEN** `createCloudflareAnalytics(undefined)` or `createCloudflareAnalytics('')` is called
+- **THEN** the returned adapter is functionally equivalent to `createNoopAnalytics()` — no network requests, no console errors
+
+Note: each consumer package (`@kaiord/landing` and `@kaiord/workout-spa-editor`) has its own independent adapter implementation and test suite verifying these scenarios.
+
+### Requirement: Editor injects analytics via React Context
+
+The system SHALL provide `AnalyticsProvider` and `useAnalytics()` in `@kaiord/workout-spa-editor`. Any component that calls `useAnalytics()` outside a provider MUST receive the noop adapter (not throw).
+
+#### Scenario: Components receive the injected adapter
+
+- **WHEN** a component calls `useAnalytics().event(...)` inside an `AnalyticsProvider`
+- **THEN** the event is forwarded to the injected `Analytics` implementation
+
+#### Scenario: Components outside provider receive noop
+
+- **WHEN** a component calls `useAnalytics()` with no `AnalyticsProvider` ancestor
+- **THEN** the noop adapter is returned and no error is thrown
+
+### Requirement: Landing tracks key funnel events
+
+The system SHALL call `analytics.event` on the following user interactions in `@kaiord/landing`: clicking the "Try the Editor" CTA (`editor-opened`), clicking the "Star on GitHub" link (`github-opened`), and clicking the "Read the Docs" link (`docs-opened`).
+
+#### Scenario: CTA click triggers editor-opened event
+
+- **WHEN** a user clicks the "Try the Editor" button on the landing page
+- **THEN** `analytics.event('editor-opened')` is called before navigation
+
+#### Scenario: GitHub link click triggers github-opened event
+
+- **WHEN** a user clicks the "Star on GitHub" link on the landing page
+- **THEN** `analytics.event('github-opened')` is called
+
+#### Scenario: Docs link click triggers docs-opened event
+
+- **WHEN** a user clicks the "Read the Docs" link on the landing page
+- **THEN** `analytics.event('docs-opened')` is called
+
+### Requirement: Editor tracks key product events
+
+The system SHALL call `analytics.event` at the following moments in `@kaiord/workout-spa-editor`: app mount (`editor-loaded`), successful AI workout generation (`workout-generated` with `provider` and `sport` props), file export (`workout-exported` with `format` prop), and Garmin Connect push completion — both success and failure — (`garmin-synced` with `result` prop). Event properties MUST NOT contain PII.
+
+#### Scenario: App mount triggers editor-loaded event
+
+- **WHEN** the editor SPA mounts for the first time
+- **THEN** `analytics.event('editor-loaded')` is called exactly once
+
+#### Scenario: AI generation fires workout-generated with dimensions
+
+- **WHEN** an AI workout generation completes successfully
+- **THEN** `analytics.event('workout-generated', { provider: '<name>', sport: '<name>' })` is called
+
+#### Scenario: File export fires workout-exported with format
+
+- **WHEN** a workout export completes (FIT, TCX, ZWO, or GCN)
+- **THEN** `analytics.event('workout-exported', { format: '<format>' })` is called with the target format as the prop value
+
+#### Scenario: Garmin sync fires on both success and failure
+
+- **WHEN** a Garmin Connect push completes (regardless of outcome)
+- **THEN** `analytics.event('garmin-synced', { result: 'success' })` or `analytics.event('garmin-synced', { result: 'failure' })` is called accordingly

--- a/openspec/changes/analytics-port-adapter/tasks.md
+++ b/openspec/changes/analytics-port-adapter/tasks.md
@@ -40,4 +40,4 @@
 - [x] 4.2 Run `pnpm -r build` — verify zero build errors/warnings; inspect built `index.html` to confirm beacon `<script>` is absent when token is unset; grep built `assets/*.js` to confirm no literal Cloudflare token value appears outside the beacon script tag
 - [x] 4.3 Run `pnpm -r test` — verify all tests pass and coverage thresholds hold
 - [x] 4.4 Run `pnpm lint` — verify zero ESLint errors/warnings and zero TypeScript errors
-- [x] 4.5 Create changeset: `pnpm exec changeset` — patch bump for `@kaiord/core` only (new port export); `@kaiord/landing` and `@kaiord/workout-spa-editor` are private packages and require no changeset entry
+- [x] 4.5 Create changeset: `pnpm exec changeset` — patch bump for `@kaiord/core` (new port export) and `@kaiord/workout-spa-editor` (participates in changesets flow — removed from `.changeset/config.json` `ignore` array); `@kaiord/landing` remains private/ignored and requires no changeset entry

--- a/openspec/changes/analytics-port-adapter/tasks.md
+++ b/openspec/changes/analytics-port-adapter/tasks.md
@@ -1,43 +1,43 @@
 ## 1. Core — Port and Noop Adapter
 
-- [ ] 1.1 Create `packages/core/src/ports/analytics.ts` with `Analytics` type and `AnalyticsEvent` alias
-- [ ] 1.2 Create `packages/core/src/adapters/analytics/noop-analytics.ts` with `createNoopAnalytics()`
-- [ ] 1.3 Write unit tests for noop adapter (`noop-analytics.test.ts`)
-- [ ] 1.4 Export `Analytics`, `AnalyticsEvent`, and `createNoopAnalytics` from `packages/core/src/ports/index.ts` and `packages/core/src/index.ts`
+- [x] 1.1 Create `packages/core/src/ports/analytics.ts` with `Analytics` type and `AnalyticsEvent` alias
+- [x] 1.2 Create `packages/core/src/adapters/analytics/noop-analytics.ts` with `createNoopAnalytics()`
+- [x] 1.3 Write unit tests for noop adapter (`noop-analytics.test.ts`)
+- [x] 1.4 Export `Analytics`, `AnalyticsEvent`, and `createNoopAnalytics` from `packages/core/src/ports/index.ts` and `packages/core/src/index.ts`
 
 ## 2. Landing — Cloudflare Adapter and Wiring
 
-- [ ] 2.1 Add Cloudflare Web Analytics beacon `<script>` tag to `packages/landing/index.html` using Vite's `%VITE_CF_ANALYTICS_TOKEN%` env-replacement pattern; wrap in a Vite `transformIndexHtml` plugin (or equivalent) that removes the `<script>` block entirely when the env var is empty or unset (empty token = tag omitted, no console errors)
-- [ ] 2.2 Create `packages/landing/src/types/cf-beacon.d.ts` — ambient TypeScript declaration for `window.cfBeacon` (required for strict-mode compilation)
-- [ ] 2.3 Create `packages/landing/src/adapters/analytics/cloudflare-analytics.ts` with `createCloudflareAnalytics(token: string | undefined): Analytics` — returns `createNoopAnalytics()` when token is falsy, otherwise wraps `window.cfBeacon` with `try/catch` guard
-- [ ] 2.4 Write unit tests for the landing Cloudflare adapter (`cloudflare-analytics.test.ts`): noop on falsy token, calls beacon when present, silent on beacon absence
-- [ ] 2.5 Create `packages/landing/src/analytics.ts` — instantiates and exports the singleton `analytics` object
-- [ ] 2.6 Wire `analytics.pageView()` call on page load in `packages/landing/src/main.ts`
-- [ ] 2.7 Wire `analytics.event('editor-opened')` on "Try the Editor" CTA click
-- [ ] 2.8 Wire `analytics.event('github-opened')` on "Star on GitHub" link click
-- [ ] 2.9 Wire `analytics.event('docs-opened')` on "Read the Docs" link click
-- [ ] 2.10 Add `VITE_CF_ANALYTICS_TOKEN` to `.env.example` in the landing package (with placeholder value)
+- [x] 2.1 Add Cloudflare Web Analytics beacon `<script>` tag to `packages/landing/index.html` using Vite's `%VITE_CF_ANALYTICS_TOKEN%` env-replacement pattern; wrap in a Vite `transformIndexHtml` plugin (or equivalent) that removes the `<script>` block entirely when the env var is empty or unset (empty token = tag omitted, no console errors)
+- [x] 2.2 Create `packages/landing/src/types/cf-beacon.d.ts` — ambient TypeScript declaration for `window.cfBeacon` (required for strict-mode compilation)
+- [x] 2.3 Create `packages/landing/src/adapters/analytics/cloudflare-analytics.ts` with `createCloudflareAnalytics(token: string | undefined): Analytics` — returns `createNoopAnalytics()` when token is falsy, otherwise wraps `window.cfBeacon` with `try/catch` guard
+- [x] 2.4 Write unit tests for the landing Cloudflare adapter (`cloudflare-analytics.test.ts`): noop on falsy token, calls beacon when present, silent on beacon absence
+- [x] 2.5 Create `packages/landing/src/analytics.ts` — instantiates and exports the singleton `analytics` object
+- [x] 2.6 Wire `analytics.pageView()` call on page load in `packages/landing/src/main.ts`
+- [x] 2.7 Wire `analytics.event('editor-opened')` on "Try the Editor" CTA click
+- [x] 2.8 Wire `analytics.event('github-opened')` on "Star on GitHub" link click
+- [x] 2.9 Wire `analytics.event('docs-opened')` on "Read the Docs" link click
+- [x] 2.10 Add `VITE_CF_ANALYTICS_TOKEN` to `.env.example` in the landing package (with placeholder value)
 
 ## 3. Editor — Cloudflare Adapter, Provider, and Hook
 
-- [ ] 3.1 Add Cloudflare Web Analytics beacon `<script>` tag to `packages/workout-spa-editor/index.html` using the same `%VITE_CF_ANALYTICS_TOKEN%` + `transformIndexHtml` conditional-removal pattern as landing (task 2.1)
-- [ ] 3.2 Create `packages/workout-spa-editor/src/types/cf-beacon.d.ts` — ambient TypeScript declaration for `window.cfBeacon`
-- [ ] 3.3 Create `packages/workout-spa-editor/src/adapters/analytics/cloudflare-analytics.ts` with `createCloudflareAnalytics(token: string | undefined): Analytics` — returns `createNoopAnalytics()` when token is falsy, wraps `window.cfBeacon` with `try/catch` guard
-- [ ] 3.4 Write unit tests for the editor Cloudflare adapter (`cloudflare-analytics.test.ts`): noop on falsy token, calls beacon when present, silent on beacon absence
-- [ ] 3.5 Create `packages/workout-spa-editor/src/contexts/analytics-context.tsx` — `AnalyticsContext`, `AnalyticsProvider`, and `useAnalytics()` hook (defaults to noop when no provider ancestor)
-- [ ] 3.6 Inject `AnalyticsProvider` with the Cloudflare adapter in `packages/workout-spa-editor/src/main.tsx`
-- [ ] 3.7 Wire `analytics.event('editor-loaded')` on app mount (`useEffect` in root component)
-- [ ] 3.8 Wire `analytics.event('workout-generated', { provider, sport })` after successful AI generation
-- [ ] 3.9 Wire `analytics.event('workout-exported', { format })` after successful export
-- [ ] 3.10 Wire `analytics.event('garmin-synced', { result: 'success' | 'failure' })` on Garmin Connect push completion (both outcomes)
-- [ ] 3.11 Write unit tests for `useAnalytics()` hook — verify noop default and injected adapter forwarding
-- [ ] 3.12 Write call-site tests for each instrumented event: verify `analytics.event` is called with the correct name and props when AI generation completes (`workout-generated`), export completes (`workout-exported`), and Garmin push completes for both success and failure (`garmin-synced`)
-- [ ] 3.13 Add `VITE_CF_ANALYTICS_TOKEN` to `.env.example` in the editor package
+- [x] 3.1 Add Cloudflare Web Analytics beacon `<script>` tag to `packages/workout-spa-editor/index.html` using the same `%VITE_CF_ANALYTICS_TOKEN%` + `transformIndexHtml` conditional-removal pattern as landing (task 2.1)
+- [x] 3.2 Create `packages/workout-spa-editor/src/types/cf-beacon.d.ts` — ambient TypeScript declaration for `window.cfBeacon`
+- [x] 3.3 Create `packages/workout-spa-editor/src/adapters/analytics/cloudflare-analytics.ts` with `createCloudflareAnalytics(token: string | undefined): Analytics` — returns `createNoopAnalytics()` when token is falsy, wraps `window.cfBeacon` with `try/catch` guard
+- [x] 3.4 Write unit tests for the editor Cloudflare adapter (`cloudflare-analytics.test.ts`): noop on falsy token, calls beacon when present, silent on beacon absence
+- [x] 3.5 Create `packages/workout-spa-editor/src/contexts/analytics-context.tsx` — `AnalyticsContext`, `AnalyticsProvider`, and `useAnalytics()` hook (defaults to noop when no provider ancestor)
+- [x] 3.6 Inject `AnalyticsProvider` with the Cloudflare adapter in `packages/workout-spa-editor/src/main.tsx`
+- [x] 3.7 Wire `analytics.event('editor-loaded')` on app mount (`useEffect` in root component)
+- [x] 3.8 Wire `analytics.event('workout-generated', { provider, sport })` after successful AI generation
+- [x] 3.9 Wire `analytics.event('workout-exported', { format })` after successful export
+- [x] 3.10 Wire `analytics.event('garmin-synced', { result: 'success' | 'failure' })` on Garmin Connect push completion (both outcomes)
+- [x] 3.11 Write unit tests for `useAnalytics()` hook — verify noop default and injected adapter forwarding
+- [x] 3.12 Write call-site tests for each instrumented event: verify `analytics.event` is called with the correct name and props when AI generation completes (`workout-generated`), export completes (`workout-exported`), and Garmin push completes for both success and failure (`garmin-synced`)
+- [x] 3.13 Add `VITE_CF_ANALYTICS_TOKEN` to `.env.example` in the editor package
 
 ## 4. Quality and Changeset
 
-- [ ] 4.1 Add an analytics disclosure to both the landing footer and the editor footer (or a shared `/privacy` page linked from both) acknowledging Cloudflare Web Analytics is used — GDPR transparency applies to every page where tracking is active
-- [ ] 4.2 Run `pnpm -r build` — verify zero build errors/warnings; inspect built `index.html` to confirm beacon `<script>` is absent when token is unset; grep built `assets/*.js` to confirm no literal Cloudflare token value appears outside the beacon script tag
-- [ ] 4.3 Run `pnpm -r test` — verify all tests pass and coverage thresholds hold
-- [ ] 4.4 Run `pnpm lint` — verify zero ESLint errors/warnings and zero TypeScript errors
-- [ ] 4.5 Create changeset: `pnpm exec changeset` — patch bump for `@kaiord/core` only (new port export); `@kaiord/landing` and `@kaiord/workout-spa-editor` are private packages and require no changeset entry
+- [x] 4.1 Add an analytics disclosure to both the landing footer and the editor footer (or a shared `/privacy` page linked from both) acknowledging Cloudflare Web Analytics is used — GDPR transparency applies to every page where tracking is active
+- [x] 4.2 Run `pnpm -r build` — verify zero build errors/warnings; inspect built `index.html` to confirm beacon `<script>` is absent when token is unset; grep built `assets/*.js` to confirm no literal Cloudflare token value appears outside the beacon script tag
+- [x] 4.3 Run `pnpm -r test` — verify all tests pass and coverage thresholds hold
+- [x] 4.4 Run `pnpm lint` — verify zero ESLint errors/warnings and zero TypeScript errors
+- [x] 4.5 Create changeset: `pnpm exec changeset` — patch bump for `@kaiord/core` only (new port export); `@kaiord/landing` and `@kaiord/workout-spa-editor` are private packages and require no changeset entry

--- a/openspec/changes/analytics-port-adapter/tasks.md
+++ b/openspec/changes/analytics-port-adapter/tasks.md
@@ -1,0 +1,43 @@
+## 1. Core — Port and Noop Adapter
+
+- [ ] 1.1 Create `packages/core/src/ports/analytics.ts` with `Analytics` type and `AnalyticsEvent` alias
+- [ ] 1.2 Create `packages/core/src/adapters/analytics/noop-analytics.ts` with `createNoopAnalytics()`
+- [ ] 1.3 Write unit tests for noop adapter (`noop-analytics.test.ts`)
+- [ ] 1.4 Export `Analytics`, `AnalyticsEvent`, and `createNoopAnalytics` from `packages/core/src/ports/index.ts` and `packages/core/src/index.ts`
+
+## 2. Landing — Cloudflare Adapter and Wiring
+
+- [ ] 2.1 Add Cloudflare Web Analytics beacon `<script>` tag to `packages/landing/index.html` using Vite's `%VITE_CF_ANALYTICS_TOKEN%` env-replacement pattern; wrap in a Vite `transformIndexHtml` plugin (or equivalent) that removes the `<script>` block entirely when the env var is empty or unset (empty token = tag omitted, no console errors)
+- [ ] 2.2 Create `packages/landing/src/types/cf-beacon.d.ts` — ambient TypeScript declaration for `window.cfBeacon` (required for strict-mode compilation)
+- [ ] 2.3 Create `packages/landing/src/adapters/analytics/cloudflare-analytics.ts` with `createCloudflareAnalytics(token: string | undefined): Analytics` — returns `createNoopAnalytics()` when token is falsy, otherwise wraps `window.cfBeacon` with `try/catch` guard
+- [ ] 2.4 Write unit tests for the landing Cloudflare adapter (`cloudflare-analytics.test.ts`): noop on falsy token, calls beacon when present, silent on beacon absence
+- [ ] 2.5 Create `packages/landing/src/analytics.ts` — instantiates and exports the singleton `analytics` object
+- [ ] 2.6 Wire `analytics.pageView()` call on page load in `packages/landing/src/main.ts`
+- [ ] 2.7 Wire `analytics.event('editor-opened')` on "Try the Editor" CTA click
+- [ ] 2.8 Wire `analytics.event('github-opened')` on "Star on GitHub" link click
+- [ ] 2.9 Wire `analytics.event('docs-opened')` on "Read the Docs" link click
+- [ ] 2.10 Add `VITE_CF_ANALYTICS_TOKEN` to `.env.example` in the landing package (with placeholder value)
+
+## 3. Editor — Cloudflare Adapter, Provider, and Hook
+
+- [ ] 3.1 Add Cloudflare Web Analytics beacon `<script>` tag to `packages/workout-spa-editor/index.html` using the same `%VITE_CF_ANALYTICS_TOKEN%` + `transformIndexHtml` conditional-removal pattern as landing (task 2.1)
+- [ ] 3.2 Create `packages/workout-spa-editor/src/types/cf-beacon.d.ts` — ambient TypeScript declaration for `window.cfBeacon`
+- [ ] 3.3 Create `packages/workout-spa-editor/src/adapters/analytics/cloudflare-analytics.ts` with `createCloudflareAnalytics(token: string | undefined): Analytics` — returns `createNoopAnalytics()` when token is falsy, wraps `window.cfBeacon` with `try/catch` guard
+- [ ] 3.4 Write unit tests for the editor Cloudflare adapter (`cloudflare-analytics.test.ts`): noop on falsy token, calls beacon when present, silent on beacon absence
+- [ ] 3.5 Create `packages/workout-spa-editor/src/contexts/analytics-context.tsx` — `AnalyticsContext`, `AnalyticsProvider`, and `useAnalytics()` hook (defaults to noop when no provider ancestor)
+- [ ] 3.6 Inject `AnalyticsProvider` with the Cloudflare adapter in `packages/workout-spa-editor/src/main.tsx`
+- [ ] 3.7 Wire `analytics.event('editor-loaded')` on app mount (`useEffect` in root component)
+- [ ] 3.8 Wire `analytics.event('workout-generated', { provider, sport })` after successful AI generation
+- [ ] 3.9 Wire `analytics.event('workout-exported', { format })` after successful export
+- [ ] 3.10 Wire `analytics.event('garmin-synced', { result: 'success' | 'failure' })` on Garmin Connect push completion (both outcomes)
+- [ ] 3.11 Write unit tests for `useAnalytics()` hook — verify noop default and injected adapter forwarding
+- [ ] 3.12 Write call-site tests for each instrumented event: verify `analytics.event` is called with the correct name and props when AI generation completes (`workout-generated`), export completes (`workout-exported`), and Garmin push completes for both success and failure (`garmin-synced`)
+- [ ] 3.13 Add `VITE_CF_ANALYTICS_TOKEN` to `.env.example` in the editor package
+
+## 4. Quality and Changeset
+
+- [ ] 4.1 Add an analytics disclosure to both the landing footer and the editor footer (or a shared `/privacy` page linked from both) acknowledging Cloudflare Web Analytics is used — GDPR transparency applies to every page where tracking is active
+- [ ] 4.2 Run `pnpm -r build` — verify zero build errors/warnings; inspect built `index.html` to confirm beacon `<script>` is absent when token is unset; grep built `assets/*.js` to confirm no literal Cloudflare token value appears outside the beacon script tag
+- [ ] 4.3 Run `pnpm -r test` — verify all tests pass and coverage thresholds hold
+- [ ] 4.4 Run `pnpm lint` — verify zero ESLint errors/warnings and zero TypeScript errors
+- [ ] 4.5 Create changeset: `pnpm exec changeset` — patch bump for `@kaiord/core` only (new port export); `@kaiord/landing` and `@kaiord/workout-spa-editor` are private packages and require no changeset entry

--- a/openspec/changes/archive/2026-04-25-spa-editor-focus-management-hardening/proposal.md
+++ b/openspec/changes/archive/2026-04-25-spa-editor-focus-management-hardening/proposal.md
@@ -1,3 +1,5 @@
+> Completed: 2026-04-25
+
 ## Why
 
 The base change `spa-editor-focus-management` delivers correct focus behavior per WCAG and the expert-panel spec (9.66/10). A subsequent AWS Well-Architected review (adapted for the client-side SPA) surfaced four operational/resilience gaps that the base change's spec-first lens does not catch:

--- a/packages/core/src/adapters/analytics/noop-analytics.test.ts
+++ b/packages/core/src/adapters/analytics/noop-analytics.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { createNoopAnalytics } from "./noop-analytics";
+
+describe("createNoopAnalytics", () => {
+  it("should create adapter with all required methods", () => {
+    // Arrange & Act
+    const analytics = createNoopAnalytics();
+
+    // Assert
+    expect(analytics.pageView).toBeDefined();
+    expect(analytics.event).toBeDefined();
+  });
+
+  it("should not throw when pageView is called", () => {
+    // Arrange
+    const analytics = createNoopAnalytics();
+
+    // Act & Assert
+    expect(() => analytics.pageView("/editor/")).not.toThrow();
+  });
+
+  it("should not throw when event is called with props", () => {
+    // Arrange
+    const analytics = createNoopAnalytics();
+
+    // Act & Assert
+    expect(() =>
+      analytics.event("workout-generated", {
+        provider: "claude",
+        sport: "cycling",
+      })
+    ).not.toThrow();
+  });
+
+  it("should not throw when event is called without props", () => {
+    // Arrange
+    const analytics = createNoopAnalytics();
+
+    // Act & Assert
+    expect(() => analytics.event("editor-loaded")).not.toThrow();
+  });
+
+  it("should produce no side effects on pageView", () => {
+    // Arrange
+    const analytics = createNoopAnalytics();
+    const result = analytics.pageView("/test/");
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should produce no side effects on event", () => {
+    // Arrange
+    const analytics = createNoopAnalytics();
+    const result = analytics.event("garmin-synced", { result: "success" });
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/core/src/adapters/analytics/noop-analytics.ts
+++ b/packages/core/src/adapters/analytics/noop-analytics.ts
@@ -1,0 +1,6 @@
+import type { Analytics } from "../../ports/analytics";
+
+export const createNoopAnalytics = (): Analytics => ({
+  pageView: () => {},
+  event: () => {},
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -95,6 +95,7 @@ export {
 } from "./domain";
 
 // Ports
+export { createNoopAnalytics } from "./adapters/analytics/noop-analytics";
 export { createConsoleLogger } from "./adapters/logger/console-logger";
 export type {
   AuthProvider,
@@ -111,6 +112,7 @@ export type {
   WorkoutService,
   WorkoutSummary,
 } from "./ports";
+export type { Analytics, AnalyticsEvent } from "./ports/analytics";
 
 // Application: Conversion Functions
 export { fromBinary, fromText } from "./application";

--- a/packages/core/src/ports/analytics.ts
+++ b/packages/core/src/ports/analytics.ts
@@ -1,0 +1,6 @@
+export type AnalyticsEvent = Record<string, string | number | boolean>;
+
+export type Analytics = {
+  pageView: (path: string) => void;
+  event: (name: string, props?: AnalyticsEvent) => void;
+};

--- a/packages/core/src/ports/index.ts
+++ b/packages/core/src/ports/index.ts
@@ -1,3 +1,4 @@
+export type { Analytics, AnalyticsEvent } from "./analytics";
 export type { AuthProvider, TokenData } from "./auth-provider";
 export type {
   BinaryReader,

--- a/packages/landing/.env.example
+++ b/packages/landing/.env.example
@@ -1,0 +1,4 @@
+# Cloudflare Web Analytics beacon token (public, not a secret).
+# Leave empty in local dev — analytics will be disabled (noop adapter).
+# Set in CI/CD to enable Cloudflare Web Analytics in production builds.
+VITE_CF_ANALYTICS_TOKEN=

--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -79,6 +79,14 @@
     </script>
 
     <link rel="stylesheet" href="/src/main.css" />
+
+    <!-- CF_BEACON_START -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token": "%VITE_CF_ANALYTICS_TOKEN%"}'
+    ></script>
+    <!-- CF_BEACON_END -->
   </head>
   <body
     class="bg-[var(--brand-bg-primary)] text-[var(--brand-text-primary)] font-sans antialiased"
@@ -988,6 +996,19 @@
             >
           </div>
         </div>
+
+        <!-- Analytics disclosure -->
+        <p class="mt-6 text-center text-xs text-[var(--brand-text-muted)]">
+          This site uses
+          <a
+            href="https://www.cloudflare.com/web-analytics/"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="underline underline-offset-2 hover:text-[var(--brand-text-secondary)]"
+            >Cloudflare Web Analytics</a
+          >
+          — cookieless, no personal data collected.
+        </p>
       </div>
     </footer>
 

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -8,12 +8,18 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test": "vitest --run",
     "lint:fix": "prettier --write src public index.html"
+  },
+  "dependencies": {
+    "@kaiord/core": "workspace:*"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.4",
+    "jsdom": "^26.1.0",
     "tailwindcss": "^4.2.4",
     "typescript": "~6.0.3",
-    "vite": "^8.0.9"
+    "vite": "^8.0.9",
+    "vitest": "^4.1.5"
   }
 }

--- a/packages/landing/src/adapters/analytics/cloudflare-analytics.test.ts
+++ b/packages/landing/src/adapters/analytics/cloudflare-analytics.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCloudflareAnalytics } from "./cloudflare-analytics";
+
+describe("createCloudflareAnalytics", () => {
+  describe("when token is falsy", () => {
+    it("should return noop on undefined token", () => {
+      // Arrange & Act
+      const analytics = createCloudflareAnalytics(undefined);
+
+      // Assert — noop: no throw, no side effects
+      expect(() => analytics.pageView("/")).not.toThrow();
+      expect(() => analytics.event("test")).not.toThrow();
+    });
+
+    it("should return noop on empty string token", () => {
+      // Arrange & Act
+      const analytics = createCloudflareAnalytics("");
+
+      // Assert
+      expect(() => analytics.pageView("/")).not.toThrow();
+      expect(() => analytics.event("test")).not.toThrow();
+    });
+  });
+
+  describe("when token is set", () => {
+    const pushEvent = vi.fn();
+
+    beforeEach(() => {
+      Object.defineProperty(window, "cfBeacon", {
+        value: { pushEvent },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+      delete (window as unknown as Record<string, unknown>).cfBeacon;
+    });
+
+    it("should call pushEvent when beacon is available", () => {
+      // Arrange
+      const analytics = createCloudflareAnalytics("test-token");
+
+      // Act
+      analytics.event("workout-generated", {
+        provider: "claude",
+        sport: "cycling",
+      });
+
+      // Assert
+      expect(pushEvent).toHaveBeenCalledWith("workout-generated", {
+        provider: "claude",
+        sport: "cycling",
+      });
+    });
+
+    it("should call pushEvent for pageView", () => {
+      // Arrange
+      const analytics = createCloudflareAnalytics("test-token");
+
+      // Act
+      analytics.pageView("/editor/");
+
+      // Assert
+      expect(pushEvent).toHaveBeenCalledWith("pageView", { path: "/editor/" });
+    });
+
+    it("should not throw when beacon is absent", () => {
+      // Arrange
+      delete (window as unknown as Record<string, unknown>).cfBeacon;
+      const analytics = createCloudflareAnalytics("test-token");
+
+      // Act & Assert
+      expect(() => analytics.event("editor-opened")).not.toThrow();
+    });
+
+    it("should not throw when pushEvent throws", () => {
+      // Arrange
+      pushEvent.mockImplementation(() => {
+        throw new Error("beacon error");
+      });
+      const analytics = createCloudflareAnalytics("test-token");
+
+      // Act & Assert
+      expect(() =>
+        analytics.event("garmin-synced", { result: "success" })
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/landing/src/adapters/analytics/cloudflare-analytics.ts
+++ b/packages/landing/src/adapters/analytics/cloudflare-analytics.ts
@@ -1,0 +1,23 @@
+import { createNoopAnalytics } from "@kaiord/core";
+import type { Analytics, AnalyticsEvent } from "@kaiord/core";
+
+export const createCloudflareAnalytics = (
+  token: string | undefined
+): Analytics => {
+  if (!token) return createNoopAnalytics();
+
+  const push = (name: string, props?: AnalyticsEvent) => {
+    if (typeof window !== "undefined" && window.cfBeacon) {
+      try {
+        window.cfBeacon.pushEvent(name, props);
+      } catch {
+        // beacon errors must not surface to the application
+      }
+    }
+  };
+
+  return {
+    pageView: (path) => push("pageView", { path }),
+    event: (name, props) => push(name, props),
+  };
+};

--- a/packages/landing/src/analytics.ts
+++ b/packages/landing/src/analytics.ts
@@ -1,0 +1,5 @@
+import { createCloudflareAnalytics } from "./adapters/analytics/cloudflare-analytics";
+
+export const analytics = createCloudflareAnalytics(
+  import.meta.env.VITE_CF_ANALYTICS_TOKEN as string | undefined
+);

--- a/packages/landing/src/main.ts
+++ b/packages/landing/src/main.ts
@@ -1,4 +1,5 @@
 import "./main.css";
+import { analytics } from "./analytics";
 
 const commands: Record<string, string> = {
   npm: "npm i @kaiord/core",
@@ -83,4 +84,31 @@ function setup() {
   });
 }
 
-document.addEventListener("DOMContentLoaded", setup);
+function setupAnalytics() {
+  analytics.pageView(window.location.pathname);
+
+  document
+    .querySelectorAll<HTMLAnchorElement>('a[href="/editor/"]')
+    .forEach((a) => {
+      a.addEventListener("click", () => analytics.event("editor-opened"));
+    });
+
+  document
+    .querySelectorAll<HTMLAnchorElement>(
+      'a[href^="https://github.com/pablo-albaladejo/kaiord"]'
+    )
+    .forEach((a) => {
+      a.addEventListener("click", () => analytics.event("github-opened"));
+    });
+
+  document
+    .querySelectorAll<HTMLAnchorElement>('a[href="/docs/"]')
+    .forEach((a) => {
+      a.addEventListener("click", () => analytics.event("docs-opened"));
+    });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  setup();
+  setupAnalytics();
+});

--- a/packages/landing/src/main.ts
+++ b/packages/landing/src/main.ts
@@ -1,5 +1,5 @@
 import "./main.css";
-import { analytics } from "./analytics";
+import { setupAnalytics } from "./setup-analytics";
 
 const commands: Record<string, string> = {
   npm: "npm i @kaiord/core",
@@ -82,30 +82,6 @@ function setup() {
       }
     });
   });
-}
-
-function setupAnalytics() {
-  analytics.pageView(window.location.pathname);
-
-  document
-    .querySelectorAll<HTMLAnchorElement>('a[href="/editor/"]')
-    .forEach((a) => {
-      a.addEventListener("click", () => analytics.event("editor-opened"));
-    });
-
-  document
-    .querySelectorAll<HTMLAnchorElement>(
-      'a[href^="https://github.com/pablo-albaladejo/kaiord"]'
-    )
-    .forEach((a) => {
-      a.addEventListener("click", () => analytics.event("github-opened"));
-    });
-
-  document
-    .querySelectorAll<HTMLAnchorElement>('a[href="/docs/"]')
-    .forEach((a) => {
-      a.addEventListener("click", () => analytics.event("docs-opened"));
-    });
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/packages/landing/src/setup-analytics.ts
+++ b/packages/landing/src/setup-analytics.ts
@@ -1,0 +1,25 @@
+import { analytics } from "./analytics";
+
+export function setupAnalytics() {
+  analytics.pageView(window.location.pathname);
+
+  document
+    .querySelectorAll<HTMLAnchorElement>('a[href="/editor/"]')
+    .forEach((a) => {
+      a.addEventListener("click", () => analytics.event("editor-opened"));
+    });
+
+  document
+    .querySelectorAll<HTMLAnchorElement>(
+      'a[href^="https://github.com/pablo-albaladejo/kaiord"]'
+    )
+    .forEach((a) => {
+      a.addEventListener("click", () => analytics.event("github-opened"));
+    });
+
+  document
+    .querySelectorAll<HTMLAnchorElement>('a[href="/docs/"]')
+    .forEach((a) => {
+      a.addEventListener("click", () => analytics.event("docs-opened"));
+    });
+}

--- a/packages/landing/src/types/cf-beacon.d.ts
+++ b/packages/landing/src/types/cf-beacon.d.ts
@@ -1,0 +1,10 @@
+interface CfBeacon {
+  pushEvent: (
+    name: string,
+    props?: Record<string, string | number | boolean>
+  ) => void;
+}
+
+interface Window {
+  cfBeacon?: CfBeacon;
+}

--- a/packages/landing/vite.config.ts
+++ b/packages/landing/vite.config.ts
@@ -1,8 +1,30 @@
 import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
+import type { Plugin } from "vite";
+
+function conditionalBeacon(): Plugin {
+  return {
+    name: "conditional-beacon",
+    transformIndexHtml(html, ctx) {
+      const token = ctx.server
+        ? process.env.VITE_CF_ANALYTICS_TOKEN
+        : process.env.VITE_CF_ANALYTICS_TOKEN;
+      if (!token) {
+        return html.replace(
+          /<!--\s*CF_BEACON_START\s*-->[\s\S]*?<!--\s*CF_BEACON_END\s*-->/g,
+          ""
+        );
+      }
+      return html
+        .replace(/<!--\s*CF_BEACON_START\s*-->/g, "")
+        .replace(/<!--\s*CF_BEACON_END\s*-->/g, "")
+        .replace(/%VITE_CF_ANALYTICS_TOKEN%/g, token);
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [tailwindcss()],
+  plugins: [tailwindcss(), conditionalBeacon()],
   build: {
     outDir: "dist",
     emptyOutDir: true,

--- a/packages/landing/vite.config.ts
+++ b/packages/landing/vite.config.ts
@@ -1,14 +1,11 @@
-import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
+import { defineConfig, loadEnv } from "vite";
 import type { Plugin } from "vite";
 
-function conditionalBeacon(): Plugin {
+function conditionalBeacon(token: string | undefined): Plugin {
   return {
     name: "conditional-beacon",
-    transformIndexHtml(html, ctx) {
-      const token = ctx.server
-        ? process.env.VITE_CF_ANALYTICS_TOKEN
-        : process.env.VITE_CF_ANALYTICS_TOKEN;
+    transformIndexHtml(html) {
       if (!token) {
         return html.replace(
           /<!--\s*CF_BEACON_START\s*-->[\s\S]*?<!--\s*CF_BEACON_END\s*-->/g,
@@ -23,10 +20,13 @@ function conditionalBeacon(): Plugin {
   };
 }
 
-export default defineConfig({
-  plugins: [tailwindcss(), conditionalBeacon()],
-  build: {
-    outDir: "dist",
-    emptyOutDir: true,
-  },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    plugins: [tailwindcss(), conditionalBeacon(env.VITE_CF_ANALYTICS_TOKEN)],
+    build: {
+      outDir: "dist",
+      emptyOutDir: true,
+    },
+  };
 });

--- a/packages/landing/vitest.config.ts
+++ b/packages/landing/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "jsdom",
+    include: ["src/**/*.{test,spec}.ts"],
+    exclude: ["node_modules", "dist"],
+  },
+});

--- a/packages/workout-spa-editor/.env.example
+++ b/packages/workout-spa-editor/.env.example
@@ -1,5 +1,10 @@
 # Workout SPA Editor Environment Variables
 
+# Cloudflare Web Analytics beacon token (public, not a secret).
+# Leave empty in local dev — analytics will be disabled (noop adapter).
+# Set in CI/CD to enable Cloudflare Web Analytics in production builds.
+VITE_CF_ANALYTICS_TOKEN=
+
 # Base path for deployment (e.g., GitHub Pages)
 # VITE_BASE_PATH=/workout-spa-editor
 

--- a/packages/workout-spa-editor/index.html
+++ b/packages/workout-spa-editor/index.html
@@ -48,6 +48,14 @@
       content="Visual workout editor for creating and converting FIT, TCX, ZWO, and Garmin Connect files. By Pablo Albaladejo."
     />
     <meta name="twitter:image" content="https://kaiord.com/og-image.png" />
+
+    <!-- CF_BEACON_START -->
+    <script
+      defer
+      src="https://static.cloudflareinsights.com/beacon.min.js"
+      data-cf-beacon='{"token": "%VITE_CF_ANALYTICS_TOKEN%"}'
+    ></script>
+    <!-- CF_BEACON_END -->
   </head>
   <body>
     <div id="root"></div>

--- a/packages/workout-spa-editor/src/App.tsx
+++ b/packages/workout-spa-editor/src/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { Redirect, Route, Switch } from "wouter";
 
 import { AppKeyboardShortcuts } from "./components/AppKeyboardShortcuts";
@@ -7,6 +7,7 @@ import { RouteSpinner } from "./components/atoms/RouteSpinner";
 import { RouteErrorBoundary } from "./components/molecules/RouteErrorBoundary";
 import { AppToastProvider } from "./components/providers/AppToastProvider";
 import { MainLayout } from "./components/templates/MainLayout";
+import { useAnalytics } from "./contexts";
 import { useOnboardingTutorial } from "./hooks/use-onboarding-tutorial";
 import { useStoreHydration } from "./hooks/use-store-hydration";
 
@@ -54,6 +55,11 @@ function AppRoutes() {
 function App() {
   useStoreHydration();
   const { showTutorial, setShowTutorial } = useOnboardingTutorial();
+  const analytics = useAnalytics();
+
+  useEffect(() => {
+    analytics.event("editor-loaded");
+  }, [analytics]);
 
   return (
     <AppToastProvider>

--- a/packages/workout-spa-editor/src/adapters/analytics/cloudflare-analytics.test.ts
+++ b/packages/workout-spa-editor/src/adapters/analytics/cloudflare-analytics.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCloudflareAnalytics } from "./cloudflare-analytics";
+
+describe("createCloudflareAnalytics", () => {
+  describe("when token is falsy", () => {
+    it("should return noop on undefined token", () => {
+      // Arrange & Act
+      const analytics = createCloudflareAnalytics(undefined);
+
+      // Assert — noop: no throw, no side effects
+      expect(() => analytics.pageView("/")).not.toThrow();
+      expect(() => analytics.event("test")).not.toThrow();
+    });
+
+    it("should return noop on empty string token", () => {
+      // Arrange & Act
+      const analytics = createCloudflareAnalytics("");
+
+      // Assert
+      expect(() => analytics.pageView("/")).not.toThrow();
+      expect(() => analytics.event("test")).not.toThrow();
+    });
+  });
+
+  describe("when token is set", () => {
+    const pushEvent = vi.fn();
+
+    beforeEach(() => {
+      Object.defineProperty(window, "cfBeacon", {
+        value: { pushEvent },
+        writable: true,
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+      delete (window as unknown as Record<string, unknown>).cfBeacon;
+    });
+
+    it("should call pushEvent when beacon is available", () => {
+      // Arrange
+      const analytics = createCloudflareAnalytics("test-token");
+
+      // Act
+      analytics.event("workout-generated", {
+        provider: "claude",
+        sport: "cycling",
+      });
+
+      // Assert
+      expect(pushEvent).toHaveBeenCalledWith("workout-generated", {
+        provider: "claude",
+        sport: "cycling",
+      });
+    });
+
+    it("should call pushEvent for pageView", () => {
+      // Arrange
+      const analytics = createCloudflareAnalytics("test-token");
+
+      // Act
+      analytics.pageView("/editor/");
+
+      // Assert
+      expect(pushEvent).toHaveBeenCalledWith("pageView", { path: "/editor/" });
+    });
+
+    it("should not throw when beacon is absent", () => {
+      // Arrange
+      delete (window as unknown as Record<string, unknown>).cfBeacon;
+      const analytics = createCloudflareAnalytics("test-token");
+
+      // Act & Assert
+      expect(() => analytics.event("editor-loaded")).not.toThrow();
+    });
+
+    it("should not throw when pushEvent throws", () => {
+      // Arrange
+      pushEvent.mockImplementation(() => {
+        throw new Error("beacon error");
+      });
+      const analytics = createCloudflareAnalytics("test-token");
+
+      // Act & Assert
+      expect(() =>
+        analytics.event("garmin-synced", { result: "success" })
+      ).not.toThrow();
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/analytics/cloudflare-analytics.ts
+++ b/packages/workout-spa-editor/src/adapters/analytics/cloudflare-analytics.ts
@@ -1,0 +1,29 @@
+import type { Analytics, AnalyticsEvent } from "@kaiord/core";
+import { createNoopAnalytics } from "@kaiord/core";
+
+import type { CfBeacon } from "../../types/cf-beacon";
+
+type WindowWithBeacon = Window & typeof globalThis & { cfBeacon?: CfBeacon };
+
+export const createCloudflareAnalytics = (
+  token: string | undefined
+): Analytics => {
+  if (!token) return createNoopAnalytics();
+
+  const push = (name: string, props?: AnalyticsEvent) => {
+    const win =
+      typeof window !== "undefined" ? (window as WindowWithBeacon) : undefined;
+    if (win?.cfBeacon) {
+      try {
+        win.cfBeacon.pushEvent(name, props);
+      } catch {
+        // beacon errors must not surface to the application
+      }
+    }
+  };
+
+  return {
+    pageView: (path) => push("pageView", { path }),
+    event: (name, props) => push(name, props),
+  };
+};

--- a/packages/workout-spa-editor/src/components/molecules/GarminPushButton/GarminPushButton.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/GarminPushButton/GarminPushButton.test.tsx
@@ -16,6 +16,7 @@ const mockState = {
 
 vi.mock("../../../contexts", () => ({
   useGarminBridge: () => ({ ...mockState }),
+  useAnalytics: () => ({ event: vi.fn(), pageView: vi.fn() }),
 }));
 
 describe("GarminPushButton", () => {

--- a/packages/workout-spa-editor/src/components/molecules/GarminPushButton/useGarminPush.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/GarminPushButton/useGarminPush.test.ts
@@ -5,6 +5,7 @@ import type { GarminBridgeState } from "../../../contexts";
 
 const mockPushWorkout = vi.fn();
 const mockSetPushing = vi.fn();
+const mockAnalyticsEvent = vi.fn();
 
 const garminState: Pick<
   GarminBridgeState,
@@ -17,6 +18,7 @@ const garminState: Pick<
 
 vi.mock("../../../contexts", () => ({
   useGarminBridge: vi.fn(() => ({ ...garminState })),
+  useAnalytics: vi.fn(() => ({ event: mockAnalyticsEvent, pageView: vi.fn() })),
 }));
 
 const workoutState: { currentWorkout: unknown } = {
@@ -132,6 +134,38 @@ describe("useGarminPush", () => {
     expect(mockSetPushing).toHaveBeenCalledWith({
       status: "error",
       message: "Push rejected",
+    });
+  });
+
+  it("should fire garmin-synced success event after successful push", async () => {
+    // Arrange
+    mockPushWorkout.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useGarminPush());
+
+    // Act
+    await act(async () => {
+      await result.current.push();
+    });
+
+    // Assert
+    expect(mockAnalyticsEvent).toHaveBeenCalledWith("garmin-synced", {
+      result: "success",
+    });
+  });
+
+  it("should fire garmin-synced failure event when push throws", async () => {
+    // Arrange
+    mockPushWorkout.mockRejectedValue(new Error("Push failed"));
+    const { result } = renderHook(() => useGarminPush());
+
+    // Act
+    await act(async () => {
+      await result.current.push();
+    });
+
+    // Assert
+    expect(mockAnalyticsEvent).toHaveBeenCalledWith("garmin-synced", {
+      result: "failure",
     });
   });
 });

--- a/packages/workout-spa-editor/src/components/molecules/GarminPushButton/useGarminPush.ts
+++ b/packages/workout-spa-editor/src/components/molecules/GarminPushButton/useGarminPush.ts
@@ -1,12 +1,13 @@
 import { useCallback } from "react";
 
-import { useGarminBridge } from "../../../contexts";
+import { useAnalytics, useGarminBridge } from "../../../contexts";
 import { useCurrentWorkout } from "../../../store/workout-store-selectors";
 import { exportGcnWorkout } from "../../../utils/export-workout-formats";
 
 export const useGarminPush = () => {
   const { pushWorkout, setPushing, sessionActive } = useGarminBridge();
   const currentWorkout = useCurrentWorkout();
+  const analytics = useAnalytics();
 
   const push = useCallback(async () => {
     if (!currentWorkout || !sessionActive) return;
@@ -14,12 +15,14 @@ export const useGarminPush = () => {
     try {
       const gcn = await exportGcnWorkout(currentWorkout);
       await pushWorkout(gcn);
+      analytics.event("garmin-synced", { result: "success" });
     } catch (error: unknown) {
       const message =
         error instanceof Error ? error.message : "Conversion failed";
       setPushing({ status: "error", message });
+      analytics.event("garmin-synced", { result: "failure" });
     }
-  }, [currentWorkout, sessionActive, pushWorkout, setPushing]);
+  }, [currentWorkout, sessionActive, pushWorkout, setPushing, analytics]);
 
   return { push };
 };

--- a/packages/workout-spa-editor/src/components/molecules/SaveButton/save-handler.analytics.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/SaveButton/save-handler.analytics.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { createSaveHandler } from "./save-handler";
+
+const mockDownloadWorkout = vi.fn();
+const mockExportWorkout = vi.fn();
+const mockGenerateWorkoutFilename = vi.fn(() => "workout.fit");
+
+vi.mock("../../../utils/export-workout", () => ({
+  downloadWorkout: (...args: unknown[]) => mockDownloadWorkout(...args),
+  exportWorkout: (...args: unknown[]) => mockExportWorkout(...args) as unknown,
+}));
+
+vi.mock("./workout-filename", () => ({
+  generateWorkoutFilename: (...args: unknown[]) =>
+    mockGenerateWorkoutFilename(...args) as unknown,
+}));
+
+describe("createSaveHandler — analytics call-site", () => {
+  const fakeWorkout = { extensions: { structured_workout: { name: "Test" } } };
+  const noop = vi.fn();
+
+  beforeEach(() => {
+    mockExportWorkout.mockResolvedValue(new Uint8Array());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should call onExported with format after successful export", async () => {
+    // Arrange
+    const onExported = vi.fn();
+    const handler = createSaveHandler(
+      fakeWorkout as never,
+      "fit",
+      noop,
+      noop,
+      noop,
+      noop,
+      noop,
+      onExported
+    );
+
+    // Act
+    await handler();
+
+    // Assert
+    expect(onExported).toHaveBeenCalledWith("fit");
+  });
+
+  it("should not call onExported when export throws", async () => {
+    // Arrange
+    mockExportWorkout.mockRejectedValue(new Error("Export failed"));
+    const onExported = vi.fn();
+    const handler = createSaveHandler(
+      fakeWorkout as never,
+      "tcx",
+      noop,
+      noop,
+      noop,
+      noop,
+      noop,
+      onExported
+    );
+
+    // Act
+    await handler();
+
+    // Assert
+    expect(onExported).not.toHaveBeenCalled();
+  });
+
+  it("should work without onExported (optional callback)", async () => {
+    // Arrange
+    const handler = createSaveHandler(
+      fakeWorkout as never,
+      "krd",
+      noop,
+      noop,
+      noop,
+      noop,
+      noop
+    );
+
+    // Act & Assert — no throw when callback is omitted
+    await expect(handler()).resolves.toBeUndefined();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/SaveButton/save-handler.analytics.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/SaveButton/save-handler.analytics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createSaveHandler } from "./save-handler";
 
 const mockDownloadWorkout = vi.fn();

--- a/packages/workout-spa-editor/src/components/molecules/SaveButton/save-handler.ts
+++ b/packages/workout-spa-editor/src/components/molecules/SaveButton/save-handler.ts
@@ -10,7 +10,8 @@ export function createSaveHandler(
   setSaveErrors: (errors: Array<ValidationError> | null) => void,
   setExportProgress: (progress: number) => void,
   success: (title: string, description: string) => void,
-  showError: (title: string, description: string) => void
+  showError: (title: string, description: string) => void,
+  onExported?: (format: string) => void
 ) {
   return async () => {
     setIsSaving(true);
@@ -40,6 +41,7 @@ export function createSaveHandler(
         "Workout Saved",
         `"${workoutName}" has been saved as ${formatLabel}`
       );
+      onExported?.(selectedFormat);
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : "Failed to export workout";

--- a/packages/workout-spa-editor/src/components/molecules/SaveButton/use-save-workout.ts
+++ b/packages/workout-spa-editor/src/components/molecules/SaveButton/use-save-workout.ts
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useAnalytics } from "../../../contexts";
 import { useToast } from "../../../hooks/useToast";
 import type { KRD, ValidationError } from "../../../types/krd";
 import type { WorkoutFileFormat } from "../../../utils/file-format-detector";
@@ -18,6 +19,7 @@ export function useSaveWorkout(workout: KRD) {
     useState<WorkoutFileFormat>("krd");
   const toast = useToast();
   const { success, error: showError } = toast;
+  const analytics = useAnalytics();
 
   const handleSave = createSaveHandler(
     workout,
@@ -26,7 +28,8 @@ export function useSaveWorkout(workout: KRD) {
     setSaveErrors,
     setExportProgress,
     success,
-    showError
+    showError,
+    (format) => analytics.event("workout-exported", { format })
   );
 
   const clearErrors = () => setSaveErrors(null);

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/useAiGeneration.analytics.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/useAiGeneration.analytics.test.ts
@@ -1,0 +1,102 @@
+import { renderHook, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockAnalyticsEvent = vi.fn();
+
+vi.mock("../../../contexts", () => ({
+  useAnalytics: vi.fn(() => ({ event: mockAnalyticsEvent, pageView: vi.fn() })),
+}));
+
+const mockSetGeneration = vi.fn();
+const mockGetSelectedProvider = vi.fn();
+const mockGetActiveProfile = vi.fn();
+
+vi.mock("../../../store/ai-store", () => ({
+  useAiStore: vi.fn(() => ({
+    getSelectedProvider: mockGetSelectedProvider,
+    customPrompt: "",
+    setGeneration: mockSetGeneration,
+  })),
+}));
+
+vi.mock("../../../store/profile-store", () => ({
+  useProfileStore: vi.fn(() => ({ getActiveProfile: mockGetActiveProfile })),
+}));
+
+const mockLoadWorkout = vi.fn();
+vi.mock("../../../store/workout-store-selectors", () => ({
+  useLoadWorkout: vi.fn(() => mockLoadWorkout),
+}));
+
+const mockGenerateWorkoutKrd = vi.fn();
+vi.mock("../../../lib/generate-workout", () => ({
+  generateWorkoutKrd: (...args: unknown[]) =>
+    mockGenerateWorkoutKrd(...args) as unknown,
+}));
+
+vi.mock("./zones-formatter", () => ({
+  formatZonesContext: vi.fn(() => undefined),
+}));
+
+import { useAiGeneration } from "./useAiGeneration";
+
+describe("useAiGeneration — analytics call-site", () => {
+  const fakeProvider = { id: "claude", isDefault: true };
+  const fakeKrd = { extensions: {} };
+
+  beforeEach(() => {
+    mockGetSelectedProvider.mockReturnValue(fakeProvider);
+    mockGetActiveProfile.mockReturnValue(null);
+    mockGenerateWorkoutKrd.mockResolvedValue(fakeKrd);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should fire workout-generated with provider and sport after successful generation", async () => {
+    // Arrange
+    const { result } = renderHook(() => useAiGeneration());
+
+    // Act
+    await act(async () => {
+      await result.current.generate("45min sweet spot", "cycling" as never);
+    });
+
+    // Assert
+    expect(mockAnalyticsEvent).toHaveBeenCalledWith("workout-generated", {
+      provider: "claude",
+      sport: "cycling",
+    });
+  });
+
+  it("should fire workout-generated with empty sport when no sport is passed", async () => {
+    // Arrange
+    const { result } = renderHook(() => useAiGeneration());
+
+    // Act
+    await act(async () => {
+      await result.current.generate("45min sweet spot");
+    });
+
+    // Assert
+    expect(mockAnalyticsEvent).toHaveBeenCalledWith("workout-generated", {
+      provider: "claude",
+      sport: "",
+    });
+  });
+
+  it("should not fire workout-generated when generation fails", async () => {
+    // Arrange
+    mockGenerateWorkoutKrd.mockRejectedValue(new Error("API error"));
+    const { result } = renderHook(() => useAiGeneration());
+
+    // Act
+    await act(async () => {
+      await result.current.generate("45min sweet spot");
+    });
+
+    // Assert
+    expect(mockAnalyticsEvent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/useAiGeneration.ts
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/useAiGeneration.ts
@@ -1,6 +1,7 @@
 import type { Sport } from "@kaiord/core";
 import { useCallback } from "react";
 
+import { useAnalytics } from "../../../contexts";
 import { generateWorkoutKrd } from "../../../lib/generate-workout";
 import { useAiStore } from "../../../store/ai-store";
 import { useProfileStore } from "../../../store/profile-store";
@@ -12,6 +13,7 @@ export const useAiGeneration = () => {
   const { getSelectedProvider, customPrompt, setGeneration } = useAiStore();
   const { getActiveProfile } = useProfileStore();
   const loadWorkout = useLoadWorkout();
+  const analytics = useAnalytics();
 
   const generate = useCallback(
     async (text: string, sport?: Sport) => {
@@ -37,6 +39,10 @@ export const useAiGeneration = () => {
 
         loadWorkout(krd);
         setGeneration({ status: "success" });
+        analytics.event("workout-generated", {
+          provider: provider.id,
+          sport: sport ?? "",
+        });
       } catch (error: unknown) {
         const message =
           error instanceof Error ? error.message : "Generation failed";
@@ -49,6 +55,7 @@ export const useAiGeneration = () => {
       setGeneration,
       getActiveProfile,
       loadWorkout,
+      analytics,
     ]
   );
 

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PrivacyInformationSection.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PrivacyInformationSection.tsx
@@ -1,0 +1,36 @@
+export function PrivacyInformationSection() {
+  return (
+    <section>
+      <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
+        Privacy Information
+      </h3>
+      <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
+        <li>We do not store your credentials on any server.</li>
+        <li>
+          Garmin integration uses a browser extension that piggybacks on your
+          existing Garmin Connect session. No credentials leave your browser.
+        </li>
+        <li>
+          Train2Go import uses a browser extension that reads the coaching plan
+          displayed on Train2Go pages you are already viewing. It does not read
+          your password or authentication tokens.
+        </li>
+        <li>
+          LLM API keys are sent directly to the provider (Anthropic, OpenAI, or
+          Google) — Kaiord does not receive or relay this data.
+        </li>
+        <li>We are not responsible for credential security on your device.</li>
+      </ul>
+      <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+        <a
+          href="https://kaiord.com/docs/legal/privacy-policy"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline underline-offset-2 hover:text-gray-700 dark:hover:text-gray-300"
+        >
+          Read the full privacy policy
+        </a>
+      </p>
+    </section>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PrivacyTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PrivacyTab.tsx
@@ -1,5 +1,6 @@
 import { useAiStore } from "../../../store/ai-store";
 import { Button } from "../../atoms/Button";
+import { PrivacyInformationSection } from "./PrivacyInformationSection";
 
 const SECURE_STORAGE_PREFIX = "kaiord_secure_";
 
@@ -19,38 +20,24 @@ export const PrivacyTab: React.FC = () => {
 
   return (
     <div className="space-y-6">
+      <PrivacyInformationSection />
+
       <section>
         <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
-          Privacy Information
+          Analytics
         </h3>
-        <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
-          <li>We do not store your credentials on any server.</li>
-          <li>
-            Garmin integration uses a browser extension that piggybacks on your
-            existing Garmin Connect session. No credentials leave your browser.
-          </li>
-          <li>
-            Train2Go import uses a browser extension that reads the coaching
-            plan displayed on Train2Go pages you are already viewing. It does
-            not read your password or authentication tokens.
-          </li>
-          <li>
-            LLM API keys are sent directly to the provider (Anthropic, OpenAI,
-            or Google) — Kaiord does not receive or relay this data.
-          </li>
-          <li>
-            We are not responsible for credential security on your device.
-          </li>
-        </ul>
-        <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          This editor uses{" "}
           <a
-            href="https://kaiord.com/docs/legal/privacy-policy"
+            href="https://www.cloudflare.com/web-analytics/"
             target="_blank"
             rel="noopener noreferrer"
-            className="underline underline-offset-2 hover:text-gray-700 dark:hover:text-gray-300"
+            className="underline underline-offset-2 hover:text-gray-800 dark:hover:text-gray-200"
           >
-            Read the full privacy policy
-          </a>
+            Cloudflare Web Analytics
+          </a>{" "}
+          to track aggregate usage (page views, workout generation, exports). No
+          cookies are set and no personal data is collected.
         </p>
       </section>
 

--- a/packages/workout-spa-editor/src/contexts/analytics-context.test.tsx
+++ b/packages/workout-spa-editor/src/contexts/analytics-context.test.tsx
@@ -1,6 +1,7 @@
 import { createNoopAnalytics } from "@kaiord/core";
 import type { Analytics } from "@kaiord/core";
 import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import { AnalyticsProvider, useAnalytics } from "./analytics-context";
@@ -22,7 +23,7 @@ describe("useAnalytics", () => {
       event: vi.fn(),
     };
 
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
+    const wrapper = ({ children }: { children: ReactNode }) => (
       <AnalyticsProvider analytics={mockAnalytics}>
         {children}
       </AnalyticsProvider>
@@ -45,7 +46,7 @@ describe("useAnalytics", () => {
       event: vi.fn(),
     };
 
-    const wrapper = ({ children }: { children: React.ReactNode }) => (
+    const wrapper = ({ children }: { children: ReactNode }) => (
       <AnalyticsProvider analytics={mockAnalytics}>
         {children}
       </AnalyticsProvider>

--- a/packages/workout-spa-editor/src/contexts/analytics-context.test.tsx
+++ b/packages/workout-spa-editor/src/contexts/analytics-context.test.tsx
@@ -1,0 +1,75 @@
+import { createNoopAnalytics } from "@kaiord/core";
+import type { Analytics } from "@kaiord/core";
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AnalyticsProvider, useAnalytics } from "./analytics-context";
+
+describe("useAnalytics", () => {
+  it("should return noop analytics when used without a provider", () => {
+    // Arrange & Act
+    const { result } = renderHook(() => useAnalytics());
+
+    // Assert — noop: methods exist and do not throw
+    expect(() => result.current.pageView("/")).not.toThrow();
+    expect(() => result.current.event("test")).not.toThrow();
+  });
+
+  it("should return injected analytics when wrapped in AnalyticsProvider", () => {
+    // Arrange
+    const mockAnalytics: Analytics = {
+      pageView: vi.fn(),
+      event: vi.fn(),
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AnalyticsProvider analytics={mockAnalytics}>
+        {children}
+      </AnalyticsProvider>
+    );
+
+    // Act
+    const { result } = renderHook(() => useAnalytics(), { wrapper });
+    result.current.event("test-event", { key: "value" });
+
+    // Assert
+    expect(mockAnalytics.event).toHaveBeenCalledWith("test-event", {
+      key: "value",
+    });
+  });
+
+  it("should forward pageView calls to the injected adapter", () => {
+    // Arrange
+    const mockAnalytics: Analytics = {
+      pageView: vi.fn(),
+      event: vi.fn(),
+    };
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <AnalyticsProvider analytics={mockAnalytics}>
+        {children}
+      </AnalyticsProvider>
+    );
+
+    // Act
+    const { result } = renderHook(() => useAnalytics(), { wrapper });
+    result.current.pageView("/editor/");
+
+    // Assert
+    expect(mockAnalytics.pageView).toHaveBeenCalledWith("/editor/");
+  });
+
+  it("should use noop by default (context default value)", () => {
+    // Arrange
+    const noop = createNoopAnalytics();
+
+    // Act — without provider wrapper, should behave like noop
+    const { result } = renderHook(() => useAnalytics());
+
+    // Assert — same interface, no throws
+    expect(result.current.event).toBeTypeOf("function");
+    expect(result.current.pageView).toBeTypeOf("function");
+    expect(() => result.current.event("any-event")).not.toThrow();
+    expect(noop.event).toBeTypeOf("function");
+  });
+});

--- a/packages/workout-spa-editor/src/contexts/analytics-context.tsx
+++ b/packages/workout-spa-editor/src/contexts/analytics-context.tsx
@@ -1,0 +1,26 @@
+import type { Analytics } from "@kaiord/core";
+import { createNoopAnalytics } from "@kaiord/core";
+import type { ReactNode } from "react";
+import { createContext, useContext } from "react";
+
+const AnalyticsContext = createContext<Analytics>(createNoopAnalytics());
+
+type AnalyticsProviderProps = Readonly<{
+  analytics: Analytics;
+  children: ReactNode;
+}>;
+
+export function AnalyticsProvider({
+  analytics,
+  children,
+}: AnalyticsProviderProps) {
+  return (
+    <AnalyticsContext.Provider value={analytics}>
+      {children}
+    </AnalyticsContext.Provider>
+  );
+}
+
+export function useAnalytics(): Analytics {
+  return useContext(AnalyticsContext);
+}

--- a/packages/workout-spa-editor/src/contexts/index.ts
+++ b/packages/workout-spa-editor/src/contexts/index.ts
@@ -1,3 +1,4 @@
+export { AnalyticsProvider, useAnalytics } from "./analytics-context";
 export { GarminBridgeProvider, useGarminBridge } from "./garmin-bridge-context";
 export type { GarminBridgeState, PushState } from "./garmin-bridge-types";
 export {

--- a/packages/workout-spa-editor/src/main.tsx
+++ b/packages/workout-spa-editor/src/main.tsx
@@ -3,13 +3,19 @@ import "./index.css";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
+import { createCloudflareAnalytics } from "./adapters/analytics/cloudflare-analytics";
 import App from "./App.tsx";
 import {
+  AnalyticsProvider,
   GarminBridgeProvider,
   SettingsDialogProvider,
   ThemeProvider,
 } from "./contexts";
 import { CoachingRegistryBootstrap } from "./contexts/coaching-registry-bootstrap";
+
+const analytics = createCloudflareAnalytics(
+  import.meta.env.VITE_CF_ANALYTICS_TOKEN as string | undefined
+);
 
 if (import.meta.env.DEV) {
   import("./store/ai-store").then(({ useAiStore }) => {
@@ -21,14 +27,16 @@ if (import.meta.env.DEV) {
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ThemeProvider>
-      <SettingsDialogProvider>
-        <GarminBridgeProvider>
-          <CoachingRegistryBootstrap>
-            <App />
-          </CoachingRegistryBootstrap>
-        </GarminBridgeProvider>
-      </SettingsDialogProvider>
-    </ThemeProvider>
+    <AnalyticsProvider analytics={analytics}>
+      <ThemeProvider>
+        <SettingsDialogProvider>
+          <GarminBridgeProvider>
+            <CoachingRegistryBootstrap>
+              <App />
+            </CoachingRegistryBootstrap>
+          </GarminBridgeProvider>
+        </SettingsDialogProvider>
+      </ThemeProvider>
+    </AnalyticsProvider>
   </StrictMode>
 );

--- a/packages/workout-spa-editor/src/types/cf-beacon.d.ts
+++ b/packages/workout-spa-editor/src/types/cf-beacon.d.ts
@@ -1,0 +1,6 @@
+export type CfBeacon = {
+  pushEvent: (
+    name: string,
+    props?: Record<string, string | number | boolean>
+  ) => void;
+};

--- a/packages/workout-spa-editor/vite.config.ts
+++ b/packages/workout-spa-editor/vite.config.ts
@@ -1,14 +1,13 @@
 import { codecovVitePlugin } from "@codecov/vite-plugin";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import type { Plugin } from "vite";
 
-function conditionalBeacon(): Plugin {
+function conditionalBeacon(token: string | undefined): Plugin {
   return {
     name: "conditional-beacon",
     transformIndexHtml(html) {
-      const token = process.env.VITE_CF_ANALYTICS_TOKEN;
       if (!token) {
         return html.replace(
           /<!--\s*CF_BEACON_START\s*-->[\s\S]*?<!--\s*CF_BEACON_END\s*-->/g,
@@ -24,55 +23,58 @@ function conditionalBeacon(): Plugin {
 }
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
-    react(),
-    conditionalBeacon(),
-    codecovVitePlugin({
-      enableBundleAnalysis: !!process.env.CODECOV_TOKEN,
-      bundleName: "workout-spa-editor",
-      uploadToken: process.env.CODECOV_TOKEN ?? "",
-    }),
-  ],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  return {
+    plugins: [
+      react(),
+      conditionalBeacon(env.VITE_CF_ANALYTICS_TOKEN),
+      codecovVitePlugin({
+        enableBundleAnalysis: !!process.env.CODECOV_TOKEN,
+        bundleName: "workout-spa-editor",
+        uploadToken: process.env.CODECOV_TOKEN ?? "",
+      }),
+    ],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
-  // GitHub Pages deployment configuration
-  base: process.env.VITE_BASE_PATH || "/",
-  build: {
-    outDir: "dist",
-    sourcemap: true,
-    // Optimize for production (Vite 8 default: oxc, 30-90x faster than terser)
-    minify: "oxc",
-    target: "es2020",
-    rolldownOptions: {
-      output: {
-        codeSplitting: {
-          groups: [
-            { name: "vendor-ui", test: /[\\/]node_modules[\\/]@radix-ui[\\/]/ },
-            {
-              name: "vendor-state",
-              test: /[\\/]node_modules[\\/]zustand[\\/]/,
-            },
-            { name: "vendor-zod", test: /[\\/]node_modules[\\/]zod[\\/]/ },
-            {
-              name: "vendor-dnd",
-              test: /[\\/]node_modules[\\/]@dnd-kit[\\/]/,
-            },
-            {
-              name: "vendor-icons",
-              test: /[\\/]node_modules[\\/]lucide-react[\\/]/,
-            },
-            { name: "kaiord-core", test: /[\\/]packages[\\/]core[\\/]/ },
-            { name: "kaiord-fit", test: /[\\/]packages[\\/]fit[\\/]/ },
-            { name: "kaiord-tcx", test: /[\\/]packages[\\/]tcx[\\/]/ },
-            { name: "kaiord-zwo", test: /[\\/]packages[\\/]zwo[\\/]/ },
-            { name: "kaiord-garmin", test: /[\\/]packages[\\/]garmin[\\/]/ },
-          ],
+    // GitHub Pages deployment configuration
+    base: process.env.VITE_BASE_PATH || "/",
+    build: {
+      outDir: "dist",
+      sourcemap: true,
+      // Optimize for production (Vite 8 default: oxc, 30-90x faster than terser)
+      minify: "oxc",
+      target: "es2020",
+      rolldownOptions: {
+        output: {
+          codeSplitting: {
+            groups: [
+              { name: "vendor-ui", test: /[\\/]node_modules[\\/]@radix-ui[\\/]/ },
+              {
+                name: "vendor-state",
+                test: /[\\/]node_modules[\\/]zustand[\\/]/,
+              },
+              { name: "vendor-zod", test: /[\\/]node_modules[\\/]zod[\\/]/ },
+              {
+                name: "vendor-dnd",
+                test: /[\\/]node_modules[\\/]@dnd-kit[\\/]/,
+              },
+              {
+                name: "vendor-icons",
+                test: /[\\/]node_modules[\\/]lucide-react[\\/]/,
+              },
+              { name: "kaiord-core", test: /[\\/]packages[\\/]core[\\/]/ },
+              { name: "kaiord-fit", test: /[\\/]packages[\\/]fit[\\/]/ },
+              { name: "kaiord-tcx", test: /[\\/]packages[\\/]tcx[\\/]/ },
+              { name: "kaiord-zwo", test: /[\\/]packages[\\/]zwo[\\/]/ },
+              { name: "kaiord-garmin", test: /[\\/]packages[\\/]garmin[\\/]/ },
+            ],
+          },
         },
       },
     },
-  },
+  };
 });

--- a/packages/workout-spa-editor/vite.config.ts
+++ b/packages/workout-spa-editor/vite.config.ts
@@ -2,11 +2,32 @@ import { codecovVitePlugin } from "@codecov/vite-plugin";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { defineConfig } from "vite";
+import type { Plugin } from "vite";
+
+function conditionalBeacon(): Plugin {
+  return {
+    name: "conditional-beacon",
+    transformIndexHtml(html) {
+      const token = process.env.VITE_CF_ANALYTICS_TOKEN;
+      if (!token) {
+        return html.replace(
+          /<!--\s*CF_BEACON_START\s*-->[\s\S]*?<!--\s*CF_BEACON_END\s*-->/g,
+          ""
+        );
+      }
+      return html
+        .replace(/<!--\s*CF_BEACON_START\s*-->/g, "")
+        .replace(/<!--\s*CF_BEACON_END\s*-->/g, "")
+        .replace(/%VITE_CF_ANALYTICS_TOKEN%/g, token);
+    },
+  };
+}
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
     react(),
+    conditionalBeacon(),
     codecovVitePlugin({
       enableBundleAnalysis: !!process.env.CODECOV_TOKEN,
       bundleName: "workout-spa-editor",

--- a/packages/workout-spa-editor/vite.config.ts
+++ b/packages/workout-spa-editor/vite.config.ts
@@ -52,7 +52,10 @@ export default defineConfig(({ mode }) => {
         output: {
           codeSplitting: {
             groups: [
-              { name: "vendor-ui", test: /[\\/]node_modules[\\/]@radix-ui[\\/]/ },
+              {
+                name: "vendor-ui",
+                test: /[\\/]node_modules[\\/]@radix-ui[\\/]/,
+              },
               {
                 name: "vendor-state",
                 test: /[\\/]node_modules[\\/]zustand[\\/]/,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,10 +393,17 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/landing:
+    dependencies:
+      '@kaiord/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      jsdom:
+        specifier: ^26.1.0
+        version: 26.1.0
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -406,6 +413,9 @@ importers:
       vite:
         specifier: ^8.0.5
         version: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.5
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/mcp:
     dependencies:
@@ -759,6 +769,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
@@ -1169,9 +1182,20 @@ packages:
     resolution: {integrity: sha512-q+0pHQ8DbqjemyaOn/mTtBRbCuKDqhnsVbZ6J9zkTsxPgMpccjy0s5oLXwomfrrxMRBH+UcbERwtUmE+SbnoIQ==}
     engines: {node: '>=22.18.0'}
 
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
   '@csstools/color-helpers@6.0.2':
     resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
     engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-calc@3.2.0':
     resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
@@ -1180,12 +1204,25 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
   '@csstools/css-color-parser@4.1.0':
     resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
 
   '@csstools/css-parser-algorithms@4.0.0':
     resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
@@ -1200,6 +1237,10 @@ packages:
     peerDependenciesMeta:
       css-tree:
         optional: true
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@csstools/css-tokenizer@4.0.0':
     resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
@@ -3883,6 +3924,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ai@6.0.168:
     resolution: {integrity: sha512-2HqCJuO+1V2aV7vfYs5LFEUfxbkGX+5oa54q/gCCTL7KLTdbxcCu5D7TdLA5kwsrs3Szgjah9q6D9tpjHM3hUQ==}
     engines: {node: '>=18'}
@@ -4308,8 +4353,16 @@ packages:
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -4969,6 +5022,10 @@ packages:
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -4982,6 +5039,14 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -4999,6 +5064,10 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -5202,6 +5271,15 @@ packages:
     resolution: {integrity: sha512-fp6Sh42W3mIPoQgZmgYmKDLQzEDnnX2vaGlTN4haILkB2vsi+ewcCHEtWR/2CR/QbsBvAvsNo8U5Sa+p9aHiGw==}
     hasBin: true
 
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsdom@29.0.2:
     resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
@@ -5397,6 +5475,9 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@11.2.6:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
@@ -5702,6 +5783,9 @@ packages:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   oauth-1.0a@2.2.6:
     resolution: {integrity: sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ==}
 
@@ -5819,6 +5903,9 @@ packages:
   parse-ms@4.0.0:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
@@ -6221,6 +6308,9 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -6573,11 +6663,18 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
   tldts-core@7.0.23:
     resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
 
   tldts-core@7.0.28:
     resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   tldts@7.0.23:
     resolution: {integrity: sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==}
@@ -6612,6 +6709,10 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tough-cookie@6.0.0:
     resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
@@ -6619,6 +6720,10 @@ packages:
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
@@ -7006,6 +7111,10 @@ packages:
     engines: {node: ^20.12||^22.13||>=24.0}
     hasBin: true
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -7013,9 +7122,22 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
@@ -7259,6 +7381,14 @@ snapshots:
       json-schema: 0.4.0
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -7789,12 +7919,26 @@ snapshots:
 
   '@cspell/url@10.0.0': {}
 
+  '@csstools/color-helpers@5.1.0': {}
+
   '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
@@ -7803,6 +7947,10 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
   '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
@@ -7810,6 +7958,8 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@csstools/css-tokenizer@4.0.0': {}
 
@@ -10106,6 +10256,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ai@6.0.168(zod@4.3.6):
     dependencies:
       '@ai-sdk/gateway': 3.0.104(zod@4.3.6)
@@ -10544,7 +10696,17 @@ snapshots:
 
   css.escape@1.5.1: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-urls@7.0.0:
     dependencies:
@@ -11322,6 +11484,10 @@ snapshots:
 
   hosted-git-info@2.8.9: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
@@ -11340,6 +11506,20 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-id@4.1.3: {}
 
   human-signals@1.1.1: {}
@@ -11347,6 +11527,10 @@ snapshots:
   human-signals@8.0.1: {}
 
   husky@9.1.7: {}
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.7.2:
     dependencies:
@@ -11503,6 +11687,33 @@ snapshots:
       commander: 5.1.0
       fs-extra: 11.3.4
       jscpd-sarif-reporter: 4.0.7
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsdom@29.0.2:
     dependencies:
@@ -11708,6 +11919,8 @@ snapshots:
   longest-streak@3.1.0: {}
 
   loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@11.2.6: {}
 
@@ -12145,6 +12358,8 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
+  nwsapi@2.2.23: {}
+
   oauth-1.0a@2.2.6: {}
 
   object-assign@4.1.1: {}
@@ -12336,6 +12551,10 @@ snapshots:
       quansync: 0.2.11
 
   parse-ms@4.0.0: {}
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parse5@8.0.0:
     dependencies:
@@ -12799,6 +13018,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrweb-cssom@0.8.0: {}
+
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -13191,9 +13412,15 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
   tldts-core@7.0.23: {}
 
   tldts-core@7.0.28: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tldts@7.0.23:
     dependencies:
@@ -13221,6 +13448,10 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tough-cookie@6.0.0:
     dependencies:
       tldts: 7.0.23
@@ -13228,6 +13459,10 @@ snapshots:
   tough-cookie@6.0.1:
     dependencies:
       tldts: 7.0.28
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tr46@6.0.0:
     dependencies:
@@ -13585,6 +13820,37 @@ snapshots:
       - universal-cookie
       - yaml
 
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@26.1.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.5
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.5
+      '@vitest/runner': 4.1.5
+      '@vitest/snapshot': 4.1.5
+      '@vitest/spy': 4.1.5
+      '@vitest/utils': 4.1.5
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.28.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.6.0
+      '@vitest/coverage-v8': 4.1.5(vitest@4.1.5)
+      '@vitest/ui': 4.1.5(vitest@4.1.5)
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - msw
+
   vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(jsdom@29.0.2)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.1)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
@@ -13675,11 +13941,24 @@ snapshots:
 
   watskeburt@5.0.3: {}
 
+  webidl-conversions@7.0.0: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
   whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@16.0.1:
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `Analytics` port to `@kaiord/core` with `pageView(path)` and `event(name, props?)` methods
- Adds `createNoopAnalytics()` — zero-tracking default for OSS consumers
- Adds Cloudflare Web Analytics adapter in `packages/landing` and `packages/workout-spa-editor` (private, not published)
- Wires analytics across both apps: page views, CTA clicks, editor-loaded, workout-generated, workout-exported, garmin-synced
- Adds GDPR disclosure in landing footer and editor Privacy tab
- Beacon `<script>` is removed from built HTML when `VITE_CF_ANALYTICS_TOKEN` is not set

## Test plan

- [ ] `pnpm -r test` — all tests pass, coverage thresholds met
- [ ] `pnpm -r build` — zero errors/warnings; confirm beacon absent in dist HTML when token unset
- [ ] `pnpm lint` — zero ESLint/TypeScript errors
- [ ] Changeset present: `@kaiord/core` patch bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional analytics for page views, editor use, workout generation, exports, and third-party sync events; disabled by default and opt-in via build/runtime configuration.
  * Emits aggregate, best-effort telemetry without cookies and without collecting personal data.

* **Documentation**
  * Added in-app privacy disclosure (settings & footer) describing analytics behavior and privacy guarantees.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->