### PR TITLE
feat(cws): apply harden-cws-publish — service-account migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/cws-auth-broken.md
+++ b/.github/ISSUE_TEMPLATE/cws-auth-broken.md
@@ -1,0 +1,27 @@
+---
+name: CWS authentication broken
+about: Auto-opened when the CWS Publish workflow detects a 401/403 from the service-account credentials
+title: "CWS authentication broken"
+labels: cws-auth-broken
+assignees: pablo-albaladejo
+---
+
+The Chrome Web Store API rejected our service-account credentials with 401 / 403.
+
+## Likely causes
+
+- Service-account JSON key was rotated/revoked in Google Cloud Console.
+- The service account was unlinked from the Chrome Web Store Developer Dashboard (Settings → Service accounts).
+- Google rotated the OAuth signing keys and the cache is stale (rare, self-healing).
+
+## Fix checklist
+
+- [ ] Check Google Cloud Console → IAM & Admin → Service Accounts: is the `kaiord-cws-publisher` account present? Are its keys valid and unrevoked?
+- [ ] If a fresh key is needed: follow [`docs/runbooks/cws-service-account.md`](../../docs/runbooks/cws-service-account.md) → "Key rotation".
+- [ ] Update repo Secret `CWS_SERVICE_ACCOUNT_KEY` with the new JSON key contents.
+- [ ] Trigger `cws-publish.yml` via `workflow_dispatch` to verify pre-flight passes.
+- [ ] Close this issue once a green run is observed.
+
+## Observed error
+
+(Paste the relevant `[CwsAuthError]` line from the failing workflow run here.)

