### PR TITLE
chore(openspec): sync spa-calendar coaching-card click scenario

### DIFF
--- a/openspec/specs/spa-calendar/spec.md
+++ b/openspec/specs/spa-calendar/spec.md
@@ -141,7 +141,7 @@ The `CoachingActivity` shape SHALL include: `id` (unique across platforms as `"{
 #### Scenario: Coaching activity card click
 
 - **WHEN** the user clicks a coaching activity card
-- **THEN** the card SHALL expand to display the full coaching description (read-only) without navigating away from the calendar
+- **THEN** the card SHALL invoke its `onClick(activity)` handler, which opens `CoachingActivityDialog` with the full coaching description (read-only); the card itself does NOT expand inline
 
 #### Scenario: Empty day with only coaching activities
 


### PR DESCRIPTION
## Summary

`/opsx-sync` drift audit on 2026-04-28 found one inconsistency in `spa-calendar/spec.md`:

- The "Coaching activity card click" scenario said the card SHALL **expand inline** to display the description.
- The actual code (`CoachingActivityCard.tsx`) only fires `onClick(activity)`; the description is rendered by `CoachingActivityDialog`, not by an inline expand.
- The newer "Click coaching activity card" scenario already documents the dialog behavior, so this older scenario was contradicting both itself and the code.

This PR rewords the older scenario to match the dialog flow. No code changes.

## Test plan

- [x] `pnpm lint:specs` (27 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated specification for coaching activity card interaction: clicking the card now opens a dialog to display the full description in read-only mode, replacing the previous inline expansion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->