### PR TITLE
feat(ci): wire Cloudflare Analytics token to deploy-site builds

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -47,11 +47,14 @@ jobs:
       # Always build all packages — the merged artifact must be complete.
       # Targeted filters build only required transitive dependencies.
       - name: Build Landing Page
+        env:
+          VITE_CF_ANALYTICS_TOKEN: ${{ secrets.CF_ANALYTICS_TOKEN }}
         run: pnpm --filter @kaiord/landing... build
 
       - name: Build SPA Editor
         env:
           VITE_BASE_PATH: /editor/
+          VITE_CF_ANALYTICS_TOKEN: ${{ secrets.CF_ANALYTICS_TOKEN }}
         run: pnpm --filter @kaiord/workout-spa-editor... build
 
       - name: Build Docs


### PR DESCRIPTION
## Summary

- Adds `VITE_CF_ANALYTICS_TOKEN` env var to both **Landing** and **SPA Editor** build steps in `deploy-site.yml`
- The `CF_ANALYTICS_TOKEN` GitHub secret was already added to the repo
- Without this, the `conditionalBeacon` Vite plugin strips the beacon script from the HTML (token empty → noop)

## Test plan

- [ ] Merge and trigger a deploy — verify the Cloudflare Web Analytics dashboard starts receiving hits for `kaiord.com` and `kaiord.com/editor/`
- [ ] Confirm the beacon `<script>` tag is present in the deployed `index.html` (not stripped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for deployment pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->