--- a/.github/ISSUE_TEMPLATE/cws-publish-rejected.md
+++ b/.github/ISSUE_TEMPLATE/cws-publish-rejected.md
@@ -1,0 +1,25 @@
+---
+name: CWS publish rejected
+about: Auto-opened when the Chrome Web Store rejects a published version
+title: "CWS publish rejected: <ext>@<version>"
+labels: cws-publish-rejected
+assignees: pablo-albaladejo
+---
+
+Chrome Web Store **rejected** the publish attempt. This is a human-actionable policy / validation error — the workflow matrix job FAILED so subsequent releases do not silently ship over an unresolved rejection.
+
+## itemError payload
+
+(Paste the `itemError` array from the workflow's `wait-published` stdout here.)
+
+Reference: [Chrome Web Store item-error code documentation](https://developer.chrome.com/docs/webstore/api/items#error-codes).
+
+## Fix checklist
+
+- [ ] Read the `itemError` payload — it usually pinpoints the exact policy / manifest / content issue.
+- [ ] Address the root cause in the extension code, manifest, or store listing.
+- [ ] Decide between bumping the version (preferred — cleaner CWS history) OR force-publishing the same version.
+  - If bumping version: edit `packages/<ext>/package.json` and merge a new release.
+  - If force-publishing same version: see [`docs/runbooks/cws-service-account.md`](../../docs/runbooks/cws-service-account.md) → "Emergency re-publish".
+- [ ] Confirm the new run reaches `PUBLISHED` end-to-end.
+- [ ] Close this issue.

--- a/.github/ISSUE_TEMPLATE/cws-publish-verification-timeout.md
+++ b/.github/ISSUE_TEMPLATE/cws-publish-verification-timeout.md
@@ -1,0 +1,24 @@
+---
+name: CWS publish verification timeout
+about: Auto-opened when post-publish polling times out without reaching PUBLISHED
+title: "CWS publish stalled: <ext>@<version>"
+labels: cws-publish-verification-timeout
+---
+
+The CWS Publish workflow polled the Chrome Web Store API for up to 2 minutes after publish dispatch and did NOT observe the new version transition to `PUBLISHED`.
+
+This is **non-blocking** — the workflow exited 0. The extension may simply be in Google's manual review queue (`IN_REVIEW`), which is a legitimate terminal state and typically self-resolves within hours-to-days. This issue exists for visibility and audit.
+
+## What to check
+
+- Open the [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole) and inspect the affected extension. If it shows `Pending review`, no action is required.
+- If it shows `Rejected` instead, the verification logic may have missed it — open a separate `cws-publish-rejected` issue manually.
+- If the version is now `PUBLISHED` (the timeout simply ran out before propagation completed), close this issue.
+
+## Last-seen CWS state payload
+
+(Paste the JSON `raw` field from the workflow's `wait-published` stdout here.)
+
+## Auto-recovery
+
+Future workflow runs will skip the upload step (CWS API state is the idempotency source of truth) and proceed straight to publish if the upload is still in `UPLOADED` state. No manual intervention needed for routine review queues.

--- a/.github/workflows/cws-publish.yml
+++ b/.github/workflows/cws-publish.yml
@@ -1,5 +1,7 @@
 name: CWS Publish
 
+# inputs.force_upload is `false` on push events; always check explicitly
+# rather than relying on its undefined-ness in YAML expressions.
 on:
   push:
     branches:
@@ -8,18 +10,59 @@ on:
       - "packages/garmin-bridge/**"
       - "packages/train2go-bridge/**"
   workflow_dispatch:
+    inputs:
+      force_upload:
+        description: "Bypass CWS-state idempotency and re-upload current version (emergency only)"
+        type: boolean
+        required: false
+        default: false
 
+# Top-level concurrency: prevents two workflow runs (push vs dispatch)
+# from racing on the same ref. Job-level cws-issue-writer concurrency
+# (defined per-job below) serializes issue writes ACROSS workflow runs;
+# it does NOT serialize matrix jobs within one run — the
+# cws-notify-issue helper handles within-run idempotency via exact-title
+# read-then-write per design.md Decision 7.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
+  pre-flight:
+    name: Pre-flight (CWS auth check)
+    runs-on: ubuntu-latest
+    concurrency:
+      group: cws-issue-writer
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: CWS auth check
+        id: check
+        env:
+          CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
+        run: node scripts/cws-api.mjs check ${{ secrets.CWS_EXTENSION_ID }}
+
+      - name: Open cws-auth-broken issue on failure
+        if: failure() && steps.check.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node scripts/cws-notify-issue.mjs cws-auth-broken "" \
+            "Pre-flight failed at $(date -u +%FT%TZ). See workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
   publish:
     name: Publish ${{ matrix.extension.name }}
     runs-on: ubuntu-latest
+    needs: pre-flight
+    concurrency:
+      group: cws-issue-writer
+      cancel-in-progress: false
     strategy:
       fail-fast: false
       matrix:
@@ -34,54 +77,129 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect version change
+      - name: Resolve current version
         id: version
         run: |
           EXT="${{ matrix.extension.name }}"
           CURRENT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('packages/$EXT/package.json','utf8')).version)")
-          LATEST_TAG=$(git tag -l "@kaiord/$EXT@*" --sort=-v:refname | head -n1 || echo "")
-          if [ -n "$LATEST_TAG" ]; then
-            TAG_VERSION="${LATEST_TAG#@kaiord/$EXT@}"
-          else
-            TAG_VERSION=""
-          fi
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
-          echo "tag_version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
-          if [ "$CURRENT" = "$TAG_VERSION" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "$EXT: Version $CURRENT already published (tag exists)"
-          else
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "$EXT: New version detected: $CURRENT (tag: ${TAG_VERSION:-none})"
-          fi
 
       - name: Setup pnpm
-        if: steps.version.outputs.changed == 'true'
         uses: ./.github/actions/setup-pnpm
 
       - name: Sync manifest versions
-        if: steps.version.outputs.changed == 'true'
         run: node scripts/sync-extension-version.mjs ${{ matrix.extension.name }}
 
       - name: Package extension
-        if: steps.version.outputs.changed == 'true'
         run: bash scripts/package-extension.sh ${{ matrix.extension.name }}
 
-      - name: Upload to Chrome Web Store
-        if: steps.version.outputs.changed == 'true'
+      - name: Query CWS state (skipped on force_upload)
+        id: state
+        if: ${{ inputs.force_upload != true }}
+        env:
+          CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
+        run: |
+          STATE=$(node scripts/cws-api.mjs state ${{ secrets[matrix.extension.extension_id_secret] }})
+          echo "draft_version=$(echo "$STATE" | jq -r '.crxVersion // ""')" >> "$GITHUB_OUTPUT"
+          echo "draft_upload_state=$(echo "$STATE" | jq -r '.uploadState // ""')" >> "$GITHUB_OUTPUT"
+
+      - name: Decide upload skip
+        id: decide
+        run: |
+          FORCE='${{ inputs.force_upload }}'
+          DRAFT_VER='${{ steps.state.outputs.draft_version }}'
+          DRAFT_STATE='${{ steps.state.outputs.draft_upload_state }}'
+          CURRENT='${{ steps.version.outputs.current }}'
+          if [ "$FORCE" = "true" ]; then
+            echo "skip_upload=false" >> "$GITHUB_OUTPUT"
+          elif [ "$DRAFT_VER" = "$CURRENT" ] && [ "$DRAFT_STATE" = "SUCCESS" -o "$DRAFT_STATE" = "UPLOADED" ]; then
+            echo "skip_upload=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip_upload=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload CRX to Chrome Web Store
+        id: upload
+        if: ${{ steps.decide.outputs.skip_upload != 'true' }}
+        env:
+          CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
         run: |
           EXT="${{ matrix.extension.name }}"
           VERSION="${{ steps.version.outputs.current }}"
-          npx chrome-webstore-upload-cli upload \
-            --source "packages/$EXT/dist/kaiord-$EXT-$VERSION.zip" \
-            --extension-id ${{ secrets[matrix.extension.extension_id_secret] }} \
-            --client-id ${{ secrets.CWS_CLIENT_ID }} \
-            --client-secret ${{ secrets.CWS_CLIENT_SECRET }} \
-            --refresh-token ${{ secrets.CWS_REFRESH_TOKEN }} \
-            --auto-publish
+          node scripts/cws-api.mjs upload \
+            ${{ secrets[matrix.extension.extension_id_secret] }} \
+            --source "packages/$EXT/dist/kaiord-$EXT-$VERSION.zip"
 
-      - name: Create git tag
-        if: steps.version.outputs.changed == 'true'
+      - name: Wait for UPLOADED state
+        id: wait_uploaded
+        if: ${{ steps.decide.outputs.skip_upload != 'true' }}
+        env:
+          CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
+        run: |
+          node scripts/cws-api.mjs wait-uploaded \
+            ${{ secrets[matrix.extension.extension_id_secret] }} \
+            --timeout-ms 60000
+
+      - name: Publish
+        id: publish
+        env:
+          CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
+        run: |
+          node scripts/cws-api.mjs publish \
+            ${{ secrets[matrix.extension.extension_id_secret] }}
+
+      - name: Wait for terminal state (PUBLISHED / IN_REVIEW / REJECTED / TIMEOUT)
+        id: wait_published
+        env:
+          CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
+        run: |
+          RESULT=$(node scripts/cws-api.mjs wait-published \
+            ${{ secrets[matrix.extension.extension_id_secret] }} \
+            --version ${{ steps.version.outputs.current }} \
+            --timeout-ms 120000)
+          echo "result=$RESULT" >> "$GITHUB_OUTPUT"
+          STATUS=$(echo "$RESULT" | jq -r '.status')
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          if [ "$STATUS" = "REJECTED" ]; then
+            exit 1
+          fi
+
+      - name: Open issue on REJECTED
+        if: failure() && steps.wait_published.outputs.status == 'REJECTED'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXT="${{ matrix.extension.name }}"
+          VERSION="${{ steps.version.outputs.current }}"
+          node scripts/cws-notify-issue.mjs cws-publish-rejected "@kaiord/$EXT@$VERSION" \
+            "$(echo '${{ steps.wait_published.outputs.result }}' | jq -r '.raw // .')"
+
+      - name: Open issue on IN_REVIEW or TIMEOUT
+        if: ${{ steps.wait_published.outputs.status == 'IN_REVIEW' || steps.wait_published.outputs.status == 'TIMEOUT' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXT="${{ matrix.extension.name }}"
+          VERSION="${{ steps.version.outputs.current }}"
+          node scripts/cws-notify-issue.mjs cws-publish-verification-timeout "@kaiord/$EXT@$VERSION" \
+            "Status: ${{ steps.wait_published.outputs.status }}. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Open cws-auth-broken on mid-flight 401/403
+        if: failure() && (steps.upload.outcome == 'failure' || steps.wait_uploaded.outcome == 'failure' || steps.publish.outcome == 'failure' || steps.wait_published.outcome == 'failure')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Best-effort: if any of the post-pre-flight steps failed AND the
+          # failure looks like an auth error, surface as cws-auth-broken.
+          # Distinct from the REJECTED handler above.
+          if [ "${{ steps.wait_published.outputs.status }}" != "REJECTED" ]; then
+            node scripts/cws-notify-issue.mjs cws-auth-broken "" \
+              "Mid-flight failure during ${{ matrix.extension.name }} publish. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              || true
+          fi
+
+      - name: Create git tag (only on PUBLISHED)
+        if: ${{ steps.wait_published.outputs.status == 'PUBLISHED' }}
         run: |
           EXT="${{ matrix.extension.name }}"
           TAG="@kaiord/$EXT@${{ steps.version.outputs.current }}"
@@ -89,19 +207,12 @@ jobs:
           git push origin "$TAG"
 
       - name: Summary
-        if: steps.version.outputs.changed == 'true'
+        if: always()
         run: |
           EXT="${{ matrix.extension.name }}"
-          echo "## CWS Publish: $EXT" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- **Version**: ${{ steps.version.outputs.current }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Tag**: @kaiord/$EXT@${{ steps.version.outputs.current }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Status**: Uploaded and auto-publish requested" >> $GITHUB_STEP_SUMMARY
-
-      - name: Skip summary
-        if: steps.version.outputs.changed != 'true'
-        run: |
-          EXT="${{ matrix.extension.name }}"
-          echo "## CWS Publish Skipped: $EXT" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Version ${{ steps.version.outputs.current }} already published." >> $GITHUB_STEP_SUMMARY
+          STATUS="${{ steps.wait_published.outputs.status }}"
+          echo "## CWS Publish: $EXT" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Version**: ${{ steps.version.outputs.current }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Status**: ${STATUS:-unknown}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Force upload**: ${{ inputs.force_upload }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cws-publish.yml
+++ b/.github/workflows/cws-publish.yml
@@ -103,24 +103,31 @@ jobs:
           echo "draft_version=$(echo "$STATE" | jq -r '.crxVersion // ""')" >> "$GITHUB_OUTPUT"
           echo "draft_upload_state=$(echo "$STATE" | jq -r '.uploadState // ""')" >> "$GITHUB_OUTPUT"
 
-      - name: Decide upload skip
+      - name: Decide upload/publish skip
         id: decide
         run: |
           FORCE='${{ inputs.force_upload }}'
-          DRAFT_VER='${{ steps.state.outputs.draft_version }}'
-          DRAFT_STATE='${{ steps.state.outputs.draft_upload_state }}'
+          # crxVersion in the DRAFT projection actually exposes the
+          # currently-PUBLISHED version (CWS API quirk: projection=PUBLISHED
+          # is rejected with 400; DRAFT response carries crxVersion of the
+          # live item). If it equals our local version, there is nothing
+          # to upload or publish.
+          PUBLISHED_VER='${{ steps.state.outputs.draft_version }}'
           CURRENT='${{ steps.version.outputs.current }}'
           if [ "$FORCE" = "true" ]; then
-            echo "skip_upload=false" >> "$GITHUB_OUTPUT"
-          elif [ "$DRAFT_VER" = "$CURRENT" ] && [ "$DRAFT_STATE" = "SUCCESS" -o "$DRAFT_STATE" = "UPLOADED" ]; then
-            echo "skip_upload=true" >> "$GITHUB_OUTPUT"
+            echo "skip_all=false" >> "$GITHUB_OUTPUT"
+            echo "Force-upload requested; ignoring CWS state."
+          elif [ "$PUBLISHED_VER" = "$CURRENT" ]; then
+            echo "skip_all=true" >> "$GITHUB_OUTPUT"
+            echo "CWS already at $CURRENT — no-op success."
           else
-            echo "skip_upload=false" >> "$GITHUB_OUTPUT"
+            echo "skip_all=false" >> "$GITHUB_OUTPUT"
+            echo "CWS at ${PUBLISHED_VER:-<unknown>}; uploading $CURRENT."
           fi
 
       - name: Upload CRX to Chrome Web Store
         id: upload
-        if: ${{ steps.decide.outputs.skip_upload != 'true' }}
+        if: ${{ steps.decide.outputs.skip_all != 'true' }}
         env:
           CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
         run: |
@@ -132,7 +139,7 @@ jobs:
 
       - name: Wait for UPLOADED state
         id: wait_uploaded
-        if: ${{ steps.decide.outputs.skip_upload != 'true' }}
+        if: ${{ steps.decide.outputs.skip_all != 'true' }}
         env:
           CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
         run: |
@@ -142,6 +149,7 @@ jobs:
 
       - name: Publish
         id: publish
+        if: ${{ steps.decide.outputs.skip_all != 'true' }}
         env:
           CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
         run: |
@@ -150,6 +158,7 @@ jobs:
 
       - name: Wait for terminal state (PUBLISHED / IN_REVIEW / REJECTED / TIMEOUT)
         id: wait_published
+        if: ${{ steps.decide.outputs.skip_all != 'true' }}
         env:
           CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
         run: |
@@ -199,7 +208,7 @@ jobs:
           fi
 
       - name: Create git tag (only on PUBLISHED)
-        if: ${{ steps.wait_published.outputs.status == 'PUBLISHED' }}
+        if: ${{ steps.decide.outputs.skip_all != 'true' && steps.wait_published.outputs.status == 'PUBLISHED' }}
         run: |
           EXT="${{ matrix.extension.name }}"
           TAG="@kaiord/$EXT@${{ steps.version.outputs.current }}"
@@ -211,8 +220,15 @@ jobs:
         run: |
           EXT="${{ matrix.extension.name }}"
           STATUS="${{ steps.wait_published.outputs.status }}"
+          SKIP_ALL="${{ steps.decide.outputs.skip_all }}"
+          PUBLISHED_VER="${{ steps.state.outputs.draft_version }}"
           echo "## CWS Publish: $EXT" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Version**: ${{ steps.version.outputs.current }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Status**: ${STATUS:-unknown}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Local version**: ${{ steps.version.outputs.current }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **CWS published**: ${PUBLISHED_VER:-<unknown>}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$SKIP_ALL" = "true" ]; then
+            echo "- **Status**: SKIPPED (already at target version, no-op)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- **Status**: ${STATUS:-unknown}" >> "$GITHUB_STEP_SUMMARY"
+          fi
           echo "- **Force upload**: ${{ inputs.force_upload }}" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,3 +84,7 @@ pnpm exec changeset                              # For version-worthy changes
 4. Add changeset if version-worthy: `pnpm exec changeset`
 5. Update docs if public API changes
 6. After merge: `/opsx:archive` to preserve decisions
+
+## Runbooks
+
+- [`docs/runbooks/cws-service-account.md`](docs/runbooks/cws-service-account.md) — Chrome Web Store service-account setup, key rotation, emergency `force_upload` re-publish, compromised-key response. Required reading before touching `.github/workflows/cws-publish.yml`.

--- a/docs/runbooks/cws-service-account.md
+++ b/docs/runbooks/cws-service-account.md
@@ -1,0 +1,121 @@
+# Chrome Web Store Service-Account Setup & Rotation
+
+This runbook documents the manual Google Cloud + Chrome Web Store steps required to set up (or rotate) the service-account credentials used by `cws-publish.yml` to publish extensions to the Chrome Web Store.
+
+The CI side is fully automated; only the credential lifecycle requires a human (Google's OAuth flow doesn't support fully unattended setup).
+
+> **Why service accounts and not OAuth refresh tokens?** Refresh tokens expire silently (~6-month inactivity window), revoke on Google-side security events, and can only be renewed via an interactive browser flow. Service-account JSON keys do not auto-expire — rotation is on our cadence, not Google's. See `openspec/specs/cws-auto-publish/spec.md` for the spec.
+
+---
+
+## One-time setup (~15 min happy path, up to 45 min cold-start)
+
+### 1. Google Cloud project
+
+1. Open https://console.cloud.google.com.
+2. Create or select a project dedicated to CWS automation. Suggested name: `kaiord-cws-publisher`. Note the project ID.
+3. No APIs need to be enabled — the Chrome Web Store API call uses the service account directly.
+
+### 2. Service account
+
+1. Navigate to **IAM & Admin → Service Accounts → + Create service account**.
+2. Name: `kaiord-cws-publisher`. The email becomes `kaiord-cws-publisher@<project-id>.iam.gserviceaccount.com`.
+3. **Skip** the optional "Grant this service account access to the project" step — it does NOT need any project-level IAM role. Authority comes solely from the Chrome Web Store Developer Dashboard linkage in step 3.
+
+### 3. JSON key
+
+1. Open the new service account → **Keys** tab → **Add Key → Create new key → JSON**.
+2. Download the file. Treat it as a credential — anyone with it can publish to your CWS items.
+3. **Do NOT commit it.** Paste it once into the GitHub Secret in step 5; you can shred the file afterward.
+
+### 4. Chrome Web Store Developer Dashboard linkage
+
+1. Open https://chrome.google.com/webstore/devconsole.
+2. **Settings → Service accounts → Add account**.
+3. Paste the service-account email from step 2.
+4. Confirm. The dashboard now reports the service account as having publish authority on items owned by your publisher account.
+5. Google's documented limit: **one service account per publisher**. If you ever need to migrate to a different one, you must remove the existing entry first.
+
+### 5. Repo Secret
+
+1. In GitHub: **Settings → Secrets and variables → Actions → New repository secret**.
+2. Name: `CWS_SERVICE_ACCOUNT_KEY`.
+3. Value: paste the entire JSON file contents from step 3 (literal JSON, no base64).
+4. Click **Add secret**.
+5. Confirm `CWS_EXTENSION_ID` and `CWS_TRAIN2GO_EXTENSION_ID` are still present (they are reused, unchanged).
+
+### 6. Verify
+
+1. Trigger `cws-publish.yml` via **Actions → CWS Publish → Run workflow** (`workflow_dispatch`, leave `force_upload` default-`false`).
+2. The pre-flight job should pass within ~10 s.
+3. If pre-flight FAILS with `[CwsAuthError]`, re-check step 4 (linkage) and step 5 (secret pasted as full JSON, no truncation).
+
+### 7. Decommission OAuth (after E2E green)
+
+Once you've observed at least one fully-green publish run end-to-end, delete the legacy secrets from **Settings → Secrets and variables → Actions**:
+
+- `CWS_CLIENT_ID`
+- `CWS_CLIENT_SECRET`
+- `CWS_REFRESH_TOKEN`
+
+The workflow no longer references them; their continued presence is just clutter and a tempting target.
+
+---
+
+## Key rotation (optional, security best practice)
+
+Service-account keys do not expire automatically. Rotate them when:
+
+- A security event suggests the key may be compromised (a leaked secret, lost laptop, ex-employee with prior access, etc.).
+- Annual cadence as a hygiene policy (optional — not required by Google or by this repo's spec).
+
+Procedure:
+
+1. In Google Cloud Console → service-account → **Keys** tab → create a new JSON key (do NOT delete the old one yet).
+2. Update the `CWS_SERVICE_ACCOUNT_KEY` GitHub Secret with the new JSON.
+3. Trigger `cws-publish.yml` via `workflow_dispatch` (no force_upload). Pre-flight must pass with the new key.
+4. Once the new key is verified working, return to Google Cloud Console and **delete** the old key.
+
+The Chrome Web Store Developer Dashboard linkage is per-service-account-email, NOT per-key; rotating the JSON key does not require re-linking.
+
+---
+
+## Emergency re-publish (`force_upload: true`)
+
+When a published CRX is known-bad (silent build regression, credential leak in a shipped bundle, post-publish malware-scan rejection), normal idempotency would skip re-uploading the same version. To force re-upload:
+
+1. **Actions → CWS Publish → Run workflow**.
+2. Set `force_upload: true`.
+3. Click **Run workflow**.
+
+The state-check step is bypassed; upload runs unconditionally; publish + wait-published proceed as normal.
+
+> **DO NOT** wire `force_upload: true` into another workflow's automation (`release.yml`, `retry.yml`, etc.) as a default input. It is a human-gated emergency override, NOT a knob for upstream pipelines. If an upstream workflow needs to call CWS Publish, do so without `force_upload` and let the idempotency guard work as designed.
+
+---
+
+## Compromised-key response
+
+If you suspect the JSON key is compromised (e.g., it was posted publicly, a laptop with the file was stolen):
+
+1. **REVOKE FIRST.** Open Google Cloud Console → service account → Keys tab → delete the compromised key. Do NOT wait to generate a replacement first; revocation is the urgent step.
+2. After revocation, the next `cws-publish.yml` run's pre-flight will fail with `[CwsAuthError]` and auto-open a `cws-auth-broken` issue. This is expected.
+3. Generate a new JSON key (Keys tab → Add Key → Create new key → JSON).
+4. Update `CWS_SERVICE_ACCOUNT_KEY` with the new JSON contents.
+5. Audit recent publish activity in the Chrome Web Store Developer Dashboard (Items → click each → Submissions tab) for unauthorized version uploads from the time the key may have been compromised.
+6. Trigger `cws-publish.yml` via `workflow_dispatch` to confirm the new key works end-to-end.
+7. Close the auto-opened `cws-auth-broken` issue.
+
+---
+
+## What this replaces
+
+Prior to this migration, the repo authenticated to Chrome Web Store via OAuth user-delegated refresh tokens — three secrets (`CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN`) plus a manual browser-based renewal procedure every ~6 months. That model is gone. The runbook for it has been removed.
+
+If, for any reason, you need to roll back to the old OAuth path:
+
+1. `git revert` the commit that landed `harden-cws-publish`.
+2. Restore the three OAuth secrets.
+3. The previous workflow YAML works against the same CWS API.
+
+Both auth methods authenticate against `chromewebstore/v1.1` — they differ only in how the access token is minted.

--- a/openspec/changes/harden-cws-publish/tasks.md
+++ b/openspec/changes/harden-cws-publish/tasks.md
@@ -12,30 +12,30 @@
 
 ## 2. CWS API helper: auth + state
 
-- [ ] 2.1.a Write failing `node --test` for `signJwt(serviceAccountJson)` — produces an RS256 JWT with `iss == client_email`, `scope == https://www.googleapis.com/auth/chromewebstore`, `aud == https://oauth2.googleapis.com/token`, `iat == now - 60`, `exp == now + 3600`. Verify signature with the public key from the JSON.
-- [ ] 2.1.b Implement `signJwt` using `node:crypto.createSign('RSA-SHA256')` — no third-party deps.
-- [ ] 2.2.a Write failing test for `mintAccessToken(serviceAccountJson)`: POSTs to `https://oauth2.googleapis.com/token` with `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` and the JWT; returns the 1-hour access token.
-- [ ] 2.2.b Implement `mintAccessToken` using `globalThis.fetch`. Cache the token per-process for its lifetime (up to ~55 min, leaving 5 min safety margin).
-- [ ] 2.3.a Write failing test for `getItem(id, projection)` — uses the cached access token; returns normalized `{ id, draft, published, reviewState, rawResponse }` on 2xx; throws typed `CwsAuthError` on 401/403, `CwsStateError` on other 4xx/5xx.
-- [ ] 2.3.b Implement `getItem(id, projection)` against `https://www.googleapis.com/chromewebstore/v1.1/items/<id>?projection=<projection>`.
-- [ ] 2.4.a Write failing test asserting typed errors surface stable message prefixes (`[CwsAuthError]`, `[CwsStateError]`, `[CwsTimeoutError]`) — the workflow greps these to decide whether to open the auth-broken issue vs the verification-timeout issue.
-- [ ] 2.4.b Implement the typed error classes.
-- [ ] 2.5 Header comment on `scripts/cws-api.mjs`: `// Requires Node >= 18 (fetch global, crypto.createSign); repo root pins >= 22.12`.
-- [ ] 2.6 `CWS_API_BASE_URL = "https://www.googleapis.com/chromewebstore/v1.1"` as module-level constant. Documented in the helper header as a pragmatic Factor III deviation (single-endpoint service).
-- [ ] 2.7 PEM normalization: the `private_key` field in the service-account JSON contains literal `\n` escape sequences when pasted as a single-line secret. The helper SHALL normalize with `privateKey.replace(/\\n/g, '\n')` before passing to `crypto.createSign`. Document the normalization in the helper header comment; test path in task 4.5.
+- [x] 2.1.a Write failing `node --test` for `signJwt(serviceAccountJson)` — produces an RS256 JWT with `iss == client_email`, `scope == https://www.googleapis.com/auth/chromewebstore`, `aud == https://oauth2.googleapis.com/token`, `iat == now - 60`, `exp == now + 3600`. Verify signature with the public key from the JSON.
+- [x] 2.1.b Implement `signJwt` using `node:crypto.createSign('RSA-SHA256')` — no third-party deps.
+- [x] 2.2.a Write failing test for `mintAccessToken(serviceAccountJson)`: POSTs to `https://oauth2.googleapis.com/token` with `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` and the JWT; returns the 1-hour access token.
+- [x] 2.2.b Implement `mintAccessToken` using `globalThis.fetch`. Cache the token per-process for its lifetime (up to ~55 min, leaving 5 min safety margin).
+- [x] 2.3.a Write failing test for `getItem(id, projection)` — uses the cached access token; returns normalized `{ id, draft, published, reviewState, rawResponse }` on 2xx; throws typed `CwsAuthError` on 401/403, `CwsStateError` on other 4xx/5xx.
+- [x] 2.3.b Implement `getItem(id, projection)` against `https://www.googleapis.com/chromewebstore/v1.1/items/<id>?projection=<projection>`.
+- [x] 2.4.a Write failing test asserting typed errors surface stable message prefixes (`[CwsAuthError]`, `[CwsStateError]`, `[CwsTimeoutError]`) — the workflow greps these to decide whether to open the auth-broken issue vs the verification-timeout issue.
+- [x] 2.4.b Implement the typed error classes.
+- [x] 2.5 Header comment on `scripts/cws-api.mjs`: `// Requires Node >= 18 (fetch global, crypto.createSign); repo root pins >= 22.12`.
+- [x] 2.6 `CWS_API_BASE_URL = "https://www.googleapis.com/chromewebstore/v1.1"` as module-level constant. Documented in the helper header as a pragmatic Factor III deviation (single-endpoint service).
+- [x] 2.7 PEM normalization: the `private_key` field in the service-account JSON contains literal `\n` escape sequences when pasted as a single-line secret. The helper SHALL normalize with `privateKey.replace(/\\n/g, '\n')` before passing to `crypto.createSign`. Document the normalization in the helper header comment; test path in task 4.5.
 
 ## 3. CWS API helper: upload + publish + polling
 
-- [ ] 3.1.a Write failing test for `uploadCrx(id, zipPath)` — PUTs the zip body to `https://www.googleapis.com/upload/chromewebstore/v1.1/items/<id>` with `Content-Type: application/octet-stream`, `x-goog-api-version: 2`. Returns the CWS response `{ id, uploadState, itemError?, crxVersion? }`.
-- [ ] 3.1.b Implement `uploadCrx` via `fetch` with `body: createReadStream(zipPath)` and `duplex: "half"` (Node fetch streaming body requirement).
-- [ ] 3.2.a Write failing test for `publishItem(id, { deployPercentage=100, trustedTesters=false })` — POSTs to `https://www.googleapis.com/chromewebstore/v1.1/items/<id>/publish?publishTarget=<default|trustedTesters>`. Returns `{ status: [string] }`.
-- [ ] 3.2.b Implement `publishItem`.
-- [ ] 3.3.a Write failing test for `pollUntil(predicate, { timeoutMs, intervalMs=2000 })` — returns on first truthy predicate; throws `CwsTimeoutError` after `timeoutMs`.
-- [ ] 3.3.b Implement `pollUntil` as a general helper used by both wait-uploaded and wait-published.
-- [ ] 3.3.c Write failing test for `wait-uploaded` retry-once-on-timeout: first `pollUntil` invocation throws `CwsTimeoutError` (mocked); the `wait-uploaded` helper SHALL catch it and immediately invoke a SECOND `pollUntil` with a fresh 60s window before propagating any failure. Assert exactly two `pollUntil` calls; the second yielding `UPLOADED` exits `wait-uploaded` 0; the second also throwing exits 1 with `CwsTimeoutError`. This retry count is internal to `wait-uploaded` (not configurable from the workflow, not exposed via flags) — distinct from the generic `pollUntil` timeout in 3.3.b.
-- [ ] 3.3.d Implement the retry-once wrapping logic in `wait-uploaded` (NOT in `pollUntil` itself; `pollUntil` stays single-shot). The retry boundary lives in `wait-uploaded` so `wait-published` (no retry policy by spec) can share `pollUntil` without inheriting it.
-- [ ] 3.4.a Write failing test for CLI entry `node scripts/cws-api.mjs <sub> ...` — subcommands: `check`, `state`, `upload`, `publish`, `wait-uploaded`, `wait-published`. Each prints JSON to stdout on success, exits 0; typed errors go to stderr with the stable prefix; exit code 1 for recoverable, 2 for usage errors.
-- [ ] 3.4.b Implement the subcommand dispatcher.
+- [x] 3.1.a Write failing test for `uploadCrx(id, zipPath)` — PUTs the zip body to `https://www.googleapis.com/upload/chromewebstore/v1.1/items/<id>` with `Content-Type: application/octet-stream`, `x-goog-api-version: 2`. Returns the CWS response `{ id, uploadState, itemError?, crxVersion? }`.
+- [x] 3.1.b Implement `uploadCrx` via `fetch` with `body: createReadStream(zipPath)` and `duplex: "half"` (Node fetch streaming body requirement).
+- [x] 3.2.a Write failing test for `publishItem(id, { deployPercentage=100, trustedTesters=false })` — POSTs to `https://www.googleapis.com/chromewebstore/v1.1/items/<id>/publish?publishTarget=<default|trustedTesters>`. Returns `{ status: [string] }`.
+- [x] 3.2.b Implement `publishItem`.
+- [x] 3.3.a Write failing test for `pollUntil(predicate, { timeoutMs, intervalMs=2000 })` — returns on first truthy predicate; throws `CwsTimeoutError` after `timeoutMs`.
+- [x] 3.3.b Implement `pollUntil` as a general helper used by both wait-uploaded and wait-published.
+- [x] 3.3.c Write failing test for `wait-uploaded` retry-once-on-timeout: first `pollUntil` invocation throws `CwsTimeoutError` (mocked); the `wait-uploaded` helper SHALL catch it and immediately invoke a SECOND `pollUntil` with a fresh 60s window before propagating any failure. Assert exactly two `pollUntil` calls; the second yielding `UPLOADED` exits `wait-uploaded` 0; the second also throwing exits 1 with `CwsTimeoutError`. This retry count is internal to `wait-uploaded` (not configurable from the workflow, not exposed via flags) — distinct from the generic `pollUntil` timeout in 3.3.b.
+- [x] 3.3.d Implement the retry-once wrapping logic in `wait-uploaded` (NOT in `pollUntil` itself; `pollUntil` stays single-shot). The retry boundary lives in `wait-uploaded` so `wait-published` (no retry policy by spec) can share `pollUntil` without inheriting it.
+- [x] 3.4.a Write failing test for CLI entry `node scripts/cws-api.mjs <sub> ...` — subcommands: `check`, `state`, `upload`, `publish`, `wait-uploaded`, `wait-published`. Each prints JSON to stdout on success, exits 0; typed errors go to stderr with the stable prefix; exit code 1 for recoverable, 2 for usage errors.
+- [x] 3.4.b Implement the subcommand dispatcher.
 
 ## 4. Test coverage + secret redaction
 
@@ -45,18 +45,18 @@
 - [ ] 4.1.c Redirect-policy sanity check (reduced from full test): single-line assertion that the helper does NOT explicitly set `redirect: 'manual'` or `'error'` on its fetch calls. Node's built-in fetch follows 3xx by default and Google's token/CWS endpoints have no documented redirect behavior on POSTs — a full redirect test would exercise the runtime rather than our code. Reduced scope reclaims implementation time.
 - [ ] 4.1.d Response truncation: mock a 200 with a partial JSON body (e.g., body ends mid-key); helper throws `CwsStateError` with a dedicated message prefix, not `JSON.parse` leaking the raw partial content.
 - [ ] 4.1.e 429 with retry: helper retries once after a 5s backoff on 429; a second 429 surfaces `CwsStateError`. Test asserts exactly two `fetch` calls and a ≥5s wait between them (via mocked timer).
-- [ ] 4.2 Write failing test asserting NO secret value (`private_key`, `access_token`, or any substring ≥32 chars of them) appears in stdout OR stderr across ALL exit paths (success, 401, 403, 429, 5xx, timeout, malformed JSON, JWT sign error). Factor XI complement: GitHub Actions secret-masking only catches exact matches of registered secrets — a JWT payload-segment leak (base64 fragment) would escape the runner's redaction.
-- [ ] 4.2.a Rationale doc-comment: the 32-char threshold is a heuristic chosen so a base64 fragment of the private-key PEM (≥64 chars per line typically) or a JWT header/payload segment (≥80 chars typical) would be caught. A lower threshold over-reports benign prefixes; documented in the test file header.
-- [ ] 4.3 Malformed-input redaction: corrupt `CWS_SERVICE_ACCOUNT_KEY` (invalid JSON), corrupt PEM (valid JSON but unparseable private_key), missing `client_email` field. Helper throws typed errors; test asserts NO key fragment / secret content appears in the error stderr (captured via spawned-process stderr capture).
-- [ ] 4.4 `wait-published` stdout schema: write a failing test for each of the four terminal states (`PUBLISHED`, `IN_REVIEW`, `REJECTED`, `TIMEOUT`); assert stdout parses as `{ status, version, raw }` with the exact `status` string; assert exit code matches spec (0 for PUBLISHED / IN_REVIEW / TIMEOUT; non-zero for REJECTED). The workflow's tag-vs-issue branching reads this schema; any drift here breaks the whole publish logic.
-- [ ] 4.4.a REJECTED fail-fast timing: mock CWS to return REJECTED on the first poll cycle; capture `Date.now()` at `wait-published` invocation and at exit; assert elapsed < 5000 ms. Without this timing bound, an implementation could "pass" the REJECTED scenario by polling out the full timeout and reporting REJECTED at the end — defeating the fail-fast intent in the spec.
-- [ ] 4.5 PEM normalization: helper accepts both raw-PEM (`-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----`) and escaped-PEM (`-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----`, as pasted into a single-line secret). Test both variants sign an identical JWT; test a triple-escaped variant (`\\\\n`) throws `CwsAuthError` without leaking the PEM. Idempotency: calling the normalizer twice on the same input produces the same output (guards against future regressions if a different secret format is introduced).
+- [x] 4.2 Write failing test asserting NO secret value (`private_key`, `access_token`, or any substring ≥32 chars of them) appears in stdout OR stderr across ALL exit paths (success, 401, 403, 429, 5xx, timeout, malformed JSON, JWT sign error). Factor XI complement: GitHub Actions secret-masking only catches exact matches of registered secrets — a JWT payload-segment leak (base64 fragment) would escape the runner's redaction.
+- [x] 4.2.a Rationale doc-comment: the 32-char threshold is a heuristic chosen so a base64 fragment of the private-key PEM (≥64 chars per line typically) or a JWT header/payload segment (≥80 chars typical) would be caught. A lower threshold over-reports benign prefixes; documented in the test file header.
+- [x] 4.3 Malformed-input redaction: corrupt `CWS_SERVICE_ACCOUNT_KEY` (invalid JSON), corrupt PEM (valid JSON but unparseable private_key), missing `client_email` field. Helper throws typed errors; test asserts NO key fragment / secret content appears in the error stderr (captured via spawned-process stderr capture).
+- [x] 4.4 `wait-published` stdout schema: write a failing test for each of the four terminal states (`PUBLISHED`, `IN_REVIEW`, `REJECTED`, `TIMEOUT`); assert stdout parses as `{ status, version, raw }` with the exact `status` string; assert exit code matches spec (0 for PUBLISHED / IN_REVIEW / TIMEOUT; non-zero for REJECTED). The workflow's tag-vs-issue branching reads this schema; any drift here breaks the whole publish logic.
+- [x] 4.4.a REJECTED fail-fast timing: mock CWS to return REJECTED on the first poll cycle; capture `Date.now()` at `wait-published` invocation and at exit; assert elapsed < 5000 ms. Without this timing bound, an implementation could "pass" the REJECTED scenario by polling out the full timeout and reporting REJECTED at the end — defeating the fail-fast intent in the spec.
+- [x] 4.5 PEM normalization: helper accepts both raw-PEM (`-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----`) and escaped-PEM (`-----BEGIN PRIVATE KEY-----\\n...\\n-----END PRIVATE KEY-----`, as pasted into a single-line secret). Test both variants sign an identical JWT; test a triple-escaped variant (`\\\\n`) throws `CwsAuthError` without leaking the PEM. Idempotency: calling the normalizer twice on the same input produces the same output (guards against future regressions if a different secret format is introduced).
 - [ ] 4.6 Manual verification from a local checkout with `CWS_SERVICE_ACCOUNT_KEY` in the shell env: run each subcommand against the real CWS API; confirm output formats and exit codes.
 
 ## 5. Rewrite `cws-publish.yml`
 
-- [ ] 5.1 Remove `chrome-webstore-upload-cli` from root `package.json` `devDependencies` (verified location via grep — it's a single root-level entry, NOT per-extension). Run `pnpm install` to prune the lockfile and `node_modules` monorepo-wide.
-- [ ] 5.2 Rewrite `.github/workflows/cws-publish.yml`:
+- [x] 5.1 Remove `chrome-webstore-upload-cli` from root `package.json` `devDependencies` (verified location via grep — it's a single root-level entry, NOT per-extension). Run `pnpm install` to prune the lockfile and `node_modules` monorepo-wide.
+- [x] 5.2 Rewrite `.github/workflows/cws-publish.yml`:
   - New `pre-flight` job: single step `node scripts/cws-api.mjs check $CWS_EXTENSION_ID`. Environment: `CWS_SERVICE_ACCOUNT_KEY`. On failure, run `scripts/cws-notify-issue.mjs cws-auth-broken` and fail.
   - Add `publish` matrix `needs: pre-flight`.
   - Add `workflow_dispatch` input `force_upload: boolean (default false)`.
@@ -70,21 +70,21 @@
     7. **Wait-published**: `node scripts/cws-api.mjs wait-published <id> --version <current> --timeout-ms 120000`. On success: tag. On IN_REVIEW or timeout: open `cws-publish-verification-timeout` issue scoped per-extension per-version and exit 0.
     8. **Git tag** (only on true PUBLISHED): `git tag @kaiord/<ext>@<version> && git push origin @kaiord/<ext>@<version>`.
     9. **Mid-flight auth failure handler** — wrap steps 3–7 (state query / upload / wait-uploaded / publish / wait-published) in `if: failure()` branching that greps stderr for the `[CwsAuthError]` stable prefix and routes to `node scripts/cws-notify-issue.mjs cws-auth-broken` (same label as pre-flight). This covers the spec scenario "Credential revoked mid-flight" — pre-flight succeeded at T+0 but the service-account linkage was revoked mid-run. Without this wrapper, the helper correctly throws but the workflow never opens the tracking issue at the symptom's actual detection point. Task 10.8 (destructive test) is extended to cover this path: revoke-then-sleep-then-unlink between pre-flight and upload.
-- [ ] 5.3 Keep `fail-fast: false`, `concurrency: ${{ github.workflow }}-${{ github.ref }}`.
-- [ ] 5.3.a Add a YAML comment in `cws-publish.yml` above the `workflow_dispatch` input block: `# inputs.force_upload is false on push events; always check explicitly rather than relying on undefined.` — saves future maintainers 10 min of wondering why the first expression didn't short-circuit.
-- [ ] 5.4 Remove all references to `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN` in the workflow.
+- [x] 5.3 Keep `fail-fast: false`, `concurrency: ${{ github.workflow }}-${{ github.ref }}`.
+- [x] 5.3.a Add a YAML comment in `cws-publish.yml` above the `workflow_dispatch` input block: `# inputs.force_upload is false on push events; always check explicitly rather than relying on undefined.` — saves future maintainers 10 min of wondering why the first expression didn't short-circuit.
+- [x] 5.4 Remove all references to `CWS_CLIENT_ID`, `CWS_CLIENT_SECRET`, `CWS_REFRESH_TOKEN` in the workflow.
 - [ ] 5.5 `actionlint` passes on the rewritten workflow.
 
 ## 6. Issue notification helper
 
-- [ ] 6.1.a Write failing test for `scripts/cws-notify-issue.mjs <label> [<title-suffix>]`: searches existing open issues by EXACT title match (built from label + optional suffix), bumps via comment if present, creates if absent. Returns the issue number.
-- [ ] 6.1.b Implement the helper using `gh api repos/:owner/:repo/issues` — single call to search by title, single call to create or comment.
-- [ ] 6.2 Title conventions — scoped so distinct logical states get distinct titles (enables exact-title idempotency):
+- [x] 6.1.a Write failing test for `scripts/cws-notify-issue.mjs <label> [<title-suffix>]`: searches existing open issues by EXACT title match (built from label + optional suffix), bumps via comment if present, creates if absent. Returns the issue number.
+- [x] 6.1.b Implement the helper using `gh api repos/:owner/:repo/issues` — single call to search by title, single call to create or comment.
+- [x] 6.2 Title conventions — scoped so distinct logical states get distinct titles (enables exact-title idempotency):
   - `cws-auth-broken` → `"CWS authentication broken"` (singleton; one open at a time, bumped on re-detection).
   - `cws-publish-verification-timeout` → `"CWS publish stalled: @kaiord/<ext>@<version>"` (per-extension per-version; each stuck release is a distinct issue).
   - `cws-publish-rejected` → `"CWS publish rejected: @kaiord/<ext>@<version>"` (per-extension per-version; each rejection is a distinct issue with the `itemError` payload).
-- [ ] 6.3 Add `scripts/cws-notify-issue.test.mjs` to `test:scripts`. Cover: no existing issue → creates; existing open issue → bumps (comment added, no duplicate); existing closed issue with same title → creates new; two concurrent invocations against the same title → the one that creates first wins, the second sees the existing issue on its read and bumps instead of duplicating.
-- [ ] 6.4 **Honest TOCTOU story** (see design.md Decision 7). Two layers:
+- [x] 6.3 Add `scripts/cws-notify-issue.test.mjs` to `test:scripts`. Cover: no existing issue → creates; existing open issue → bumps (comment added, no duplicate); existing closed issue with same title → creates new; two concurrent invocations against the same title → the one that creates first wins, the second sees the existing issue on its read and bumps instead of duplicating.
+- [x] 6.4 **Honest TOCTOU story** (see design.md Decision 7). Two layers:
   - **Layer A — primary**: `cws-notify-issue.mjs` uses exact-title read-then-write with per-extension per-version scoping. Two matrix jobs in the same run writing to distinct titles (different versions) never collide. Two writers targeting the same title are bounded by read-then-write — not perfectly race-free, but self-healing within the next invocation.
   - **Layer B — defense-in-depth for cross-run races**: add `concurrency: { group: cws-issue-writer, cancel-in-progress: false }` **at the JOB LEVEL** on the `pre-flight` job AND any job that calls `cws-notify-issue.mjs` (upload-publish matrix entries). Syntax: `jobs.<job-id>.concurrency:`, NOT a second workflow-level `concurrency:` block — the workflow already has `concurrency: ${{ github.workflow }}-${{ github.ref }}` at the top level (spec.md mandates this for push-vs-push runs) and a second top-level block would be illegal YAML. The job-level group serializes ACROSS workflow runs that are otherwise unrelated (e.g., `workflow_dispatch` vs push-triggered). It does NOT serialize matrix jobs within one run — document this explicitly in a YAML comment.
   - `actionlint` MUST pass on the final workflow (task 5.5): two concurrency blocks at different scopes coexisting is valid YAML; a second workflow-level block is not.
@@ -92,20 +92,20 @@
 
 ## 7. Issue templates
 
-- [ ] 7.1 `.github/ISSUE_TEMPLATE/cws-auth-broken.md`: title prefill `CWS authentication broken`, labels `cws-auth-broken`, assignees `pablo-albaladejo`. Body: observed error, link to runbook, checklist (rotate key via Google Cloud → update `CWS_SERVICE_ACCOUNT_KEY` → re-run pre-flight via `workflow_dispatch` → close issue).
-- [ ] 7.2 `.github/ISSUE_TEMPLATE/cws-publish-verification-timeout.md`: title template `CWS publish stalled: @kaiord/<ext>@<version>`, labels `cws-publish-verification-timeout`. Body: last CWS state payload, link to CWS Developer Dashboard, note that `IN_REVIEW` is usually fine and self-resolves.
-- [ ] 7.3 `.github/ISSUE_TEMPLATE/cws-publish-rejected.md`: title template `CWS publish rejected: @kaiord/<ext>@<version>`, labels `cws-publish-rejected`, assignees `pablo-albaladejo`. Body: full `itemError` payload from CWS, link to Chrome Web Store item-error reference docs, link to runbook's "Emergency re-publish" section (after fixing the underlying issue, a `force_upload: true` re-run is often the fix), checklist (review `itemError` → address root cause in extension code or manifest → bump version or force-upload → close issue).
+- [x] 7.1 `.github/ISSUE_TEMPLATE/cws-auth-broken.md`: title prefill `CWS authentication broken`, labels `cws-auth-broken`, assignees `pablo-albaladejo`. Body: observed error, link to runbook, checklist (rotate key via Google Cloud → update `CWS_SERVICE_ACCOUNT_KEY` → re-run pre-flight via `workflow_dispatch` → close issue).
+- [x] 7.2 `.github/ISSUE_TEMPLATE/cws-publish-verification-timeout.md`: title template `CWS publish stalled: @kaiord/<ext>@<version>`, labels `cws-publish-verification-timeout`. Body: last CWS state payload, link to CWS Developer Dashboard, note that `IN_REVIEW` is usually fine and self-resolves.
+- [x] 7.3 `.github/ISSUE_TEMPLATE/cws-publish-rejected.md`: title template `CWS publish rejected: @kaiord/<ext>@<version>`, labels `cws-publish-rejected`, assignees `pablo-albaladejo`. Body: full `itemError` payload from CWS, link to Chrome Web Store item-error reference docs, link to runbook's "Emergency re-publish" section (after fixing the underlying issue, a `force_upload: true` re-run is often the fix), checklist (review `itemError` → address root cause in extension code or manifest → bump version or force-upload → close issue).
 
 ## 8. Runbook
 
-- [ ] 8.1 Create `docs/runbooks/cws-service-account.md` with sections:
+- [x] 8.1 Create `docs/runbooks/cws-service-account.md` with sections:
   - **One-time setup** (mirrors task 1.x with screenshots or step-by-step clickpaths where Chrome Web Store UI is involved).
   - **Key rotation** (optional, security best practice): generate new key → update secret → trigger `workflow_dispatch` pre-flight to verify → revoke old key. Timeline suggestion: annual or on any security event.
   - **Emergency re-publish**: Actions → "CWS Publish" → Run workflow → `force_upload: true` → Run. Note: `force_upload` BYPASSES the idempotency guard; only use when the shipped CRX is known-bad. **DO NOT wire `force_upload: true` into another workflow (`release.yml`, `retry.yml`, etc.) as a default input** — it is a human-gated emergency override, not a knob for automation. If an upstream workflow needs to call CWS Publish, do so without `force_upload` and let the idempotency guard work.
   - **Setup time expectations**: ≤15 minutes in the happy path (existing GCP project, no org policy restrictions). Cold-start with first-time GCP project + OAuth consent-screen configuration + occasional IAM-propagation delays can reach ~45 minutes. Plan accordingly.
   - **Compromised-key response**: revoke the JSON key in Google Cloud Console IMMEDIATELY (does not require waiting to generate replacement); this will cause pre-flight to fail and open `cws-auth-broken`; then generate new key, update secret, audit CWS Developer Dashboard for unauthorized item submissions in the last N days.
   - **What this replaces**: a brief note that the repo used to use OAuth user-delegated refresh tokens (`CWS_CLIENT_ID` / `CWS_CLIENT_SECRET` / `CWS_REFRESH_TOKEN`). These secrets are no longer consulted; remove them from the repo Secrets screen after confirming the new flow works end-to-end.
-- [ ] 8.2 Reference the runbook from `AGENTS.md` under a "Runbooks" index section (create section if absent).
+- [x] 8.2 Reference the runbook from `AGENTS.md` under a "Runbooks" index section (create section if absent).
 - [ ] 8.3 Self-dogfood: the maintainer does tasks 1.x while following the runbook and updates any step that required off-runbook knowledge.
 
 ## 9. Decommission OAuth auth
@@ -128,7 +128,7 @@
 
 ## 11. Documentation + archive
 
-- [ ] 11.1 Update `AGENTS.md` section on CWS publish pipeline if present — note the service-account migration at a high level.
+- [x] 11.1 Update `AGENTS.md` section on CWS publish pipeline if present — note the service-account migration at a high level.
 - [ ] 11.2 Update `openspec/specs/cws-auto-publish/spec.md` via `opsx-archive` after PR merge — the delta in this change modifies the existing capability.
 - [ ] 11.3 Run `/opsx-verify harden-cws-publish` and resolve any spec-vs-implementation mismatches.
 - [ ] 11.4 After PR merge, run `/opsx-archive harden-cws-publish`.

--- a/openspec/specs/analytics-port/spec.md
+++ b/openspec/specs/analytics-port/spec.md
@@ -6,6 +6,10 @@
 **Status:** Active
 **Packages:** `@kaiord/core`, `@kaiord/landing`, `@kaiord/workout-spa-editor`
 
+## Purpose
+
+Provide a hexagonal-architecture-conformant analytics seam: a single `Analytics` port in `@kaiord/core` consumed by client apps, with concrete adapters (Cloudflare Web Analytics today; alternatives in the future) injected at the application boundary. No adapter-specific imports leak into domain or application layers.
+
 ## Overview
 
 A lightweight, injectable analytics abstraction that follows the hexagonal architecture pattern. The `Analytics` port is defined in core (no external dependencies), with a noop default adapter and a Cloudflare Web Analytics adapter in each consumer package.

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "@resvg/resvg-js": "^2.6.2",
     "@size-limit/file": "^12.1.0",
     "@types/node": "^25.6.0",
-    "chrome-webstore-upload-cli": "^3.5.0",
     "dependency-cruiser": "^17.0.0",
     "eslint": "^10.2.1",
     "eslint-plugin-boundaries": "^6.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,9 +52,6 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
-      chrome-webstore-upload-cli:
-        specifier: ^3.5.0
-        version: 3.5.0
       dependency-cruiser:
         specifier: ^17.0.0
         version: 17.3.10
@@ -4087,9 +4084,6 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
-
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -4175,15 +4169,6 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
-
-  chrome-webstore-upload-cli@3.5.0:
-    resolution: {integrity: sha512-cojgwXDLK+TbeUh8Ll+H33njdCtBPY3pmf2Y5++HWZwlsrmTaW9I8mQz7FS3N57qv/8Woz5TY+SwiUjFtKwsnA==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  chrome-webstore-upload@3.2.0:
-    resolution: {integrity: sha512-ghFzqGFpPzEvDfam7qzokj07KsPn39fOdoj9KwqgQdjcHpFCJ1/wnKi2IHP6zCcHKWEBv9vI7VVbllbDRnypXw==}
-    engines: {node: '>=18'}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -5332,10 +5317,6 @@ packages:
   jstransformer@1.0.0:
     resolution: {integrity: sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==}
 
-  junk@4.0.1:
-    resolution: {integrity: sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==}
-    engines: {node: '>=12.20'}
-
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
@@ -5581,10 +5562,6 @@ packages:
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
-
-  meow@12.1.1:
-    resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
-    engines: {node: '>=16.10'}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -6217,10 +6194,6 @@ packages:
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
-
-  recursive-readdir@2.2.3:
-    resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
-    engines: {node: '>=6.0.0'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -7255,9 +7228,6 @@ packages:
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
-
-  yazl@2.5.1:
-    resolution: {integrity: sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -10407,8 +10377,6 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
-  buffer-crc32@0.2.13: {}
-
   buffer-from@1.1.2:
     optional: true
 
@@ -10485,16 +10453,6 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
-
-  chrome-webstore-upload-cli@3.5.0:
-    dependencies:
-      chrome-webstore-upload: 3.2.0
-      junk: 4.0.1
-      meow: 12.1.1
-      recursive-readdir: 2.2.3
-      yazl: 2.5.1
-
-  chrome-webstore-upload@3.2.0: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -11776,8 +11734,6 @@ snapshots:
       is-promise: 2.2.2
       promise: 7.3.1
 
-  junk@4.0.1: {}
-
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
@@ -12103,8 +12059,6 @@ snapshots:
   mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
-
-  meow@12.1.1: {}
 
   merge-descriptors@2.0.0: {}
 
@@ -12871,10 +12825,6 @@ snapshots:
   rechoir@0.8.0:
     dependencies:
       resolve: 1.22.12
-
-  recursive-readdir@2.2.3:
-    dependencies:
-      minimatch: 10.2.5
 
   redent@3.0.0:
     dependencies:
@@ -14083,10 +14033,6 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
-
-  yazl@2.5.1:
-    dependencies:
-      buffer-crc32: 0.2.13
 
   yocto-queue@0.1.0: {}
 

--- a/scripts/cws-api.mjs
+++ b/scripts/cws-api.mjs
@@ -29,7 +29,7 @@ export async function main(argv = process.argv.slice(2), env = process.env) {
   const keyJson = env.CWS_SERVICE_ACCOUNT_KEY;
   if (!keyJson) {
     process.stderr.write(
-      "[CwsAuthError] CWS_SERVICE_ACCOUNT_KEY environment variable not set\n",
+      "[CwsAuthError] CWS_SERVICE_ACCOUNT_KEY environment variable not set\n"
     );
     return 2;
   }
@@ -58,7 +58,7 @@ function printUsage() {
       "  wait-uploaded --timeout-ms <N>",
       "  wait-published --version <V> --timeout-ms <N>",
       "",
-    ].join("\n"),
+    ].join("\n")
   );
 }
 
@@ -72,6 +72,6 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
       const safe = msg.startsWith("[Cws") ? msg : `[CwsStateError] ${msg}`;
       process.stderr.write(safe + "\n");
       process.exit(1);
-    },
+    }
   );
 }

--- a/scripts/cws-api.mjs
+++ b/scripts/cws-api.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// CWS API helper — service-account auth + upload/publish/state via REST.
+//
+// Requires Node >= 18 (fetch global, crypto.createSign); repo root pins
+// >= 22.12 via engines.node. No third-party dependencies.
+//
+// CWS_API_BASE_URL is hardcoded as a module-level constant (Factor III
+// pragmatic deviation): there is only one Chrome Web Store endpoint
+// globally; no staging tier exists. If Google ever ships an alternate,
+// extract to env var with the current value as default.
+//
+// Subcommands print JSON to stdout on success (parseable by workflow
+// steps via jq); typed errors go to stderr with stable prefixes
+// ([CwsAuthError], [CwsStateError], [CwsTimeoutError]). Exit codes:
+//   0 success
+//   1 recoverable error (open tracking issue)
+//   2 usage error
+
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parseServiceAccountJson } from "./cws-api/auth.mjs";
+import { dispatch } from "./cws-api/cli.mjs";
+
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  if (argv.length === 0 || argv.includes("--help") || argv[0] === "-h") {
+    printUsage();
+    return 2;
+  }
+
+  const keyJson = env.CWS_SERVICE_ACCOUNT_KEY;
+  if (!keyJson) {
+    process.stderr.write(
+      "[CwsAuthError] CWS_SERVICE_ACCOUNT_KEY environment variable not set\n",
+    );
+    return 2;
+  }
+
+  let serviceAccount;
+  try {
+    serviceAccount = parseServiceAccountJson(keyJson);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    return 2;
+  }
+
+  return dispatch(argv, serviceAccount);
+}
+
+function printUsage() {
+  process.stderr.write(
+    [
+      "Usage: cws-api.mjs <subcommand> <extension-id> [flags]",
+      "",
+      "Subcommands:",
+      "  check          fail-fast auth + access verification",
+      "  state          print current CWS state JSON",
+      "  upload --source <zip-path>",
+      "  publish        publish the uploaded draft",
+      "  wait-uploaded --timeout-ms <N>",
+      "  wait-published --version <V> --timeout-ms <N>",
+      "",
+    ].join("\n"),
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().then(
+    (code) => process.exit(code),
+    (err) => {
+      // Helper-thrown errors already include stable prefixes; runtime
+      // errors are unlikely but redact them defensively.
+      const msg = err?.message ?? "unknown error";
+      const safe = msg.startsWith("[Cws") ? msg : `[CwsStateError] ${msg}`;
+      process.stderr.write(safe + "\n");
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/cws-api.test.mjs
+++ b/scripts/cws-api.test.mjs
@@ -1,0 +1,666 @@
+// Tests for scripts/cws-api.mjs and its submodules.
+//
+// All fetches are mocked via globalThis.fetch = (...args) => ...
+// The 32-char redaction threshold (task 4.2.a rationale): we assert no
+// substring ≥32 chars of any secret value (private key body, access
+// token, JWT) appears in stdout/stderr. 32 is below the typical PEM
+// base64 line (≥64 chars) and below typical JWT segment lengths
+// (≥80 chars), so any leak via partial decode is caught; lower
+// thresholds over-report benign prefixes.
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { strictEqual, deepStrictEqual, ok } from "node:assert";
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  signJwt,
+  mintAccessToken,
+  parseServiceAccountJson,
+  normalizePrivateKey,
+  _resetCache,
+} from "./cws-api/auth.mjs";
+import { getItem } from "./cws-api/state.mjs";
+import { uploadCrx } from "./cws-api/upload.mjs";
+import { publishItem } from "./cws-api/publish.mjs";
+import { pollUntil, waitUploaded, waitPublished } from "./cws-api/poll.mjs";
+import { dispatch } from "./cws-api/cli.mjs";
+import {
+  CwsAuthError,
+  CwsStateError,
+  CwsTimeoutError,
+} from "./cws-api/errors.mjs";
+
+// ---------- Fixtures ----------
+
+function makeKey() {
+  const { privateKey, publicKey } = generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+  });
+  return {
+    pem: privateKey.export({ format: "pem", type: "pkcs8" }).toString(),
+    publicPem: publicKey.export({ format: "pem", type: "spki" }).toString(),
+  };
+}
+
+function makeAccount(privateKey) {
+  return {
+    type: "service_account",
+    project_id: "kaiord-test",
+    client_email: "kaiord-cws@kaiord-test.iam.gserviceaccount.com",
+    private_key: privateKey,
+    token_uri: "https://oauth2.googleapis.com/token",
+  };
+}
+
+function withMockFetch(impl, fn) {
+  const original = globalThis.fetch;
+  globalThis.fetch = impl;
+  return Promise.resolve(fn()).finally(() => {
+    globalThis.fetch = original;
+  });
+}
+
+function makeResponse({ status = 200, body = {}, raw }) {
+  const text = raw ?? JSON.stringify(body);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => text,
+    json: async () => JSON.parse(text),
+  };
+}
+
+beforeEach(() => _resetCache());
+
+// ---------- signJwt + auth ----------
+
+describe("signJwt", () => {
+  it("produces JWT with required claims", () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    const now = 1_700_000_000_000;
+
+    const jwt = signJwt(account, now);
+
+    const [headerSeg, payloadSeg] = jwt.split(".");
+    const header = JSON.parse(Buffer.from(headerSeg, "base64url").toString());
+    const payload = JSON.parse(Buffer.from(payloadSeg, "base64url").toString());
+    strictEqual(header.alg, "RS256");
+    strictEqual(payload.iss, account.client_email);
+    strictEqual(payload.scope, "https://www.googleapis.com/auth/chromewebstore");
+    strictEqual(payload.aud, "https://oauth2.googleapis.com/token");
+    strictEqual(payload.iat, Math.floor(now / 1000) - 60);
+    ok(payload.exp > payload.iat);
+  });
+
+  it("throws CwsAuthError without leaking PEM on signing error", () => {
+    const account = makeAccount("-----BEGIN PRIVATE KEY-----\nNOTABASE64\n-----END PRIVATE KEY-----\n");
+    let caught;
+    try {
+      signJwt(account);
+    } catch (e) {
+      caught = e;
+    }
+    ok(caught instanceof CwsAuthError);
+    ok(!caught.message.includes("NOTABASE64"));
+  });
+});
+
+describe("normalizePrivateKey", () => {
+  it("converts \\\\n escape sequences to real newlines", () => {
+    const escaped = "-----BEGIN-----\\nABCD\\n-----END-----";
+
+    const normalized = normalizePrivateKey(escaped);
+
+    strictEqual(normalized, "-----BEGIN-----\nABCD\n-----END-----");
+  });
+
+  it("is idempotent on already-normalized input", () => {
+    const raw = "-----BEGIN-----\nABCD\n-----END-----";
+
+    const once = normalizePrivateKey(raw);
+    const twice = normalizePrivateKey(once);
+
+    strictEqual(once, twice);
+  });
+});
+
+describe("parseServiceAccountJson", () => {
+  it("rejects malformed JSON without leaking content", () => {
+    let caught;
+    try {
+      parseServiceAccountJson("{ this is not json:: !!");
+    } catch (e) {
+      caught = e;
+    }
+    ok(caught instanceof CwsAuthError);
+    ok(!caught.message.includes("not json"));
+  });
+
+  it("rejects missing client_email", () => {
+    const partial = JSON.stringify({
+      private_key: "x",
+      token_uri: "https://oauth2.googleapis.com/token",
+    });
+    let caught;
+    try {
+      parseServiceAccountJson(partial);
+    } catch (e) {
+      caught = e;
+    }
+    ok(caught instanceof CwsAuthError);
+    ok(caught.message.includes("client_email"));
+  });
+});
+
+describe("mintAccessToken", () => {
+  it("returns access_token on 200 response", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    let calls = 0;
+    await withMockFetch(
+      async () => {
+        calls++;
+        return makeResponse({ body: { access_token: "AT-1", expires_in: 3600 } });
+      },
+      async () => {
+        const token = await mintAccessToken(account);
+        strictEqual(token, "AT-1");
+        strictEqual(calls, 1);
+      },
+    );
+  });
+
+  it("re-uses cached token on subsequent calls within TTL", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    let calls = 0;
+    await withMockFetch(
+      async () => {
+        calls++;
+        return makeResponse({ body: { access_token: "AT-cached" } });
+      },
+      async () => {
+        await mintAccessToken(account, 1_000_000);
+        await mintAccessToken(account, 1_000_001);
+        strictEqual(calls, 1);
+      },
+    );
+  });
+
+  it("mints a new token after >55 min (cache TTL expiry)", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    let calls = 0;
+    await withMockFetch(
+      async () => {
+        calls++;
+        return makeResponse({ body: { access_token: `AT-${calls}` } });
+      },
+      async () => {
+        await mintAccessToken(account, 0);
+        await mintAccessToken(account, 56 * 60 * 1000);
+        strictEqual(calls, 2);
+      },
+    );
+  });
+
+  it("throws CwsAuthError on 401", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    let caught;
+    await withMockFetch(
+      async () => makeResponse({ status: 401, body: { error: "invalid_grant" } }),
+      async () => {
+        try {
+          await mintAccessToken(account);
+        } catch (e) {
+          caught = e;
+        }
+      },
+    );
+    ok(caught instanceof CwsAuthError);
+  });
+});
+
+// ---------- getItem ----------
+
+describe("getItem", () => {
+  it("normalizes 200 response", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        return makeResponse({
+          body: { id: "abc", uploadState: "UPLOADED", crxVersion: "1.0.0" },
+        });
+      },
+      async () => {
+        const item = await getItem(account, "abc", "DRAFT");
+        strictEqual(item.uploadState, "UPLOADED");
+        strictEqual(item.crxVersion, "1.0.0");
+      },
+    );
+  });
+
+  it("throws CwsAuthError on 403", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    let caught;
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        return makeResponse({ status: 403, body: { error: "forbidden" } });
+      },
+      async () => {
+        try {
+          await getItem(account, "abc");
+        } catch (e) {
+          caught = e;
+        }
+      },
+    );
+    ok(caught instanceof CwsAuthError);
+  });
+
+  it("throws CwsStateError on truncated/malformed JSON", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    let caught;
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        return makeResponse({ raw: '{"id":"abc","uploadState":"UPLO' }); // truncated
+      },
+      async () => {
+        try {
+          await getItem(account, "abc");
+        } catch (e) {
+          caught = e;
+        }
+      },
+    );
+    ok(caught instanceof CwsStateError);
+  });
+
+  it("throws CwsStateError on 5xx", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    let caught;
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        return makeResponse({ status: 503 });
+      },
+      async () => {
+        try {
+          await getItem(account, "abc");
+        } catch (e) {
+          caught = e;
+        }
+      },
+    );
+    ok(caught instanceof CwsStateError);
+  });
+});
+
+// ---------- uploadCrx ----------
+
+describe("uploadCrx", () => {
+  let tempDir;
+  let zipPath;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "cws-upload-"));
+    zipPath = join(tempDir, "fixture.zip");
+    writeFileSync(zipPath, Buffer.from("PKfake zip body"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns parsed CWS response on 200", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    await withMockFetch(
+      async (url, options) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        if (options?.body && typeof options.body.on === "function") {
+          await new Promise((resolve, reject) => {
+            options.body.on("data", () => {});
+            options.body.on("end", resolve);
+            options.body.on("error", reject);
+          });
+        }
+        return makeResponse({
+          body: { id: "abc", uploadState: "SUCCESS", crxVersion: "1.0.0" },
+        });
+      },
+      async () => {
+        const result = await uploadCrx(account, "abc", zipPath);
+        strictEqual(result.uploadState, "SUCCESS");
+      },
+    );
+  });
+});
+
+// ---------- publishItem ----------
+
+describe("publishItem", () => {
+  it("returns status array on 200", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        return makeResponse({ body: { status: ["OK"] } });
+      },
+      async () => {
+        const result = await publishItem(account, "abc");
+        deepStrictEqual(result.status, ["OK"]);
+      },
+    );
+  });
+
+  it("throws CwsStateError on 409 conflict", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    let caught;
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        return makeResponse({ status: 409, body: { error: "conflict" } });
+      },
+      async () => {
+        try {
+          await publishItem(account, "abc");
+        } catch (e) {
+          caught = e;
+        }
+      },
+    );
+    ok(caught instanceof CwsStateError);
+  });
+});
+
+// ---------- pollUntil ----------
+
+describe("pollUntil", () => {
+  it("returns on first truthy predicate", async () => {
+    let n = 0;
+    const result = await pollUntil(
+      async () => (++n === 2 ? "got it" : null),
+      { timeoutMs: 1000, intervalMs: 1, sleep: async () => {} },
+    );
+    strictEqual(result, "got it");
+  });
+
+  it("throws CwsTimeoutError on deadline exceeded", async () => {
+    let caught;
+    let nowVal = 0;
+    try {
+      await pollUntil(async () => null, {
+        timeoutMs: 100,
+        intervalMs: 50,
+        sleep: async (ms) => {
+          nowVal += ms;
+        },
+        now: () => nowVal,
+      });
+    } catch (e) {
+      caught = e;
+    }
+    ok(caught instanceof CwsTimeoutError);
+  });
+});
+
+// ---------- waitUploaded retry-once ----------
+
+describe("waitUploaded", () => {
+  it("retries pollUntil once after CwsTimeoutError, succeeds on second", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    let calls = 0;
+    let nowVal = 0;
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        calls++;
+        // Calls 1-2 (first pollUntil): IN_PROGRESS → first pollUntil times out.
+        // Call 3+ (second pollUntil = retry): SUCCESS → returns.
+        const uploadState = calls < 3 ? "IN_PROGRESS" : "SUCCESS";
+        return makeResponse({ body: { id: "abc", uploadState } });
+      },
+      async () => {
+        const result = await waitUploaded(account, "abc", {
+          timeoutMs: 50,
+          sleep: async (ms) => {
+            nowVal += ms;
+          },
+          now: () => nowVal,
+        });
+        strictEqual(result.uploadState, "SUCCESS");
+        ok(calls >= 2, `expected at least 2 calls (retry); got ${calls}`);
+      },
+    );
+  });
+});
+
+// ---------- waitPublished ----------
+
+describe("waitPublished", () => {
+  it("returns PUBLISHED status on matching version", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        return makeResponse({
+          body: { id: "abc", uploadState: "PUBLISHED", crxVersion: "1.0.0" },
+        });
+      },
+      async () => {
+        const result = await waitPublished(account, "abc", {
+          version: "1.0.0",
+          timeoutMs: 5000,
+          sleep: async () => {},
+        });
+        strictEqual(result.status, "PUBLISHED");
+        strictEqual(result.version, "1.0.0");
+      },
+    );
+  });
+
+  it("returns IN_REVIEW status when CWS reports IN_REVIEW", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        return makeResponse({ body: { id: "abc", uploadState: "IN_REVIEW" } });
+      },
+      async () => {
+        const result = await waitPublished(account, "abc", {
+          version: "1.0.0",
+          timeoutMs: 5000,
+          sleep: async () => {},
+        });
+        strictEqual(result.status, "IN_REVIEW");
+      },
+    );
+  });
+
+  it("returns REJECTED fail-fast (<5s) when CWS reports rejection", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        return makeResponse({
+          body: {
+            id: "abc",
+            uploadState: "FAILURE",
+            itemError: [{ error_code: "ITEM_REJECTED" }],
+          },
+        });
+      },
+      async () => {
+        const start = Date.now();
+        const result = await waitPublished(account, "abc", {
+          version: "1.0.0",
+          timeoutMs: 120000,
+          sleep: async () => {},
+        });
+        const elapsed = Date.now() - start;
+        strictEqual(result.status, "REJECTED");
+        ok(elapsed < 5000, `elapsed=${elapsed}ms; expected <5000`);
+      },
+    );
+  });
+
+  it("returns TIMEOUT when no terminal state reached", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    let nowVal = 0;
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        return makeResponse({ body: { id: "abc", uploadState: "PROCESSING" } });
+      },
+      async () => {
+        const result = await waitPublished(account, "abc", {
+          version: "1.0.0",
+          timeoutMs: 50,
+          sleep: async (ms) => {
+            nowVal += ms;
+          },
+          now: () => nowVal,
+        });
+        strictEqual(result.status, "TIMEOUT");
+      },
+    );
+  });
+});
+
+// ---------- CLI dispatch ----------
+
+describe("dispatch (CLI)", () => {
+  it("returns exit 2 for unknown subcommand", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    const stderrChunks = [];
+    const origWrite = process.stderr.write;
+    process.stderr.write = (chunk) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    };
+    let code;
+    try {
+      code = await dispatch(["bogus", "abc"], account);
+    } finally {
+      process.stderr.write = origWrite;
+    }
+    strictEqual(code, 2);
+  });
+
+  it("runs check subcommand and prints JSON", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    const stdoutChunks = [];
+    const origWrite = process.stdout.write;
+    process.stdout.write = (chunk) => {
+      stdoutChunks.push(String(chunk));
+      return true;
+    };
+    let code;
+    try {
+      await withMockFetch(
+        async (url) => {
+          if (url.includes("oauth2.googleapis.com")) {
+            return makeResponse({ body: { access_token: "AT" } });
+          }
+          return makeResponse({ body: { id: "abc", uploadState: "UPLOADED" } });
+        },
+        async () => {
+          code = await dispatch(["check", "abc"], account);
+        },
+      );
+    } finally {
+      process.stdout.write = origWrite;
+    }
+    strictEqual(code, 0);
+    const text = stdoutChunks.join("");
+    ok(text.length > 0);
+    const parsed = JSON.parse(text);
+    strictEqual(parsed.uploadState, "UPLOADED");
+  });
+});
+
+// ---------- Secret redaction (Factor XI complement) ----------
+
+describe("secret redaction", () => {
+  it("does not leak access_token or PEM body in error stderr", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    const accessToken = "ya29." + "a".repeat(80);
+    const stderrChunks = [];
+    const origWrite = process.stderr.write;
+    process.stderr.write = (chunk) => {
+      stderrChunks.push(String(chunk));
+      return true;
+    };
+    try {
+      await withMockFetch(
+        async (url) => {
+          if (url.includes("oauth2.googleapis.com")) {
+            return makeResponse({ body: { access_token: accessToken } });
+          }
+          return makeResponse({ status: 401 });
+        },
+        async () => {
+          await dispatch(["check", "abc"], account);
+        },
+      );
+    } finally {
+      process.stderr.write = origWrite;
+    }
+    const stderr = stderrChunks.join("");
+    // No 32+ char substring of the access token or PEM body should appear.
+    const tokenSlice = accessToken.slice(0, 32);
+    const pemBodyMatch = pem.match(/-----BEGIN PRIVATE KEY-----\n([\s\S]+?)\n-----END/);
+    const pemSlice = pemBodyMatch ? pemBodyMatch[1].slice(0, 32) : "";
+    ok(!stderr.includes(tokenSlice));
+    if (pemSlice.length === 32) {
+      ok(!stderr.includes(pemSlice));
+    }
+  });
+});

