### PR TITLE
openspec: propose coaching-test-coverage-fill (close 6 test gaps from #372 verify)

### DIFF
--- a/openspec/changes/coaching-test-coverage-fill/.openspec.yaml
+++ b/openspec/changes/coaching-test-coverage-fill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/coaching-test-coverage-fill/design.md
+++ b/openspec/changes/coaching-test-coverage-fill/design.md
@@ -1,0 +1,62 @@
+## Context
+
+This is a tests-only follow-up to `train2go-profile-link` (archived 2026-04-28). The 6 invariants closed here are documented in `openspec/specs/spa-coaching-integration/spec.md` and `spa-train2go-extension/spec.md` but are not asserted today. No production code changes; no new dependencies; no migrations.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Lock in 6 silently-regressible invariants as test assertions on `main`.
+- Keep each test isolated to a single behavioral claim — when a test fails, the cause is unambiguous.
+- Use the existing in-memory persistence + mocked transports already established by `train2go-profile-link`. No new test infrastructure.
+
+**Non-Goals:**
+
+- Production code changes. If any test fails on first run, the failing scenario is a real bug — fix it in a separate PR, not as a side-effect here.
+- Spec changes. The scenarios already exist in synced main specs.
+- Restructuring existing tests. Add tests; do not refactor tests.
+- Pre-existing scenarios from prior specs (e.g., "Click RAW workout", "Click empty day") and Dexie migration scenarios (v3→v4 backfill) — those are out of scope; verify report classified them as pre-existing or implicitly covered.
+
+## Decisions
+
+### D1. One scenario → one test, in the file closest to the production code
+
+Each of the 6 gaps maps to exactly one new `it(...)` block in the test file that lives next to the production code under test:
+
+| Gap                                     | File                                                                    | Surface under test                                                   |
+| --------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Manual sync bypasses gate               | `components/organisms/CalendarHeader.test.tsx`                          | `CalendarHeader` Sync button → `source.sync()` (no staleness lookup) |
+| Coaching row preserved on convert       | `application/coaching/convert-coaching-activity.test.ts`                | `convertCoachingActivity` does not delete `coachingActivities` row   |
+| Convert navigates + closes dialog       | `components/molecules/CoachingCard/use-coaching-convert.test.tsx` (NEW) | `useCoachingConvert.handleConvert`                                   |
+| Sync buttons reactive to profile switch | `components/organisms/CalendarHeader.test.tsx`                          | Same as #1 — re-render on `useActiveProfile` change                  |
+| Lossless userId                         | `adapters/train2go/train2go-coaching-transport.test.ts`                 | JSON parse boundary stringification                                  |
+| Concurrent disconnect aborts link       | `application/coaching/use-cases.test.ts` (existing `attemptLink` block) | `AbortSignal` propagation through poll loop                          |
+
+**Why colocate?** The verify report flagged these because the closest test file did not assert them. Adding the assertion next to the existing tests minimises context overhead for a future reviewer.
+
+### D2. The `concurrent disconnect` test drives the `AbortController` directly, not via the UI
+
+The race is at the use-case level (`attemptLink` with an injected `signal`). Driving it from the React component would require timing tricks; driving it from the use-case test is deterministic.
+
+```
+const controller = new AbortController();
+const linkPromise = attemptLink(deps, "p1", controller.signal);
+controller.abort();  // simulates Disconnect arriving mid-poll
+const result = await linkPromise;
+expect(result).toEqual({ ok: false, reason: "aborted" });
+expect(profile.linkedAccounts).toEqual([]);
+```
+
+### D3. The `lossless userId` test asserts the wire→port boundary, not transport internals
+
+Use a numeric `userId: 9007199254740993` (one above `MAX_SAFE_INTEGER`) in the mocked `chrome.runtime.sendMessage` response. Assert that `t.ping().externalUserId === "9007199254740993"` (string-equal, byte-identical). This locks in the JSON-reviver-based stringification pattern in `train2go-ping-result.ts` without coupling the test to its internals.
+
+### D4. The `Sync buttons reactive` test uses two renders, not `rerender`
+
+Test the `CalendarHeader` with two mounts (profile A linked → profile B unlinked) rather than mutating `useActiveProfile` mid-render. This avoids relying on the order in which `useLiveQuery` and `useActiveProfile` flush, which is implementation-detail.
+
+## Risks / Trade-offs
+
+- [Risk: A test surfaces a real bug] → Pause this PR, open a separate fix PR, then come back. Don't bundle code fixes into this tests-only PR.
+- [Risk: Test for `coachingActivities preserved on convert` over-asserts] → Assert only that `getByProfileAndSourceId(p, src, sid)` still returns the row after convert. Don't compare every field — that would couple the test to the row shape.
+- [Risk: `CalendarHeader` profile-switch test flakes on re-render order] → D4 mitigation (two distinct mounts).

--- a/openspec/changes/coaching-test-coverage-fill/proposal.md
+++ b/openspec/changes/coaching-test-coverage-fill/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+The `train2go-profile-link` change shipped (PR #372, archived 2026-04-28). The post-merge `/opsx:verify` report flagged 7 genuine test gaps; PR #374 fast-followed and closed 1. Six gaps remain — all are scenarios already documented in the synced specs (`spa-coaching-integration`, `spa-train2go-extension`) but not yet asserted by tests. They cover behaviors that work today but are silently regressible: lossless `userId` capture, manual sync gate bypass, idempotent conversion preserving the source row, navigation after convert, profile-switch reactivity on the calendar header, and connect-vs-disconnect race handling.
+
+Closing these gaps now (while the implementation is fresh) is cheaper than re-deriving the invariants months later from a regression.
+
+## What Changes
+
+- **Tests-only change.** No production code, no spec edits, no behavior changes. Each new test asserts behavior that already exists in `main` after PR #372.
+- Add 6 surgical test additions across 5 files (one new test file for `use-coaching-convert`):
+  1. `CalendarHeader.test.tsx` — Manual Sync button calls `source.sync()` even when `lastSyncedAt < 10 minutes` (bypasses staleness gate, distinct from auto-sync).
+  2. `convert-coaching-activity.test.ts` — `coachingActivities` row still exists after `convertCoachingActivity` (the conversion creates a `WorkoutRecord`; the source coaching row MUST be preserved for re-conversion + history).
+  3. `use-coaching-convert.test.tsx` (new) — `handleConvert` calls `navigate("/workout/:id")` and `onClose` after a successful conversion; on failure, sets `error` and stays on the page.
+  4. `CalendarHeader.test.tsx` — Switching the active profile reactively updates the rendered Sync buttons (linked sources for new profile shown, unlinked sources hidden).
+  5. `train2go-coaching-transport.test.ts` — A wire response carrying a numeric `userId` larger than `Number.MAX_SAFE_INTEGER` is preserved byte-identically as the resulting `externalUserId` string (asserts the JSON parse boundary stringifier, not `String(parsedNumber)`).
+  6. `attempt-link.test.ts` (or extend `use-cases.test.ts`) — Calling `unlinkAccount(profileId, source)` while `attemptLink` is mid-poll causes the poll's `AbortSignal` to fire and the link is NOT written; final profile state matches the disconnect.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+None — no spec-level requirements change. All 6 scenarios are already documented in the synced main specs after `train2go-profile-link`.
+
+## Impact
+
+- **Affected packages:** `@kaiord/workout-spa-editor` only. No other packages touched.
+- **Affected layers:** test files in `application/coaching/`, `adapters/train2go/`, `components/molecules/CoachingCard/`, `components/organisms/CalendarHeader/`. No port, domain, or adapter implementation changes.
+- **APIs:** No public-API changes.
+- **Dependencies:** No dependency changes.
+- **Coverage:** Pushes diff coverage on `coaching` namespace toward 90% on the affected files; no global coverage threshold change.
+- **Risk:** Very low — tests-only PR; if any of the 6 invariants do NOT hold today, the failing test will surface a real bug that warrants a separate code fix. Each test is independent and can be split into its own commit if a fix is needed.

--- a/openspec/changes/coaching-test-coverage-fill/specs/spa-coaching-integration/spec.md
+++ b/openspec/changes/coaching-test-coverage-fill/specs/spa-coaching-integration/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Test coverage for previously-undertested invariants
+
+The test suite SHALL include assertions for the following six scenarios that already exist in the synced `spa-coaching-integration` and `spa-train2go-extension` specs but were flagged as uncovered by the post-merge `train2go-profile-link` verify report.
+
+This requirement adds NO new behavior — it only formalizes the test-coverage obligation. When the corresponding tests land, this requirement and its scenarios become redundant with the parent specs and SHALL be removed at archive time (no merge into `openspec/specs/`).
+
+#### Scenario: Manual sync bypasses the staleness gate
+
+- **WHEN** the user clicks the per-source Sync button on `CalendarHeader` while `lastSyncedAt < 10 minutes`
+- **THEN** the test asserts `source.sync(profileId, weekStart)` is called exactly once (the staleness gate is auto-sync-only)
+
+#### Scenario: Coaching activity row preserved after conversion
+
+- **WHEN** `convertCoachingActivity(deps, coachingActivityId)` succeeds and creates a `WorkoutRecord`
+- **THEN** the test asserts the original `coachingActivities` row at `(profileId, source, sourceId)` still exists and is unchanged
+
+#### Scenario: Convert action navigates to editor and closes dialog
+
+- **WHEN** `useCoachingConvert.handleConvert()` resolves with `{ created: true, workoutId }`
+- **THEN** the test asserts `navigate` was called with `/workout/<workoutId>` and `onClose` was called once
+
+#### Scenario: Sync buttons re-render when active profile changes
+
+- **WHEN** `CalendarHeader` is rendered first with a profile linked to Train2Go, then re-mounted with a profile that has no linked accounts
+- **THEN** the first render exposes the Train2Go Sync button; the second render does not
+
+#### Scenario: Lossless userId at the JSON parse boundary
+
+- **WHEN** the Train2Go transport receives a wire response with `userId: 9007199254740993` (one above `Number.MAX_SAFE_INTEGER`)
+- **THEN** the test asserts `t.ping().externalUserId === "9007199254740993"` (string-equal, byte-identical to the wire digits)
+
+#### Scenario: Concurrent disconnect aborts an in-flight link
+
+- **WHEN** `attemptLink(deps, profileId, signal)` is mid-poll and the caller calls `signal.abort()` (modeling a Disconnect click on Profile Settings)
+- **THEN** the test asserts the returned result is `{ ok: false, reason: "aborted" }` and `profile.linkedAccounts` is unchanged

--- a/openspec/changes/coaching-test-coverage-fill/tasks.md
+++ b/openspec/changes/coaching-test-coverage-fill/tasks.md
@@ -1,0 +1,39 @@
+## 1. Manual sync bypass
+
+- [ ] 1.1 In `packages/workout-spa-editor/src/components/organisms/CalendarHeader/CalendarHeader.test.tsx`, add `it("Manual Sync button bypasses staleness gate", ...)` — render with a profile linked to Train2Go and a `coachingSyncState` row whose `lastSyncedAt` is 30 seconds ago; click the per-source Sync button; assert `source.sync(profileId, weekStart)` was called once
+- [ ] 1.2 Run only `packages/workout-spa-editor` tests for that file; assert pass
+
+## 2. Coaching row preserved on convert
+
+- [ ] 2.1 In `packages/workout-spa-editor/src/application/coaching/convert-coaching-activity.test.ts`, add `it("preserves the coachingActivities row after a successful conversion", ...)` — set up a coaching record, call `convertCoachingActivity`, assert `coaching.getByProfileAndSourceId(profileId, source, sourceId)` still returns a row equal to the original
+- [ ] 2.2 Run only that file; assert pass
+
+## 3. Convert navigation + dialog close
+
+- [ ] 3.1 Create `packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-convert.test.tsx` with a hook test that mocks `useLocation` from `wouter` and `convertCoachingActivity`; assert `handleConvert` calls `navigate("/workout/<workoutId>")` and `onClose()` exactly once on success
+- [ ] 3.2 Add a second `it(...)` in the same file: on `convertCoachingActivity` rejection, `error` is set and neither `navigate` nor `onClose` are called
+- [ ] 3.3 Run only that file; assert pass
+
+## 4. Sync buttons reactive to profile switch
+
+- [ ] 4.1 In `packages/workout-spa-editor/src/components/organisms/CalendarHeader/CalendarHeader.test.tsx`, add `it("hides the Sync button when active profile has no linked accounts", ...)` — first mount with profile A (Train2Go-linked) and assert the Sync button is present; unmount; remount with profile B (no linked accounts) and assert the Sync button is absent
+- [ ] 4.2 Run only that file; assert pass
+
+## 5. Lossless userId
+
+- [ ] 5.1 In `packages/workout-spa-editor/src/adapters/train2go/train2go-coaching-transport.test.ts`, add `it("preserves a userId larger than Number.MAX_SAFE_INTEGER as a string at the JSON parse boundary", ...)` — mock `chrome.runtime.sendMessage` to deliver a wire response with `userId: 9007199254740993`; await `t.ping()`; assert `result.externalUserId === "9007199254740993"` (string equality, not numeric)
+- [ ] 5.2 Run only that file; assert pass
+
+## 6. Concurrent disconnect aborts in-flight link
+
+- [ ] 6.1 In `packages/workout-spa-editor/src/application/coaching/use-cases.test.ts` (existing `attemptLink` describe block), add `it("returns aborted and writes nothing when the signal is aborted mid-poll", ...)` — start `attemptLink(deps, profileId, controller.signal)`, then `controller.abort()` before the first ping resolves; assert result is `{ ok: false, reason: "aborted" }` and `profiles.getById(profileId).linkedAccounts === []`
+- [ ] 6.2 Run only that file; assert pass
+
+## 7. Wrap-up
+
+- [ ] 7.1 Run `pnpm -r test` — all packages pass
+- [ ] 7.2 Run `pnpm -r build` — all packages build
+- [ ] 7.3 Run `pnpm lint` — zero warnings
+- [ ] 7.4 `pnpm exec changeset` — add a `patch` changeset for `@kaiord/workout-spa-editor` noting "test: close 6 coaching test gaps from train2go-profile-link verify report"
+- [ ] 7.5 `/opsx:verify` against this change to confirm all 6 scenarios are covered by tests
+- [ ] 7.6 After PR merge: `/opsx:archive` (no spec sync needed — the stub spec at archive time has zero impact since no main spec is referenced)


### PR DESCRIPTION
## Summary

OpenSpec proposal only — no code, no tests yet. Implementation will follow via `/opsx:apply` in a separate PR.

This is a **tests-only** follow-up to `train2go-profile-link` (PR #372, archived in #375). The post-merge `/opsx:verify` flagged 7 genuine test gaps; PR #374 closed 1. This proposal scopes the remaining 6 surgical test additions:

1. Manual Sync button bypasses the 10-min staleness gate
2. `coachingActivities` row preserved after `convertCoachingActivity`
3. `handleConvert` navigates to `/workout/:id` and closes the dialog
4. `CalendarHeader` Sync buttons re-render on active-profile switch
5. Lossless `userId` at the JSON parse boundary (>`Number.MAX_SAFE_INTEGER`)
6. Concurrent disconnect aborts an in-flight `attemptLink`

No production code, no spec changes. Each scenario already exists in the synced `spa-coaching-integration` and `spa-train2go-extension` main specs after PR #372.

## Test plan

- [x] `openspec status --change coaching-test-coverage-fill` — 4/4 artifacts complete
- [ ] After merge: `/opsx:apply coaching-test-coverage-fill` to land the 6 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)