### PR TITLE
chore(spa-editor): persistence-read-rule-cleanup Phase 4 — no-Zustand-write-through guard

### DIFF
--- a/.changeset/persistence-read-rule-cleanup-4.md
+++ b/.changeset/persistence-read-rule-cleanup-4.md
@@ -1,0 +1,7 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+chore(spa-editor): lock in no-Zustand-write-through guard for persisted entities
+
+Adds `scripts/check-no-zustand-writethrough.mjs`, a `pnpm test:scripts`-wired static-import check that fails CI if a file under `packages/workout-spa-editor/src/store/**` imports `adapters/dexie/dexie-database` (relative, alias, barrel re-export, or dynamic import) or imports a `persistState` identifier — and if any file under `packages/workout-spa-editor/src/application/**` imports `dexie-database` at all. A small allowlist exempts explicit-user-action writers from the store rule. The application rule has no allowlist.

--- a/openspec/changes/persistence-read-rule-cleanup/tasks.md
+++ b/openspec/changes/persistence-read-rule-cleanup/tasks.md
@@ -207,22 +207,22 @@ Pattern for these tests per D5.1: mount inside `<PersistenceProvider persistence
 - [x] 3.7.5 Run `pnpm -r build` — clean.
 - [x] 3.7.6 Update internal docs.
 - [x] 3.7.7 Add a `patch` changeset titled `refactor(spa-editor): split AI store into persisted slice (Dexie/useLiveQuery) and runtime slice (Zustand)`.
-- [ ] 3.7.8 Open PR; ensure CI green; squash merge. Verify in production: AI providers reload after refresh; generation status still updates live; no encryption regression.
+- [x] 3.7.8 Open PR; ensure CI green; squash merge. Verify in production: AI providers reload after refresh; generation status still updates live; no encryption regression.
 
 ## 4. Phase 4 — Mechanical guard + final consolidation (PR #N+4)
 
 ### 4.1 — Guard script
 
-- [ ] 4.1.1 Create `scripts/check-no-zustand-writethrough.mjs` per design D4. Implementation: walk `packages/workout-spa-editor/src/store/**/*.{ts,tsx}` AND `packages/workout-spa-editor/src/application/**/*.{ts,tsx}` (excluding `*.test.{ts,tsx}`), parse each file's import statements (using the TypeScript compiler API or a small AST parser), and:
+- [x] 4.1.1 Create `scripts/check-no-zustand-writethrough.mjs` per design D4. Implementation: walk `packages/workout-spa-editor/src/store/**/*.{ts,tsx}` AND `packages/workout-spa-editor/src/application/**/*.{ts,tsx}` (excluding `*.test.{ts,tsx}`), parse each file's import statements (using the TypeScript compiler API or a small AST parser), and:
   - Fail (rule R-DexieImport) if any non-allowlisted file under `src/store/**` imports a path resolving to `adapters/dexie/dexie-database`. The script normalises through (a) relative paths, (b) tsconfig path aliases (parse from the workspace `tsconfig.json`), (c) barrel re-exports, (d) `await import(...)` dynamic imports.
   - Fail (rule R-PersistStateImport) if any non-allowlisted file under `src/store/**` imports an identifier named `persistState` from any path.
   - Fail (rule R-AppDexieImport) if ANY file under `src/application/**` imports a path resolving to `adapters/dexie/dexie-database` (no allowlist — application code MUST go through `PersistencePort`).
   - Output the offending file + import + rule on failure.
-- [ ] 4.1.2 Hard-coded allowlist in 4.1.1: file paths confirmed by reading the current `useWorkoutStore` implementation (after Phases 1–3 land). Each entry has a one-line comment explaining why.
+- [x] 4.1.2 Hard-coded allowlist in 4.1.1: file paths confirmed by reading the current `useWorkoutStore` implementation (after Phases 1–3 land). Each entry has a one-line comment explaining why.
 
 ### 4.2 — Co-located test
 
-- [ ] 4.2.1 Create `scripts/check-no-zustand-writethrough.test.mjs` (`node:test`) covering fixture files under `scripts/__fixtures__/check-no-zustand-writethrough/`:
+- [x] 4.2.1 Create `scripts/check-no-zustand-writethrough.test.mjs` (`node:test`) covering fixture files under `scripts/__fixtures__/check-no-zustand-writethrough/`:
   - Positive case: post-Phase-3 codebase passes.
   - R-DexieImport relative path negative.
   - R-DexieImport alias path (`@/...`) negative.
@@ -235,20 +235,20 @@ Pattern for these tests per D5.1: mount inside `<PersistenceProvider persistence
 
 ### 4.3 — Wire into CI
 
-- [ ] 4.3.1 Confirm `pnpm test:scripts` includes the new script. If not, update the script glob and `package.json`.
-- [ ] 4.3.2 Run `pnpm test:scripts` locally — all green including the new file.
+- [x] 4.3.1 Confirm `pnpm test:scripts` includes the new script. If not, update the script glob and `package.json`.
+- [x] 4.3.2 Run `pnpm test:scripts` locally — all green including the new file.
 
 ### 4.4 — Final dead-code sweep
 
-- [ ] 4.4.1 Search the repo for any leftover references to deleted modules (`useProfileStore`, `useLibraryStore`, `useAiStore`, `use-active-profile`, `use-library`, `use-ai-hydration`). All should be zero. Delete any orphaned imports.
-- [ ] 4.4.2 Confirm `useStoreHydration` no longer references AI hydration.
+- [x] 4.4.1 Search the repo for any leftover references to deleted modules (`useProfileStore`, `useLibraryStore`, `useAiStore`, `use-active-profile`, `use-library`, `use-ai-hydration`). All should be zero. Delete any orphaned imports.
+- [x] 4.4.2 Confirm `useStoreHydration` no longer references AI hydration.
 
 ### 4.5 — Validation
 
-- [ ] 4.5.1 Run `pnpm --filter @kaiord/workout-spa-editor test` — passing.
-- [ ] 4.5.2 Run `pnpm --filter @kaiord/workout-spa-editor lint` — clean.
-- [ ] 4.5.3 Run `pnpm -r build` — clean.
-- [ ] 4.5.4 Run `pnpm test:scripts` — passing including the new guard.
+- [x] 4.5.1 Run `pnpm --filter @kaiord/workout-spa-editor test` — passing.
+- [x] 4.5.2 Run `pnpm --filter @kaiord/workout-spa-editor lint` — clean.
+- [x] 4.5.3 Run `pnpm -r build` — clean.
+- [x] 4.5.4 Run `pnpm test:scripts` — passing including the new guard.
 - [ ] 4.5.5 Update internal docs to reference the new persistence rule and the guard script.
 - [ ] 4.5.6 Add a `patch` changeset titled `chore(spa-editor): lock in no-Zustand-write-through guard for persisted entities`.
 - [ ] 4.5.7 Open PR; ensure CI green; squash merge.

--- a/scripts/check-no-zustand-writethrough.mjs
+++ b/scripts/check-no-zustand-writethrough.mjs
@@ -58,6 +58,15 @@ const STATIC_IMPORT_RE =
 const DYNAMIC_IMPORT_RE = /\bimport\(\s*["']([^"']+)["']\s*\)/g;
 const PERSIST_STATE_NAMED_RE =
   /import(?:\s+type)?\s*\{([^}]*?)\}\s*from\s+["'][^"']+["']/g;
+// Catches `import persistState from "..."` and
+// `import persistState, { other } from "..."`. The leading clause
+// matches default imports only — namespace imports are handled by the
+// dedicated namespace regex below.
+const PERSIST_STATE_DEFAULT_RE =
+  /import(?:\s+type)?\s+([A-Za-z_$][\w$]*)(?:\s*,\s*[\s\S]*?)?\s+from\s+["'][^"']+["']/g;
+// Catches `import * as persistState from "..."`.
+const PERSIST_STATE_NAMESPACE_RE =
+  /import\s+\*\s+as\s+([A-Za-z_$][\w$]*)\s+from\s+["'][^"']+["']/g;
 
 const findRoots = (dir) => {
   const out = [];
@@ -104,16 +113,128 @@ function importsPersistState(source) {
       .map((s) => s.trim().replace(/\s+as\s+\w+$/, ""));
     if (names.includes("persistState")) return true;
   }
+  for (const m of source.matchAll(PERSIST_STATE_DEFAULT_RE)) {
+    if (m[1] === "persistState") return true;
+  }
+  for (const m of source.matchAll(PERSIST_STATE_NAMESPACE_RE)) {
+    if (m[1] === "persistState") return true;
+  }
   return false;
 }
 
-function resolveSpecifier(fromFile, spec) {
-  if (spec.startsWith("@/")) {
-    return resolveTsModule(join(SPA_SRC, spec.slice(2)));
+// Strip TypeScript's allowed JSON-with-comments noise so JSON.parse
+// succeeds. tsconfig.json allows // and /* */ comments and trailing
+// commas. The naive regex pass treats `/*` inside a string literal
+// (e.g. `"@/*"`) as a block-comment opener, so we walk the source
+// character-by-character and only treat comment markers seen outside
+// strings as comments.
+function stripJsonc(source) {
+  let out = "";
+  let i = 0;
+  let inString = false;
+  let stringChar = "";
+  while (i < source.length) {
+    const ch = source[i];
+    const next = source[i + 1];
+    if (inString) {
+      out += ch;
+      if (ch === "\\" && i + 1 < source.length) {
+        out += next;
+        i += 2;
+        continue;
+      }
+      if (ch === stringChar) inString = false;
+      i += 1;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inString = true;
+      stringChar = ch;
+      out += ch;
+      i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      while (i < source.length && source[i] !== "\n") i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      i += 2;
+      while (
+        i < source.length &&
+        !(source[i] === "*" && source[i + 1] === "/")
+      ) {
+        i += 1;
+      }
+      i += 2; // skip closing */
+      continue;
+    }
+    out += ch;
+    i += 1;
   }
+  return out.replace(/,(\s*[}\]])/g, "$1");
+}
+
+let aliasCache;
+
+function loadTsconfigAliases() {
+  if (aliasCache) return aliasCache;
+  aliasCache = [];
+  const tsconfigPath = join(
+    REPO_ROOT,
+    "packages",
+    "workout-spa-editor",
+    "tsconfig.app.json"
+  );
+  let raw;
+  try {
+    raw = readFileSync(tsconfigPath, "utf8");
+  } catch {
+    return aliasCache;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(stripJsonc(raw));
+  } catch {
+    return aliasCache;
+  }
+  const paths = parsed?.compilerOptions?.paths ?? {};
+  for (const [pattern, targets] of Object.entries(paths)) {
+    if (!Array.isArray(targets) || targets.length === 0) continue;
+    // tsconfig path patterns end in /* — strip and treat the rest as a prefix.
+    const prefix = pattern.endsWith("/*") ? pattern.slice(0, -2) : pattern;
+    const target = targets[0].endsWith("/*")
+      ? targets[0].slice(0, -2)
+      : targets[0];
+    aliasCache.push({
+      prefix: prefix.endsWith("/") ? prefix.slice(0, -1) : prefix,
+      target: join(
+        REPO_ROOT,
+        "packages",
+        "workout-spa-editor",
+        target.startsWith("./") ? target.slice(2) : target
+      ),
+    });
+  }
+  return aliasCache;
+}
+
+function resolveAlias(spec) {
+  for (const { prefix, target } of loadTsconfigAliases()) {
+    if (spec === prefix) return target;
+    if (spec.startsWith(`${prefix}/`)) {
+      return join(target, spec.slice(prefix.length + 1));
+    }
+  }
+  return null;
+}
+
+function resolveSpecifier(fromFile, spec) {
   if (spec.startsWith(".")) {
     return resolveTsModule(resolve(dirname(fromFile), spec));
   }
+  const aliased = resolveAlias(spec);
+  if (aliased) return resolveTsModule(aliased);
   return null; // external package, irrelevant for these rules
 }
 

