### PR TITLE
chore(openspec): full deep sync of 26 specs (2026-04-27)

### DIFF
--- a/openspec/specs/adapter-contracts/spec.md
+++ b/openspec/specs/adapter-contracts/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-27
 
 # Adapter Contracts
 

--- a/openspec/specs/analytics-port/spec.md
+++ b/openspec/specs/analytics-port/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-25
+> Synced: 2026-04-27
 
 # Analytics Port & Adapter
 

--- a/openspec/specs/branding/spec.md
+++ b/openspec/specs/branding/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-18
+> Synced: 2026-04-27
 
 # Branding
 

--- a/openspec/specs/bridge-runtime-discovery/spec.md
+++ b/openspec/specs/bridge-runtime-discovery/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20 (bridge-runtime-discovery)
+> Synced: 2026-04-27
 
 # Bridge Runtime Discovery
 

--- a/openspec/specs/ci-release/spec.md
+++ b/openspec/specs/ci-release/spec.md
@@ -43,7 +43,7 @@ The App ID SHALL be read from `vars.RELEASE_APP_ID` and the private key from `se
 #### Scenario: Version Packages PR triggers required checks
 
 - **WHEN** `changesets/action` pushes a commit to the Version Packages PR using the release-bot token
-- **THEN** GitHub Actions SHALL re-run the branch-protection-required workflows (lint/typecheck/test/build/Link checker/Check for Changeset) on that commit, allowing the PR to become mergeable
+- **THEN** GitHub Actions SHALL re-run the branch-protection-required status checks on that commit, allowing the PR to become mergeable
 
 #### Scenario: Release bot token is short-lived
 

--- a/openspec/specs/ci-release/spec.md
+++ b/openspec/specs/ci-release/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-27
 
 # CI Release
 
@@ -31,6 +31,24 @@ The release workflow SHALL use `changesets/action@v1` to create a "Version Packa
 
 - **WHEN** the workflow is triggered via `workflow_dispatch`
 - **THEN** the workflow SHALL behave identically to a push trigger (create PR if changesets exist, publish if none)
+
+### Requirement: Release bot GitHub App authentication
+
+The release workflow SHALL authenticate via a short-lived (≤1 h) installation token minted from the `kaiord-release-bot` GitHub App rather than the default `GITHUB_TOKEN`. This is required so that pushes from `changesets/action` (notably the "Version Packages" PR) trigger branch-protection-required workflows on the new commit — `GITHUB_TOKEN`-authored pushes are intentionally excluded from re-triggering workflows by GitHub Actions, which would otherwise leave the PR unmergeable.
+
+The minted token SHALL be requested with least-privilege permissions: `contents: write` and `pull-requests: write`. The App's `workflows: write` permission SHALL NOT be requested at the workflow level even though the App grants it, so the release scripts cannot modify `.github/workflows/`.
+
+The App ID SHALL be read from `vars.RELEASE_APP_ID` and the private key from `secrets.RELEASE_APP_PRIVATE_KEY`. The token SHALL be used for both `actions/checkout` (with `persist-credentials: true`) and the `GITHUB_TOKEN` env var passed to `changesets/action` and `create-github-releases.js`.
+
+#### Scenario: Version Packages PR triggers required checks
+
+- **WHEN** `changesets/action` pushes a commit to the Version Packages PR using the release-bot token
+- **THEN** GitHub Actions SHALL re-run the branch-protection-required workflows (lint/typecheck/test/build/Link checker/Check for Changeset) on that commit, allowing the PR to become mergeable
+
+#### Scenario: Release bot token is short-lived
+
+- **WHEN** the release workflow completes
+- **THEN** the minted token SHALL expire within 1 hour and SHALL NOT be persisted as a long-lived secret
 
 ### Requirement: Workflow permissions are minimal and sufficient
 

--- a/openspec/specs/cws-train2go-listing/spec.md
+++ b/openspec/specs/cws-train2go-listing/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-27
 
 # CWS Train2Go Listing
 

--- a/openspec/specs/doc-drift-prevention/spec.md
+++ b/openspec/specs/doc-drift-prevention/spec.md
@@ -85,4 +85,3 @@ The CI pipeline SHALL run spellcheck (cspell) on documentation content. Unrecogn
 
 - **WHEN** documentation contains a misspelled word not in the project dictionary
 - **THEN** the CI spellcheck SHALL fail and report the typo
-

--- a/openspec/specs/doc-drift-prevention/spec.md
+++ b/openspec/specs/doc-drift-prevention/spec.md
@@ -1,10 +1,10 @@
-> Synced: 2026-04-24 (harden-link-checker)
+> Synced: 2026-04-27
 
 # Doc Drift Prevention
 
 ## Purpose
 
-Safeguards — type-checked code examples, TypeDoc generation, link checking, spellcheck, and a doc-sync hook — that keep the documentation faithful to the code it describes.
+Safeguards — type-checked code examples, TypeDoc generation, link checking, and spellcheck — that keep the documentation faithful to the code it describes.
 
 ## Requirements
 
@@ -86,16 +86,3 @@ The CI pipeline SHALL run spellcheck (cspell) on documentation content. Unrecogn
 - **WHEN** documentation contains a misspelled word not in the project dictionary
 - **THEN** the CI spellcheck SHALL fail and report the typo
 
-### Requirement: Claude Code doc-sync hook
-
-A Claude Code pre-commit hook SHALL check `git diff --cached --name-only` — if source files in `packages/*/src/` are staged but no `packages/docs/` files are staged, it SHALL display a reminder. If docs files are also staged, it SHALL pass silently.
-
-#### Scenario: Source changed without docs
-
-- **WHEN** a developer commits changes to `packages/core/src/` without staging any `packages/docs/` files
-- **THEN** the pre-commit hook SHALL display a reminder to check if docs need updating
-
-#### Scenario: Source and docs changed together
-
-- **WHEN** a developer commits changes to both `packages/core/src/` and `packages/docs/`
-- **THEN** the pre-commit hook SHALL pass silently

--- a/openspec/specs/docs-site/spec.md
+++ b/openspec/specs/docs-site/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-27
 
 # Docs Site
 

--- a/openspec/specs/extension-store-publish/spec.md
+++ b/openspec/specs/extension-store-publish/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-27
 
 # Extension Store Publish
 

--- a/openspec/specs/garmin-bridge/spec.md
+++ b/openspec/specs/garmin-bridge/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-27
 
 # Garmin Bridge
 
@@ -137,6 +137,26 @@ All API operations SHALL require an open Garmin Connect tab (`https://connect.ga
 
 - **WHEN** the SPA or popup requests an API operation and no `connect.garmin.com` tab exists
 - **THEN** the extension returns an error: "No Garmin Connect tab open. Open connect.garmin.com first."
+
+### Requirement: Runtime extension ID announcement on SPA origins
+
+The extension SHALL inject a content script (`kaiord-announce.js`) at `document_start` on SPA origins (`https://*.kaiord.com/*` and, in dev, `http://localhost/*`). The script SHALL post a `KAIORD_BRIDGE_ANNOUNCE` message via `window.postMessage` to the page's own origin so the SPA can discover the extension's runtime ID without hardcoding it.
+
+The announcement payload SHALL include: `type: "KAIORD_BRIDGE_ANNOUNCE"`, `bridgeId: "garmin-bridge"`, `extensionId: chrome.runtime.id`, `name: "Garmin Connect"`, `version` (from manifest), `protocolVersion: 1`, and `capabilities: ["write:workouts"]`.
+
+The script SHALL re-announce when it receives a `KAIORD_BRIDGE_DISCOVER` message from the page (`event.source === window`).
+
+The production manifest (`manifest.prod.json`) SHALL only declare `https://*.kaiord.com/*` as the announce-script match; localhost origins SHALL NOT be present in the production build.
+
+#### Scenario: SPA loads on kaiord.com
+
+- **WHEN** the SPA loads on `https://*.kaiord.com/*` and the extension is installed
+- **THEN** the announce content script posts `{ type: "KAIORD_BRIDGE_ANNOUNCE", bridgeId: "garmin-bridge", extensionId, ... }` to the page so the SPA can register the bridge
+
+#### Scenario: SPA requests rediscovery
+
+- **WHEN** the SPA dispatches `window.postMessage({ type: "KAIORD_BRIDGE_DISCOVER" }, window.location.origin)`
+- **THEN** the announce script re-announces with the same payload
 
 ### Requirement: External message API
 

--- a/openspec/specs/hexagonal-arch/spec.md
+++ b/openspec/specs/hexagonal-arch/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-27
 
 # Hexagonal Architecture
 

--- a/openspec/specs/krd-format/spec.md
+++ b/openspec/specs/krd-format/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-27
 
 # KRD Format
 

--- a/openspec/specs/landing-page/spec.md
+++ b/openspec/specs/landing-page/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-27
 
 # Landing Page
 

--- a/openspec/specs/privacy-policy/spec.md
+++ b/openspec/specs/privacy-policy/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20 (bridge-runtime-discovery)
+> Synced: 2026-04-27
 
 # Privacy Policy
 

--- a/openspec/specs/spa-ai-batch/spec.md
+++ b/openspec/specs/spa-ai-batch/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-18
+> Synced: 2026-04-27
 
 # SPA AI Batch
 

--- a/openspec/specs/spa-bridge-protocol/spec.md
+++ b/openspec/specs/spa-bridge-protocol/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20 (bridge-runtime-discovery)
+> Synced: 2026-04-27
 
 # SPA Bridge Protocol
 

--- a/openspec/specs/spa-calendar/spec.md
+++ b/openspec/specs/spa-calendar/spec.md
@@ -1,10 +1,10 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-27
 
 # SPA Calendar
 
 ## Purpose
 
-Week-view calendar as the editor's home page — URL-addressable weeks, per-day workout grouping, state indicators, and integration with batch processing.
+Week-view calendar as the editor's home page — URL-addressable weeks, per-day workout grouping, state indicators, integration with batch processing, and overlay of planned activities from external coaching platforms (Train2Go, TrainingPeaks, etc.).
 
 ## Requirements
 
@@ -95,6 +95,27 @@ Clicking a workout card SHALL navigate to the editor. Clicking an empty day SHAL
 
 - **WHEN** the user clicks an empty calendar day
 - **THEN** the system SHALL offer "Add from Library" and "Create new workout" options, with the date pre-filled
+
+### Requirement: Coaching activities overlay
+
+The calendar SHALL render planned activities from registered coaching sources (e.g., Train2Go) as a separate row of cards above each day's workouts. Coaching activities are read-only and use a generic `CoachingActivity` shape — calendar components SHALL NOT consume platform-specific types directly. Each adapter (e.g., `adapters/train2go/`) maps its raw payload to `CoachingActivity` at the boundary.
+
+The `CoachingActivity` shape SHALL include: `id` (unique across platforms as `"{source}:{platformId}"`), `source` (platform identifier), `sourceBadge` (short UI label), `date` (`YYYY-MM-DD`), `sport` (`{ label, icon }`), `title`, optional `duration`, optional normalised `effort` (1-5), `status` (`pending` | `completed` | `skipped`), and optional `description`.
+
+#### Scenario: Day with coaching activities
+
+- **WHEN** the calendar week contains coaching activities for a given day
+- **THEN** the day column SHALL render a stack of `CoachingActivityCard`s above the workout cards, each tagged with the source badge
+
+#### Scenario: Coaching activity card click
+
+- **WHEN** the user clicks a coaching activity card
+- **THEN** the card SHALL expand to display the full coaching description (read-only) without navigating away from the calendar
+
+#### Scenario: Empty day with only coaching activities
+
+- **WHEN** a day has coaching activities but no workouts
+- **THEN** the calendar SHALL NOT render the empty-day "+" affordance for that day
 
 ### Requirement: Batch AI processing banner
 

--- a/openspec/specs/spa-editor-context-menu/spec.md
+++ b/openspec/specs/spa-editor-context-menu/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-24 (spa-editor-focus-management)
+> Synced: 2026-04-27
 
 # SPA Editor Context Menu
 

--- a/openspec/specs/spa-editor-focus-management/spec.md
+++ b/openspec/specs/spa-editor-focus-management/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-25 (spa-editor-focus-management-hardening)
+> Synced: 2026-04-27
 
 # Focus Management
 

--- a/openspec/specs/spa-editor-focus-telemetry/spec.md
+++ b/openspec/specs/spa-editor-focus-telemetry/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-25 (spa-editor-focus-management-hardening)
+> Synced: 2026-04-27
 
 # Focus Telemetry
 

--- a/openspec/specs/spa-garmin-extension/spec.md
+++ b/openspec/specs/spa-garmin-extension/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20 (bridge-runtime-discovery)
+> Synced: 2026-04-27
 
 # SPA Garmin Extension
 

--- a/openspec/specs/spa-persistence-port/spec.md
+++ b/openspec/specs/spa-persistence-port/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-27
 
 # SPA Persistence Port
 

--- a/openspec/specs/spa-train2go-extension/spec.md
+++ b/openspec/specs/spa-train2go-extension/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20 (bridge-runtime-discovery)
+> Synced: 2026-04-27
 
 # SPA Train2Go Extension
 

--- a/openspec/specs/spa-workout-state-machine/spec.md
+++ b/openspec/specs/spa-workout-state-machine/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-17
+> Synced: 2026-04-27
 
 # SPA Workout State Machine
 

--- a/openspec/specs/train2go-bridge/spec.md
+++ b/openspec/specs/train2go-bridge/spec.md
@@ -1,4 +1,4 @@
-> Synced: 2026-04-20
+> Synced: 2026-04-27
 
 # Train2Go Bridge
 
@@ -184,6 +184,26 @@ All API operations SHALL require an open Train2Go tab (`https://app.train2go.com
 
 - **WHEN** the SPA or popup requests an API operation and no `app.train2go.com` tab exists
 - **THEN** the extension returns an error: "No Train2Go tab open. Open app.train2go.com first."
+
+### Requirement: Runtime extension ID announcement on SPA origins
+
+The extension SHALL inject a content script (`kaiord-announce.js`) at `document_start` on SPA origins (`https://*.kaiord.com/*` and, in dev, `http://localhost/*`). The script SHALL post a `KAIORD_BRIDGE_ANNOUNCE` message via `window.postMessage` to the page's own origin so the SPA can discover the extension's runtime ID without hardcoding it.
+
+The announcement payload SHALL include: `type: "KAIORD_BRIDGE_ANNOUNCE"`, `bridgeId: "train2go-bridge"`, `extensionId: chrome.runtime.id`, `name: "Kaiord Train2Go Bridge"`, `version` (from manifest), `protocolVersion: 1`, and `capabilities: ["read:training-plan"]`.
+
+The script SHALL re-announce when it receives a `KAIORD_BRIDGE_DISCOVER` message from the page (`event.source === window`).
+
+The production manifest (`manifest.prod.json`) SHALL only declare `https://*.kaiord.com/*` as the announce-script match; localhost origins SHALL NOT be present in the production build.
+
+#### Scenario: SPA loads on kaiord.com
+
+- **WHEN** the SPA loads on `https://*.kaiord.com/*` and the extension is installed
+- **THEN** the announce content script posts `{ type: "KAIORD_BRIDGE_ANNOUNCE", bridgeId: "train2go-bridge", extensionId, ... }` to the page so the SPA can register the bridge
+
+#### Scenario: SPA requests rediscovery
+
+- **WHEN** the SPA dispatches `window.postMessage({ type: "KAIORD_BRIDGE_DISCOVER" }, window.location.origin)`
+- **THEN** the announce script re-announces with the same payload
 
 ### Requirement: External message API
 

--- a/openspec/specs/train2go-bridge/spec.md
+++ b/openspec/specs/train2go-bridge/spec.md
@@ -189,7 +189,7 @@ All API operations SHALL require an open Train2Go tab (`https://app.train2go.com
 
 The extension SHALL inject a content script (`kaiord-announce.js`) at `document_start` on SPA origins (`https://*.kaiord.com/*` and, in dev, `http://localhost/*`). The script SHALL post a `KAIORD_BRIDGE_ANNOUNCE` message via `window.postMessage` to the page's own origin so the SPA can discover the extension's runtime ID without hardcoding it.
 
-The announcement payload SHALL include: `type: "KAIORD_BRIDGE_ANNOUNCE"`, `bridgeId: "train2go-bridge"`, `extensionId: chrome.runtime.id`, `name: "Kaiord Train2Go Bridge"`, `version` (from manifest), `protocolVersion: 1`, and `capabilities: ["read:training-plan"]`.
+The announcement payload SHALL include: `type: "KAIORD_BRIDGE_ANNOUNCE"`, `bridgeId: "train2go-bridge"`, `extensionId: chrome.runtime.id`, `name: "Train2Go"`, `version` (from manifest), `protocolVersion: 1`, and `capabilities: ["read:training-plan"]`.
 
 The script SHALL re-announce when it receives a `KAIORD_BRIDGE_DISCOVER` message from the page (`event.source === window`).
 


### PR DESCRIPTION
## Summary

`opsx-sync` Level C — full deep sync of all 26 capability specs against the current code state. Bumps `> Synced: 2026-04-27` markers everywhere and lands 5 drift fixes detected by parallel audit:

| Spec | Drift |
|---|---|
| `spa-calendar` | Missing `Coaching activities overlay` requirement (Train2Go integration is shipped) |
| `garmin-bridge` | Missing `Runtime extension ID announcement` requirement (`kaiord-announce.js`) |
| `train2go-bridge` | Same kaiord-announce drift |
| `ci-release` | Missing `Release bot GitHub App authentication` (kaiord-release-bot mint in release.yml) |
| `doc-drift-prevention` | Removed `Claude Code doc-sync hook` requirement — not implemented in `.husky/pre-commit`, sync follows code |

The remaining 21 specs are unchanged in body — just the date marker was bumped. `cws-auto-publish` was already at 2026-04-27 from #365.

## Test plan

- [x] `pnpm lint:specs` — 26/26 pass
- [x] `pnpm lint:archive` — date-prefix invariant holds
- [x] `pnpm lint:archive-index` — README in sync
- [x] `pnpm exec openspec validate --specs` — 26/26 pass
- [x] Pre-commit hook passed (build + tsc + tests + scripts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar now displays coaching activity overlay cards sourced from registered coaching platforms.
  * Bridge extensions implement runtime discovery mechanism to announce availability to host pages.
  * Release workflow now uses secure, short-lived authentication tokens.

* **Documentation**
  * Updated specification sync timestamps across multiple modules.
  * Removed doc-sync hook requirement from documentation drift prevention specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->