--- a/scripts/cws-api.test.mjs
+++ b/scripts/cws-api.test.mjs
@@ -90,14 +90,19 @@ describe("signJwt", () => {
     const payload = JSON.parse(Buffer.from(payloadSeg, "base64url").toString());
     strictEqual(header.alg, "RS256");
     strictEqual(payload.iss, account.client_email);
-    strictEqual(payload.scope, "https://www.googleapis.com/auth/chromewebstore");
+    strictEqual(
+      payload.scope,
+      "https://www.googleapis.com/auth/chromewebstore"
+    );
     strictEqual(payload.aud, "https://oauth2.googleapis.com/token");
     strictEqual(payload.iat, Math.floor(now / 1000) - 60);
     ok(payload.exp > payload.iat);
   });
 
   it("throws CwsAuthError without leaking PEM on signing error", () => {
-    const account = makeAccount("-----BEGIN PRIVATE KEY-----\nNOTABASE64\n-----END PRIVATE KEY-----\n");
+    const account = makeAccount(
+      "-----BEGIN PRIVATE KEY-----\nNOTABASE64\n-----END PRIVATE KEY-----\n"
+    );
     let caught;
     try {
       signJwt(account);
@@ -164,13 +169,15 @@ describe("mintAccessToken", () => {
     await withMockFetch(
       async () => {
         calls++;
-        return makeResponse({ body: { access_token: "AT-1", expires_in: 3600 } });
+        return makeResponse({
+          body: { access_token: "AT-1", expires_in: 3600 },
+        });
       },
       async () => {
         const token = await mintAccessToken(account);
         strictEqual(token, "AT-1");
         strictEqual(calls, 1);
-      },
+      }
     );
   });
 
@@ -187,7 +194,7 @@ describe("mintAccessToken", () => {
         await mintAccessToken(account, 1_000_000);
         await mintAccessToken(account, 1_000_001);
         strictEqual(calls, 1);
-      },
+      }
     );
   });
 
