### PR TITLE
test(spa-editor): replace inline 5s waitFor overrides with global asyncUtilTimeout

### DIFF
--- a/packages/workout-spa-editor/src/App.test.tsx
+++ b/packages/workout-spa-editor/src/App.test.tsx
@@ -55,13 +55,8 @@ describe("App", () => {
   it("should render the calendar page by default when no workout is loaded", async () => {
     window.localStorage.setItem("workout-spa-onboarding-completed", "true");
     renderWithProviders(<App />);
-    // Default route redirects to /calendar
-    await waitFor(
-      () => {
-        expect(screen.getByText("Welcome to Kaiord")).toBeInTheDocument();
-      },
-      { timeout: 5000 }
-    );
+
+    expect(await screen.findByText("Welcome to Kaiord")).toBeInTheDocument();
   });
 
   describe("onboarding tutorial integration (Requirements 37.1, 37.5)", () => {

--- a/packages/workout-spa-editor/src/components/pages/CalendarPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPage.test.tsx
@@ -92,12 +92,7 @@ describe("CalendarPage", () => {
 
     renderCalendar();
 
-    await waitFor(
-      () => {
-        expect(screen.getByTestId("workout-card-w-mon")).toBeInTheDocument();
-      },
-      { timeout: 5000 }
-    );
+    expect(await screen.findByTestId("workout-card-w-mon")).toBeInTheDocument();
   });
 
   // Covered by e2e: calendar-batch.spec.ts "banner shows count"
@@ -109,12 +104,9 @@ describe("CalendarPage", () => {
 
     renderCalendar();
 
-    await waitFor(
-      () => {
-        expect(screen.getByText(/2 raw workouts/)).toBeInTheDocument();
-      },
-      { timeout: 5000 }
-    );
+    await waitFor(() => {
+      expect(screen.getByText(/2 raw workouts/)).toBeInTheDocument();
+    });
   });
 
   // Covered by e2e: calendar-workouts.spec.ts "Multiple workouts per day"
@@ -151,15 +143,12 @@ describe("CalendarPage", () => {
 
     renderCalendar();
 
-    await waitFor(
-      () => {
-        const cards = screen.getAllByTestId(/^workout-card-/);
-        expect(cards).toHaveLength(2);
-        expect(cards[0]).toHaveTextContent("Morning swim");
-        expect(cards[1]).toHaveTextContent("Evening run");
-      },
-      { timeout: 5000 }
-    );
+    await waitFor(() => {
+      const cards = screen.getAllByTestId(/^workout-card-/);
+      expect(cards).toHaveLength(2);
+      expect(cards[0]).toHaveTextContent("Morning swim");
+      expect(cards[1]).toHaveTextContent("Evening run");
+    });
   });
 
   it("shows week navigation controls", async () => {

--- a/packages/workout-spa-editor/src/components/templates/MainLayout/LayoutHeader.test.tsx
+++ b/packages/workout-spa-editor/src/components/templates/MainLayout/LayoutHeader.test.tsx
@@ -149,11 +149,7 @@ describe("LayoutHeader", () => {
 
       // Assert
       expect(
-        await screen.findByRole(
-          "heading",
-          { name: /profile manager/i },
-          { timeout: 5000 }
-        )
+        await screen.findByRole("heading", { name: /profile manager/i })
       ).toBeInTheDocument();
     });
   });

--- a/packages/workout-spa-editor/src/routes.test.tsx
+++ b/packages/workout-spa-editor/src/routes.test.tsx
@@ -58,12 +58,7 @@ describe("Routing", () => {
   it("renders CalendarPage at /calendar", async () => {
     renderAtPath("/calendar");
 
-    await waitFor(
-      () => {
-        expect(screen.getByText("Welcome to Kaiord")).toBeInTheDocument();
-      },
-      { timeout: 5000 }
-    );
+    expect(await screen.findByText("Welcome to Kaiord")).toBeInTheDocument();
   });
 
   it("renders LibraryPage at /library", async () => {
@@ -77,13 +72,10 @@ describe("Routing", () => {
   it("renders EditorPage at /workout/new", async () => {
     renderAtPath("/workout/new");
 
-    await waitFor(
-      () => {
-        const container = document.querySelector(".space-y-6");
-        expect(container).toBeInTheDocument();
-      },
-      { timeout: 5000 }
-    );
+    await waitFor(() => {
+      const container = document.querySelector(".space-y-6");
+      expect(container).toBeInTheDocument();
+    });
   });
 
   it("redirects / to /calendar", async () => {

--- a/packages/workout-spa-editor/src/test-setup.ts
+++ b/packages/workout-spa-editor/src/test-setup.ts
@@ -1,10 +1,16 @@
 import "fake-indexeddb/auto";
 import * as matchers from "@testing-library/jest-dom/matchers";
-import { cleanup } from "@testing-library/react";
+import { cleanup, configure } from "@testing-library/react";
 import { afterEach, beforeEach, expect, vi } from "vitest";
 
 // Extend Vitest's expect with jest-dom matchers
 expect.extend(matchers);
+
+// RTL default asyncUtilTimeout is 1s; route-level tests mounting React.lazy
+// chunks (CalendarPage, EditorPage) under post-build pre-commit load need more
+// headroom. Bumping globally is the deterministic alternative to per-call
+// `{ timeout: 5000 }` overrides scattered across tests.
+configure({ asyncUtilTimeout: 5000 });
 
 // Mock window.matchMedia for theme tests
 beforeEach(() => {


### PR DESCRIPTION
## Summary

Cleanup follow-up to closed PR #373 (the deterministic-fix nit raised in review's section C). No behavior change — only test ergonomics.

The test suite scattered `{ timeout: 5000 }` options across individual `waitFor` / `findBy*` calls to give route-level tests (mounting `React.lazy` chunks like `CalendarPage`, `EditorPage`) enough headroom under post-build pre-commit load. This PR moves the bump to a single place — `configure({ asyncUtilTimeout: 5000 })` in `test-setup.ts` — and removes the per-call overrides.

## Changes

- `test-setup.ts`: add `configure({ asyncUtilTimeout: 5000 })` (one-time global RTL config)
- `App.test.tsx`: replace `waitFor(..., { timeout: 5000 })` with `findByText`
- `routes.test.tsx`: same — `findByText` for `/calendar`; plain `waitFor` for `/workout/new`
- `CalendarPage.test.tsx`: drop 3 inline 5s overrides (1 active, 2 in `it.skip` blocks)
- `LayoutHeader.test.tsx`: drop the 5s `findByRole` override

Net: −22 LOC.

## Test plan

- [x] `pnpm exec vitest run` on the 4 touched test files: 45 passed, 3 skipped (no behavior change)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)