### PR TITLE
test(spa-editor): close 4 spec coverage gaps from /opsx:verify on train2go-profile-link

### DIFF
--- a/packages/workout-spa-editor/src/application/coaching/use-cases.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/use-cases.test.ts
@@ -135,6 +135,29 @@ describe("unlinkAccount", () => {
     const a = await profiles.getById("A");
     expect(a?.linkedAccounts).toEqual([]);
   });
+
+  it("does NOT cascade to coachingActivities (disconnect retains historical activities)", async () => {
+    // Spec: "Persisted coachingActivities rows for that profile remain on disk;
+    // only profile deletion fully purges them."
+    const profiles = createInMemoryProfileRepository();
+    const coaching = createInMemoryCoachingRepository();
+    await profiles.put(makeProfile("A", [T2G_LINK]));
+    await coaching.upsertMany([makeRecord({ profileId: "A" })]);
+
+    await unlinkAccount(profiles, "A", "train2go");
+
+    // Profile no longer linked
+    const a = await profiles.getById("A");
+    expect(a?.linkedAccounts).toEqual([]);
+
+    // Coaching activities untouched — unlinkAccount has no coaching repo access
+    const activities = await coaching.getByProfileAndDateRange(
+      "A",
+      "2026-01-01",
+      "2026-12-31"
+    );
+    expect(activities).toHaveLength(1);
+  });
 });
 
 describe("syncWeek", () => {

--- a/packages/workout-spa-editor/src/application/profile/delete-profile-with-cascade.test.ts
+++ b/packages/workout-spa-editor/src/application/profile/delete-profile-with-cascade.test.ts
@@ -6,6 +6,8 @@ import { describe, expect, it } from "vitest";
 
 import { createInMemoryCoachingRepository } from "../../test-utils/in-memory-coaching-repository";
 import { createInMemoryCoachingSyncStateRepository } from "../../test-utils/in-memory-coaching-sync-state-repository";
+import { createInMemoryWorkoutRepository } from "../../test-utils/in-memory-workout-repository";
+import type { WorkoutRecord } from "../../types/calendar-record";
 import {
   buildCoachingActivityId,
   type CoachingActivityRecord,
@@ -13,6 +15,28 @@ import {
 import { deleteProfileWithCascade } from "./delete-profile-with-cascade";
 
 const NOW = "2026-04-28T10:00:00.000Z";
+
+const makeWorkout = (id: string): WorkoutRecord => ({
+  id,
+  date: "2026-04-13",
+  sport: "cycling",
+  source: "train2go",
+  sourceId: `p1:${id}`,
+  planId: null,
+  state: "raw",
+  raw: null,
+  krd: null,
+  lastProcessingError: null,
+  feedback: null,
+  aiMeta: null,
+  garminPushId: null,
+  tags: [],
+  previousState: null,
+  createdAt: NOW,
+  modifiedAt: null,
+  updatedAt: NOW,
+});
+
 const makeRecord = (
   profileId: string,
   sourceId: string
@@ -70,6 +94,25 @@ describe("deleteProfileWithCascade", () => {
     expect(
       await coachingSyncState.getBySourceAndProfile("train2go", "p2")
     ).toBeDefined();
+  });
+
+  it("does NOT cascade to converted WorkoutRecord rows (workouts survive)", async () => {
+    // deleteProfileWithCascade has no access to WorkoutRepository by design —
+    // workouts are profile-agnostic. This test documents the invariant.
+    const coaching = createInMemoryCoachingRepository();
+    const coachingSyncState = createInMemoryCoachingSyncStateRepository();
+    const workouts = createInMemoryWorkoutRepository();
+
+    await workouts.put(makeWorkout("w1"));
+    await coaching.upsertMany([makeRecord("p1", "1")]);
+
+    await deleteProfileWithCascade({ coaching, coachingSyncState }, "p1");
+
+    // Coaching activities deleted; workout is untouched
+    expect(
+      await coaching.getByProfileAndDateRange("p1", "2026-01-01", "2026-12-31")
+    ).toHaveLength(0);
+    expect(await workouts.getById("w1")).toBeDefined();
   });
 
   it("uses the supplied id (NOT getActiveId)", async () => {

--- a/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync-helpers.test.ts
+++ b/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync-helpers.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for runSourceSync and isStale helpers.
+ *
+ * Key invariant (spec §12.2): when auto-sync fails (throw or src.error set),
+ * coaching.sync.failure MUST be emitted with isAutoSync: true.
+ */
+
+import type { Analytics } from "@kaiord/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createInMemoryPersistence } from "../test-utils/in-memory-persistence";
+import type { CoachingSyncState } from "./use-coaching-activities";
+import { isStale, runSourceSync } from "./use-coaching-auto-sync-helpers";
+
+const makeAnalytics = (): Analytics => ({
+  pageView: vi.fn(),
+  event: vi.fn(),
+});
+
+const makeSource = (
+  overrides: Partial<CoachingSyncState> = {}
+): CoachingSyncState => ({
+  id: "train2go",
+  label: "Train2Go",
+  linked: true,
+  connected: true,
+  loading: false,
+  error: null,
+  sync: vi.fn(async () => undefined),
+  connect: vi.fn(async () => undefined),
+  ...overrides,
+});
+
+const NOW_MS = Date.now();
+
+describe("isStale", () => {
+  it("returns true when lastSyncedAt is undefined", () => {
+    expect(isStale(undefined, NOW_MS)).toBe(true);
+  });
+
+  it("returns true when lastSyncedAt is unparseable", () => {
+    expect(isStale("not-a-date", NOW_MS)).toBe(true);
+  });
+
+  it("returns false when lastSyncedAt is within 10 minutes", () => {
+    const recent = new Date(NOW_MS - 5 * 60 * 1000).toISOString();
+    expect(isStale(recent, NOW_MS)).toBe(false);
+  });
+
+  it("returns true when lastSyncedAt is older than 10 minutes", () => {
+    const old = new Date(NOW_MS - 11 * 60 * 1000).toISOString();
+    expect(isStale(old, NOW_MS)).toBe(true);
+  });
+});
+
+describe("runSourceSync — auto-sync failure emits isAutoSync: true (spec §12.2)", () => {
+  let analytics: Analytics;
+  let persistence: ReturnType<typeof createInMemoryPersistence>;
+
+  beforeEach(() => {
+    analytics = makeAnalytics();
+    persistence = createInMemoryPersistence();
+  });
+
+  it("emits coaching.sync.failure with isAutoSync: true when src.sync throws", async () => {
+    const src = makeSource({
+      sync: vi.fn(async () => {
+        throw new Error("tab closed");
+      }),
+    });
+
+    await runSourceSync(
+      src,
+      "p1",
+      "2026-04-13",
+      "auto-mount",
+      NOW_MS,
+      persistence,
+      analytics
+    );
+
+    expect(analytics.event).toHaveBeenCalledWith("coaching.sync.failure", {
+      source: "train2go",
+      profileId: "p1",
+      errorKind: "transport-error",
+      isAutoSync: true,
+    });
+  });
+
+  it("emits coaching.sync.failure with isAutoSync: true when src.error is set after sync", async () => {
+    const src = makeSource({
+      sync: vi.fn(async () => {
+        src.error = "session expired";
+      }),
+    });
+
+    await runSourceSync(
+      src,
+      "p1",
+      "2026-04-13",
+      "auto-mount",
+      NOW_MS,
+      persistence,
+      analytics
+    );
+
+    expect(analytics.event).toHaveBeenCalledWith("coaching.sync.failure", {
+      source: "train2go",
+      profileId: "p1",
+      errorKind: "transport-error",
+      isAutoSync: true,
+    });
+  });
+
+  it("emits coaching.sync.invoked before syncing", async () => {
+    const src = makeSource();
+
+    await runSourceSync(
+      src,
+      "p1",
+      "2026-04-13",
+      "auto-week-change",
+      NOW_MS,
+      persistence,
+      analytics
+    );
+
+    expect(analytics.event).toHaveBeenCalledWith("coaching.sync.invoked", {
+      source: "train2go",
+      profileId: "p1",
+      trigger: "auto-week-change",
+    });
+  });
+
+  it("skips sync and emits nothing when state is fresh", async () => {
+    const fresh = new Date(NOW_MS - 60_000).toISOString();
+    await persistence.coachingSyncState.put({
+      source: "train2go",
+      profileId: "p1",
+      lastSyncedAt: fresh,
+    });
+    const src = makeSource();
+
+    await runSourceSync(
+      src,
+      "p1",
+      "2026-04-13",
+      "auto-mount",
+      NOW_MS,
+      persistence,
+      analytics
+    );
+
+    expect(src.sync).not.toHaveBeenCalled();
+    expect(analytics.event).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync.test.tsx
@@ -131,4 +131,34 @@ describe("useCoachingAutoSync", () => {
     await new Promise((r) => setTimeout(r, 5));
     expect(src.sync).not.toHaveBeenCalled();
   });
+
+  it("profile switch invalidates staleness — A's fresh row does NOT suppress sync for B", async () => {
+    // Profile A has a fresh syncState row; the active profile is B which has
+    // no row at all. The hook MUST read B's own row, not A's.
+    const persistence = createInMemoryPersistence();
+    const recent = new Date(Date.now() - 60_000).toISOString();
+    await persistence.coachingSyncState.put({
+      source: "train2go",
+      profileId: "p1", // A's row — must NOT suppress B
+      lastSyncedAt: recent,
+    });
+    mockProfile = {
+      id: "p2",
+      profile: { ...linkedProfile, id: "p2" },
+    };
+    const src = makeSource();
+
+    renderHook(() => useCoachingAutoSync([src], "2026-04-13"), {
+      wrapper: ({ children }) => (
+        <PersistenceProvider persistence={persistence}>
+          {children}
+        </PersistenceProvider>
+      ),
+    });
+
+    // B has no syncState row → stale → sync fires
+    await waitFor(() => {
+      expect(src.sync).toHaveBeenCalledWith("2026-04-13");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds the 4 scenarios flagged as missing by `/opsx:verify` on the `train2go-profile-link` change (PR #372, now merged):

- **Profile switch invalidates staleness** (`use-coaching-auto-sync.test.tsx`): asserts that profile A's fresh `coachingSyncState` row does NOT suppress auto-sync for profile B — the hook must read B's own row.
- **`coaching.sync.failure` with `isAutoSync: true`** (new file `use-coaching-auto-sync-helpers.test.ts`): spec §12.2 requires this event to be emitted when auto-sync fails silently. Also covers `isStale` helper and `coaching.sync.invoked`.
- **Workouts survive profile deletion** (`delete-profile-with-cascade.test.ts`): documents spec §11.5 invariant — `deleteProfileWithCascade` must not cascade to `WorkoutRecord` rows.
- **Disconnect retains coaching activities** (`use-cases.test.ts`): asserts that `unlinkAccount` removes only the `linkedAccounts` entry and leaves `coachingActivities` rows intact.

## Test plan

- [x] All 4 new scenarios pass locally (`pnpm --filter workout-spa-editor exec vitest run`)
- [x] Full test suite passes (pre-commit hook)
- [x] TypeScript type-check passes (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for unlinking accounts to verify coaching data persistence is not affected.
  * Added tests to ensure profile deletion with cascading correctly handles coaching activities while preserving workout records.
  * Added unit tests for auto-sync helpers to validate staleness detection and sync failure handling.
  * Added tests to verify auto-sync correctly uses the active profile's sync state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->