--- a/scripts/check-no-zustand-writethrough.mjs
+++ b/scripts/check-no-zustand-writethrough.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Mechanical guard: no Zustand store may write through to the Dexie
+ * database directly. Persisted state belongs behind PersistencePort.
+ *
+ * Three rules, all import-based:
+ *
+ *   R-DexieImport       — Files under packages/workout-spa-editor/src/store/**
+ *                         must NOT import (statically or dynamically) from a
+ *                         path resolving to adapters/dexie/dexie-database.
+ *                         The barrel `adapters/dexie/index.ts` is followed
+ *                         through. Allowlist exempts a small set of
+ *                         explicit-user-action writers.
+ *
+ *   R-PersistStateImport — Files under packages/workout-spa-editor/src/store/**
+ *                         must NOT import an identifier named `persistState`
+ *                         from any path. Same allowlist applies.
+ *
+ *   R-AppDexieImport    — Files under packages/workout-spa-editor/src/application/**
+ *                         must NEVER import a path resolving to dexie-database.
+ *                         Application code goes through PersistencePort; no
+ *                         allowlist.
+ *
+ * Why import-based rather than action-body matching: lower false-positive
+ * rate. A file that imports neither dexie-database nor persistState cannot
+ * write through. New write-throughs would have to add an import; that is
+ * the signal we catch.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const SPA_SRC = join(
+  REPO_ROOT,
+  "packages",
+  "workout-spa-editor",
+  "src"
+);
+
+// Allowlisted files (relative to repo root, posix-style) that are
+// permitted to bypass R-DexieImport and R-PersistStateImport. Keep this
+// list tiny; every entry must document why.
+export const ALLOWLIST = new Set([
+  // workout-store actions trigger an explicit user-driven save-to-library
+  // write. The action runs through PersistencePort but the legacy entry
+  // point still lives in the store module; tracked for future migration.
+  "packages/workout-spa-editor/src/store/workout-store-actions.ts",
+]);
+
+const TS_EXTENSIONS = [".ts", ".tsx"];
+const SKIP_EXTENSIONS = [".test.ts", ".test.tsx", ".stories.ts", ".stories.tsx"];
+
+const STATIC_IMPORT_RE =
+  /import(?:\s+type)?\s+(?:[\s\S]*?\s+from\s+)?["']([^"']+)["']/g;
+const DYNAMIC_IMPORT_RE = /\bimport\(\s*["']([^"']+)["']\s*\)/g;
+const PERSIST_STATE_NAMED_RE =
+  /import(?:\s+type)?\s*\{([^}]*?)\}\s*from\s+["'][^"']+["']/g;
+
+const findRoots = (dir) => {
+  const out = [];
+  if (!safeStat(dir)) return out;
+  walk(dir, (file) => out.push(file));
+  return out;
+};
+
+function safeStat(p) {
+  try {
+    return statSync(p);
+  } catch {
+    return null;
+  }
+}
+
+function walk(dir, visit) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(p, visit);
+    } else if (entry.isFile() && shouldScan(entry.name)) {
+      visit(p);
+    }
+  }
+}
+
+function shouldScan(name) {
+  if (SKIP_EXTENSIONS.some((ext) => name.endsWith(ext))) return false;
+  return TS_EXTENSIONS.some((ext) => name.endsWith(ext));
+}
+
+function extractImports(source) {
+  const specs = [];
+  for (const m of source.matchAll(STATIC_IMPORT_RE)) specs.push(m[1]);
+  for (const m of source.matchAll(DYNAMIC_IMPORT_RE)) specs.push(m[1]);
+  return specs;
+}
+
+function importsPersistState(source) {
+  for (const m of source.matchAll(PERSIST_STATE_NAMED_RE)) {
+    const names = m[1]
+      .split(",")
+      .map((s) => s.trim().replace(/\s+as\s+\w+$/, ""));
+    if (names.includes("persistState")) return true;
+  }
+  return false;
+}
+
+function resolveSpecifier(fromFile, spec) {
+  if (spec.startsWith("@/")) {
+    return resolveTsModule(join(SPA_SRC, spec.slice(2)));
+  }
+  if (spec.startsWith(".")) {
+    return resolveTsModule(resolve(dirname(fromFile), spec));
+  }
+  return null; // external package, irrelevant for these rules
+}
+
+function resolveTsModule(absPath) {
+  for (const ext of TS_EXTENSIONS) {
+    const candidate = `${absPath}${ext}`;
+    if (safeStat(candidate)?.isFile()) return candidate;
+  }
+  for (const ext of TS_EXTENSIONS) {
+    const candidate = join(absPath, `index${ext}`);
+    if (safeStat(candidate)?.isFile()) return candidate;
+  }
+  if (safeStat(absPath)?.isFile()) return absPath;
+  return null;
+}
+
+const DEXIE_DB_LEAF = join("adapters", "dexie", "dexie-database");
+
+function resolvesToDexieDatabase(absResolved) {
+  if (!absResolved) return false;
+  const noExt = absResolved.replace(/\.tsx?$/, "");
+  return noExt.endsWith(DEXIE_DB_LEAF);
+}
+
+const barrelCache = new Map();
+
+function isDexieBarrel(absResolved) {
+  if (!absResolved) return false;
+  if (barrelCache.has(absResolved)) return barrelCache.get(absResolved);
+  const value = computeIsDexieBarrel(absResolved);
+  barrelCache.set(absResolved, value);
+  return value;
+}
+
+function computeIsDexieBarrel(absResolved) {
+  // A barrel module re-exports `db` from dexie-database and lives under
+  // adapters/dexie/index.ts. Detect by reading its imports/re-exports
+  // and checking whether any of them resolves to dexie-database.
+  if (!absResolved.endsWith(`${join("adapters", "dexie")}.ts`)) {
+    if (
+      !absResolved.endsWith(`${join("adapters", "dexie", "index.ts")}`) &&
+      !absResolved.endsWith(`${join("adapters", "dexie", "index.tsx")}`)
+    ) {
+      return false;
+    }
+  }
+  let source;
+  try {
+    source = readFileSync(absResolved, "utf8");
+  } catch {
+    return false;
+  }
+  const reExportFromRe =
+    /export\s+(?:\*|\{[^}]*\})\s+from\s+["']([^"']+)["']/g;
+  for (const m of [
+    ...source.matchAll(STATIC_IMPORT_RE),
+    ...source.matchAll(reExportFromRe),
+  ]) {
+    const target = resolveSpecifier(absResolved, m[1]);
+    if (resolvesToDexieDatabase(target)) return true;
+  }
+  return false;
+}
+
+function dexieImportSpec(file, source) {
+  const specs = extractImports(source);
+  for (const spec of specs) {
+    const resolved = resolveSpecifier(file, spec);
+    if (!resolved) continue;
+    if (resolvesToDexieDatabase(resolved)) return spec;
+    if (isDexieBarrel(resolved)) return spec;
+  }
+  return null;
+}
+
+const violations = [];
+
+function relForRule(file) {
+  return relative(REPO_ROOT, file).replaceAll("\\", "/");
+}
+
+function isAllowlisted(file) {
+  return ALLOWLIST.has(relForRule(file));
+}
+
+function checkStoreFile(file) {
+  const source = readFileSync(file, "utf8");
+  const allowlisted = isAllowlisted(file);
+
+  const dexieSpec = dexieImportSpec(file, source);
+  if (dexieSpec && !allowlisted) {
+    violations.push({
+      rule: "R-DexieImport",
+      file: relForRule(file),
+      detail: `imports dexie-database via "${dexieSpec}"`,
+    });
+  }
+
+  if (importsPersistState(source) && !allowlisted) {
+    violations.push({
+      rule: "R-PersistStateImport",
+      file: relForRule(file),
+      detail: "imports a `persistState` identifier",
+    });
+  }
+}
+
+function checkApplicationFile(file) {
+  const source = readFileSync(file, "utf8");
+  const dexieSpec = dexieImportSpec(file, source);
+  if (dexieSpec) {
+    violations.push({
+      rule: "R-AppDexieImport",
+      file: relForRule(file),
+      detail: `imports dexie-database via "${dexieSpec}"`,
+    });
+  }
+}
+
+export function runCheck({ storeRoot, applicationRoot } = {}) {
+  violations.length = 0;
+  barrelCache.clear();
+  const sRoot = storeRoot ?? join(SPA_SRC, "store");
+  const aRoot = applicationRoot ?? join(SPA_SRC, "application");
+  for (const file of findRoots(sRoot)) checkStoreFile(file);
+  for (const file of findRoots(aRoot)) checkApplicationFile(file);
+  return [...violations];
+}
+
+const isMain =
+  process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isMain) {
+  const found = runCheck();
+  if (found.length === 0) {
+    console.log("✅ No Zustand→Dexie write-through detected.");
+    process.exit(0);
+  }
+  console.error("❌ Zustand→Dexie write-through guard violations:");
+  for (const v of found) {
+    console.error(`  [${v.rule}] ${v.file} — ${v.detail}`);
+  }
+  process.exit(1);
+}

--- a/scripts/check-no-zustand-writethrough.mjs
+++ b/scripts/check-no-zustand-writethrough.mjs
@@ -33,12 +33,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
-const SPA_SRC = join(
-  REPO_ROOT,
-  "packages",
-  "workout-spa-editor",
-  "src"
-);
+const SPA_SRC = join(REPO_ROOT, "packages", "workout-spa-editor", "src");
 
 // Allowlisted files (relative to repo root, posix-style) that are
 // permitted to bypass R-DexieImport and R-PersistStateImport. Keep this
@@ -51,7 +46,12 @@ export const ALLOWLIST = new Set([
 ]);
 
 const TS_EXTENSIONS = [".ts", ".tsx"];
-const SKIP_EXTENSIONS = [".test.ts", ".test.tsx", ".stories.ts", ".stories.tsx"];
+const SKIP_EXTENSIONS = [
+  ".test.ts",
+  ".test.tsx",
+  ".stories.ts",
+  ".stories.tsx",
+];
 
 const STATIC_IMPORT_RE =
   /import(?:\s+type)?\s+(?:[\s\S]*?\s+from\s+)?["']([^"']+)["']/g;
@@ -166,8 +166,7 @@ function computeIsDexieBarrel(absResolved) {
   } catch {
     return false;
   }
-  const reExportFromRe =
-    /export\s+(?:\*|\{[^}]*\})\s+from\s+["']([^"']+)["']/g;
+  const reExportFromRe = /export\s+(?:\*|\{[^}]*\})\s+from\s+["']([^"']+)["']/g;
   for (const m of [
     ...source.matchAll(STATIC_IMPORT_RE),
     ...source.matchAll(reExportFromRe),

--- a/scripts/check-no-zustand-writethrough.test.mjs
+++ b/scripts/check-no-zustand-writethrough.test.mjs
@@ -8,7 +8,13 @@
 // allowlist exemption.
 
 import { strict as assert } from "node:assert";
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -39,10 +45,7 @@ beforeEach(() => {
   mkdirSync(storeDir, { recursive: true });
   mkdirSync(applicationDir, { recursive: true });
   mkdirSync(dexieDir, { recursive: true });
-  write(
-    "adapters/dexie/dexie-database.ts",
-    "export const db = {} as const;\n"
-  );
+  write("adapters/dexie/dexie-database.ts", "export const db = {} as const;\n");
 });
 
 afterEach(() => {
@@ -82,7 +85,9 @@ describe("check-no-zustand-writethrough", () => {
     );
     try {
       const violations = runCheck();
-      const hit = violations.find((v) => v.file.endsWith("__alias-fixture-leak.ts"));
+      const hit = violations.find((v) =>
+        v.file.endsWith("__alias-fixture-leak.ts")
+      );
       assert.ok(hit, "expected the alias fixture to be flagged");
       assert.equal(hit.rule, "R-DexieImport");
     } finally {
@@ -108,7 +113,7 @@ describe("check-no-zustand-writethrough", () => {
   test("R-DexieImport: dynamic import() flags the file", () => {
     write(
       "store/dynamic-leak-store.ts",
-      "export const load = async () => {\n  const m = await import(\"../adapters/dexie/dexie-database\");\n  return m.db;\n};\n"
+      'export const load = async () => {\n  const m = await import("../adapters/dexie/dexie-database");\n  return m.db;\n};\n'
     );
     const violations = sandboxRun();
     assert.equal(violations.length, 1);

--- a/scripts/check-no-zustand-writethrough.test.mjs
+++ b/scripts/check-no-zustand-writethrough.test.mjs
@@ -63,19 +63,24 @@ describe("check-no-zustand-writethrough", () => {
   });
 
   test("R-DexieImport: relative path import flags the file", () => {
+    // Arrange
     write(
       "store/leak-store.ts",
       'import { db } from "../adapters/dexie/dexie-database";\nexport const x = db;\n'
     );
+
+    // Act
     const violations = sandboxRun();
+
+    // Assert
     assert.equal(violations.length, 1);
     assert.equal(violations[0].rule, "R-DexieImport");
     assert.match(violations[0].file, /leak-store\.ts$/);
   });
 
-  test("R-DexieImport: alias path (@/...) flags the file", () => {
-    // The script's @/ alias is hard-wired to the production SPA src.
-    // Drop a synthetic file at that location and clean up afterwards.
+  test("R-DexieImport: alias path (@/...) flags the file via tsconfig paths", () => {
+    // Arrange — the alias map is loaded from the production tsconfig,
+    // so drop a synthetic file under the real SPA src tree.
     const aliasFile = join(REAL_SPA_SRC, "store", "__alias-fixture-leak.ts");
     mkdirSync(dirname(aliasFile), { recursive: true });
     writeFileSync(
@@ -83,8 +88,12 @@ describe("check-no-zustand-writethrough", () => {
       'import { db } from "@/adapters/dexie/dexie-database";\nexport const x = db;\n',
       "utf8"
     );
+
     try {
+      // Act
       const violations = runCheck();
+
+      // Assert
       const hit = violations.find((v) =>
         v.file.endsWith("__alias-fixture-leak.ts")
       );
@@ -96,6 +105,7 @@ describe("check-no-zustand-writethrough", () => {
   });
 
   test("R-DexieImport: barrel re-export flags the file", () => {
+    // Arrange
     write(
       "adapters/dexie/index.ts",
       'export { db } from "./dexie-database";\n'
@@ -104,24 +114,34 @@ describe("check-no-zustand-writethrough", () => {
       "store/barrel-leak-store.ts",
       'import { db } from "../adapters/dexie";\nexport const x = db;\n'
     );
+
+    // Act
     const violations = sandboxRun();
+
+    // Assert
     assert.equal(violations.length, 1);
     assert.equal(violations[0].rule, "R-DexieImport");
     assert.match(violations[0].file, /barrel-leak-store\.ts$/);
   });
 
   test("R-DexieImport: dynamic import() flags the file", () => {
+    // Arrange
     write(
       "store/dynamic-leak-store.ts",
       'export const load = async () => {\n  const m = await import("../adapters/dexie/dexie-database");\n  return m.db;\n};\n'
     );
+
+    // Act
     const violations = sandboxRun();
+
+    // Assert
     assert.equal(violations.length, 1);
     assert.equal(violations[0].rule, "R-DexieImport");
     assert.match(violations[0].file, /dynamic-leak-store\.ts$/);
   });
 
   test("R-PersistStateImport: named-import import detects persistState", () => {
+    // Arrange
     write(
       "store/persist-state-store.ts",
       'import { persistState } from "./persist-helpers";\nexport const init = () => persistState();\n'
@@ -130,10 +150,46 @@ describe("check-no-zustand-writethrough", () => {
       "store/persist-helpers.ts",
       "export const persistState = () => {};\n"
     );
+
+    // Act
     const violations = sandboxRun();
+
+    // Assert
     const hit = violations.find((v) => v.rule === "R-PersistStateImport");
     assert.ok(hit, "expected R-PersistStateImport violation");
     assert.match(hit.file, /persist-state-store\.ts$/);
+  });
+
+  test("R-PersistStateImport: default-import import is also caught", () => {
+    // Arrange
+    write(
+      "store/default-persist-store.ts",
+      'import persistState from "./persist-helpers";\nexport const init = () => persistState();\n'
+    );
+
+    // Act
+    const violations = sandboxRun();
+
+    // Assert
+    const hit = violations.find((v) => v.rule === "R-PersistStateImport");
+    assert.ok(hit, "default-import bypass must be caught");
+    assert.match(hit.file, /default-persist-store\.ts$/);
+  });
+
+  test("R-PersistStateImport: namespace-import import is also caught", () => {
+    // Arrange
+    write(
+      "store/namespace-persist-store.ts",
+      'import * as persistState from "./persist-helpers";\nexport const init = () => persistState.run();\n'
+    );
+
+    // Act
+    const violations = sandboxRun();
+
+    // Assert
+    const hit = violations.find((v) => v.rule === "R-PersistStateImport");
+    assert.ok(hit, "namespace-import bypass must be caught");
+    assert.match(hit.file, /namespace-persist-store\.ts$/);
   });
 
   test("allowlist exemption: an allowlisted store file with a dexie-database import passes", async () => {
@@ -179,25 +235,34 @@ describe("check-no-zustand-writethrough", () => {
   });
 
   test("R-AppDexieImport: an application-layer file importing dexie-database is flagged", () => {
+    // Arrange
     write(
       "application/foo/bar.ts",
       'import { db } from "../../adapters/dexie/dexie-database";\nexport const x = db;\n'
     );
+
+    // Act
     const violations = sandboxRun();
+
+    // Assert
     const hit = violations.find((v) => v.rule === "R-AppDexieImport");
     assert.ok(hit, "expected R-AppDexieImport violation");
     assert.match(hit.file, /application\/foo\/bar\.ts$/);
   });
 
   test("R-AppDexieImport: no allowlist exemption applies to application files", () => {
-    // Reuse the allowlist key from the store rule and put a fixture under
-    // application/. The script must still flag it because the allowlist
+    // Arrange — the same name used in the store-rule allowlist must NOT
+    // exempt a file living under application/, because that allowlist
     // is store-scoped.
     write(
       "application/workout-store-actions.ts",
       'import { db } from "../adapters/dexie/dexie-database";\nexport const x = db;\n'
     );
+
+    // Act
     const violations = sandboxRun();
+
+    // Assert
     const hit = violations.find(
       (v) =>
         v.rule === "R-AppDexieImport" &&

--- a/scripts/check-no-zustand-writethrough.test.mjs
+++ b/scripts/check-no-zustand-writethrough.test.mjs
@@ -1,0 +1,203 @@
+// Tests for scripts/check-no-zustand-writethrough.mjs using node:test.
+//
+// Strategy: create temp store/ + application/ trees mirroring the SPA
+// layout under packages/workout-spa-editor/src and exercise `runCheck`
+// against them. The fixtures cover the four import shapes the script
+// must normalise (relative, alias, barrel re-export, dynamic import)
+// plus persistState detection, application-layer scope, and the
+// allowlist exemption.
+
+import { strict as assert } from "node:assert";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, test } from "node:test";
+
+import { runCheck } from "./check-no-zustand-writethrough.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const REAL_SPA_SRC = join(REPO_ROOT, "packages", "workout-spa-editor", "src");
+
+let sandbox;
+let storeDir;
+let applicationDir;
+let dexieDir;
+
+function write(rel, body) {
+  const abs = join(sandbox, rel);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, body, "utf8");
+}
+
+beforeEach(() => {
+  sandbox = mkdtempSync(join(tmpdir(), "no-zustand-writethrough-"));
+  storeDir = join(sandbox, "store");
+  applicationDir = join(sandbox, "application");
+  dexieDir = join(sandbox, "adapters", "dexie");
+  mkdirSync(storeDir, { recursive: true });
+  mkdirSync(applicationDir, { recursive: true });
+  mkdirSync(dexieDir, { recursive: true });
+  write(
+    "adapters/dexie/dexie-database.ts",
+    "export const db = {} as const;\n"
+  );
+});
+
+afterEach(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+const sandboxRun = () =>
+  runCheck({ storeRoot: storeDir, applicationRoot: applicationDir });
+
+describe("check-no-zustand-writethrough", () => {
+  test("post-Phase-3 codebase passes (no violations under real src/store + src/application)", () => {
+    if (!existsSync(REAL_SPA_SRC)) return; // Only meaningful inside the monorepo.
+    const violations = runCheck();
+    assert.deepEqual(violations, []);
+  });
+
+  test("R-DexieImport: relative path import flags the file", () => {
+    write(
+      "store/leak-store.ts",
+      'import { db } from "../adapters/dexie/dexie-database";\nexport const x = db;\n'
+    );
+    const violations = sandboxRun();
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].rule, "R-DexieImport");
+    assert.match(violations[0].file, /leak-store\.ts$/);
+  });
+
+  test("R-DexieImport: alias path (@/...) flags the file", () => {
+    // The script's @/ alias is hard-wired to the production SPA src.
+    // Drop a synthetic file at that location and clean up afterwards.
+    const aliasFile = join(REAL_SPA_SRC, "store", "__alias-fixture-leak.ts");
+    mkdirSync(dirname(aliasFile), { recursive: true });
+    writeFileSync(
+      aliasFile,
+      'import { db } from "@/adapters/dexie/dexie-database";\nexport const x = db;\n',
+      "utf8"
+    );
+    try {
+      const violations = runCheck();
+      const hit = violations.find((v) => v.file.endsWith("__alias-fixture-leak.ts"));
+      assert.ok(hit, "expected the alias fixture to be flagged");
+      assert.equal(hit.rule, "R-DexieImport");
+    } finally {
+      rmSync(aliasFile, { force: true });
+    }
+  });
+
+  test("R-DexieImport: barrel re-export flags the file", () => {
+    write(
+      "adapters/dexie/index.ts",
+      'export { db } from "./dexie-database";\n'
+    );
+    write(
+      "store/barrel-leak-store.ts",
+      'import { db } from "../adapters/dexie";\nexport const x = db;\n'
+    );
+    const violations = sandboxRun();
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].rule, "R-DexieImport");
+    assert.match(violations[0].file, /barrel-leak-store\.ts$/);
+  });
+
+  test("R-DexieImport: dynamic import() flags the file", () => {
+    write(
+      "store/dynamic-leak-store.ts",
+      "export const load = async () => {\n  const m = await import(\"../adapters/dexie/dexie-database\");\n  return m.db;\n};\n"
+    );
+    const violations = sandboxRun();
+    assert.equal(violations.length, 1);
+    assert.equal(violations[0].rule, "R-DexieImport");
+    assert.match(violations[0].file, /dynamic-leak-store\.ts$/);
+  });
+
+  test("R-PersistStateImport: named-import import detects persistState", () => {
+    write(
+      "store/persist-state-store.ts",
+      'import { persistState } from "./persist-helpers";\nexport const init = () => persistState();\n'
+    );
+    write(
+      "store/persist-helpers.ts",
+      "export const persistState = () => {};\n"
+    );
+    const violations = sandboxRun();
+    const hit = violations.find((v) => v.rule === "R-PersistStateImport");
+    assert.ok(hit, "expected R-PersistStateImport violation");
+    assert.match(hit.file, /persist-state-store\.ts$/);
+  });
+
+  test("allowlist exemption: an allowlisted store file with a dexie-database import passes", async () => {
+    const ALLOWLIST_FILE = "store/workout-store-actions.ts";
+    write(
+      ALLOWLIST_FILE,
+      'import { db } from "../adapters/dexie/dexie-database";\nexport const noop = () => db;\n'
+    );
+
+    // The production allowlist key is `packages/workout-spa-editor/src/store/...`.
+    // Mirror the fixture under that exact path so the allowlist matches.
+    const realAllowlistFile = join(
+      REAL_SPA_SRC,
+      "store",
+      "__allowlist-fixture-actions.ts"
+    );
+    mkdirSync(dirname(realAllowlistFile), { recursive: true });
+    writeFileSync(
+      realAllowlistFile,
+      'import { db } from "../adapters/dexie/dexie-database";\nexport const noop = () => db;\n',
+      "utf8"
+    );
+
+    // Patch the allowlist for the duration of this assertion so the
+    // synthetic fixture sits under the entry we control.
+    const { ALLOWLIST } = await import(
+      // Re-import to grab the live Set; ESM caches by URL so the same Set is shared.
+      "./check-no-zustand-writethrough.mjs"
+    );
+    const allowlistKey = relative(REPO_ROOT, realAllowlistFile).replaceAll(
+      "\\",
+      "/"
+    );
+    ALLOWLIST.add(allowlistKey);
+    try {
+      const violations = runCheck();
+      const hit = violations.find((v) => v.file === allowlistKey);
+      assert.equal(hit, undefined, "allowlisted file must not be flagged");
+    } finally {
+      ALLOWLIST.delete(allowlistKey);
+      rmSync(realAllowlistFile, { force: true });
+    }
+  });
+
+  test("R-AppDexieImport: an application-layer file importing dexie-database is flagged", () => {
+    write(
+      "application/foo/bar.ts",
+      'import { db } from "../../adapters/dexie/dexie-database";\nexport const x = db;\n'
+    );
+    const violations = sandboxRun();
+    const hit = violations.find((v) => v.rule === "R-AppDexieImport");
+    assert.ok(hit, "expected R-AppDexieImport violation");
+    assert.match(hit.file, /application\/foo\/bar\.ts$/);
+  });
+
+  test("R-AppDexieImport: no allowlist exemption applies to application files", () => {
+    // Reuse the allowlist key from the store rule and put a fixture under
+    // application/. The script must still flag it because the allowlist
+    // is store-scoped.
+    write(
+      "application/workout-store-actions.ts",
+      'import { db } from "../adapters/dexie/dexie-database";\nexport const x = db;\n'
+    );
+    const violations = sandboxRun();
+    const hit = violations.find(
+      (v) =>
+        v.rule === "R-AppDexieImport" &&
+        v.file.endsWith("application/workout-store-actions.ts")
+    );
+    assert.ok(hit, "application allowlist must NOT apply");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `scripts/check-no-zustand-writethrough.mjs`, an import-based static check wired into `pnpm test:scripts`.
- Three rules: `R-DexieImport` (store/** must not import `dexie-database`), `R-PersistStateImport` (store/** must not import a `persistState` identifier), `R-AppDexieImport` (application/** must not import `dexie-database`, no allowlist).
- 9 node:test fixtures cover relative + alias + barrel + dynamic-import shapes for the dexie rule, the persistState case, the allowlist exemption, and an application-layer negative.
- Final dead-code sweep shows zero references to `useProfileStore`, `useLibraryStore`, `useAiStore`, `use-active-profile`, `use-library`, or `use-ai-hydration`.

## Why import-based?
A file that imports neither `dexie-database` nor `persistState` cannot write through. New write-throughs would have to add an import — that is the signal we catch. Lower false-positive rate than action-body string matching.

## Test plan
- [x] `pnpm test:scripts` — 85 tests pass including the 9 new ones
- [x] `pnpm vitest run` — 2838 tests pass
- [x] `pnpm lint` clean
- [x] `pnpm build` clean
- [x] Guard runs clean against the post-Phase-3 codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for static import validation across store and application modules.

* **Chores**
  * Introduced new validation script integrated into test pipeline to enforce architectural constraints.
  * Updated project tracking documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->