### PR TITLE
fix(spa-editor): Toast auto-dismiss in Safari/webkit (closes #379)

### DIFF
--- a/packages/workout-spa-editor/src/components/atoms/Toast/ToastProvider.tsx
+++ b/packages/workout-spa-editor/src/components/atoms/Toast/ToastProvider.tsx
@@ -30,7 +30,14 @@ export const ToastProvider = ({
       duration={duration}
     >
       {children}
-      <ToastPrimitive.Viewport className="fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:left-1/2 sm:-translate-x-1/2 sm:top-auto sm:flex-col md:max-w-[420px]" />
+      {/*
+        pointer-events-none on the viewport: per Radix Toast guidance,
+        the viewport itself must NOT capture pointer events — otherwise
+        webkit reports the empty viewport area as "hovered" and Radix
+        pauses every toast's auto-dismiss timer indefinitely (issue #379).
+        Individual toasts re-enable `pointer-events-auto` via baseToastStyles.
+      */}
+      <ToastPrimitive.Viewport className="pointer-events-none fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:left-1/2 sm:-translate-x-1/2 sm:top-auto sm:flex-col md:max-w-[420px]" />
     </ToastPrimitive.Provider>
   );
 };


### PR DESCRIPTION
## Root cause

The \`Toast.Viewport\` was missing \`pointer-events-none\`. Per Radix Toast guidance, the viewport must not capture pointer events, otherwise the entire viewport region (the fixed-position rectangle reserved for toasts) is treated as "hovered" whenever the cursor sits inside that rectangle — and Radix pauses every toast's auto-dismiss timer for the duration of the "hover".

In webkit / Safari, hit-testing of the empty viewport area is more aggressive than in chromium / firefox: even when the cursor is over the underlying page (e.g., immediately after clicking the paste button), webkit still reports a hover on the viewport, so the dismiss timer never fires.

Individual toasts re-enable \`pointer-events-auto\` via \`baseToastStyles\` (\`Toast.styles.ts:20\`), so the close button and the legitimate "pause on hover the actual toast" behavior are preserved.

## Symptom (before fix)

Issue #379 — \`e2e/copy-paste.spec.ts:352:5 — should show notification when pasting step\` failed deterministically on webkit only:

\`\`\`
Locator:  getByText(/step pasted successfully/i).first()
Expected: not visible
Received: visible
14 × locator resolved to <div class=\"text-sm font-semibold\">Step pasted successfully</div>
\`\`\`

Two consecutive runs failed identically, ruling out timing flake.

## Test plan

- [x] Toast unit suite passes (\`pnpm exec vitest run src/components/atoms/Toast/\`): 18/18
- [ ] CI runs the failing webkit e2e test against this branch
- [ ] Verify chromium / firefox / mobile-chrome / mobile-safari still pass (no behavior change for them — they were never affected by the viewport hover bug)
- [ ] Manual check: hover over an actual toast still pauses its dismiss (the legitimate Radix feature)

Closes #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed pointer event handling for Toast notifications to ensure they respond correctly to user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->