### PR TITLE
openspec: propose cleanup-open-issues-may-2026 (5-phase queue sweep)

### DIFF
--- a/openspec/changes/cleanup-open-issues-may-2026/design.md
+++ b/openspec/changes/cleanup-open-issues-may-2026/design.md
@@ -1,0 +1,172 @@
+## Context
+
+15 open issues. Triage matrix (state at proposal time, 2026-05-01):
+
+| Bucket | Issues | Action |
+| --- | --- | --- |
+| Stale CI failure auto-issues (commits superseded; main green) | #393, #355, #345 | Phase 1: close with reference to the green follow-up commit. |
+| Stale security alerts (high-severity criterion no longer met) | #168, #177, #178, #182 | Phase 1: close with per-issue specific CVE / advisory ID + current package state. |
+| Tracking meta-issue for an archived change | #388 | Phase 1: close with link to the archive folder. |
+| Real user-visible bug | #386 (404 on SPA refresh) | Phase 2: rafgraph SPA-fallback pattern in `deploy-site.yml`. |
+| Hardening follow-up | #395 (PII guard) | Phase 3: new mechanical guard script. |
+| Cosmetic polish (single-source `cosmetic-polish` change) | #266, #267, #268, #269, #270 | Phase 4: bundled UI refinements. |
+
+Issue **#395** is explicitly the deferred follow-up captured in `openspec/changes/archive/2026-04-30-persistence-read-rule-cleanup/design.md` under "Open Questions / Follow-ups". This change closes that loop. The pattern being generalised is the file-local `packages/workout-spa-editor/src/components/organisms/SettingsPanel/use-ai-tab-handlers.audit.test.ts`, which audited two files; the new repo-wide guard subsumes its scope while the original test stays as defense-in-depth (see D6).
+
+The five phases are ordered to maximise short-term cleanup value (Phase 1 alone takes 8 issues out of the queue) while putting the highest-risk batch (Phase 4 #266 remap) behind the smaller fixes so reviewers see a steady drip of green main commits.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Issue queue empties to ≤1 (only an issue opened during the rollout can survive).
+- Every phase ends with main green on every CI lane (`test`, `lint`, `build`, `e2e-frontend`, `test-cli`, `test-frontend`, `test:scripts`).
+- One real user-visible bug fixed and verified in production (#386), with a CI smoke step so regressions are caught.
+- One hardening guard landed and wired into CI so future PRs cannot regress on the rule (#395), with a structural rule that does not allow indirection bypasses.
+
+**Non-Goals**
+
+- Migrating off GitHub Pages — the rafgraph SPA-fallback workaround is sufficient and reversible.
+- Closing the 7 moderate `pnpm audit` findings — out of the auto-bot's high-severity criterion. Tracked as a separate sweep if any of them upgrades.
+- Migrating the existing "No Zustand-to-Dexie write-through" requirement from `spa-persistence-port` to `spa-quality-gates`. The new capability houses only the new PII rule for now; consolidation is a future cleanup.
+
+## Decisions
+
+### D1. SPA fallback strategy for #386 — rafgraph/spa-github-pages root-redirect pattern.
+
+GitHub Pages with a custom domain (kaiord.com is a CNAME → GitHub Pages model) serves the **root-level** `404.html` for unmatched paths regardless of the requested subdirectory. Per-subdirectory `404.html` files are unreliable (some Pages configs serve them, some don't, and the behaviour has changed silently across Pages updates). The empirical-spike approach ("just drop a 404.html in /editor/ and see if it works") is fragile; we adopt the documented, widely-deployed rafgraph pattern instead.
+
+Mechanism (https://github.com/rafgraph/spa-github-pages):
+
+1. **Root `404.html`** contains a small inline script that:
+   - Captures `window.location.pathname` and `window.location.search`.
+   - Encodes the **absolute path** (always leading `/`, e.g., `/editor/calendar`, never relative `editor/calendar`) into a single query string (`?p=%2Feditor%2Fcalendar`), URL-encoding `&` and `=` characters within the original path/query.
+   - Calls `window.location.replace(...)` to redirect to the SPA's `index.html` at `/editor/?p=%2Feditor%2Fcalendar`.
+   - Absolute-path emission is required so the SPA's `history.replaceState` is unambiguous regardless of any `<base href="/editor/">` declaration in `index.html`.
+2. **SPA `index.html`** (the editor's entry point) contains an inline script that runs **before** the React bundle:
+   - Detects the `?p=` query parameter.
+   - Decodes it and calls `window.history.replaceState(null, null, decodedPath)` to restore the original URL.
+   - The user sees `/editor/calendar` in the address bar; React Router resolves the route normally.
+
+The redirect is server-driven (Pages serves `404.html`), so refresh, deep-link, and back-button all work uniformly. The decoder runs synchronously before React Router boots, so there is no flicker of `?p=...` in the URL bar.
+
+The deploy workflow change (`.github/workflows/deploy-site.yml`):
+- Replaces the root `merged-dist/404.html` with a rafgraph-shaped 404 (the existing landing's blue 404 markup PLUS the redirect script — the script triggers only if the path starts with `/editor/`, otherwise it lets the blue 404 render normally for landing routes).
+- Injects the decoder script into `merged-dist/editor/index.html` after the SPA build, before artifact upload.
+- VitePress already produces `docs/404.html`; docs is unaffected.
+
+Why not a per-subdirectory `editor/404.html` copy? Pages behaviour is not contractually documented for that case; the rafgraph pattern works against any Pages config and is the standard SPA-on-Pages-subpath fix.
+
+### D2. PII guard scope: SPA editor only, components AND hooks AND lib.
+
+The existing `use-ai-tab-handlers.audit.test.ts` covers two files. The generalised guard scans:
+
+- `packages/workout-spa-editor/src/components/**/*.{ts,tsx}` (UI consumers)
+- `packages/workout-spa-editor/src/hooks/**/*.{ts,tsx}` (cross-cutting hooks that may toast)
+- `packages/workout-spa-editor/src/lib/**/*.{ts,tsx}` (utility helpers that may `console.error`)
+- excluding `*.test.{ts,tsx}` and `*.stories.{ts,tsx}`
+
+Other packages (core, fit, tcx, zwo, garmin, garmin-connect, cli, mcp, garmin-bridge, train2go-bridge) are out of scope: they have no toast surface and their `console.*` is logger-internal (`@kaiord/core/adapters/logger`), already disciplined.
+
+### D3. PII guard rule shape: SCREAMING_SNAKE_CASE identifier OR string literal — no chains, no indirection.
+
+Two accepted argument shapes for `toast.{error,success,info,warning}(...)`, `useToastContext().{error,success,info,warning}(...)`, and `console.{log,warn,error,info,debug}(...)`:
+
+1. A bare string literal: `toast.error("Failed to save profile")`.
+2. A bare SCREAMING_SNAKE_CASE identifier (`/^[A-Z][A-Z0-9_]*$/`) that resolves to a top-level `const X = "string-literal"` declaration whose right-hand side is **itself** a bare string literal — no template, no concatenation, no call, no other identifier.
+
+Rejected:
+
+- Template literals: `` `Failed to save: ${error.message}` ``.
+- String concatenation: `"Failed: " + error.message`.
+- Identifier reference to a `catch (err)` binding, function parameter, or any closure-captured variable.
+- Bare lowercase / camelCase identifiers (the existing audit at `use-ai-tab-handlers.audit.test.ts:46` enforces SCREAMING_SNAKE_CASE; the new guard does not weaken that).
+- Identifier chains (`const A = B; const B = "x"; toast.error(A);`) — the rule is depth-1 only. The const must directly equal a string literal, not transitively.
+- Helper-function indirection at definition time (`const SAVE_FAILED_TOAST = formatError(err); toast.error(SAVE_FAILED_TOAST);` — the RHS is a `CallExpression`, not a literal, so the identifier reference fails the rule).
+
+The rule is **structural**: it forbids interpolation in any form, regardless of which field gets interpolated. The threat model lists `apiKey`, `externalUserId`, `externalUserName`, `error.message` as illustrative leak categories that the structural rule covers, but the script does not inspect identifier names — it inspects argument shape.
+
+The script's parser is regex-grade (matching the style of `check-no-zustand-writethrough.mjs`). The canonical implementation list lives in tasks.md `3.2.3`; this paragraph is a high-level English summary. Four dispatch shapes are recognized as call-site anchors:
+
+1. Member dispatch (including `console.*`): `(toast|useToastContext\(\))\s*\.\s*(error|success|info|warning)\(...)` and `console\.(log|warn|error|info|debug)\(...)`.
+2. Computed-member dispatch: `(toast|useToastContext\(\))\s*\[\s*["'](error|success|info|warning)["']\s*\]\s*\(...)`.
+3. Destructured dispatch (`const { error } = useToastContext(); error(...);`) — the script tracks `useToastContext()` destructuring patterns within a file and treats subsequent calls to those bindings as in-scope.
+4. Re-bound dispatch (`const ctx = useToastContext(); ctx.error(...);`) — the script tracks `const <ID> = useToastContext()` re-bindings and treats subsequent `<ID>.<method>(...)` calls as member dispatch on a known toast receiver.
+
+If a file contains conflicting bindings (multiple destructures from different sources, or a destructure plus a re-bind), the script biases to false-positives: every `<name>(` or `<name>.<method>(` call is treated as in-scope. See tasks 3.2.2.
+
+For each call site, extract the first argument's source text and trim whitespace. The acceptance check runs in this order (see tasks 3.2.3 for the implementation):
+
+1. **Bare-literal accept first**: if the trimmed text matches `/^"[^"\\]*(?:\\.[^"\\]*)*"$/` or the equivalent single-quote regex, ACCEPT regardless of inner content (so `toast.error("URL: example.com")` is accepted even though the body contains `:`).
+2. **Bare-identifier accept second**: if the trimmed text matches `/^[A-Z][A-Z0-9_]*$/`, scan the same file for a top-level `const <ID>\s*=\s*("...")|('...');` whose RHS is exactly a bare string literal (depth-1 only; no chains, no calls, no expressions). If found, ACCEPT.
+3. **Reject everything else**: any remaining shape (template literals, concatenation, parenthesized expressions, TS type assertions `as`/`<>`/`satisfies`, TS post-fix operators `!`/`as const`, unary operators `void`/`+`, member access, calls, lowercase identifiers, identifier chains) is rejected. The rejection message names the offending operator/shape verbatim so contributors can fix without consulting the spec.
+
+Parenthesized literals (e.g., `toast.error(("Failed"))`), non-null assertions (`SAVE_FAILED!`), and `as const` post-fixes are rejected as a strict-shape false positive. Contributors strip the operator at the call site; the rejection message recommends this.
+
+Encoders for D1 SHALL emit absolute paths (`/editor/calendar`, never relative `editor/calendar`) so the `history.replaceState` call is unambiguous regardless of any `<base href="/editor/">` declaration in the SPA's `index.html`.
+
+### D4. Cosmetic polish bundle: one PR with internal commit-per-chore, screenshot-diff gate.
+
+Single PR. The five chores total ≤300 lines of CSS + index.html changes (excluding the gray→slate remap, which is a single `@theme` alias block). Splitting them creates five trivial PRs each requiring its own CI pass; bundling reflects the user's recorded preference for fatter PRs over thinner ones.
+
+The high-risk one (#266 gray→slate via Tailwind 4 `@theme` alias) gets:
+- A **spike task** at Phase 4 task 4.5.1 that validates the `@theme` override actually propagates to already-emitted utility classes (`bg-gray-*`, `text-gray-*`, `dark:bg-gray-*`, etc.) before committing to the approach. The spike runs `pnpm dev` and inspects DevTools' computed-style values for at least one element using each gray utility shade.
+- An **explicit fallback** at Phase 4 task 4.5.X: if the `@theme` alias does not propagate (Tailwind 4's emission strategy may inline values at build time), the fallback is a per-file `gray-*` → `slate-*` find-and-replace across the ~90 files. The fallback is pre-decided here, not a runtime panic decision.
+- A **screenshot-diff gate** via Playwright fixtures: at minimum calendar week view, editor full-form, AI Tab + Privacy Tab in settings, library dialog. Before/after diffs posted in the PR description for human visual review.
+
+### D5. Phase 5 archive: lint:archive invariant.
+
+Same convention as `2026-04-30-persistence-read-rule-cleanup`: archive folder is `YYYY-MM-DD-cleanup-open-issues-may-2026` where `YYYY-MM-DD` matches the `> Completed:` marker added to the archived `proposal.md`. `pnpm lint:archive` enforces the invariant; `pnpm archive:index` regenerates `openspec/changes/archive/README.md`. Both run in CI.
+
+### D6. Existing audit reconciliation: KEEP `use-ai-tab-handlers.audit.test.ts` as defense-in-depth.
+
+CLAUDE.md states: "Never delete a test. Never skip a test." The existing audit at `packages/workout-spa-editor/src/components/organisms/SettingsPanel/use-ai-tab-handlers.audit.test.ts` audits two files via vitest (runs in `pnpm --filter @kaiord/workout-spa-editor test`). The new repo-wide guard runs in `pnpm test:scripts`. Two test surfaces catching the same regression is defense-in-depth, not duplication. The two are kept side-by-side; if the AiTab audit ever drifts (e.g., the SCREAMING_SNAKE_CASE allowlist grows in a way the broader script's allowlist does not), reviewers see the divergence in two places.
+
+If a future contributor finds the duplication burdensome, they may propose a separate change to remove the focused audit, but it is **not** removed by this rollout.
+
+### D7. Spec capability scope: NEW `spa-quality-gates` capability houses the PII rule.
+
+`spa-persistence-port`'s `## Purpose` is "PersistencePort contract (workouts, templates, profiles, AI providers, sync state, monthly usage) and the Dexie adapter that backs editor-local state in IndexedDB." Toast strings and console messages are not part of that contract; placing the PII rule there stretches the capability beyond its purpose.
+
+The new `spa-quality-gates` capability houses the PII rule and serves as a home for future static-source-style guards (e.g., the existing No Zustand-to-Dexie write-through requirement could migrate here in a future cleanup, but that consolidation is **not** in this rollout's scope per the proposal's Out-of-Scope list).
+
+The new capability's `## Purpose`: "Mechanically enforced repo-wide quality gates implemented as static-source `pnpm test:scripts` checks. Each requirement specifies a structural rule the SPA editor source code SHALL obey, plus the script that enforces it in CI."
+
+### D8. Identifier-chain depth: depth-1 only, no recursion.
+
+Per Spec Analyst's finding, the spec language must bound the identifier chain. **Decision**: depth-1 only. The const's right-hand side must be a string literal directly; transitively-resolved chains (`A → B → "x"`) are rejected.
+
+Rationale: matches the existing audit (no chain following). Avoids cycle-detection complexity in the script. Keeps the rule trivially auditable by a reviewer reading the code (the toast call's identifier resolves to a literal in one hop).
+
+### D9. Allowlist criterion: narrowly constrained.
+
+D3's structural rule is strict; legitimate exceptions exist (e.g., echoing a user-typed value back in the same render frame, where the value is the user's own data and not PII in the GDPR sense). To prevent the allowlist from becoming a leaky abstraction:
+
+**Allowlist criterion** (codified in the script's allowlist comment block):
+1. The interpolated value MUST originate from the same user's same-render-frame input (no traversal across a network boundary, no read from persisted storage of another entity, no read from any field named `apiKey` / `externalUserId` / `externalUserName` / `email` / `phone` / `address`).
+2. The interpolated value MUST never be written to a persistent log (`console.error`, `console.warn`, analytics events, server logs).
+3. Each allowlist entry MUST carry a one-line comment with: (a) the file path + line, (b) the value being interpolated, (c) why it satisfies criteria (1) and (2).
+
+Initial allowlist: empty. Phase 3 sweep is expected to surface zero legitimate exceptions (the existing audit already enforces SCREAMING_SNAKE_CASE in AiTab; the broader sweep will surface debug `console.error` template literals that should be refactored to constants, not allowlisted).
+
+A PR adding to the allowlist must include a reviewer comment confirming criteria (1) and (2). Reviewers cite this design decision when rejecting inappropriate allowlist additions.
+
+## Risks / Trade-offs
+
+- **R1 — Bot reopens a stale issue mid-sweep.** A new CI failure between Phase 1 close-out and the final main-green commit would reopen one of the auto-categories. Acceptable: the close-out comments document the specific CVE/commit, and the new issue would point at a fresh commit anyway.
+- **R2 — Phase 4 #266 visual regression.** Tailwind `gray-*` and `slate-*` differ in undertone (warm vs cool); some component combinations look fine in isolation but jarring side-by-side. Mitigations: the spike task validates the `@theme` mechanic before commit, the per-file fallback is pre-decided, the screenshot-diff gate runs against a representative fixture set, and the PR description carries before/after screenshots.
+- **R3 — Phase 3 PII guard false positives.** Sweep across all of `components/**`, `hooks/**`, `lib/**` will surface legitimate-but-not-allowlisted call sites. Mitigation: each surfaced site refactors to a SCREAMING_SNAKE_CASE constant; allowlist remains empty unless D9 criteria are met.
+- **R4 — Phase 2 rafgraph script edge cases.** The redirect-then-decode mechanic has known edge cases: hash fragments in the original URL, deep query strings, and routes that legitimately want a literal `?p=...` parameter. Mitigations: the rafgraph reference implementation handles fragments and double-encoding; route table contains no `p` query param today; the CI smoke step exercises the round-trip on at least one representative route.
+- **R5 — Phase 3 regex parser brittleness.** Iteration-3 closed the high-likelihood bypasses (`toast["error"](...)`, `const { error } = ...`, `const ctx = ...`). Genuinely exotic shapes remain known limitations: receiver type-assertions (`(toast as any).error(...)`), decorator-modified toast functions, dynamic `Function`-constructed dispatch. These are out-of-scope for the structural script — they fail human review on aesthetic grounds long before they fail a CI check. Mitigations: D2 scope excludes test files where these tricks are most likely; the existing AiTab audit (D6 keep) catches the *covered* shapes redundantly but does NOT extend coverage to type-assertion bypasses; the D9-criteria allowlist is the controlled escape hatch.
+
+## Migration Plan
+
+This change is internally consistent and forward-rollable; nothing here is a destructive migration. The phases are sequential because each one is a reviewable PR, but Phase 4 could merge before Phase 3 without correctness risk (the order chosen is by triage value, not by dependency).
+
+## Follow-ups
+
+All design questions are resolved by D1–D9; the items below are deliberately out-of-scope follow-ups.
+
+- **Follow-up: 7 moderate-severity `pnpm audit` findings.** Out of scope for this change (the auto-bot fires on high/critical). If any moderate upgrades to high during the rollout, the new auto-issue gets handled in the next sweep. Closure rationale in Phase 1 cites the criterion explicitly so the paper trail is clear.
+- **Follow-up: visual regression test infrastructure.** Phase 4 #266 leans on Playwright screenshots. If the existing fixture set is thin, the visual diff is partial coverage, not a guarantee. Tracked as a candidate for a future sweep — not blocking this rollout.
+- **Follow-up: consolidate static-source guards under `spa-quality-gates`.** The existing "No Zustand-to-Dexie write-through" requirement under `spa-persistence-port` could migrate to the new `spa-quality-gates` capability for a cleaner separation of concerns. Out of scope for this rollout; a future spec-only refactor.

--- a/openspec/changes/cleanup-open-issues-may-2026/proposal.md
+++ b/openspec/changes/cleanup-open-issues-may-2026/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+The repo has 15 open issues. Triage shows the queue is mostly noise:
+
+- **8 stale auto-bot artefacts** that no longer reflect reality. Three CI failure tickets (#393, #355, #345) point at commits that have since been superseded — `gh run list` confirms main is green from `cf14aa4` onward. Four security alerts (#168, #177, #178, #182) reported "high" severity dependency findings; today `pnpm audit` reports 0 high and 0 critical (7 moderate remain — out of scope for the high-severity bot rule). The tracking meta-issue #388 is for the persistence-read-rule-cleanup change, archived as `2026-04-30-persistence-read-rule-cleanup`.
+- **1 user-visible bug**: #386 — refreshing `kaiord.com/calendar` (or any in-app SPA route) returns the landing's static `404.html` because GitHub Pages has no SPA fallback configured.
+- **1 hardening follow-up**: #395 — the deferred PII / secret-leakage mechanical guard documented in the archived `persistence-read-rule-cleanup`'s `design.md` "Open Questions / Follow-ups" section. The pattern exists locally (`use-ai-tab-handlers.audit.test.ts`); it has not been generalised across the SPA editor.
+- **5 cosmetic chores** (#266, #267, #268, #269, #270) from a prior `cosmetic-polish` change: gray→slate remap (~90 affected files; resolved via a one-line Tailwind `@theme` alias per Phase 4 task 4.5.2), viewport `safe-area-inset` for notch devices, focus-visible unification across landing/docs/editor, Inter `size-adjust` for CLS, and shared `@font-face` extraction.
+
+The list as-is creates triage friction: every time a contributor opens issues, they have to mentally filter out the noise to find real work. Closing them in coordinated phases — each ending with main green on every CI lane — clears the queue, keeps progress visible, and lands the one real fix (#386) and the one hardening item (#395) without losing them in the cosmetic batch.
+
+## What Changes
+
+Five phases, each shipping as a single squash-merged PR with main green at end-of-phase:
+
+1. **Triage sweep** (no code, just GitHub bookkeeping) — close #388, #393, #355, #345, #168, #177, #178, #182. Each closure carries an issue-specific rationale (resolving commit SHA for CI failures; specific CVE/advisory ID + current package state for security alerts; archive-folder reference for the meta-issue).
+2. **SPA refresh 404 fix** (#386) — add the rafgraph/spa-github-pages SPA-fallback pattern: root `404.html` contains a redirect script that captures the requested path, encodes it into a query string, and redirects to the SPA's `index.html`; the SPA's `index.html` contains a decoder that restores the path via `history.replaceState` before React Router boots. A CI smoke step `curl`s a representative deep route post-deploy and asserts the SPA bundle bytes are returned, so the fix is self-monitoring.
+3. **PII / secret-leakage mechanical guard** (#395) — generalise `use-ai-tab-handlers.audit.test.ts` into `scripts/check-no-pii-leakage.mjs`. Walk every file under `packages/workout-spa-editor/src/{components,hooks,lib}/**` that calls `useToastContext().{error,success,info,warning}(...)`, `toast.{...}(...)`, or `console.{log,warn,error,info,debug}(...)`. Each call's first argument MUST be either (a) a bare string literal, OR (b) a bare SCREAMING_SNAKE_CASE identifier resolving to a top-level `const X = "string-literal"` whose right-hand side is itself a bare string literal — no template literals, no concatenation, no helper indirection, no chain following beyond depth 1. Wired into `pnpm test:scripts` with a fixture matrix covering the structural-bypass cases. The existing `use-ai-tab-handlers.audit.test.ts` is **kept** as defense-in-depth (per CLAUDE.md "Never delete a test").
+4. **Cosmetic polish bundle** (#266–#270) — five small UI refinements:
+   - **#270** extract a shared `styles/brand-fontface.css` and import it from `brand-tokens.css`, `custom.css`, and `index.css` so a unicode-range or weight change happens in one place.
+   - **#269** add `size-adjust: 100%` (or measured value) to the Inter `@font-face` rules to reduce Cumulative Layout Shift on first paint.
+   - **#268** copy the editor's `:focus-visible` ring into landing and docs CSS so all three surfaces show the same focus indicator.
+   - **#267** add `<meta name="viewport" content="..., viewport-fit=cover">` and `padding: env(safe-area-inset-*)` on the SPA's root layout for notch-device support.
+   - **#266** remap Tailwind `gray-*` to `slate-*` editor-wide via a single `@theme` alias block. A spike task validates the override actually propagates to compiled utility classes before committing to the approach; if it does not, the design's reserved fallback (per-file `gray-*` → `slate-*` find-and-replace) ships instead. Visual-diff gate via Playwright screenshot fixtures.
+5. **Verify and archive** — `pnpm -r test`, `pnpm -r build`, `pnpm lint`, `pnpm test:scripts` all green on main. Archive this change to `openspec/changes/archive/YYYY-MM-DD-cleanup-open-issues-may-2026/`. Confirm the GitHub issue list is empty (modulo any new auto-bot issue opened during the rollout — those become the next sweep, not this change's responsibility).
+
+## Impact
+
+- **Affected specs**:
+  - **NEW capability** `spa-quality-gates` (1 ADDED requirement: "User-facing string hygiene"). The PII / secret-leakage guard is mechanically enforced by `scripts/check-no-pii-leakage.mjs`, parallel in style to the existing `scripts/check-no-zustand-writethrough.mjs`. Housing the rule under a new `spa-quality-gates` capability avoids stretching `spa-persistence-port` (whose `## Purpose` is the PersistencePort contract) to cover UI-presentation hygiene. Long-term, the existing "No Zustand-to-Dexie write-through" requirement could migrate to `spa-quality-gates` too; that migration is a separate change, not this one.
+- **Affected code**:
+  - `.github/workflows/deploy-site.yml` (Phase 2): replace the root `404.html` build with the rafgraph redirect script; inject the decoder snippet into the SPA's `index.html`; add a post-deploy smoke step that curls a representative deep route.
+  - `scripts/check-no-pii-leakage.mjs` + `scripts/check-no-pii-leakage.test.mjs` + `scripts/__fixtures__/check-no-pii-leakage/` (Phase 3, new files).
+  - `scripts/lib/strip-jsonc.mjs` (Phase 3, extracted from `check-no-zustand-writethrough.mjs` and shared with the new script).
+  - `packages/workout-spa-editor/src/styles/brand-fontface.css` (Phase 4 / #270, new file).
+  - `packages/workout-spa-editor/src/index.css`, `packages/landing/src/styles/custom.css`, `packages/docs/.vitepress/theme/styles/brand-tokens.css` (Phase 4 / #268, #269, #270).
+  - `packages/workout-spa-editor/index.html` and `packages/workout-spa-editor/src/components/templates/MainLayout/MainLayout.tsx` (Phase 4 / #267).
+  - `packages/workout-spa-editor/src/index.css` Tailwind `@theme` block (Phase 4 / #266).
+- **Affected tests**: new `scripts/check-no-pii-leakage.test.mjs` with twelve fixtures listed in the same order as the spec scenarios: (1) template-literal rejection, (2) concatenation rejection, (3) `catch` / function-parameter binding rejection, (4) helper-call indirection rejection, (5) computed-member dispatch (`toast["error"]`) rejection, (6) destructured dispatch (`const { error } = useToastContext()`) rejection, (7) re-bound dispatch (`const ctx = useToastContext(); ctx.error(...)`) rejection, (8) identifier-chain rejection (depth-1 only), (9) bare-literal positive (including inner `:` / `+`), (10) SCREAMING_SNAKE_CASE positive, (11) allowlist-injected positive, (12) post-rollout positive. The existing AiTab audit at `use-ai-tab-handlers.audit.test.ts` stays as defense-in-depth.
+- **Risk**:
+  - **Phase 2 SPA fallback**: the rafgraph pattern is a documented, widely-deployed workaround; the empirical risk is the SPA `index.html`'s decoder running before React Router boots. Mitigation: smoke-test in a deploy-preview branch before the production merge; CI smoke step catches future regressions.
+  - **Phase 3 PII guard false positives**: extending the rule across all of `components/**`, `hooks/**`, and `lib/**` will likely surface a few legitimate template literals in `console.error` debug paths. Mitigation: each call site refactors to a SCREAMING_SNAKE_CASE constant; the allowlist mechanism is intentionally narrow per design D9.
+  - **Phase 4 #266 visual regression**: gray and slate differ in undertone; the screenshot-diff gate may surface unexpected combinations. Mitigation: the per-file fallback is pre-decided in design.md D4 and an explicit task branch in 4.5.
+- **Out of scope**:
+  - Fixing the 7 moderate-severity `pnpm audit` findings (the auto-bot fires only on high/critical; track separately if any of them upgrades).
+  - Migrating off GitHub Pages — the rafgraph workaround in Phase 2 is sufficient and reversible.
+  - Migrating the existing "No Zustand-to-Dexie write-through" requirement from `spa-persistence-port` to the new `spa-quality-gates` capability — out of scope; tracked as a future cleanup if needed.
+  - Any new `useWorkoutStore` write paths or persistence-port surface changes — Phase 4 is presentation-only.

--- a/openspec/changes/cleanup-open-issues-may-2026/specs/spa-quality-gates/spec.md
+++ b/openspec/changes/cleanup-open-issues-may-2026/specs/spa-quality-gates/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: User-facing string hygiene
+
+User-facing strings rendered by the SPA editor — invocations of `useToastContext().{error,success,info,warning}(...)`, `toast.{error,success,info,warning}(...)`, and `console.{log,warn,error,info,debug}(...)` under `packages/workout-spa-editor/src/{components,hooks,lib}/**` (excluding `*.test.{ts,tsx}` and `*.stories.{ts,tsx}`) — SHALL pass a single first argument that resolves at audit time to a static string.
+
+A first argument is "static" when it matches one of exactly two shapes:
+
+1. **A bare string literal**: `toast.error("Failed to save profile")`.
+2. **A bare SCREAMING_SNAKE_CASE identifier** (matching `/^[A-Z][A-Z0-9_]*$/`) that resolves to a top-level `const <ID>` declaration in the same file whose right-hand side is **directly** a bare string literal — no template, no concatenation, no function call, no other identifier (depth-1 only; chains are rejected).
+
+The following first-argument shapes are forbidden:
+
+- Template literals with substitutions (e.g., `` `Failed to save: ${error.message}` ``).
+- String concatenation expressions (e.g., `"Failed: " + error.message`).
+- Function calls (e.g., `formatError(err)`, even when assigned to a top-level const before the toast call).
+- Identifiers resolving to a `catch (err)` binding, function parameter, or any closure-captured / non-top-level variable.
+- Bare lowercase or camelCase identifiers (only SCREAMING_SNAKE_CASE constants are accepted).
+- Identifier chains (e.g., `const A = B; const B = "x"; toast.error(A);`) — the rule is depth-1 only.
+- TypeScript type-assertions on the argument (e.g., `SAVE_FAILED as string`, `<string>SAVE_FAILED`, `SAVE_FAILED satisfies string`).
+- Post-fix non-null and `as const` operators on the argument (e.g., `SAVE_FAILED!`, `SAVE_FAILED as const`).
+- Unary operators on the argument (e.g., `void "Failed"`, `+SAVE_FAILED`).
+- Parenthesized expressions wrapping the argument (e.g., `("Failed")`) — strip the parentheses.
+
+The rule is **structural and mechanical**: forbidding interpolation in any form prevents any field — including but not limited to `apiKey`, `externalUserId`, `externalUserName`, `email`, and `error.message` — from leaking into a user-visible string or a persistent console log. The static guard does NOT match identifier names or substring patterns; it only matches argument-shape syntax. Identifier-name awareness lives entirely in the **reviewer-side** allowlist criteria below; the two layers (mechanical script enforcement, human reviewer gate on allowlist additions) are deliberately separated.
+
+The script SHALL recognize four call-site dispatch shapes so contributors cannot bypass via syntactic indirection:
+
+1. **Member dispatch**: `toast.error(...)`, `useToastContext().error(...)`, `console.error(...)`, etc.
+2. **Computed-member dispatch**: `toast["error"](...)`, `useToastContext()["error"](...)` — the bracket form is forbidden but if used MUST be checked with the same rule.
+3. **Destructured dispatch**: `const { error } = useToastContext(); error(...);` — the script tracks `useToastContext()` destructurings within a file and treats subsequent calls to those bound names as in-scope.
+4. **Re-bound dispatch**: `const ctx = useToastContext(); ctx.error(...);` — the script tracks `const <ID> = useToastContext()` rebindings within a file and treats subsequent `<ID>.<method>(...)` calls as member dispatch under the same rule. If a file contains conflicting bindings (e.g., two `const { error } = ...` from different sources, or both a re-bind and a destructure), the script treats every potentially-toast call as in-scope (false-positive bias is the safe default; the contributor either renames the conflict or refactors).
+
+A static guard at `scripts/check-no-pii-leakage.mjs`, executed in CI via `pnpm test:scripts`, SHALL enforce this rule across all four dispatch shapes. The script SHALL maintain a hard-coded allowlist mechanism — a Set of file paths where a legitimate exception is documented inline. **The initial production allowlist MUST be empty.** The SHALL on the allowlist applies to the *mechanism* (an exported `ALLOWLIST` Set the test fixture can manipulate), not to the *contents*. Allowlist entries are added only via PRs that satisfy reviewer-gated criteria below. Each allowlist entry MUST carry a comment block satisfying two criteria:
+
+1. The interpolated value originates from the same user's same-render-frame input and never traverses a network boundary, persistent log, or analytics event.
+2. The interpolated value is not read from any field that the team's PII / secret classification considers sensitive. Illustrative (non-exhaustive) examples: `apiKey`, `externalUserId`, `externalUserName`, `email`, `phone`, `address`. Reviewers apply the spirit of this criterion to new field names not on the list (e.g., `ssn`, `dob`, `latitude`/`longitude`).
+
+Reviewers cite these criteria when accepting or rejecting allowlist additions. The initial allowlist is empty. The two criteria are reviewer-gated, not script-enforced — the script's structural rule is the mechanical layer; this allowlist is the controlled escape hatch.
+
+The rule supersedes the file-local audit at `packages/workout-spa-editor/src/components/organisms/SettingsPanel/use-ai-tab-handlers.audit.test.ts` in scope (the broader script covers the same surface plus more) but does NOT replace it: the file-local audit is kept as defense-in-depth per CLAUDE.md's "Never delete a test" rule.
+
+#### Scenario: Toast string with template-literal interpolation is rejected
+
+- **WHEN** a contributor adds a `toast.error(\`Failed: ${error.message}\`)` call in any file under `packages/workout-spa-editor/src/{components,hooks,lib}/**` not on the allowlist
+- **THEN** `pnpm test:scripts` SHALL fail in CI with rule `R-PIIInterpolation`, naming the offending file, line number, and call expression, blocking the merge
+
+#### Scenario: Concatenation with a closure-captured error is rejected
+
+- **WHEN** a contributor adds a `console.error("Failed: " + err.message)` call in any file under the scoped paths not on the allowlist
+- **THEN** `pnpm test:scripts` SHALL fail with rule `R-PIIInterpolation`, naming the offending file, line number, and call expression
+
+#### Scenario: Identifier reference to a `catch` / function-parameter binding is rejected
+
+- **WHEN** a `try { ... } catch (err) { const msg = err.message; toast.error(msg); }` block is added in a scoped file, where `msg` is a local (non-top-level) const
+- **THEN** the static guard SHALL reject the call: `msg` is not a top-level SCREAMING_SNAKE_CASE constant resolving to a string literal, so it fails the rule
+
+#### Scenario: Helper-call indirection at definition time is rejected
+
+- **WHEN** a top-level declaration `const SAVE_FAILED = formatError(err);` is added (RHS is a `CallExpression`, not a string literal) and used as `toast.error(SAVE_FAILED);`
+- **THEN** the static guard SHALL reject the call: `SAVE_FAILED` is a top-level SCREAMING_SNAKE_CASE identifier, but the depth-1 lookup of its declaration finds `formatError(err)` (a call expression) on the right-hand side, not a string literal
+
+#### Scenario: Computed-member dispatch is rejected
+
+- **WHEN** a contributor writes `toast["error"](\`Failed: ${err.message}\`)` in any file under the scoped paths not on the allowlist
+- **THEN** the script's computed-member dispatch regex catches the bracket form, runs the same shape check on the first argument, and fails with rule `R-PIIInterpolation` because the argument is a template literal
+
+#### Scenario: Destructured dispatch is rejected
+
+- **WHEN** a contributor writes `const { error } = useToastContext(); error(\`Failed: ${err.message}\`);` in a scoped file
+- **THEN** the script's destructure scan binds `error` to the toast context within that file, treats the subsequent `error(...)` call as in-scope, runs the shape check, and fails with rule `R-PIIInterpolation`
+
+#### Scenario: Re-bound dispatch is rejected
+
+- **WHEN** a contributor writes `const ctx = useToastContext(); ctx.error(\`Failed: ${err.message}\`);` in a scoped file
+- **THEN** the script's re-binding scan binds `ctx` to the toast context, treats the subsequent `ctx.error(...)` call as member dispatch on a known toast receiver, runs the shape check, and fails with rule `R-PIIInterpolation`
+
+#### Scenario: Identifier chain is rejected (depth-1 only)
+
+- **WHEN** a contributor writes `const A = B; const B = "x"; toast.error(A);` in a scoped file
+- **THEN** the script's depth-1 lookup of `A` finds `const A = B` (RHS is the identifier `B`, not a string literal), and rejects with rule `R-PIIInterpolation`. Transitive resolution (`A → B → "x"`) is intentionally not supported per design D8
+
+#### Scenario: Bare string literal (including inner colons / plus signs) is accepted
+
+- **WHEN** any of `toast.error("Failed to save profile")`, `toast.error("URL: https://example.com")`, or `toast.error("a + b > c")` is parsed in a scoped file
+- **THEN** the static guard SHALL accept the call without flagging the inner `:`, `/`, `+`, or `>` characters — bare-literal acceptance runs BEFORE rejection char-class checks
+
+#### Scenario: Bare SCREAMING_SNAKE_CASE identifier with literal RHS is accepted
+
+- **WHEN** a `toast.error(SAVE_FAILED_TOAST)` call is parsed in any scoped file, AND the same file declares `const SAVE_FAILED_TOAST = "Failed to save profile";` at module top-level (RHS is exactly a bare string literal, depth-1 only)
+- **THEN** the static guard SHALL accept the call
+
+#### Scenario: Allowlisted file with a template literal passes (test-injected)
+
+- **WHEN** the production allowlist (initially empty per the requirement body) is augmented in a test fixture by inserting a path into the exported `ALLOWLIST` Set, AND that file contains a template-literal toast call
+- **THEN** the static guard SHALL accept the call. The scenario exercises the escape-hatch mechanic via test injection; production allowlist additions require reviewer-gated D9-criteria compliance and are not exercised here
+
+#### Scenario: Post-rollout codebase passes the static check
+
+- **WHEN** `node scripts/check-no-pii-leakage.mjs` runs against the SPA editor source tree on the merge commit that closes this rollout
+- **THEN** the script exits 0 with `✅ No PII / secret leakage detected.`

--- a/openspec/changes/cleanup-open-issues-may-2026/tasks.md
+++ b/openspec/changes/cleanup-open-issues-may-2026/tasks.md
@@ -1,0 +1,222 @@
+## 1. Phase 1 — Triage sweep (no code; GitHub bookkeeping only)
+
+This phase ships as a comment on the proposal PR (or as standalone `gh issue close` invocations after the proposal merges). No worktree, no code change, no changeset. Each closure carries an issue-specific rationale.
+
+### 1.1 — Stale CI failure auto-issues
+
+For each issue, look up the failing commit in the issue body, confirm via `gh run list --branch main --workflow CI` that subsequent runs on later commits are green, then close with a comment naming the resolving commit SHA.
+
+- [ ] 1.1.1 Close `#393` (CI failure on `e59efe1`). Look up the latest green CI run on main at execution time via `gh run list --branch main --workflow CI --status success --limit 1 --json headSha,createdAt -q '.[0]'`. Substitute its SHA + date into the closure-comment template: "Resolved on commit `<SHA>`; main green as of `<date>`. Original failure was a Phase 3 e2e flake; the resolving commit is among the post-Phase-3 commits that landed before this lookup."
+- [ ] 1.1.2 Close `#355` (CI failure on `a1b6264`). Look up the resolving commit by `gh run list --branch main --workflow CI --created '>2026-04-24'` and citing the first green run on a commit newer than `a1b6264`. Closure comment template: `Resolved on commit <SHA>; CI green on main from <date> onward.`
+- [ ] 1.1.3 Close `#345` (Link Checker failure on `fec3a92`). Same lookup pattern as 1.1.2 against the Link Checker workflow.
+
+### 1.2 — Stale security alerts
+
+- [ ] 1.2.1 Run `pnpm audit --json | jq '.metadata.vulnerabilities'` and capture the result. Confirm `critical: 0` and `high: 0`.
+- [ ] 1.2.2 For each of `#168, #177, #178, #182`, read the issue body to identify the specific CVE / GitHub Advisory ID(s) referenced. For each:
+  - Run `pnpm why <package>` to confirm whether the package is still in the dep tree.
+  - If absent: closure comment "Package `<name>` is no longer in the dependency tree as of `pnpm-lock.yaml` commit `<SHA>` (`pnpm why <name>` returns no results). Advisory `<GHSA-id>` is no longer applicable."
+  - If present at a patched version: closure comment "Package `<name>` is at version `<X.Y.Z>` (locked in commit `<SHA>`); advisory `<GHSA-id>` patched in `<X.Y.W>`. Current `pnpm audit` reports 0 critical and 0 high; the bot's high-severity criterion is no longer met."
+  - If present at the still-vulnerable version but the advisory has been re-categorised: closure comment cites the re-categorisation.
+
+### 1.3 — Tracking meta-issue
+
+- [ ] 1.3.1 Close `#388`. Closure comment looks up the actual PR numbers at execution time via `gh pr list --state merged --search 'persistence-read-rule-cleanup' --limit 10 --json number,mergedAt,title` and lists them in chronological order. Template: "All `<N>` phase PRs (#<list>) merged; change archived as `openspec/changes/archive/2026-04-30-persistence-read-rule-cleanup/`. Tracking issue closed."
+
+### 1.4 — Validation
+
+- [ ] 1.4.1 `gh issue list --state open --json number | jq 'length'` returns ≤7 (15 minus the 8 closed).
+- [ ] 1.4.2 Phase 1 ships with **no PR**. The closures are manual `gh issue close` invocations after the proposal merges (or as part of the proposal-PR's description if the user prefers to bundle).
+
+## 2. Phase 2 — Fix #386 (SPA route 404 on refresh) via rafgraph SPA-fallback
+
+- [ ] 2.0 Worktree setup: `git worktree add -b feature/cleanup-issues-2-spa-fallback /Users/pablo/development/personal/kaiord-cleanup-2 main`. Run `pnpm install` and rebuild workspace deps.
+
+### 2.1 — Implement the rafgraph pattern in the deploy workflow
+
+- [ ] 2.1.1 Inspect `.github/workflows/deploy-site.yml` to identify the step that produces `merged-dist/404.html` (the landing's blue 404). Confirm the deploy structure matches the issue body's description.
+- [ ] 2.1.2 Replace the `merged-dist/404.html` build step with a rafgraph-shaped 404. The script captures `window.location.pathname + window.location.search`, encodes the path into a `?p=<encoded>` query, and `window.location.replace`s to `/editor/?p=<encoded>` ONLY IF the original path begins with `/editor/`. For non-`/editor/` 404s, the script no-ops and the existing landing 404 markup renders.
+- [ ] 2.1.3 Inject the decoder snippet into `merged-dist/editor/index.html` (post-SPA-build, pre-artifact-upload). The decoder runs synchronously before the React bundle; it reads `?p=<encoded>`, decodes via `decodeURIComponent`, and calls `window.history.replaceState(null, null, decoded)` to restore the original URL.
+- [ ] 2.1.4 Verify VitePress already produces `docs/404.html` (it does); no docs-side change.
+
+### 2.2 — CI smoke step (self-monitoring)
+
+- [ ] 2.2.1 Add a post-deploy smoke step in `.github/workflows/deploy-site.yml` that runs after the `actions/deploy-pages@v5` step completes. The step:
+  - Targets `${{ steps.deployment.outputs.page_url }}editor/calendar` (the GitHub Pages-issued `*.github.io` host, which propagates faster than the custom domain). Falls back to `https://kaiord.com/editor/calendar` only if the workflow is triggered on `main` AND the page-url output is unavailable.
+  - **Build-derived marker**: read the SPA's emitted `index.html` post-build to extract a unique `<script src="...">` reference (e.g., `MARKER=$(grep -oE 'src="/editor/assets/index-[^"]+\.js"' merged-dist/editor/index.html | head -1)`). Hardcoded path prefixes break silently if `vite.config.ts` ever changes `base` or `build.assetsDir`; deriving the marker from the actual build output keeps the smoke step robust to those refactors.
+  - **Retry-with-backoff**: Pages CDN propagation is eventually consistent (typical 30s–2min). The step runs `for i in $(seq 1 10); do curl -sL "$URL" > resp.html && grep -qF "$MARKER" resp.html && break || sleep 10; done` so an early-cache miss does not flake CI.
+  - Final assertion: response body contains the build-derived `$MARKER` (positive: SPA bundle served) AND does NOT contain the landing's 404 marker (negative: `error-page-blue` or whatever the post-rafgraph 404 markup uses).
+  - Fails the workflow on regression after the retry loop exhausts, pinging via the existing failure-notification path.
+- [ ] 2.2.2 Run the smoke step locally against `pnpm preview` or a deploy-preview branch before merging.
+
+### 2.3 — Manual verification (not gated, complementary)
+
+- [ ] 2.3.1 GET `/editor/calendar` after a hard refresh returns the SPA bundle.
+- [ ] 2.3.2 GET `/editor/this-route-does-not-exist` returns the SPA bundle, which then renders the SPA's in-app 404 screen (router-driven), not the landing's blue 404.
+- [ ] 2.3.3 GET `/this-route-does-not-exist` (root, outside `/editor`) still returns the landing's `404.html` blue page.
+- [ ] 2.3.4 Hash fragments survive the round-trip: `/editor/workout/abc#step-3` after refresh restores both path and fragment.
+
+### 2.4 — Validation, changeset, PR
+
+- [ ] 2.4.1 Run `pnpm lint` and `pnpm test` — no expected impact (workflow change), but confirm clean.
+- [ ] 2.4.2 No changeset: Phase 2 modifies `.github/workflows/deploy-site.yml` only, which does not ship in any npm package. Verify against `.changeset/config.json` `ignore` list. (If repo policy requires a `none`-typed changeset for the audit trail, add one; otherwise skip.)
+- [ ] 2.4.3 Commit: `fix(deploy): add SPA fallback for editor routes via rafgraph pattern (closes #386)`.
+- [ ] 2.4.4 Open PR; ensure CI green (especially the new smoke step); squash merge.
+- [ ] 2.4.5 Verify in production: `curl -I https://kaiord.com/editor/calendar` returns the SPA bundle; navigate manually to confirm refresh no longer wipes the URL.
+- [ ] 2.4.6 After merge: clean local worktree (`git worktree remove /Users/pablo/development/personal/kaiord-cleanup-2`) and delete the local branch.
+
+## 3. Phase 3 — PII / secret-leakage mechanical guard (#395)
+
+### 3.1 — Shared parser primitive (extracted from existing script)
+
+- [ ] 3.0 Worktree setup: `git worktree add -b feature/cleanup-issues-3-pii-guard /Users/pablo/development/personal/kaiord-cleanup-3 main`.
+- [ ] 3.1.1 Extract the string-aware JSONC stripper from `scripts/check-no-zustand-writethrough.mjs` into `scripts/lib/strip-jsonc.mjs`. Update `check-no-zustand-writethrough.mjs` to import from the shared module. Re-run `pnpm test:scripts` to confirm no behavioural regression in the existing 11 fixtures.
+
+### 3.2 — Guard script
+
+- [ ] 3.2.1 Create `scripts/check-no-pii-leakage.mjs` per design D2 / D3. Walk `packages/workout-spa-editor/src/{components,hooks,lib}/**/*.{ts,tsx}` excluding `*.test.{ts,tsx}` and `*.stories.{ts,tsx}`.
+- [ ] 3.2.2 Parse each file for four call-site dispatch shapes (canonical anchors):
+  - **Member dispatch**: `(toast|useToastContext\(\))\s*\.\s*(error|success|info|warning)\(` and `console\.(log|warn|error|info|debug)\(`.
+  - **Computed-member dispatch**: `(toast|useToastContext\(\))\s*\[\s*["'](error|success|info|warning)["']\s*\]\s*\(` — catches `toast["error"](...)` bypass.
+  - **Destructured dispatch**: scan the file for `const\s*\{\s*([^}]+)\s*\}\s*=\s*useToastContext\(\)` and capture the bound names (e.g., `error`, `success`). Subsequent calls of the form `<bound-name>\(` within the same file are treated as in-scope; their first argument is checked.
+  - **Re-bound dispatch**: scan the file for `const\s+([A-Za-z_$][\w$]*)\s*=\s*useToastContext\(\)` and capture the receiver name (e.g., `ctx`). Subsequent member-dispatch calls of the form `<ID>\.\s*(error|success|info|warning)\(` are treated as in-scope.
+  - **Multi-binding ambiguity policy**: if a file contains conflicting bindings (e.g., a destructure and a re-bind, or two destructures from different sources), the script treats every potentially-toast `<name>(` or `<name>.<method>(` call as in-scope (false-positive bias is the safe default). The contributor either renames the conflict, refactors, or — last resort — allowlists the file under D9 criteria.
+  Extract the first argument's source text using a balanced-paren scanner that respects string literals (so `toast.error("oops, ).")` parses correctly).
+- [ ] 3.2.3 Validate the first argument shape per D3 in this exact order (bare-literal accept comes BEFORE rejection, so `toast.error("URL: example.com")` and `toast.error("a + b")` are accepted as bare literals despite their inner `:` and `+` characters):
+  1. Trim leading/trailing whitespace.
+  2. **Bare-literal accept first**: if the trimmed text matches `/^"[^"\\]*(?:\\.[^"\\]*)*"$/` or the equivalent single-quote regex, ACCEPT and continue to the next call site. Inner content is irrelevant — the bare-literal cannot interpolate.
+  3. **Bare-identifier accept second**: if the trimmed text matches `/^[A-Z][A-Z0-9_]*$/`, scan the same file for a top-level `const <ID>\s*=\s*("[^"\\]*(?:\\.[^"\\]*)*"|'[^'\\]*(?:\\.[^'\\]*)*');` whose RHS is exactly a bare string literal. Depth-1 only per D8 — chains (`A → B → "x"`) are rejected at this step. If found, ACCEPT.
+  4. **Reject everything else**: template literals, concatenation, parenthesized expressions (e.g., `("Failed")`), TS type assertions (`SAVE_FAILED as string`, `<string>SAVE_FAILED`, `SAVE_FAILED satisfies string`), TS post-fix operators (`SAVE_FAILED!`, `SAVE_FAILED as const`), unary operators (`void "Failed"`, `+SAVE_FAILED`), member access, function calls, lowercase / camelCase identifiers, identifier chains. The rejection message names the offending operator/shape verbatim so contributors can fix without consulting the spec: e.g., "rule R-PIIInterpolation: `SAVE_FAILED!` rejected — strip the non-null assertion; the constant is already statically known not-null".
+- [ ] 3.2.4 Hard-coded allowlist — empty initially. The allowlist mechanism mirrors `check-no-zustand-writethrough.mjs`'s exported `ALLOWLIST` Set so test fixtures can manipulate it. Each entry MUST carry a comment satisfying D9 criteria.
+- [ ] 3.2.5 CLI behaviour: print `✅ No PII / secret leakage detected.` on success; print one line per violation with file path, line number, call site, and the offending argument shape on failure. Exit 0 / 1.
+- [ ] 3.2.6 The script must be ESM (`.mjs`), use no external dependencies (`node --test`-compatible), and follow the existing `scripts/check-no-zustand-writethrough.mjs` style (export `runCheck` and `ALLOWLIST` for test injection).
+
+### 3.3 — Co-located test + fixtures
+
+- [ ] 3.3.1 Create `scripts/check-no-pii-leakage.test.mjs` (`node:test`) covering twelve fixtures under `scripts/__fixtures__/check-no-pii-leakage/`:
+- [ ] 3.3.1.1 Positive: post-rollout codebase passes — `runCheck()` against the real SPA editor source returns no violations.
+- [ ] 3.3.1.2 Negative: template literal interpolating `error.message` is flagged (`toast.error(\`Failed: ${error.message}\`)`).
+- [ ] 3.3.1.3 Negative: string concatenation with a closure-captured error is flagged (`console.error("Failed: " + err.message)`).
+- [ ] 3.3.1.4 Negative: identifier reference to a non-top-level binding is flagged. Fixture: `try { ... } catch (err) { const msg = err.message; toast.error(msg); }` — `msg` is a function-local const, not top-level, so the depth-1 lookup fails and the call is rejected.
+- [ ] 3.3.1.5 Negative: helper-call indirection at definition time is flagged (`const SAVE_FAILED = formatError(err); toast.error(SAVE_FAILED);` — RHS is a `CallExpression`, not a literal).
+- [ ] 3.3.1.6 Negative: computed-member dispatch is flagged (`toast["error"](\`Failed: ${err.message}\`)` — the dispatch regex catches the bracket form).
+- [ ] 3.3.1.7 Negative: destructured dispatch is flagged (`const { error } = useToastContext(); error(\`Failed: ${err.message}\`);` — the destructure scan binds `error` to the toast context, and the subsequent call is treated as in-scope).
+- [ ] 3.3.1.8 Positive: bare string literal containing colons / plus signs is accepted (`toast.error("URL: https://example.com")`, `toast.error("a + b")`) — verifies that bare-literal acceptance runs BEFORE the rejection char-class.
+- [ ] 3.3.1.9 Positive: bare SCREAMING_SNAKE_CASE identifier resolving to a top-level string-literal const is accepted (`const SAVE_FAILED_TOAST = "Failed to save"; toast.error(SAVE_FAILED_TOAST);`).
+- [ ] 3.3.1.10 Positive: allowlist exemption — an allowlisted file with a template literal passes; the production allowlist is empty, the fixture injects an entry into the exported `ALLOWLIST` Set.
+- [ ] 3.3.1.11 Negative: re-bound dispatch is flagged (`const ctx = useToastContext(); ctx.error(\`Failed: ${err.message}\`);` — the re-binding scan binds `ctx` to the toast context, treats `ctx.error(...)` as member dispatch).
+- [ ] 3.3.1.12 Negative: identifier chain is flagged (`const A = B; const B = "x"; toast.error(A);` — depth-1 lookup of `A` finds the identifier `B` on the RHS, not a string literal).
+
+### 3.4 — Wire into CI
+
+- [ ] 3.4.1 Confirm `pnpm test:scripts` glob (`node --test scripts/*.test.mjs`) picks up `scripts/check-no-pii-leakage.test.mjs` automatically.
+- [ ] 3.4.2 Run `pnpm test:scripts` locally — all green including the new file plus the existing 11 no-Zustand-writethrough fixtures (confirming D7 shared-primitive extraction did not regress).
+
+### 3.5 — Existing audit reconciliation per D6
+
+- [ ] 3.5.1 **Keep** `packages/workout-spa-editor/src/components/organisms/SettingsPanel/use-ai-tab-handlers.audit.test.ts` per D6 (CLAUDE.md "Never delete a test"). Add a one-line header comment to the audit file: `// Defense-in-depth: scripts/check-no-pii-leakage.mjs provides repo-wide coverage of the same rule. This focused vitest variant catches regressions in the package's test surface.`
+
+### 3.6 — Validation
+
+- [ ] 3.6.1 Run the new guard against the current SPA editor source: `node scripts/check-no-pii-leakage.mjs`. Address every flagged call site (refactor to a SCREAMING_SNAKE_CASE constant; do NOT allowlist unless D9 criteria are met).
+- [ ] 3.6.2 Run `pnpm --filter @kaiord/workout-spa-editor test` — passing, including the kept AiTab audit.
+- [ ] 3.6.3 Run `pnpm --filter @kaiord/workout-spa-editor lint` — clean.
+- [ ] 3.6.4 Run `pnpm test:scripts` — passing.
+- [ ] 3.6.5 Run `pnpm -r build` — clean.
+- [ ] 3.6.6 Update internal docs (`CLAUDE.md` "Quality Standards" section): add a bullet referencing the new guard alongside the existing no-Zustand-writethrough one.
+- [ ] 3.6.7 Add a `none` changeset unconditionally. The PR adds repo scripts (not packaged) and a comment-only edit to a `.test.ts` file inside the SPA editor; neither is a user-facing change. If the changeset bot complains, the right fix is to update `.changeset/config.json` `ignore` rules — never to misrepresent the change as `patch`.
+- [ ] 3.6.8 Open PR; ensure CI green; squash merge.
+- [ ] 3.6.9 After merge: clean local worktree and delete local branch.
+
+## 4. Phase 4 — Cosmetic polish bundle (#266, #267, #268, #269, #270)
+
+- [ ] 4.0 Worktree setup: `git worktree add -b feature/cleanup-issues-4-cosmetic-polish /Users/pablo/development/personal/kaiord-cleanup-4 main`.
+
+### 4.1 — Shared @font-face extraction (#270)
+
+- [ ] 4.1.1 Identify the three duplicate `@font-face` blocks: `packages/workout-spa-editor/src/index.css`, `packages/landing/src/styles/custom.css`, `packages/docs/.vitepress/theme/styles/brand-tokens.css`.
+- [ ] 4.1.2 Extract into `packages/workout-spa-editor/src/styles/brand-fontface.css` (or a workspace-shared location if landing/docs cannot import from the editor's path due to build-system constraints; in that case create parallel files that import from a shared `packages/shared-styles/`).
+- [ ] 4.1.3 Replace the inline blocks with `@import` references; verify each surface's font still loads in dev (`pnpm --filter @kaiord/workout-spa-editor dev`, `pnpm --filter @kaiord/landing dev`, `pnpm --filter @kaiord/docs dev`).
+
+### 4.2 — Inter font size-adjust (#269)
+
+- [ ] 4.2.1 Add `size-adjust: 100%` (or measured value if Inter's metrics differ from the system fallback) to the consolidated `@font-face` block, eliminating CLS on first paint.
+- [ ] 4.2.2 Lighthouse CLS measurement: capture a one-before / one-after value; target reduction is non-zero. Capture in the PR description.
+
+### 4.3 — Unified focus-visible (#268)
+
+- [ ] 4.3.1 Copy the editor's `:focus-visible` ring rule into landing and docs CSS so all three surfaces show the same focus indicator.
+- [ ] 4.3.2 Manual keyboard-tab smoke check: tab through landing nav, docs nav, editor calendar — focus ring identical width / colour / offset on all three.
+
+### 4.4 — Viewport-fit + safe-area-inset (#267)
+
+- [ ] 4.4.1 Update `packages/workout-spa-editor/index.html` `<meta name="viewport">` to include `viewport-fit=cover`.
+- [ ] 4.4.2 Add `padding-{left,right,bottom}: env(safe-area-inset-{left,right,bottom})` to the SPA's root layout container.
+- [ ] 4.4.3 Manual check using Playwright's `iPhone 14 Pro` device descriptor confirms no content under the notch and no white bars in landscape.
+
+### 4.5 — gray → slate remap (#266)
+
+- [ ] 4.5.1 **Spike — validate Tailwind 4 `@theme` mechanism BEFORE committing to the approach, with a captured artifact.** In a temporary branch, add the following to `packages/workout-spa-editor/src/index.css`:
+  ```css
+  @theme {
+    --color-gray-50: var(--color-slate-50);
+    --color-gray-500: var(--color-slate-500);
+    --color-gray-800: var(--color-slate-800);
+    --color-gray-950: var(--color-slate-950);
+  }
+  ```
+  Create a temporary spike component `packages/workout-spa-editor/src/__spike__/gray-slate-spike.tsx` (excluded from production build) that renders one element per (utility-family × shade-extreme × dark-mode) cell. Minimum **10 cells**, covering all utility-emission pathways Tailwind 4 may treat differently: `bg-gray-50`, `bg-gray-500`, `bg-gray-950`, `text-gray-500`, `border-gray-500`, `ring-gray-500`, `outline-gray-500`, `divide-gray-500`, `placeholder-gray-400`, `dark:bg-gray-800`. Use `getComputedStyle()` in a Vitest at `__spike__/gray-slate-spike.test.tsx` to assert each gray utility's computed colour byte-equals the corresponding slate utility's value. Capture the test output (pass/fail per cell) and paste it in the spike PR description as the canonical artifact. If all cells pass → the `@theme` alias propagates; proceed to 4.5.2. If any cell fails → Tailwind 4 has inlined the gray values at build time; SKIP 4.5.2 and proceed to 4.5.4 (per-file fallback).
+- [ ] 4.5.1a **Spike cleanup**: before the Phase 4 PR opens, `git rm -r packages/workout-spa-editor/src/__spike__` and confirm `find packages -type d -name __spike__` returns empty. Add a CI grep guard (one-line shell step in `.github/workflows/ci.yml` lint job): `! find packages -type d -name __spike__ | grep -q .` so a forgotten spike folder fails CI on any future PR.
+- [ ] 4.5.2 (Conditional on 4.5.1 success) Edit the SPA editor's Tailwind 4 `@theme` block to remap every `--color-gray-*` shade (50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950) to the corresponding `--color-slate-*` value via `var()` aliases.
+- [ ] 4.5.3 (Conditional on 4.5.1 success) Skip directly to 4.5.5 (screenshot diff).
+- [ ] 4.5.4 (Conditional on 4.5.1 failure) Per-file fallback: `grep -rl 'gray-' packages/workout-spa-editor/src` and run a careful sed across each file replacing `(text|bg|border|ring|outline)-gray-(\d+)` → `\1-slate-\2`. Manually review the diff for any standalone `gray-` references (CSS custom property names, comments) that should not be touched.
+- [ ] 4.5.5 Generate Playwright screenshot fixtures for at least: calendar week view, editor full-form, settings dialog (AI Tab + Privacy Tab), library dialog. Capture before / after screenshots. Post the diff in the PR description.
+- [ ] 4.5.6 Spot-check for combinations that look jarring under slate (any stale hand-tinted colour that no longer matches the new neutral). Patch those few files individually if needed.
+
+### 4.6 — Validation
+
+- [ ] 4.6.1 Run `pnpm --filter @kaiord/workout-spa-editor test` — passing.
+- [ ] 4.6.2 Run `pnpm --filter @kaiord/workout-spa-editor lint` — clean.
+- [ ] 4.6.3 Run `pnpm -r build` — clean.
+- [ ] 4.6.4 Run the Playwright e2e suite — passing; visual screenshot diff posted in PR description.
+- [ ] 4.6.5 Add a `patch` changeset for `@kaiord/workout-spa-editor` titled `chore(spa-editor): cosmetic polish bundle (closes #266, #267, #268, #269, #270)`.
+- [ ] 4.6.6 Open PR; ensure CI green; squash merge.
+- [ ] 4.6.7 After merge: clean local worktree and delete local branch.
+
+## 5. Phase 5 — Verify and archive
+
+- [ ] 5.1 `git checkout main && git pull` to sync the merge commits from Phases 2, 3, 4.
+- [ ] 5.2 Confirm `gh issue list --state open --json number | jq 'length'` returns 0 (or only newly auto-bot-opened issues post Phase 1).
+- [ ] 5.3 Run `pnpm -r test`, `pnpm -r build`, `pnpm lint`, `pnpm test:scripts` on main — all green.
+- [ ] 5.4 Confirm the change-scoped delta is well-formed: `openspec validate cleanup-open-issues-may-2026 --strict` passes. (Repo-wide `openspec validate --specs --strict` runs AFTER archive at task 5.6.5, when the new `spa-quality-gates` spec exists in `openspec/specs/`.)
+
+### 5.5 — Spec-scenario coverage map (validated at archive time)
+
+For each scenario in this change's `specs/spa-quality-gates/spec.md` ADDED block, identify the task that delivers the test. The order matches the spec's scenario order:
+
+| # | Scenario | Task that adds the test |
+| - | --- | --- |
+| 1 | Toast string with template-literal interpolation is rejected | 3.3.1.2 |
+| 2 | Concatenation with a closure-captured error is rejected | 3.3.1.3 |
+| 3 | Identifier reference to a `catch` / function-parameter binding is rejected | 3.3.1.4 |
+| 4 | Helper-call indirection at definition time is rejected | 3.3.1.5 |
+| 5 | Computed-member dispatch (`toast["error"]`) is rejected | 3.3.1.6 |
+| 6 | Destructured dispatch (`const { error } = useToastContext()`) is rejected | 3.3.1.7 |
+| 7 | Re-bound dispatch (`const ctx = useToastContext(); ctx.error(...)`) is rejected | 3.3.1.11 |
+| 8 | Identifier chain (`A → B → "x"`) is rejected (depth-1 only) | 3.3.1.12 |
+| 9 | Bare string literal (including inner `:` / `+`) is accepted | 3.3.1.8 |
+| 10 | Bare SCREAMING_SNAKE_CASE identifier with literal RHS is accepted | 3.3.1.9 |
+| 11 | Allowlisted file with a template literal passes (test-injected `ALLOWLIST` Set) | 3.3.1.10 |
+| 12 | Post-rollout codebase passes the static check | 3.3.1.1 |
+
+- [ ] 5.5.1 Confirm the table above is bidirectionally in sync with the final spec scenarios at archive time: every scenario maps to a task AND every fixture (3.3.1.X) maps to a scenario. Adjust either side if drift is detected during the rollout.
+
+### 5.6 — Archive
+
+- [ ] 5.6.0a **Pre-flight**: run `pnpm lint:specs` against the change-scoped spec delta (`openspec/changes/cleanup-open-issues-may-2026/specs/spa-quality-gates/spec.md`) and `openspec validate cleanup-open-issues-may-2026 --strict` once more. Both green before invoking archive — the goal is to avoid discovering a spec-format issue mid-archive.
+- [ ] 5.6.1 Run `openspec archive cleanup-open-issues-may-2026 --yes` — moves the change to `openspec/changes/archive/YYYY-MM-DD-cleanup-open-issues-may-2026/` and applies spec deltas to `openspec/specs/spa-quality-gates/spec.md` (creating the new capability spec).
+- [ ] 5.6.2 **Verify the new capability spec was materialised correctly with H1 + `## Purpose` + `> Synced:` header.** The `openspec archive` CLI auto-emits these for new capabilities; double-check because new-capability creation is rare. Open `openspec/specs/spa-quality-gates/spec.md` and confirm: (a) line 1 is `> Synced: YYYY-MM-DD` matching the archive folder; (b) the H1 is exactly `# SPA Quality Gates` (no "or equivalent" — lock the wording to avoid drift across archive runs); (c) a `## Purpose` paragraph copied from the design.md D7 paragraph that begins "Mechanically enforced repo-wide quality gates" (search design.md for that exact opening). If any of (a)/(b)/(c) is absent, hand-write the trio. **PR-description guidance**: if the trio is hand-written, the archive PR's body MUST include a one-line note like "Hand-wrote H1+Purpose+Synced for new capability `spa-quality-gates` because `openspec archive` did not auto-emit them." so future archive PRs can be audited mechanically by grepping descriptions.
+- [ ] 5.6.3 Add the `> Completed: YYYY-MM-DD` marker at the top of the archived `proposal.md`, where `YYYY-MM-DD` matches the folder prefix.
+- [ ] 5.6.4 Run `pnpm archive:index` to regenerate `openspec/changes/archive/README.md`. Run `pnpm lint:archive` and `pnpm lint:archive-index` — both clean.
+- [ ] 5.6.5 Run `openspec validate --specs --strict` and `pnpm lint:specs` against the materialised specs — the new `spa-quality-gates` spec must pass alongside the existing 27 specs, total 28 passing.
+- [ ] 5.6.6 Open the archive PR; ensure CI green; squash merge.


### PR DESCRIPTION
## Summary

Coordinates the cleanup of all 15 open issues across 5 phases, each ending with main green:

- **Phase 1** — Triage sweep: close 8 stale auto-bot artefacts (#388, #393, #355, #345, #168, #177, #178, #182).
- **Phase 2** — Fix #386 (SPA route 404 on refresh) via rafgraph SPA-fallback pattern with build-derived smoke marker.
- **Phase 3** — Generalize the file-local PII audit into a repo-wide guard (#395). 4 dispatch shapes, 12 fixtures, new `spa-quality-gates` capability.
- **Phase 4** — Cosmetic polish bundle (#266, #267, #268, #269, #270) with a 10-cell spike for the gray→slate Tailwind 4 `@theme` remap.
- **Phase 5** — Verify and archive.

## Validation

- ✅ `openspec validate cleanup-open-issues-may-2026 --strict`
- ✅ `pnpm lint:specs` 27/27
- ✅ Expert-panel review: 9.90/10 average across 5 staff/principal-level perspectives over 4 iterations (7.30 → 8.20 → 9.10 → 9.90).

## Spec impact

- NEW capability `spa-quality-gates` (1 ADDED requirement, 12 scenarios).

## Test plan

- [x] OpenSpec validation green
- [ ] Phase 2: deploy-preview smoke test on rafgraph fallback
- [ ] Phase 3: repo-wide guard against current SPA editor source returns 0 violations
- [ ] Phase 4: 10-cell `@theme` spike before committing to the alias approach; per-file fallback pre-decided

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design specification for multi-phase cleanup initiative addressing open issues
  * Documented planned improvements to SPA refresh behavior and UI/UX enhancements
  * Defined quality gates and verification procedures for upcoming releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->