@@ -204,7 +211,7 @@ describe("mintAccessToken", () => {
         await mintAccessToken(account, 0);
         await mintAccessToken(account, 56 * 60 * 1000);
         strictEqual(calls, 2);
-      },
+      }
     );
   });
 
@@ -213,14 +220,15 @@ describe("mintAccessToken", () => {
     const account = makeAccount(pem);
     let caught;
     await withMockFetch(
-      async () => makeResponse({ status: 401, body: { error: "invalid_grant" } }),
+      async () =>
+        makeResponse({ status: 401, body: { error: "invalid_grant" } }),
       async () => {
         try {
           await mintAccessToken(account);
         } catch (e) {
           caught = e;
         }
-      },
+      }
     );
     ok(caught instanceof CwsAuthError);
   });
@@ -245,7 +253,7 @@ describe("getItem", () => {
         const item = await getItem(account, "abc", "DRAFT");
         strictEqual(item.uploadState, "UPLOADED");
         strictEqual(item.crxVersion, "1.0.0");
-      },
+      }
     );
   });
 
@@ -266,7 +274,7 @@ describe("getItem", () => {
         } catch (e) {
           caught = e;
         }
-      },
+      }
     );
     ok(caught instanceof CwsAuthError);
   });
@@ -288,7 +296,7 @@ describe("getItem", () => {
         } catch (e) {
           caught = e;
         }
-      },
+      }
     );
     ok(caught instanceof CwsStateError);
   });
@@ -310,7 +318,7 @@ describe("getItem", () => {
         } catch (e) {
           caught = e;
         }
-      },
+      }
     );
     ok(caught instanceof CwsStateError);
   });
@@ -354,7 +362,7 @@ describe("uploadCrx", () => {
       async () => {
         const result = await uploadCrx(account, "abc", zipPath);
         strictEqual(result.uploadState, "SUCCESS");
-      },
+      }
     );
   });
 });
@@ -375,7 +383,7 @@ describe("publishItem", () => {
       async () => {
         const result = await publishItem(account, "abc");
         deepStrictEqual(result.status, ["OK"]);
-      },
+      }
     );
   });
 
@@ -396,7 +404,7 @@ describe("publishItem", () => {
         } catch (e) {
           caught = e;
         }
-      },
+      }
     );
     ok(caught instanceof CwsStateError);
   });
@@ -407,10 +415,11 @@ describe("publishItem", () => {
 describe("pollUntil", () => {
   it("returns on first truthy predicate", async () => {
     let n = 0;
-    const result = await pollUntil(
-      async () => (++n === 2 ? "got it" : null),
-      { timeoutMs: 1000, intervalMs: 1, sleep: async () => {} },
-    );
+    const result = await pollUntil(async () => (++n === 2 ? "got it" : null), {
+      timeoutMs: 1000,
+      intervalMs: 1,
+      sleep: async () => {},
+    });
     strictEqual(result, "got it");
   });
 
@@ -462,7 +471,7 @@ describe("waitUploaded", () => {
         });
         strictEqual(result.uploadState, "SUCCESS");
         ok(calls >= 2, `expected at least 2 calls (retry); got ${calls}`);
-      },
+      }
     );
   });
 });
@@ -490,7 +499,7 @@ describe("waitPublished", () => {
         });
         strictEqual(result.status, "PUBLISHED");
         strictEqual(result.version, "1.0.0");
-      },
+      }
     );
   });
 
@@ -511,7 +520,7 @@ describe("waitPublished", () => {
           sleep: async () => {},
         });
         strictEqual(result.status, "IN_REVIEW");
-      },
+      }
     );
   });
 
@@ -541,7 +550,7 @@ describe("waitPublished", () => {
         const elapsed = Date.now() - start;
         strictEqual(result.status, "REJECTED");
         ok(elapsed < 5000, `elapsed=${elapsed}ms; expected <5000`);
-      },
+      }
     );
   });
 
@@ -566,7 +575,7 @@ describe("waitPublished", () => {
           now: () => nowVal,
         });
         strictEqual(result.status, "TIMEOUT");
-      },
+      }
     );
   });
 });
@@ -612,7 +621,7 @@ describe("dispatch (CLI)", () => {
         },
         async () => {
           code = await dispatch(["check", "abc"], account);
-        },
+        }
       );
     } finally {
       process.stdout.write = origWrite;
@@ -648,7 +657,7 @@ describe("secret redaction", () => {
         },
         async () => {
           await dispatch(["check", "abc"], account);
-        },
+        }
       );
     } finally {
       process.stderr.write = origWrite;
@@ -656,7 +665,9 @@ describe("secret redaction", () => {
     const stderr = stderrChunks.join("");
     // No 32+ char substring of the access token or PEM body should appear.
     const tokenSlice = accessToken.slice(0, 32);
-    const pemBodyMatch = pem.match(/-----BEGIN PRIVATE KEY-----\n([\s\S]+?)\n-----END/);
+    const pemBodyMatch = pem.match(
+      /-----BEGIN PRIVATE KEY-----\n([\s\S]+?)\n-----END/
+    );
     const pemSlice = pemBodyMatch ? pemBodyMatch[1].slice(0, 32) : "";
     ok(!stderr.includes(tokenSlice));
     if (pemSlice.length === 32) {

--- a/scripts/cws-api/auth.mjs
+++ b/scripts/cws-api/auth.mjs
@@ -55,7 +55,9 @@ export function signJwt(serviceAccount, now = Date.now()) {
     exp,
   };
   const signingInput =
-    base64url(JSON.stringify(header)) + "." + base64url(JSON.stringify(payload));
+    base64url(JSON.stringify(header)) +
+    "." +
+    base64url(JSON.stringify(payload));
   let signature;
   try {
     const signer = createSign("RSA-SHA256");

--- a/scripts/cws-api/auth.mjs
+++ b/scripts/cws-api/auth.mjs
@@ -1,0 +1,96 @@
+// Service-account JWT auth flow.
+//
+// Flow: parse JSON key → normalize PEM → sign RS256 JWT → exchange at
+// Google token endpoint → cache 1-hour access token (with 5-min safety
+// margin so we never use a token within 5 min of its expiry).
+//
+// PEM normalization (task 2.7): the `private_key` field in the
+// service-account JSON contains literal `\n` escape sequences when
+// pasted as a single-line GitHub Secret. We replace them with real
+// newlines before passing to crypto.createSign. Idempotent — calling
+// it twice on the same input produces the same output.
+
+import { createSign } from "node:crypto";
+import { CwsAuthError } from "./errors.mjs";
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const SCOPE = "https://www.googleapis.com/auth/chromewebstore";
+const GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+let cached = null; // { token, expiresAt }
+
+export function normalizePrivateKey(pem) {
+  return pem.replace(/\\n/g, "\n");
+}
+
+export function parseServiceAccountJson(raw) {
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CwsAuthError("CWS_SERVICE_ACCOUNT_KEY is not valid JSON");
+  }
+  const required = ["client_email", "private_key", "token_uri"];
+  for (const k of required) {
+    if (typeof parsed[k] !== "string" || parsed[k].length === 0) {
+      throw new CwsAuthError(`service-account JSON missing field: ${k}`);
+    }
+  }
+  return { ...parsed, private_key: normalizePrivateKey(parsed.private_key) };
+}
+
+function base64url(buf) {
+  return Buffer.from(buf).toString("base64url");
+}
+
+export function signJwt(serviceAccount, now = Date.now()) {
+  const iat = Math.floor(now / 1000) - 60;
+  const exp = iat + 3660;
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = {
+    iss: serviceAccount.client_email,
+    scope: SCOPE,
+    aud: TOKEN_URL,
+    iat,
+    exp,
+  };
+  const signingInput =
+    base64url(JSON.stringify(header)) + "." + base64url(JSON.stringify(payload));
+  let signature;
+  try {
+    const signer = createSign("RSA-SHA256");
+    signer.update(signingInput);
+    signature = signer.sign(serviceAccount.private_key);
+  } catch (err) {
+    throw new CwsAuthError(`JWT signing failed: ${err.code ?? "ERR"}`);
+  }
+  return signingInput + "." + base64url(signature);
+}
+
+export async function mintAccessToken(serviceAccount, now = Date.now()) {
+  if (cached && cached.expiresAt > now) return cached.token;
+  const jwt = signJwt(serviceAccount, now);
+  const body = new URLSearchParams({ grant_type: GRANT_TYPE, assertion: jwt });
+  const res = await fetch(TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (res.status === 401 || res.status === 403) {
+    throw new CwsAuthError(`token endpoint returned ${res.status}`);
+  }
+  if (!res.ok) {
+    throw new CwsAuthError(`token endpoint returned ${res.status}`);
+  }
+  const data = await res.json().catch(() => null);
+  if (!data || typeof data.access_token !== "string") {
+    throw new CwsAuthError("token endpoint response missing access_token");
+  }
+  // 1h expiry minus 5 min safety margin
+  cached = { token: data.access_token, expiresAt: now + 55 * 60 * 1000 };
+  return cached.token;
+}
+
+export function _resetCache() {
+  cached = null;
+}

--- a/scripts/cws-api/cli.mjs
+++ b/scripts/cws-api/cli.mjs
@@ -1,0 +1,97 @@
+// Subcommand dispatcher for cws-api.mjs. Each subcommand prints JSON
+// stdout on success and translates typed errors into the appropriate
+// exit code (1 for recoverable, 2 for usage).
+
+import { mintAccessToken } from "./auth.mjs";
+import { CwsAuthError, CwsStateError, CwsTimeoutError } from "./errors.mjs";
+import { getItem } from "./state.mjs";
+import { uploadCrx } from "./upload.mjs";
+import { publishItem } from "./publish.mjs";
+import { waitPublished, waitUploaded } from "./poll.mjs";
+
+export async function dispatch(argv, serviceAccount) {
+  const [subcommand, id, ...rest] = argv;
+  const flags = parseFlags(rest);
+  try {
+    const result = await runSubcommand(subcommand, id, flags, serviceAccount);
+    if (result !== undefined) {
+      process.stdout.write(JSON.stringify(result) + "\n");
+    }
+    return 0;
+  } catch (err) {
+    return handleError(err);
+  }
+}
+
+async function runSubcommand(subcommand, id, flags, serviceAccount) {
+  if (!subcommand) throw new UsageError("missing subcommand");
+  if (subcommand === "check") {
+    if (!id) throw new UsageError("check requires <extension-id>");
+    await mintAccessToken(serviceAccount);
+    return await getItem(serviceAccount, id, "DRAFT");
+  }
+  if (subcommand === "state") {
+    if (!id) throw new UsageError("state requires <extension-id>");
+    return await getItem(serviceAccount, id, flags.projection ?? "DRAFT");
+  }
+  if (subcommand === "upload") {
+    if (!id || !flags.source) {
+      throw new UsageError("upload requires <id> --source <zip>");
+    }
+    return await uploadCrx(serviceAccount, id, flags.source);
+  }
+  if (subcommand === "publish") {
+    if (!id) throw new UsageError("publish requires <extension-id>");
+    return await publishItem(serviceAccount, id, {
+      trustedTesters: flags.trustedTesters === true,
+    });
+  }
+  if (subcommand === "wait-uploaded") {
+    if (!id) throw new UsageError("wait-uploaded requires <extension-id>");
+    return await waitUploaded(serviceAccount, id, {
+      timeoutMs: flags.timeoutMs ?? 60000,
+    });
+  }
+  if (subcommand === "wait-published") {
+    if (!id || !flags.version) {
+      throw new UsageError("wait-published requires <id> --version <V>");
+    }
+    return await waitPublished(serviceAccount, id, {
+      version: flags.version,
+      timeoutMs: flags.timeoutMs ?? 120000,
+    });
+  }
+  throw new UsageError(`unknown subcommand: ${subcommand}`);
+}
+
+function parseFlags(args) {
+  const flags = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--source") flags.source = args[++i];
+    else if (arg === "--version") flags.version = args[++i];
+    else if (arg === "--projection") flags.projection = args[++i];
+    else if (arg === "--timeout-ms") flags.timeoutMs = Number(args[++i]);
+    else if (arg === "--trusted-testers") flags.trustedTesters = true;
+  }
+  return flags;
+}
+
+class UsageError extends Error {}
+
+function handleError(err) {
+  if (err instanceof UsageError) {
+    process.stderr.write(`[CwsStateError] usage: ${err.message}\n`);
+    return 2;
+  }
+  if (
+    err instanceof CwsAuthError ||
+    err instanceof CwsStateError ||
+    err instanceof CwsTimeoutError
+  ) {
+    process.stderr.write(err.message + "\n");
+    return 1;
+  }
+  process.stderr.write(`[CwsStateError] ${err?.code ?? "ERR"}\n`);
+  return 1;
+}

--- a/scripts/cws-api/errors.mjs
+++ b/scripts/cws-api/errors.mjs
@@ -1,0 +1,30 @@
+// Typed error classes with stable message prefixes. The workflow greps
+// these prefixes from stderr to decide between cws-auth-broken vs
+// verification-timeout vs rejected vs generic state errors.
+
+export const ERROR_PREFIX = {
+  AUTH: "[CwsAuthError]",
+  STATE: "[CwsStateError]",
+  TIMEOUT: "[CwsTimeoutError]",
+};
+
+export class CwsAuthError extends Error {
+  constructor(message) {
+    super(`${ERROR_PREFIX.AUTH} ${message}`);
+    this.name = "CwsAuthError";
+  }
+}
+
+export class CwsStateError extends Error {
+  constructor(message) {
+    super(`${ERROR_PREFIX.STATE} ${message}`);
+    this.name = "CwsStateError";
+  }
+}
+
+export class CwsTimeoutError extends Error {
+  constructor(message) {
+    super(`${ERROR_PREFIX.TIMEOUT} ${message}`);
+    this.name = "CwsTimeoutError";
+  }
+}

--- a/scripts/cws-api/poll.mjs
+++ b/scripts/cws-api/poll.mjs
@@ -8,7 +8,7 @@ import { getItem } from "./state.mjs";
 
 export async function pollUntil(
   predicate,
-  { timeoutMs, intervalMs = 2000, sleep = defaultSleep, now = Date.now } = {},
+  { timeoutMs, intervalMs = 2000, sleep = defaultSleep, now = Date.now } = {}
 ) {
   const deadline = now() + timeoutMs;
   for (;;) {
@@ -28,7 +28,7 @@ function defaultSleep(ms) {
 export async function waitUploaded(
   serviceAccount,
   id,
-  { timeoutMs = 60000, sleep, now } = {},
+  { timeoutMs = 60000, sleep, now } = {}
 ) {
   const predicate = async () => {
     const item = await getItem(serviceAccount, id, "DRAFT");
@@ -49,7 +49,7 @@ export async function waitUploaded(
 export async function waitPublished(
   serviceAccount,
   id,
-  { version, timeoutMs = 120000, sleep, now = Date.now } = {},
+  { version, timeoutMs = 120000, sleep, now = Date.now } = {}
 ) {
   const start = now();
   const deadline = start + timeoutMs;
@@ -80,8 +80,7 @@ function isRejected(item) {
     item.itemError.some(
       (e) =>
         e?.error_code === "ITEM_REJECTED" ||
-        (typeof e?.error_detail === "string" &&
-          /reject/i.test(e.error_detail)),
+        (typeof e?.error_detail === "string" && /reject/i.test(e.error_detail))
     )
   ) {
     return true;

--- a/scripts/cws-api/poll.mjs
+++ b/scripts/cws-api/poll.mjs
@@ -31,10 +31,23 @@ export async function waitUploaded(
   { timeoutMs = 60000, sleep, now } = {}
 ) {
   const predicate = async () => {
-    const item = await getItem(serviceAccount, id, "DRAFT");
-    return item.uploadState === "SUCCESS" || item.uploadState === "UPLOADED"
-      ? item
-      : null;
+    const draft = await getItem(serviceAccount, id, "DRAFT");
+    // Standard upload-complete states.
+    if (draft.uploadState === "SUCCESS" || draft.uploadState === "UPLOADED") {
+      return draft;
+    }
+    // Still in progress: keep polling.
+    if (draft.uploadState === "IN_PROGRESS") return null;
+    // Other states (FAILURE, null, unknown): check if the published
+    // version already matches what we just uploaded. CWS does not create
+    // a new draft when the upload's version equals the currently-live
+    // one — the upload PUT returns SUCCESS but the DRAFT projection
+    // never transitions. Treat that as a successful no-op.
+    const published = await getItem(serviceAccount, id, "PUBLISHED");
+    if (published.uploadState === "PUBLISHED" || published.crxVersion) {
+      return { ...published, alreadyLive: true };
+    }
+    return null;
   };
   const opts = { timeoutMs, sleep, now };
   try {

--- a/scripts/cws-api/poll.mjs
+++ b/scripts/cws-api/poll.mjs
@@ -1,0 +1,90 @@
+// Polling helpers. pollUntil is a generic single-shot helper; the
+// retry-once policy for wait-uploaded lives in this module's wrapper
+// (NOT inside pollUntil) so wait-published can share pollUntil without
+// inheriting the retry behavior.
+
+import { CwsTimeoutError } from "./errors.mjs";
+import { getItem } from "./state.mjs";
+
+export async function pollUntil(
+  predicate,
+  { timeoutMs, intervalMs = 2000, sleep = defaultSleep, now = Date.now } = {},
+) {
+  const deadline = now() + timeoutMs;
+  for (;;) {
+    const value = await predicate();
+    if (value) return value;
+    if (now() >= deadline) {
+      throw new CwsTimeoutError(`pollUntil exceeded ${timeoutMs}ms`);
+    }
+    await sleep(intervalMs);
+  }
+}
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function waitUploaded(
+  serviceAccount,
+  id,
+  { timeoutMs = 60000, sleep, now } = {},
+) {
+  const predicate = async () => {
+    const item = await getItem(serviceAccount, id, "DRAFT");
+    return item.uploadState === "SUCCESS" || item.uploadState === "UPLOADED"
+      ? item
+      : null;
+  };
+  const opts = { timeoutMs, sleep, now };
+  try {
+    return await pollUntil(predicate, opts);
+  } catch (err) {
+    if (!(err instanceof CwsTimeoutError)) throw err;
+    // Retry-once internal to wait-uploaded only.
+    return await pollUntil(predicate, opts);
+  }
+}
+
+export async function waitPublished(
+  serviceAccount,
+  id,
+  { version, timeoutMs = 120000, sleep, now = Date.now } = {},
+) {
+  const start = now();
+  const deadline = start + timeoutMs;
+  for (;;) {
+    const item = await getItem(serviceAccount, id, "PUBLISHED");
+    const rejected = isRejected(item);
+    if (rejected) {
+      return { status: "REJECTED", version, raw: item.rawResponse };
+    }
+    if (item.crxVersion === version || item.uploadState === "PUBLISHED") {
+      return { status: "PUBLISHED", version, raw: item.rawResponse };
+    }
+    if (item.uploadState === "IN_REVIEW" || item.uploadState === "PENDING") {
+      return { status: "IN_REVIEW", version, raw: item.rawResponse };
+    }
+    if (now() >= deadline) {
+      return { status: "TIMEOUT", version, raw: item.rawResponse };
+    }
+    await (sleep ?? defaultSleep)(2000);
+  }
+}
+
+function isRejected(item) {
+  if (item.uploadState === "FAILURE") return true;
+  if (item.uploadState === "REJECTED") return true;
+  if (
+    item.itemError &&
+    item.itemError.some(
+      (e) =>
+        e?.error_code === "ITEM_REJECTED" ||
+        (typeof e?.error_detail === "string" &&
+          /reject/i.test(e.error_detail)),
+    )
+  ) {
+    return true;
+  }
+  return false;
+}

--- a/scripts/cws-api/poll.mjs
+++ b/scripts/cws-api/poll.mjs
@@ -32,22 +32,19 @@ export async function waitUploaded(
 ) {
   const predicate = async () => {
     const draft = await getItem(serviceAccount, id, "DRAFT");
-    // Standard upload-complete states.
-    if (draft.uploadState === "SUCCESS" || draft.uploadState === "UPLOADED") {
-      return draft;
+    // Real failure: itemError populated. Throw with details.
+    if (draft.itemError && draft.itemError.length > 0) {
+      throw new CwsStateError(
+        `upload itemError: ${JSON.stringify(draft.itemError)}`
+      );
     }
-    // Still in progress: keep polling.
+    // Still uploading: keep polling.
     if (draft.uploadState === "IN_PROGRESS") return null;
-    // Other states (FAILURE, null, unknown): check if the published
-    // version already matches what we just uploaded. CWS does not create
-    // a new draft when the upload's version equals the currently-live
-    // one — the upload PUT returns SUCCESS but the DRAFT projection
-    // never transitions. Treat that as a successful no-op.
-    const published = await getItem(serviceAccount, id, "PUBLISHED");
-    if (published.uploadState === "PUBLISHED" || published.crxVersion) {
-      return { ...published, alreadyLive: true };
-    }
-    return null;
+    // Anything else (SUCCESS, UPLOADED, null/empty, unknown): accept as
+    // terminal. The upload PUT already confirmed receipt; the wait here
+    // is a defensive double-check that we are no longer mid-upload.
+    // wait-published is the authoritative end-to-end gate.
+    return draft;
   };
   const opts = { timeoutMs, sleep, now };
   try {

--- a/scripts/cws-api/publish.mjs
+++ b/scripts/cws-api/publish.mjs
@@ -9,7 +9,7 @@ import { CWS_API_BASE_URL } from "./state.mjs";
 export async function publishItem(
   serviceAccount,
   id,
-  { trustedTesters = false } = {},
+  { trustedTesters = false } = {}
 ) {
   const token = await mintAccessToken(serviceAccount);
   const target = trustedTesters ? "trustedTesters" : "default";
@@ -50,7 +50,7 @@ async function parseJsonOrThrow(res) {
     return JSON.parse(text);
   } catch {
     throw new CwsStateError(
-      `publishItem body is not valid JSON (length=${text.length})`,
+      `publishItem body is not valid JSON (length=${text.length})`
     );
   }
 }

--- a/scripts/cws-api/publish.mjs
+++ b/scripts/cws-api/publish.mjs
@@ -1,0 +1,56 @@
+// Publish an uploaded CRX. POST without body to /items/<id>/publish.
+// Returns { status: [string] } per Google docs. 409 → conflict (a
+// concurrent publish is locking the item).
+
+import { CwsAuthError, CwsStateError } from "./errors.mjs";
+import { mintAccessToken } from "./auth.mjs";
+import { CWS_API_BASE_URL } from "./state.mjs";
+
+export async function publishItem(
+  serviceAccount,
+  id,
+  { trustedTesters = false } = {},
+) {
+  const token = await mintAccessToken(serviceAccount);
+  const target = trustedTesters ? "trustedTesters" : "default";
+  const url =
+    `${CWS_API_BASE_URL}/items/${encodeURIComponent(id)}/publish` +
+    `?publishTarget=${target}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "x-goog-api-version": "2",
+      "content-length": "0",
+    },
+  });
+  if (res.status === 401 || res.status === 403) {
+    throw new CwsAuthError(`publishItem returned ${res.status}`);
+  }
+  if (res.status === 409) {
+    throw new CwsStateError("publishItem returned 409 (item locked)");
+  }
+  if (res.status === 429) {
+    throw new CwsStateError("publishItem returned 429 (rate limited)");
+  }
+  if (!res.ok) {
+    throw new CwsStateError(`publishItem returned ${res.status}`);
+  }
+  const body = await parseJsonOrThrow(res);
+  return {
+    status: Array.isArray(body.status) ? body.status : [],
+    statusDetail: Array.isArray(body.statusDetail) ? body.statusDetail : [],
+    rawResponse: body,
+  };
+}
+
+async function parseJsonOrThrow(res) {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new CwsStateError(
+      `publishItem body is not valid JSON (length=${text.length})`,
+    );
+  }
+}

--- a/scripts/cws-api/state.mjs
+++ b/scripts/cws-api/state.mjs
@@ -33,10 +33,22 @@ export async function getItem(serviceAccount, id, projection = "DRAFT") {
     throw new CwsAuthError(`getItem returned ${res.status}`);
   }
   if (!res.ok) {
-    throw new CwsStateError(`getItem returned ${res.status}`);
+    const detail = await readErrorDetail(res);
+    throw new CwsStateError(
+      `getItem(${projection}) returned ${res.status}: ${detail}`
+    );
   }
   const body = await safeJson(res);
   return normalizeItem(body);
+}
+
+async function readErrorDetail(res) {
+  try {
+    const text = await res.text();
+    return text.replace(/\s+/g, " ").slice(0, 400);
+  } catch {
+    return "(no body)";
+  }
 }
 
 function normalizeItem(body) {

--- a/scripts/cws-api/state.mjs
+++ b/scripts/cws-api/state.mjs
@@ -5,7 +5,8 @@
 import { CwsAuthError, CwsStateError } from "./errors.mjs";
 import { mintAccessToken } from "./auth.mjs";
 
-export const CWS_API_BASE_URL = "https://www.googleapis.com/chromewebstore/v1.1";
+export const CWS_API_BASE_URL =
+  "https://www.googleapis.com/chromewebstore/v1.1";
 
 async function safeJson(res) {
   const text = await res.text();
@@ -13,7 +14,7 @@ async function safeJson(res) {
     return JSON.parse(text);
   } catch {
     throw new CwsStateError(
-      `response body is not valid JSON (status=${res.status}, length=${text.length})`,
+      `response body is not valid JSON (status=${res.status}, length=${text.length})`
     );
   }
 }

--- a/scripts/cws-api/state.mjs
+++ b/scripts/cws-api/state.mjs
@@ -1,0 +1,50 @@
+// Chrome Web Store state queries (getItem). Single-endpoint module-level
+// constant for the API base — Factor III pragmatic deviation: there is
+// only one CWS endpoint globally, no staging tier exists.
+
+import { CwsAuthError, CwsStateError } from "./errors.mjs";
+import { mintAccessToken } from "./auth.mjs";
+
+export const CWS_API_BASE_URL = "https://www.googleapis.com/chromewebstore/v1.1";
+
+async function safeJson(res) {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new CwsStateError(
+      `response body is not valid JSON (status=${res.status}, length=${text.length})`,
+    );
+  }
+}
+
+export async function getItem(serviceAccount, id, projection = "DRAFT") {
+  const token = await mintAccessToken(serviceAccount);
+  const url = `${CWS_API_BASE_URL}/items/${encodeURIComponent(id)}?projection=${projection}`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "x-goog-api-version": "2",
+    },
+  });
+  if (res.status === 401 || res.status === 403) {
+    throw new CwsAuthError(`getItem returned ${res.status}`);
+  }
+  if (!res.ok) {
+    throw new CwsStateError(`getItem returned ${res.status}`);
+  }
+  const body = await safeJson(res);
+  return normalizeItem(body);
+}
+
+function normalizeItem(body) {
+  return {
+    id: body.id ?? null,
+    uploadState: body.uploadState ?? null,
+    crxVersion: body.crxVersion ?? null,
+    publicKey: undefined,
+    itemError: Array.isArray(body.itemError) ? body.itemError : [],
+    rawResponse: body,
+  };
+}

--- a/scripts/cws-api/upload.mjs
+++ b/scripts/cws-api/upload.mjs
@@ -49,7 +49,7 @@ async function parseJsonOrThrow(res) {
     return JSON.parse(text);
   } catch {
     throw new CwsStateError(
-      `uploadCrx body is not valid JSON (length=${text.length})`,
+      `uploadCrx body is not valid JSON (length=${text.length})`
     );
   }
 }

--- a/scripts/cws-api/upload.mjs
+++ b/scripts/cws-api/upload.mjs
@@ -1,0 +1,55 @@
+// Upload a CRX zip to Chrome Web Store. PUT body is the raw zip with
+// `Content-Type: application/octet-stream`. Returns the parsed CWS
+// response { id, uploadState, itemError?, crxVersion? }.
+
+import { createReadStream, statSync } from "node:fs";
+import { CwsAuthError, CwsStateError } from "./errors.mjs";
+import { mintAccessToken } from "./auth.mjs";
+
+const UPLOAD_BASE_URL =
+  "https://www.googleapis.com/upload/chromewebstore/v1.1/items";
+
+export async function uploadCrx(serviceAccount, id, zipPath) {
+  const token = await mintAccessToken(serviceAccount);
+  const url = `${UPLOAD_BASE_URL}/${encodeURIComponent(id)}`;
+  const stats = statSync(zipPath);
+  const res = await fetch(url, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "x-goog-api-version": "2",
+      "Content-Type": "application/octet-stream",
+      "Content-Length": String(stats.size),
+    },
+    body: createReadStream(zipPath),
+    duplex: "half",
+  });
+  if (res.status === 401 || res.status === 403) {
+    throw new CwsAuthError(`uploadCrx returned ${res.status}`);
+  }
+  if (res.status === 429) {
+    throw new CwsStateError("uploadCrx returned 429 (rate limited)");
+  }
+  if (!res.ok) {
+    throw new CwsStateError(`uploadCrx returned ${res.status}`);
+  }
+  const body = await parseJsonOrThrow(res);
+  return {
+    id: body.id ?? null,
+    uploadState: body.uploadState ?? null,
+    crxVersion: body.crxVersion ?? null,
+    itemError: Array.isArray(body.itemError) ? body.itemError : [],
+    rawResponse: body,
+  };
+}
+
+async function parseJsonOrThrow(res) {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new CwsStateError(
+      `uploadCrx body is not valid JSON (length=${text.length})`,
+    );
+  }
+}

--- a/scripts/cws-notify-issue.mjs
+++ b/scripts/cws-notify-issue.mjs
@@ -85,7 +85,10 @@ function parseIssueNumberFromUrl(url) {
 function defaultDeps() {
   return {
     exec: (cmd, args) =>
-      execFileSync(cmd, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }),
+      execFileSync(cmd, args, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      }),
   };
 }
 

--- a/scripts/cws-notify-issue.mjs
+++ b/scripts/cws-notify-issue.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Open-or-bump a GitHub issue for CWS-related auth/publish events.
+// Idempotent: searches by exact title (NOT just label) — two concurrent
+// invocations targeting the same title settle to one issue (one creates,
+// the other reads it on its retry and bumps via comment).
+//
+// Usage:
+//   node scripts/cws-notify-issue.mjs <kind> [title-suffix]
+//
+// Where <kind> is one of:
+//   cws-auth-broken                  → singleton (no suffix)
+//   cws-publish-verification-timeout → suffix is "@kaiord/<ext>@<version>"
+//   cws-publish-rejected             → suffix is "@kaiord/<ext>@<version>"
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const TITLES = {
+  "cws-auth-broken": () => "CWS authentication broken",
+  "cws-publish-verification-timeout": (suffix) =>
+    `CWS publish stalled: ${suffix}`,
+  "cws-publish-rejected": (suffix) => `CWS publish rejected: ${suffix}`,
+};
+
+export function buildTitle(kind, suffix) {
+  const fn = TITLES[kind];
+  if (!fn) throw new Error(`unknown notify kind: ${kind}`);
+  if (kind !== "cws-auth-broken" && !suffix) {
+    throw new Error(`${kind} requires title suffix (extension+version)`);
+  }
+  return fn(suffix);
+}
+
+export function findOpenIssue(title, deps = defaultDeps()) {
+  const args = [
+    "issue",
+    "list",
+    "--state",
+    "open",
+    "--search",
+    `${title} in:title`,
+    "--json",
+    "number,title",
+    "--limit",
+    "20",
+  ];
+  const out = deps.exec("gh", args);
+  const list = JSON.parse(out || "[]");
+  const exact = list.find((i) => i.title === title);
+  return exact ? exact.number : null;
+}
+
+export function openOrBump(kind, suffix, body, deps = defaultDeps()) {
+  const title = buildTitle(kind, suffix);
+  const existing = findOpenIssue(title, deps);
+  if (existing != null) {
+    deps.exec("gh", [
+      "issue",
+      "comment",
+      String(existing),
+      "--body",
+      `Re-detected at ${new Date().toISOString()}\n\n${body}`,
+    ]);
+    return { issue: existing, action: "bumped" };
+  }
+  const out = deps.exec("gh", [
+    "issue",
+    "create",
+    "--title",
+    title,
+    "--label",
+    kind,
+    "--body",
+    body,
+  ]);
+  const created = parseIssueNumberFromUrl(String(out).trim());
+  return { issue: created, action: "created" };
+}
+
+function parseIssueNumberFromUrl(url) {
+  const m = url.match(/\/issues\/(\d+)/);
+  return m ? Number(m[1]) : null;
+}
+
+function defaultDeps() {
+  return {
+    exec: (cmd, args) =>
+      execFileSync(cmd, args, { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }),
+  };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [kind, suffix, ...rest] = process.argv.slice(2);
+  const body = rest.join(" ") || "(no body provided)";
+  try {
+    const result = openOrBump(kind, suffix, body);
+    process.stdout.write(JSON.stringify(result) + "\n");
+  } catch (err) {
+    process.stderr.write(`[CwsStateError] ${err.message}\n`);
+    process.exit(1);
+  }
+}

--- a/scripts/cws-notify-issue.test.mjs
+++ b/scripts/cws-notify-issue.test.mjs
@@ -3,11 +3,7 @@
 import { describe, it } from "node:test";
 import { strictEqual, ok, deepStrictEqual } from "node:assert";
 
-import {
-  buildTitle,
-  findOpenIssue,
-  openOrBump,
-} from "./cws-notify-issue.mjs";
+import { buildTitle, findOpenIssue, openOrBump } from "./cws-notify-issue.mjs";
 
 function fakeDeps(behaviors) {
   const calls = [];
@@ -39,15 +35,18 @@ describe("buildTitle", () => {
 
   it("scopes verification-timeout title with suffix", () => {
     strictEqual(
-      buildTitle("cws-publish-verification-timeout", "@kaiord/garmin-bridge@7.1.1"),
-      "CWS publish stalled: @kaiord/garmin-bridge@7.1.1",
+      buildTitle(
+        "cws-publish-verification-timeout",
+        "@kaiord/garmin-bridge@7.1.1"
+      ),
+      "CWS publish stalled: @kaiord/garmin-bridge@7.1.1"
     );
   });
 
   it("scopes rejected title with suffix", () => {
     strictEqual(
       buildTitle("cws-publish-rejected", "@kaiord/train2go-bridge@7.1.1"),
-      "CWS publish rejected: @kaiord/train2go-bridge@7.1.1",
+      "CWS publish rejected: @kaiord/train2go-bridge@7.1.1"
     );
   });
 
@@ -71,9 +70,7 @@ describe("findOpenIssue", () => {
   it("returns issue number on exact title match", () => {
     const deps = fakeDeps([
       () =>
-        JSON.stringify([
-          { number: 42, title: "CWS authentication broken" },
-        ]),
+        JSON.stringify([{ number: 42, title: "CWS authentication broken" }]),
     ]);
     strictEqual(findOpenIssue("CWS authentication broken", deps), 42);
   });
@@ -100,7 +97,7 @@ describe("openOrBump", () => {
       "cws-auth-broken",
       undefined,
       "Pre-flight returned 401",
-      deps,
+      deps
     );
 
     strictEqual(result.action, "created");
@@ -112,10 +109,7 @@ describe("openOrBump", () => {
 
   it("bumps existing issue with comment when title matches", () => {
     const deps = fakeDeps([
-      () =>
-        JSON.stringify([
-          { number: 7, title: "CWS authentication broken" },
-        ]),
+      () => JSON.stringify([{ number: 7, title: "CWS authentication broken" }]),
       () => "", // gh issue comment returns nothing meaningful
     ]);
 
@@ -123,7 +117,7 @@ describe("openOrBump", () => {
       "cws-auth-broken",
       undefined,
       "Re-detected at next pre-flight",
-      deps,
+      deps
     );
 
     strictEqual(result.action, "bumped");
@@ -141,14 +135,14 @@ describe("openOrBump", () => {
       "cws-publish-verification-timeout",
       "@kaiord/garmin-bridge@7.1.1",
       "stuck",
-      deps,
+      deps
     );
 
     const createArgs = deps.calls[1].args;
     const titleIdx = createArgs.indexOf("--title");
     strictEqual(
       createArgs[titleIdx + 1],
-      "CWS publish stalled: @kaiord/garmin-bridge@7.1.1",
+      "CWS publish stalled: @kaiord/garmin-bridge@7.1.1"
     );
   });
 
@@ -162,23 +156,21 @@ describe("openOrBump", () => {
       "cws-auth-broken",
       undefined,
       "first detection",
-      writerA,
+      writerA
     );
     strictEqual(a.action, "created");
 
     // Writer B (slightly later): list returns issue 50; bumps it instead of creating.
     const writerB = fakeDeps([
       () =>
-        JSON.stringify([
-          { number: 50, title: "CWS authentication broken" },
-        ]),
+        JSON.stringify([{ number: 50, title: "CWS authentication broken" }]),
       () => "",
     ]);
     const b = openOrBump(
       "cws-auth-broken",
       undefined,
       "second detection",
-      writerB,
+      writerB
     );
     strictEqual(b.action, "bumped");
     strictEqual(b.issue, 50);

--- a/scripts/cws-notify-issue.test.mjs
+++ b/scripts/cws-notify-issue.test.mjs
@@ -1,0 +1,186 @@
+// Tests for scripts/cws-notify-issue.mjs
+
+import { describe, it } from "node:test";
+import { strictEqual, ok, deepStrictEqual } from "node:assert";
+
+import {
+  buildTitle,
+  findOpenIssue,
+  openOrBump,
+} from "./cws-notify-issue.mjs";
+
+function fakeDeps(behaviors) {
+  const calls = [];
+  return {
+    calls,
+    exec: (cmd, args) => {
+      calls.push({ cmd, args });
+      const handler = behaviors.shift();
+      if (!handler) throw new Error("unexpected call");
+      return handler(cmd, args);
+    },
+  };
+}
+
+describe("buildTitle", () => {
+  it("returns singleton title for cws-auth-broken without suffix", () => {
+    strictEqual(buildTitle("cws-auth-broken"), "CWS authentication broken");
+  });
+
+  it("requires suffix for verification-timeout kind", () => {
+    let caught;
+    try {
+      buildTitle("cws-publish-verification-timeout");
+    } catch (e) {
+      caught = e;
+    }
+    ok(caught);
+  });
+
+  it("scopes verification-timeout title with suffix", () => {
+    strictEqual(
+      buildTitle("cws-publish-verification-timeout", "@kaiord/garmin-bridge@7.1.1"),
+      "CWS publish stalled: @kaiord/garmin-bridge@7.1.1",
+    );
+  });
+
+  it("scopes rejected title with suffix", () => {
+    strictEqual(
+      buildTitle("cws-publish-rejected", "@kaiord/train2go-bridge@7.1.1"),
+      "CWS publish rejected: @kaiord/train2go-bridge@7.1.1",
+    );
+  });
+
+  it("rejects unknown kind", () => {
+    let caught;
+    try {
+      buildTitle("bogus");
+    } catch (e) {
+      caught = e;
+    }
+    ok(caught);
+  });
+});
+
+describe("findOpenIssue", () => {
+  it("returns null when no exact title match", () => {
+    const deps = fakeDeps([() => JSON.stringify([])]);
+    strictEqual(findOpenIssue("CWS authentication broken", deps), null);
+  });
+
+  it("returns issue number on exact title match", () => {
+    const deps = fakeDeps([
+      () =>
+        JSON.stringify([
+          { number: 42, title: "CWS authentication broken" },
+        ]),
+    ]);
+    strictEqual(findOpenIssue("CWS authentication broken", deps), 42);
+  });
+
+  it("ignores label-only fuzzy matches and requires exact title", () => {
+    const deps = fakeDeps([
+      () =>
+        JSON.stringify([
+          { number: 99, title: "CWS authentication broken (legacy)" },
+        ]),
+    ]);
+    strictEqual(findOpenIssue("CWS authentication broken", deps), null);
+  });
+});
+
+describe("openOrBump", () => {
+  it("creates a new issue when none exists", () => {
+    const deps = fakeDeps([
+      () => JSON.stringify([]), // findOpenIssue list returns empty
+      () => "https://github.com/owner/repo/issues/123\n", // create returns URL
+    ]);
+
+    const result = openOrBump(
+      "cws-auth-broken",
+      undefined,
+      "Pre-flight returned 401",
+      deps,
+    );
+
+    strictEqual(result.action, "created");
+    strictEqual(result.issue, 123);
+    strictEqual(deps.calls.length, 2);
+    strictEqual(deps.calls[1].args[0], "issue");
+    strictEqual(deps.calls[1].args[1], "create");
+  });
+
+  it("bumps existing issue with comment when title matches", () => {
+    const deps = fakeDeps([
+      () =>
+        JSON.stringify([
+          { number: 7, title: "CWS authentication broken" },
+        ]),
+      () => "", // gh issue comment returns nothing meaningful
+    ]);
+
+    const result = openOrBump(
+      "cws-auth-broken",
+      undefined,
+      "Re-detected at next pre-flight",
+      deps,
+    );
+
+    strictEqual(result.action, "bumped");
+    strictEqual(result.issue, 7);
+    deepStrictEqual(deps.calls[1].args.slice(0, 3), ["issue", "comment", "7"]);
+  });
+
+  it("scopes verification-timeout title per extension+version", () => {
+    const deps = fakeDeps([
+      () => JSON.stringify([]),
+      () => "https://github.com/owner/repo/issues/200",
+    ]);
+
+    openOrBump(
+      "cws-publish-verification-timeout",
+      "@kaiord/garmin-bridge@7.1.1",
+      "stuck",
+      deps,
+    );
+
+    const createArgs = deps.calls[1].args;
+    const titleIdx = createArgs.indexOf("--title");
+    strictEqual(
+      createArgs[titleIdx + 1],
+      "CWS publish stalled: @kaiord/garmin-bridge@7.1.1",
+    );
+  });
+
+  it("simulates concurrent writers: second invocation bumps instead of duplicating", () => {
+    // Writer A: list returns empty, then creates issue 50.
+    const writerA = fakeDeps([
+      () => JSON.stringify([]),
+      () => "https://github.com/owner/repo/issues/50",
+    ]);
+    const a = openOrBump(
+      "cws-auth-broken",
+      undefined,
+      "first detection",
+      writerA,
+    );
+    strictEqual(a.action, "created");
+
+    // Writer B (slightly later): list returns issue 50; bumps it instead of creating.
+    const writerB = fakeDeps([
+      () =>
+        JSON.stringify([
+          { number: 50, title: "CWS authentication broken" },
+        ]),
+      () => "",
+    ]);
+    const b = openOrBump(
+      "cws-auth-broken",
+      undefined,
+      "second detection",
+      writerB,
+    );
+    strictEqual(b.action, "bumped");
+    strictEqual(b.issue, 50);
+  });
+});


### PR DESCRIPTION
Implements the harden-cws-publish proposal merged in #359. Migrates Chrome Web Store auth from OAuth refresh tokens (failing 7/12 recent runs) to Google Cloud service-account JWT — same model as fastlane-supply for Play Store.

## What lands

- **Helper script `scripts/cws-api.mjs` + 7 modules** (auth, state, upload, publish, poll, cli, errors) — all <100 LOC, no third-party deps. JWT signing via `node:crypto`, REST against CWS API directly. Drops `chrome-webstore-upload-cli` dependency.
- **27 tests in `scripts/cws-api.test.mjs`** — all auth/state/upload/publish/poll/dispatch paths, secret-redaction (≥32 chars), PEM normalization (raw/escaped/idempotent), wait-uploaded retry-once, wait-published 4-state schema, REJECTED fail-fast timing.
- **`scripts/cws-notify-issue.mjs` + 12 tests** — open-or-bump GitHub issues by exact-title match. Three labels (cws-auth-broken, cws-publish-verification-timeout, cws-publish-rejected) with per-extension per-version scoping.
- **Workflow rewrite `.github/workflows/cws-publish.yml`** — pre-flight job, conditional upload (skip if CWS already at current version unless force_upload=true), wait-uploaded with retry-once, publish, wait-published with 4 terminal states branching tag-vs-issue. Mid-flight 401/403 routes to `cws-auth-broken`. `force_upload` workflow_dispatch input. Job-level `concurrency: cws-issue-writer` for cross-run TOCTOU defense.
- **3 issue templates** under `.github/ISSUE_TEMPLATE/`.
- **Runbook `docs/runbooks/cws-service-account.md`** — one-time setup, key rotation, emergency re-publish, compromised-key response. Linked from `AGENTS.md`.
- **Drive-by**: `openspec/specs/analytics-port/spec.md` gained `## Purpose` section (`pnpm lint:specs` was failing on a missing-Purpose error from #360).

## Tasks done: 43/74

Sections fully complete: 2.x, 3.x, 5.x (workflow), 6.x (notify-issue), 7.x (templates), 8.1-8.2 (runbook + AGENTS), 11.1.

## Tasks NOT done in this PR (require human action or post-merge)

- **1.x** (Google Cloud setup) — manual maintainer steps. Documented step-by-step in `docs/runbooks/cws-service-account.md`. **The maintainer MUST complete tasks 1.1-1.5 before this PR can land an end-to-end working publish.** Specifically: create service account in Google Cloud Console, generate JSON key, link in CWS Developer Dashboard, paste key into `CWS_SERVICE_ACCOUNT_KEY` GitHub Secret.
- **4.1.c, 4.1.e**: redirect-policy assertion + 429-with-retry test (tests not yet implemented; helper currently throws on 429 without retry — adding retry is a small follow-up).
- **4.6**: manual end-to-end against real CWS API.
- **5.5**: actionlint (CI runs it; `actionlint` not installed locally).
- **8.3**: maintainer self-dogfood of the runbook.
- **9.x**: OAuth secrets decommission (post-merge after E2E green).
- **10.6-10.8.a**: end-to-end + destructive tests (require real CWS access).
- **11.2-11.4**: opsx-archive (post-merge).

## Quality gates

- ✅ `pnpm lint:specs` — 26/26 pass
- ✅ `pnpm test:scripts` — 76/76 pass (includes 27 cws-api + 12 cws-notify-issue + existing scripts tests)
- ⏳ `pnpm lint` — pending CI
- ⏳ `actionlint` — pending CI
- ⏳ End-to-end CWS test — pending maintainer Google Cloud setup

## Followups (not blocking)

1. Maintainer completes Google Cloud setup (tasks 1.x) before merging.
2. Add 4.1.c / 4.1.e tests + 429-retry implementation in a small follow-up PR.
3. After first green E2E run on main: remove `CWS_CLIENT_ID` / `CWS_CLIENT_SECRET` / `CWS_REFRESH_TOKEN` secrets from repo settings.
4. Run `/opsx-archive harden-cws-publish` to sync the spec delta into `openspec/specs/cws-auto-publish/spec.md`.

## Test plan

- [x] `pnpm test:scripts` green
- [x] `pnpm lint:specs` green
- [ ] CI green
- [ ] CodeRabbit review addressed (likely follow-ups, not blockers)
- [ ] Maintainer completes Google Cloud setup before merge
- [ ] First post-merge run: pre-flight passes, publish reaches PUBLISHED on both extensions, git tags created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hardened Chrome Web Store publish flow: pre-flight auth check, CWS-state-driven idempotency, manual `force_upload` override, and automatic issue creation for auth failures, rejects, and verification timeouts.
  * New CLI for CWS operations with stable error tags and safer stderr output.

* **Documentation**
  * Runbook for CWS service-account setup/rotation/emergency steps; runbook pointer added to docs.
  * Spec clarification for analytics port.

* **Tests**
  * Extensive test suites covering CLI, CWS flows, and issue-notification behavior.

* **Chores**
  * Removed unused dev dependency and updated task checklist statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->