### PR TITLE
openspec: propose fix-spa-router-basename — SPA route refresh 404 fix

### DIFF
--- a/openspec/changes/fix-spa-router-basename/design.md
+++ b/openspec/changes/fix-spa-router-basename/design.md
@@ -1,0 +1,118 @@
+## Context
+
+`cleanup-open-issues-may-2026` Phase 2 (PR #398, archived 2026-05-01) shipped a rafgraph SPA-fallback in `.github/workflows/deploy-site.yml`:
+
+- Root `merged-dist/404.html` carries an inline redirect script that captures the requested path, encodes it into `?p=<encoded>`, and `window.location.replace`s to `/editor/?p=<encoded>` — but **only if** the original pathname starts with `/editor/`.
+- `merged-dist/editor/index.html` carries an inline decoder that runs before React boots, restoring the path via `history.replaceState`.
+
+The guard `pathname.indexOf('/editor/') === 0` was added so non-editor 404s on the landing surface (e.g. `kaiord.com/typo-here`) keep falling through to the landing's blue 404 markup instead of being aggressively redirected into the SPA.
+
+User-reported regression (2026-05-01): refreshing `kaiord.com/calendar` returns the blue 404. Investigation:
+
+```
+  ┌──────────────────────────────────────────────────────────┐
+  │  vite.config.ts:44                                       │
+  │  base: process.env.VITE_BASE_PATH || "/"                 │
+  │  → CI sets VITE_BASE_PATH=/editor/ → assets at /editor/  │
+  │                                                          │
+  │  main.tsx                                                │
+  │  No <Router> wrapper. App imported and rendered raw.     │
+  │  → Wouter's default Router base = "" (empty string)      │
+  │                                                          │
+  │  App.tsx:25-52                                           │
+  │  <Route path="/"> <Redirect to="/calendar" />            │
+  │  <Route path="/calendar/:weekId?">                       │
+  │  <Route path="/library">                                 │
+  │  <Route path="/workout/new"> ...                         │
+  │  → Routes declared at root, no /editor prefix anywhere   │
+  └──────────────────────────────────────────────────────────┘
+```
+
+Mismatch: Vite emits assets under `/editor/`, wouter emits URLs at root. The SPA loads (assets resolve), wouter immediately runs the catch-all `<Redirect to="/calendar" />`, the URL bar reads `/calendar`, and any subsequent refresh fails.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- A user refreshing any in-app SPA URL on `kaiord.com` keeps the SPA bundle and the route, with no 404 flash.
+- The fix is local to the SPA (one-line wrap in `main.tsx`); the deploy workflow's existing rafgraph script keeps its `/editor/*` guard unchanged.
+- Existing 6-case `routes.test.tsx` continues to pass.
+- A regression test prevents this exact bug from re-introducing silently.
+
+**Non-Goals**
+
+- Generalising the rafgraph script to redirect non-`/editor/` paths (band-aid for the symptom; misses the architectural root cause).
+- Rewriting wouter routes to hardcode `/editor/calendar` etc. (verbose, ties source to deploy path).
+- Migrating off wouter to React Router or anything else.
+- Changing the docs surface routing.
+
+## Decisions
+
+### D1. Use wouter's `<Router base={...}>` API derived from `import.meta.env.BASE_URL`.
+
+Wouter exports a `Router` component that accepts a `base` prop — see https://github.com/molefrog/wouter#router-base-baseroute-children. Setting `base="/editor"` makes:
+
+- `useLocation()` return paths relative to the base (so `<Route path="/calendar">` continues to match the user being at `/editor/calendar`).
+- `<Redirect to="/calendar" />` produce an absolute URL of `/editor/calendar`.
+- All wouter `<Link>` components emit `/editor/<href>` URLs.
+
+Vite already exposes the deploy base at `import.meta.env.BASE_URL`. In dev: `/`. In prod (with `VITE_BASE_PATH=/editor/`): `/editor/`. Wouter's `base` accepts an empty string OR a path without trailing slash, so the value passed becomes:
+
+```ts
+const base = computeRouterBase(import.meta.env.BASE_URL);
+// dev:  base = ""        (wouter treats as no-base)
+// prod: base = "/editor"
+```
+
+`computeRouterBase` (defined in `router-base.ts` per D2) strips the trailing slash that Vite always emits.
+
+**Rafgraph ↔ wouter-base handoff (interaction with the prior `cleanup-open-issues-may-2026` rafgraph requirement).** The 404 redirect script captures `l.pathname` (e.g. `/editor/calendar`) and bounces to `/editor/?p=%2Feditor%2Fcalendar`. The decoder injected into `editor/index.html` runs **synchronously before React mounts** and calls `history.replaceState(null, "", "/editor/calendar" + hash)`. By the time wouter's `<Router base="/editor">` reads `window.location.pathname`, the URL already carries the `/editor/` prefix that wouter then strips for route matching. The two requirements compose cleanly: rafgraph restores the URL; wouter base resolves the deep route.
+
+### D2. Test surface — pure helper unit test + e2e against production-base build.
+
+Two tests guard the rule:
+
+**Unit test** (`packages/workout-spa-editor/src/router-base.test.ts`): exercises a pure exported helper `computeRouterBase(baseUrl: string): string` declared in `packages/workout-spa-editor/src/router-base.ts` and consumed by `main.tsx`. The helper centralises the trailing-slash strip so the rule is testable in isolation, table-driven, and survives JSX-shape refactors:
+
+| input            | expected output |
+| ---------------- | --------------- |
+| `"/"`            | `""`            |
+| `"/editor/"`     | `"/editor"`     |
+| `"/a/b/"`        | `"/a/b"`        |
+| `""`             | `""`            |
+
+The helper exists so the unit test is behavioural (not a source-grep). `main.tsx` imports `computeRouterBase` and applies it to `import.meta.env.BASE_URL`. Vite normalises `BASE_URL` to always start AND end with `/` (verified in Vite's `resolveBaseUrl`), so the regex-strip's correctness is grounded in that invariant; if Vite ever changes the contract, the unit test catches the discrepancy.
+
+**E2E test** (`packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts`, new): builds the SPA with `VITE_BASE_PATH=/editor/`, serves the merged dist (including the rafgraph 404) via a static server that does NOT expose SPA fallback, then:
+- GET `/editor/calendar` directly. Asserts the response is the SPA bundle (entry script tag) — proves Pages-equivalent fallback works.
+- Navigate to `/editor/`, then click into the calendar route, observe the URL becomes `/editor/calendar` (NOT `/calendar`).
+- Refresh from inside the SPA. Asserts the URL stays `/editor/calendar` and the calendar view re-renders.
+
+### D3. Tests existing today vs new.
+
+- `routes.test.tsx` (6 cases) tests wouter's `<Switch>` matching at the component level, NOT against full URLs. With the new `<Router base="">` wrapper (default in tests where `BASE_URL` is not set or is `/`), behaviour is identical. Should pass unchanged.
+- E2E tests under `packages/workout-spa-editor/e2e/` run against `pnpm dev` which uses Vite's dev server with `base: "/"`. Wouter base resolves to `""`, behaviour is identical to today. No e2e file edits required for dev-mode runs.
+- The new `spa-route-refresh.spec.ts` is the only test that exercises the production-base build. It runs as part of the standard e2e suite if the CI provides `VITE_BASE_PATH` — otherwise it skips with a `test.skip` guard so local `pnpm test:e2e` keeps working.
+
+### D4. Spec capability home.
+
+The new requirement creates a new `spa-routing` capability with the rule as its single requirement. Two options were considered:
+
+1. **Add to `spa-quality-gates`** (capability created in `cleanup-open-issues-may-2026`). Rejected: that capability's Purpose narrowly says "Mechanically enforced repo-wide quality gates implemented as static-source `pnpm test:scripts` checks" — but the new rule is enforced by Vitest unit + Playwright e2e, not by `pnpm test:scripts`. Updating the Purpose paragraph through a change delta is awkward in OpenSpec (deltas express ADDED/MODIFIED/REMOVED at the requirement level, not the capability-Purpose level), and broadening the Purpose dilutes the capability's identity.
+2. **Create a new `spa-routing` capability**. Adopted. Single-requirement specs have a direct precedent — `spa-quality-gates` itself shipped with one requirement and has room to grow. The capability's Purpose paragraph self-describes the routing/deploy-alignment rules without contorting another spec.
+
+The new `spa-routing` capability's Purpose: "Routing-layer rules for the SPA editor, including alignment between client-side router base configuration and Vite deploy base, plus any additional invariants needed to keep deep URLs refresh-safe under static hosting." Future routing rules (e.g., reserved-path policy, deep-link navigation contracts) land in the same capability without reopening this scope debate.
+
+## Risks / Trade-offs
+
+- **R1 — wouter `base` edge cases.** Trailing slash, empty base, redirect interaction. Mitigation: D2 unit + e2e tests; behaviour verified against the wouter source / docs before merge.
+- **R2 — bookmark breakage.** Anyone with a bookmark pointing at `kaiord.com/calendar` (without `/editor/` prefix) will see the URL change to `kaiord.com/editor/calendar` after this fix. The old URL never worked across refresh — the bookmark was already broken — so this is a no-regression. Calling it out for the PR description so any external observers (mostly the user themselves) understand.
+- **R3 — analytics URL change.** `analytics.pageView(path)` is called from `App.tsx:72` with `path` from `useLocation()`. Wouter's `useLocation` returns paths relative to the base, so `path` continues to be `/calendar` (NOT `/editor/calendar`) regardless of the wrapper. Existing analytics dashboards are unaffected.
+
+## Migration Plan
+
+Pure additive change. No data migration. No config-file rename. Forward-compatible.
+
+## Follow-ups
+
+None. The fix is one line plus two tests; the architectural cleanup (`Router base` matching `Vite base`) is the right resting state.

--- a/openspec/changes/fix-spa-router-basename/design.md
+++ b/openspec/changes/fix-spa-router-basename/design.md
@@ -9,7 +9,7 @@ The guard `pathname.indexOf('/editor/') === 0` was added so non-editor 404s on t
 
 User-reported regression (2026-05-01): refreshing `kaiord.com/calendar` returns the blue 404. Investigation:
 
-```
+```text
   ┌──────────────────────────────────────────────────────────┐
   │  vite.config.ts:44                                       │
   │  base: process.env.VITE_BASE_PATH || "/"                 │

--- a/openspec/changes/fix-spa-router-basename/design.md
+++ b/openspec/changes/fix-spa-router-basename/design.md
@@ -74,16 +74,17 @@ Two tests guard the rule:
 
 **Unit test** (`packages/workout-spa-editor/src/router-base.test.ts`): exercises a pure exported helper `computeRouterBase(baseUrl: string): string` declared in `packages/workout-spa-editor/src/router-base.ts` and consumed by `main.tsx`. The helper centralises the trailing-slash strip so the rule is testable in isolation, table-driven, and survives JSX-shape refactors:
 
-| input            | expected output |
-| ---------------- | --------------- |
-| `"/"`            | `""`            |
-| `"/editor/"`     | `"/editor"`     |
-| `"/a/b/"`        | `"/a/b"`        |
-| `""`             | `""`            |
+| input        | expected output |
+| ------------ | --------------- |
+| `"/"`        | `""`            |
+| `"/editor/"` | `"/editor"`     |
+| `"/a/b/"`    | `"/a/b"`        |
+| `""`         | `""`            |
 
 The helper exists so the unit test is behavioural (not a source-grep). `main.tsx` imports `computeRouterBase` and applies it to `import.meta.env.BASE_URL`. Vite normalises `BASE_URL` to always start AND end with `/` (verified in Vite's `resolveBaseUrl`), so the regex-strip's correctness is grounded in that invariant; if Vite ever changes the contract, the unit test catches the discrepancy.
 
 **E2E test** (`packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts`, new): builds the SPA with `VITE_BASE_PATH=/editor/`, serves the merged dist (including the rafgraph 404) via a static server that does NOT expose SPA fallback, then:
+
 - GET `/editor/calendar` directly. Asserts the response is the SPA bundle (entry script tag) — proves Pages-equivalent fallback works.
 - Navigate to `/editor/`, then click into the calendar route, observe the URL becomes `/editor/calendar` (NOT `/calendar`).
 - Refresh from inside the SPA. Asserts the URL stays `/editor/calendar` and the calendar view re-renders.

--- a/openspec/changes/fix-spa-router-basename/proposal.md
+++ b/openspec/changes/fix-spa-router-basename/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+The Phase 2 SPA-fallback fix in `cleanup-open-issues-may-2026` (PR #398) shipped the rafgraph redirect script wrapped behind a `pathname.indexOf('/editor/') === 0` guard, on the assumption that the editor's React Router resolves URLs under the `/editor/` deploy prefix. This assumption is wrong in production: the SPA uses **wouter**, and `main.tsx` does not wrap `<App />` in a `<Router>` with a `base` prop. The default wouter Router base is the empty string, so wouter's routes (`/`, `/calendar`, `/library`, `/workout/new`, `/workout/:id`) match against the address-bar pathname WITHOUT any deploy prefix.
+
+Concrete reproduction (verified by user screenshot — `kaiord.com/calendar` shows the landing's blue 404):
+
+1. User opens `kaiord.com/editor/`. SPA loads from `/editor/index.html`; assets resolve at `/editor/assets/...` (Vite `base: "/editor/"`).
+2. Wouter sees pathname `/editor/`, doesn't match any explicit route, hits the catch-all and `<Redirect to="/calendar" />` fires. URL bar becomes `kaiord.com/calendar` (no `/editor/` prefix).
+3. SPA renders fine because it's already loaded.
+4. User refreshes `kaiord.com/calendar`. GitHub Pages has no `/calendar/index.html`, falls back to root `404.html`.
+5. Root `404.html` runs the rafgraph redirect script, but the path-prefix guard `pathname.indexOf('/editor/') === 0` is false, so the script no-ops and the user sees the landing's blue 404.
+
+The deploy fix already handles `/editor/*` correctly — what's missing is for the SPA to actually emit `/editor/*` URLs in the address bar.
+
+## What Changes
+
+A one-line fix in `packages/workout-spa-editor/src/main.tsx`: wrap `<App />` in wouter's `<Router base={...}>` derived from `import.meta.env.BASE_URL` (which Vite already exposes — `/` in dev, `/editor/` in production). Wouter prepends the base to every route match and to every `<Redirect to>` / `useLocation` write, so:
+
+- `<Redirect to="/calendar" />` becomes `kaiord.com/editor/calendar` instead of `kaiord.com/calendar`.
+- A user navigating into the SPA sees `/editor/<route>` in the address bar and can refresh that URL.
+- The rafgraph script's existing `/editor/*` guard now matches the user's actual URL on refresh.
+
+The fix is conceptually correct (a SPA deployed at a subpath SHOULD declare its base) and aligns wouter's behaviour with Vite's `base` config that already governs the asset emission path.
+
+A regression test is added at the unit level (assert `main.tsx` wraps in `<Router base={...}>` resolving from `import.meta.env.BASE_URL`) and at the e2e level (build with `VITE_BASE_PATH=/editor/`, serve the built artifact with a static server that does NOT expose SPA fallback, verify a deep refresh against `/editor/calendar` returns the SPA bundle via the rafgraph 404).
+
+## Impact
+
+- **Affected specs**: NEW capability `spa-routing` (1 ADDED requirement: "SPA router base alignment with Vite deploy base", 7 scenarios). The new capability has its own Purpose paragraph covering routing-layer rules; future routing invariants land here without contorting another spec.
+- **Affected code**:
+  - `packages/workout-spa-editor/src/router-base.ts` (new) — pure helper `computeRouterBase(baseUrl: string): string` that strips Vite's trailing slash.
+  - `packages/workout-spa-editor/src/router-base.test.ts` (new) — table-driven Vitest exercising the helper.
+  - `packages/workout-spa-editor/src/main.tsx` — wrap `<App />` in `<Router base={computeRouterBase(import.meta.env.BASE_URL)}>`.
+  - `packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts` (new) — Playwright e2e gated by `E2E_PROD_BASE=1`, builds with `VITE_BASE_PATH=/editor/`, serves via a Pages-equivalent static fixture, exercises 5 sub-tests (cold deep refresh, in-app navigation prefix, refresh round-trip, analytics base-relativity, garbage-path catch-all).
+  - `packages/workout-spa-editor/e2e/fixtures/static-pages-server.ts` (likely new) — small Node `http` fixture if `http-server` proves unreliable; mimics GitHub Pages 404 behaviour.
+  - `.github/workflows/ci.yml` — new `e2e-prod-base` job running the gated spec.
+  - `packages/workout-spa-editor/e2e/...` — sweep for hardcoded production-base URL assertions; update any that would diverge under the new prefix.
+- **Affected tests**: The existing `routes.test.tsx` (6 cases) tests wouter behaviour at the component layer with no Router base wrapper — passes unchanged. The dev-mode Playwright suite (`pnpm test:e2e` without `E2E_PROD_BASE`) runs against `pnpm dev` where `BASE_URL = "/"` and wouter base resolves to `""` — passes unchanged.
+- **Risk**:
+  - **Risk-1 — Existing test URL assertions**: covered by sweep task 4.7. Dev-mode default keeps wouter base empty; only production-base tests need explicit `/editor/` prefixes.
+  - **Risk-2 — Wouter base edge cases**: the helper extraction with table-driven unit tests catches trailing-slash and empty-base cases; the e2e covers the integrated runtime behaviour.
+  - **Risk-3 — Bookmark behaviour change**: a user who shares `kaiord.com/calendar` before this fix sees the URL change to `kaiord.com/editor/calendar` after the fix. The pre-fix URL never survived refresh, so no working state regresses.
+  - **Risk-4 — No new redirect surface**: the rafgraph script's redirect target is hardcoded same-origin `/editor/?p=<encoded>`. The decoder's `history.replaceState` updates the URL bar (no markup execution). Wouter base only changes the route-matching prefix. No new XSS or open-redirect surface introduced.
+- **Out of scope**: No changes to `.github/workflows/deploy-site.yml`'s rafgraph script — its `/editor/*` guard is correct; this fix makes the SPA's URLs match what the script already handles. No changes to the docs surface (`/docs/...`) — VitePress generates its own per-route HTML and does not have this issue.

--- a/openspec/changes/fix-spa-router-basename/specs/spa-routing/spec.md
+++ b/openspec/changes/fix-spa-router-basename/specs/spa-routing/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: SPA router base alignment with Vite deploy base
+
+The `@kaiord/workout-spa-editor` SPA bootstrap (`packages/workout-spa-editor/src/main.tsx`) SHALL wrap `<App />` in wouter's `<Router>` component with a `base` prop derived from `import.meta.env.BASE_URL`. The derivation SHALL strip the trailing slash that Vite always emits, yielding an empty string in dev (`BASE_URL = "/"` → `base = ""`) or a path without trailing slash in production (`BASE_URL = "/editor/"` → `base = "/editor"`).
+
+The strip is centralised in a pure helper `computeRouterBase(baseUrl: string): string` exported from `packages/workout-spa-editor/src/router-base.ts` so the rule is testable without rendering the JSX tree. Vite's `BASE_URL` always begins and ends with `/` (verified in Vite's `resolveBaseUrl`); the helper relies on that invariant and the unit test catches any future divergence.
+
+The requirement exists to prevent a subpath-deployed SPA from emitting URLs that diverge from the deploy path. Without `<Router base>`, wouter's catch-all `<Redirect to="/calendar" />` writes `/calendar` to the address bar even though the SPA itself is served from `/editor/`. On refresh, GitHub Pages cannot serve `/calendar` because no asset lives at that path, falls back to the landing's blue 404, and the previously-shipped rafgraph fallback (rooted under `cleanup-open-issues-may-2026`, scoped to `/editor/*` paths) does not match. Aligning wouter's base with Vite's deploy base closes this class of bug at the source. The two requirements compose: rafgraph restores the URL pre-mount, then wouter's base resolves the deep route.
+
+A unit test (`packages/workout-spa-editor/src/router-base.test.ts`) SHALL exercise `computeRouterBase` against representative inputs (`/`, `/editor/`, `/a/b/`, ``). An end-to-end test (`packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts`, gated by `E2E_PROD_BASE=1`) SHALL build the SPA with `VITE_BASE_PATH=/editor/`, serve the merged dist via a static file server that returns 404 for unknown paths (no SPA fallback, mimicking GitHub Pages exactly), and verify a deep URL refresh keeps the SPA bundle and the route.
+
+#### Scenario: Wouter is wrapped at SPA bootstrap
+
+- **WHEN** `packages/workout-spa-editor/src/main.tsx` is parsed and rendered
+- **THEN** the rendered tree SHALL include a wouter `<Router base={...}>` wrapping `<App />`, where `base` is the value returned by `computeRouterBase(import.meta.env.BASE_URL)`
+
+#### Scenario: computeRouterBase strips the Vite trailing slash
+
+- **WHEN** `computeRouterBase` is invoked with each of `"/"`, `"/editor/"`, `"/a/b/"`, `""`
+- **THEN** the helper SHALL return `""`, `"/editor"`, `"/a/b"`, `""` respectively
+
+#### Scenario: Production base produces deploy-prefixed URLs
+
+- **WHEN** the SPA is built with `VITE_BASE_PATH=/editor/` and a user navigates from the SPA root to the calendar route
+- **THEN** the address bar SHALL read a URL prefixed with `/editor/` (e.g. `/editor/calendar`), NOT a root-relative URL (`/calendar`)
+
+#### Scenario: Refreshing a deep SPA URL keeps the SPA
+
+- **WHEN** the SPA is served via a static file server that returns 404 for unknown paths (no SPA fallback) and the user refreshes a deep URL such as `/editor/calendar`
+- **THEN** the static host SHALL serve the merged-dist `404.html`, the previously-shipped rafgraph fallback SHALL restore the URL pre-mount (per the existing rafgraph injection helper at `scripts/inject-spa-fallback.mjs`), the SPA's router SHALL strip the configured base before route matching, and the calendar view SHALL re-render — no blue 404 page
+
+#### Scenario: Dev-mode behaviour is unchanged
+
+- **WHEN** the SPA runs under `pnpm dev` (Vite dev server, `BASE_URL = "/"`) and a user navigates to the calendar route
+- **THEN** the address bar SHALL read `/calendar` with no `/editor/` prefix; wouter base resolves to the empty string in dev so this scenario asserts the fix is non-disruptive at the dev path
+
+#### Scenario: Analytics paths remain base-relative
+
+- **WHEN** the SPA runs in production base (`/editor/`) and the user navigates to the calendar route, triggering an analytics page-view event
+- **THEN** the analytics emitter SHALL have been invoked at least once (guards against a future refactor that silently stops emitting page views), AND the captured path SHALL be `/calendar` (the router's base-stripped value), NOT `/editor/calendar`. Existing analytics dashboards see the same paths as before the fix
+
+#### Scenario: Garbage path under the deploy base resolves to the catch-all
+
+- **WHEN** a user requests `/editor/<malformed-path>` directly (cold) on a Pages-equivalent host
+- **THEN** the rafgraph round-trip SHALL restore the URL, the SPA's router SHALL strip the configured base, the SPA's catch-all route SHALL redirect to the canonical calendar route, the URL bar SHALL settle at `/editor/calendar`, and no infinite redirect loop or XSS SHALL occur (the address bar containing user-supplied characters is treated as a path string by `history.replaceState`, never as HTML)

--- a/openspec/changes/fix-spa-router-basename/tasks.md
+++ b/openspec/changes/fix-spa-router-basename/tasks.md
@@ -1,0 +1,97 @@
+## 1. Phase 1 — Implement the wouter base wrapper
+
+- [ ] 1.0 Worktree setup: `git worktree add -b feature/fix-spa-router-basename /Users/pablo/development/personal/kaiord-routerfix-impl main`. Run `pnpm install` and rebuild workspace deps.
+- [ ] 1.1 Create `packages/workout-spa-editor/src/router-base.ts` exporting `computeRouterBase(baseUrl: string): string`. Body: `return baseUrl.replace(/\/$/, "")`. One-line, zero dependencies, pure.
+- [ ] 1.2 Edit `packages/workout-spa-editor/src/main.tsx`:
+  - Import `Router` from `wouter`.
+  - Import `computeRouterBase` from `./router-base`.
+  - Compute `base` at module top level: `const base = computeRouterBase(import.meta.env.BASE_URL)`.
+  - Wrap `<App />` in `<Router base={base}>` immediately inside `<CoachingRegistryBootstrap>`.
+- [ ] 1.3 Verify dev mode unchanged: `pnpm --filter @kaiord/workout-spa-editor dev`, navigate to `localhost:5173/calendar`, confirm calendar renders. Wouter base is `""` here so behaviour matches pre-change.
+- [ ] 1.4 Verify production build emits the correct base: `VITE_BASE_PATH=/editor/ pnpm --filter @kaiord/workout-spa-editor build`. The build itself does not exercise the runtime base value; the e2e at task 3.x is the runtime check.
+
+## 2. Phase 1 — Pure-helper unit test
+
+- [ ] 2.1 Create `packages/workout-spa-editor/src/router-base.test.ts`. Vitest with table-driven cases:
+
+      | input         | expected output | note |
+      | ------------- | --------------- | ---- |
+      | `"/"`         | `""`            | dev mode (Vite default) |
+      | `"/editor/"`  | `"/editor"`     | production base |
+      | `"/a/b/"`     | `"/a/b"`        | nested base |
+      | `""`          | `""`            | defensive: Vite normalises BASE_URL to start+end with `/`; this row guards against a future Vite contract regression |
+
+      AAA structure: arrange the input string, act `computeRouterBase`, assert against expected. The table drives a single `it.each` block. Add a comment next to the empty-string row recording the defensive intent so readers don't think it's a contract Vite emits.
+- [ ] 2.2 Add a wouter contract test in the same file: mount `<Router base="/editor"><Route path="/x">{() => "ok"}</Route></Router>` via Testing Library (`@testing-library/react`'s `render`) and assert that visiting `/editor/x` matches the route. Pin the wouter `package.json` resolved version in the assertion so a major-version bump that changes the base contract trips this test.
+- [ ] 2.3 Run `pnpm --filter @kaiord/workout-spa-editor test src/router-base.test.ts` — passing.
+
+## 3. Phase 1 — E2E regression test (production-base build)
+
+- [ ] 3.0 **Custom Node static-server fixture (decision pre-committed).** GitHub Pages-equivalent behaviour requires: (a) serve files for known paths, (b) return the merged-dist `404.html` content with **status 404** for unknown paths, (c) NOT serve `index.html` as a SPA fallback. Only a custom fixture meets all three contracts byte-equally:
+  - `npx http-server` returns 200 for missing paths even with no SPA fallback — silently weakens Test 1's status-code expectation.
+  - `npx serve` defaults to SPA fallback (`-s`) — would mask the bug.
+  - **Custom fixture** at `packages/workout-spa-editor/e2e/fixtures/static-pages-server.ts`: small `http.createServer` reading from `merged-dist/`, serving the matching file with status 200 OR the `404.html` body with status 404 for unknown paths. The fixture exports `startStaticPagesServer(rootDir): Promise<{ url, close }>` so the e2e spec's `beforeAll` / `afterAll` can drive lifecycle cleanly.
+  Implement the fixture; verify behaviour empirically against Pages parity (status code 404 on unknown, exact 404.html body served) before writing Test 1.
+- [ ] 3.0a **Extract the rafgraph injection helper** to `scripts/inject-spa-fallback.mjs`. The helper takes a `mergedDistDir` argument, appends the rafgraph redirect script to `<dir>/404.html`, and injects the decoder snippet into `<dir>/editor/index.html` — same logic as the inline bash heredoc in `.github/workflows/deploy-site.yml` lines 102-152. Update the workflow to call `node scripts/inject-spa-fallback.mjs merged-dist` instead of the inline bash + Python heredocs. Co-located test `scripts/inject-spa-fallback.test.mjs` exercises the helper against a temp-dir fixture. The e2e spec's `beforeAll` calls the same helper after the SPA build so the redirect script is byte-identical between production and tests.
+- [ ] 3.1 Create `packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts`. The spec's top-level `describe` block carries the `@spa-route-refresh` tag (e.g. `test.describe("@spa-route-refresh SPA route refresh", () => { ... })`) so the CI grep filter in 3.2 selects this whole spec, not individual tests:
+  - `test.skip` guard at the top: `test.skip(process.env.E2E_PROD_BASE !== "1", "Production-base e2e gated behind E2E_PROD_BASE=1");` so the standard `pnpm test:e2e` (dev-mode) continues to run unchanged.
+  - `beforeAll`: shells out to `VITE_BASE_PATH=/editor/ pnpm --filter @kaiord/workout-spa-editor build`, mirrors the merged-dist structure, calls `inject-spa-fallback.mjs` (3.0a) so the rafgraph script is present byte-equal to production, starts the static-server fixture (3.0) on a free port.
+  - `afterAll`: stops the server.
+  - **Test 1 — direct deep refresh**: `page.goto(${baseUrl}/editor/calendar)`. The first response will have status 404 (rafgraph 404.html); the page's `replace`-driven navigation then loads `/editor/?p=...`, the decoder restores the URL, and React mounts. After `page.goto` resolves, assert: (a) `page.url()` ends with `/editor/calendar` (decoder restored); (b) the rendered DOM contains a `script[src^="/editor/assets/index-"]` tag (SPA bundle present). Do NOT assert on the initial response body — `page.goto` returns the 404 response which is the rafgraph carrier, not the final document.
+  - **Test 2 — in-app navigation prefixes URL**: `page.goto(${baseUrl}/editor/)`, wait for the calendar redirect, assert `page.url()` ends with `/editor/calendar` (NOT `/calendar`).
+  - **Test 3 — refresh inside SPA**: continue from Test 2 state, call `page.reload()`, assert URL stays `/editor/calendar` and the calendar view re-renders (e.g., the calendar header is visible).
+  - **Test 4 — analytics path remains base-relative**: install a `page.exposeFunction("__captureAnalytics", ...)` shim at boot, navigate to `/editor/calendar`, then assert: (a) `__captureAnalytics` was called at least once (count ≥ 1) — guards against a future refactor that silently stops emitting pageViews; (b) the captured path is `/calendar` (NOT `/editor/calendar`). Both assertions are required; without the count assertion the path assertion vacuously passes if no event is captured.
+  - **Test 5 — garbage-path round-trip**: `page.goto(${baseUrl}/editor/<malformed%20path>)`, assert no infinite redirect, URL settles at `/editor/calendar` (catch-all), DOM contains no injected script tags from the path.
+- [ ] 3.2 Wire the test into CI: edit `.github/workflows/ci.yml` to add a job named `e2e-prod-base` that runs `E2E_PROD_BASE=1 pnpm --filter @kaiord/workout-spa-editor test:e2e --grep '@spa-route-refresh'` (or equivalent), gated by the same conditions as the existing e2e-frontend job. Document the job name in the PR description.
+- [ ] 3.3 Run the spec locally: `E2E_PROD_BASE=1 pnpm --filter @kaiord/workout-spa-editor test:e2e --grep '@spa-route-refresh'`. All five sub-tests pass.
+
+## 4. Phase 1 — Existing test-suite checks
+
+- [ ] 4.1 Run `pnpm --filter @kaiord/workout-spa-editor test` — full vitest. Confirm no regressions from the Router wrapper.
+- [ ] 4.2 Run `pnpm test:e2e` (dev-mode default) — full Playwright suite. Confirm no e2e regressions.
+- [ ] 4.3 Run `pnpm --filter @kaiord/workout-spa-editor lint` — clean.
+- [ ] 4.4 Run `pnpm -r build` — clean.
+- [ ] 4.5 Run `pnpm test:scripts` — passing including the existing fixtures from `cleanup-open-issues-may-2026` (count: confirm at branch time).
+- [ ] 4.6 Run `openspec validate fix-spa-router-basename --strict` — passing.
+- [ ] 4.7 Sweep e2e specs for hardcoded production-base URLs: `rg "kaiord\\.com/(calendar|library|workout)" packages/workout-spa-editor/e2e/`. Update any URL assertions that would diverge under the new prefix; if dev-mode tests use root-relative URLs, leave them — wouter base resolves to `""` in dev so they are still correct.
+
+## 5. Phase 1 — Validation, changeset, PR
+
+- [ ] 5.1 Add a `patch` changeset for `@kaiord/workout-spa-editor` titled `fix(spa-editor): align wouter Router base with Vite deploy base so /editor/<route> URLs survive refresh`. Body MUST include the user-facing note: "URLs deep-linked into the SPA editor now consistently include the `/editor/` prefix, matching the deploy path. Pre-fix bookmarks pointing at `kaiord.com/<route>` (without the prefix) never survived a refresh; the canonical address is now `kaiord.com/editor/<route>`. Open SPA tabs may briefly show a one-time URL update on the next navigation as the new base takes effect." This lands in the auto-generated release notes so external observers understand the URL-shape change.
+- [ ] 5.2 Open PR with body referencing this change's `design.md` and the screenshot from the user demonstrating the bug. Test plan covers dev unchanged, prod refresh fixed, regression tests added, garbage-path safety asserted.
+- [ ] 5.3 Ensure CI green (including the new `e2e-prod-base` job).
+- [ ] 5.4 Squash merge.
+- [ ] 5.5 Verify in production: navigate to `kaiord.com/editor/`, observe URL becomes `kaiord.com/editor/calendar`, refresh, confirm calendar view re-renders without the blue 404.
+- [ ] 5.6 After merge: clean local worktree (`git worktree remove /Users/pablo/development/personal/kaiord-routerfix-impl`) and delete local branch.
+
+## 6. Phase 2 — Archive
+
+- [ ] 6.1 Pull main; run `pnpm lint:specs` — pre-archive expectation: specs under `openspec/specs/` count is 28 (the change-folder spec at `openspec/changes/fix-spa-router-basename/specs/` is NOT counted by `lint:specs` until archive).
+- [ ] 6.2 Run `openspec validate fix-spa-router-basename --strict` once more.
+- [ ] 6.3 Run `openspec archive fix-spa-router-basename --yes` — moves the change to `openspec/changes/archive/YYYY-MM-DD-fix-spa-router-basename/` and creates `openspec/specs/spa-routing/spec.md`.
+- [ ] 6.4 Verify the archive landed cleanly. Each sub-bullet is a separate check; failures must be addressed individually rather than batched:
+  - [ ] 6.4.1 H1 of `openspec/specs/spa-routing/spec.md` is exactly `# SPA Routing` (not "SPA routing" or "Spa Routing").
+  - [ ] 6.4.2 `## Purpose` paragraph matches design.md D4 verbatim: "Routing-layer rules for the SPA editor, including alignment between client-side router base configuration and Vite deploy base, plus any additional invariants needed to keep deep URLs refresh-safe under static hosting."
+  - [ ] 6.4.3 `> Synced: YYYY-MM-DD` header present and dated to the archive day.
+  - [ ] 6.4.4 The single requirement "SPA router base alignment with Vite deploy base" landed with all 7 scenarios intact.
+  - [ ] 6.4.5 If `openspec archive` ships a TBD Purpose for new capabilities, hand-write 6.4.1–6.4.3 inline and note the manual fix in the archive PR description.
+- [ ] 6.5 Verify the archived `proposal.md` carries `> Completed: YYYY-MM-DD` matching the folder prefix.
+- [ ] 6.6 Run `pnpm archive:index`, `pnpm lint:archive`, `pnpm lint:archive-index` — all clean.
+- [ ] 6.7 Run `openspec validate --specs --strict` and `pnpm lint:specs` — post-archive expectation: specs under `openspec/specs/` count is 29 (28 existing + new `spa-routing`).
+- [ ] 6.8 Open archive PR; ensure CI green; squash merge.
+
+## 7. Spec-scenario coverage map
+
+For each scenario in this change's `specs/spa-routing/spec.md` ADDED block, identify the task that delivers the test:
+
+| # | Scenario | Task that adds the test |
+| - | --- | --- |
+| 1 | Wouter is wrapped at SPA bootstrap | 3.1 / Test 2 (e2e exercises the wrapper presence behaviourally) |
+| 2 | computeRouterBase strips the Vite trailing slash | 2.1 (unit) |
+| 3 | Production base produces deploy-prefixed URLs | 3.1 / Test 2 (e2e) |
+| 4 | Refreshing a deep SPA URL keeps the SPA | 3.1 / Test 1 + Test 3 (e2e) |
+| 5 | Dev-mode behaviour is unchanged | 1.3 + 4.2 |
+| 6 | Analytics paths remain base-relative | 3.1 / Test 4 (e2e) |
+| 7 | Garbage path under the deploy base resolves to the catch-all | 3.1 / Test 5 (e2e) |
+
+- [ ] 7.1 Confirm the table is bidirectionally in sync with the final spec scenarios at archive time: every scenario maps to a task AND every test/sub-test maps to a scenario.

--- a/openspec/changes/fix-spa-router-basename/tasks.md
+++ b/openspec/changes/fix-spa-router-basename/tasks.md
@@ -22,6 +22,7 @@
       | `""`          | `""`            | defensive: Vite normalises BASE_URL to start+end with `/`; this row guards against a future Vite contract regression |
 
       AAA structure: arrange the input string, act `computeRouterBase`, assert against expected. The table drives a single `it.each` block. Add a comment next to the empty-string row recording the defensive intent so readers don't think it's a contract Vite emits.
+
 - [ ] 2.2 Add a wouter contract test in the same file: mount `<Router base="/editor"><Route path="/x">{() => "ok"}</Route></Router>` via Testing Library (`@testing-library/react`'s `render`) and assert that visiting `/editor/x` matches the route. Pin the wouter `package.json` resolved version in the assertion so a major-version bump that changes the base contract trips this test.
 - [ ] 2.3 Run `pnpm --filter @kaiord/workout-spa-editor test src/router-base.test.ts` — passing.
 
@@ -31,7 +32,7 @@
   - `npx http-server` returns 200 for missing paths even with no SPA fallback — silently weakens Test 1's status-code expectation.
   - `npx serve` defaults to SPA fallback (`-s`) — would mask the bug.
   - **Custom fixture** at `packages/workout-spa-editor/e2e/fixtures/static-pages-server.ts`: small `http.createServer` reading from `merged-dist/`, serving the matching file with status 200 OR the `404.html` body with status 404 for unknown paths. The fixture exports `startStaticPagesServer(rootDir): Promise<{ url, close }>` so the e2e spec's `beforeAll` / `afterAll` can drive lifecycle cleanly.
-  Implement the fixture; verify behaviour empirically against Pages parity (status code 404 on unknown, exact 404.html body served) before writing Test 1.
+    Implement the fixture; verify behaviour empirically against Pages parity (status code 404 on unknown, exact 404.html body served) before writing Test 1.
 - [ ] 3.0a **Extract the rafgraph injection helper** to `scripts/inject-spa-fallback.mjs`. The helper takes a `mergedDistDir` argument, appends the rafgraph redirect script to `<dir>/404.html`, and injects the decoder snippet into `<dir>/editor/index.html` — same logic as the inline bash heredoc in `.github/workflows/deploy-site.yml` lines 102-152. Update the workflow to call `node scripts/inject-spa-fallback.mjs merged-dist` instead of the inline bash + Python heredocs. Co-located test `scripts/inject-spa-fallback.test.mjs` exercises the helper against a temp-dir fixture. The e2e spec's `beforeAll` calls the same helper after the SPA build so the redirect script is byte-identical between production and tests.
 - [ ] 3.1 Create `packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts`. The spec's top-level `describe` block carries the `@spa-route-refresh` tag (e.g. `test.describe("@spa-route-refresh SPA route refresh", () => { ... })`) so the CI grep filter in 3.2 selects this whole spec, not individual tests:
   - `test.skip` guard at the top: `test.skip(process.env.E2E_PROD_BASE !== "1", "Production-base e2e gated behind E2E_PROD_BASE=1");` so the standard `pnpm test:e2e` (dev-mode) continues to run unchanged.
@@ -84,14 +85,14 @@
 
 For each scenario in this change's `specs/spa-routing/spec.md` ADDED block, identify the task that delivers the test:
 
-| # | Scenario | Task that adds the test |
-| - | --- | --- |
-| 1 | Wouter is wrapped at SPA bootstrap | 3.1 / Test 2 (e2e exercises the wrapper presence behaviourally) |
-| 2 | computeRouterBase strips the Vite trailing slash | 2.1 (unit) |
-| 3 | Production base produces deploy-prefixed URLs | 3.1 / Test 2 (e2e) |
-| 4 | Refreshing a deep SPA URL keeps the SPA | 3.1 / Test 1 + Test 3 (e2e) |
-| 5 | Dev-mode behaviour is unchanged | 1.3 + 4.2 |
-| 6 | Analytics paths remain base-relative | 3.1 / Test 4 (e2e) |
-| 7 | Garbage path under the deploy base resolves to the catch-all | 3.1 / Test 5 (e2e) |
+| #   | Scenario                                                     | Task that adds the test                                         |
+| --- | ------------------------------------------------------------ | --------------------------------------------------------------- |
+| 1   | Wouter is wrapped at SPA bootstrap                           | 3.1 / Test 2 (e2e exercises the wrapper presence behaviourally) |
+| 2   | computeRouterBase strips the Vite trailing slash             | 2.1 (unit)                                                      |
+| 3   | Production base produces deploy-prefixed URLs                | 3.1 / Test 2 (e2e)                                              |
+| 4   | Refreshing a deep SPA URL keeps the SPA                      | 3.1 / Test 1 + Test 3 (e2e)                                     |
+| 5   | Dev-mode behaviour is unchanged                              | 1.3 + 4.2                                                       |
+| 6   | Analytics paths remain base-relative                         | 3.1 / Test 4 (e2e)                                              |
+| 7   | Garbage path under the deploy base resolves to the catch-all | 3.1 / Test 5 (e2e)                                              |
 
 - [ ] 7.1 Confirm the table is bidirectionally in sync with the final spec scenarios at archive time: every scenario maps to a task AND every test/sub-test maps to a scenario.

--- a/openspec/changes/fix-spa-router-basename/tasks.md
+++ b/openspec/changes/fix-spa-router-basename/tasks.md
@@ -1,3 +1,9 @@
+<!-- opsx-ship: chunking
+PR 0 (proposal): openspec artifacts only — already open as #403
+PR 1 (implementation): §1, §2, §3, §4, §5, §7 — branch feature/fix-spa-router-basename
+PR 2 (archive): §6 — branch chore/fix-spa-router-basename-archive
+-->
+
 ## 1. Phase 1 — Implement the wouter base wrapper
 
 - [ ] 1.0 Worktree setup: `git worktree add -b feature/fix-spa-router-basename /Users/pablo/development/personal/kaiord-routerfix-impl main`. Run `pnpm install` and rebuild workspace deps.

--- a/openspec/changes/fix-spa-router-basename/tasks.md
+++ b/openspec/changes/fix-spa-router-basename/tasks.md
@@ -6,7 +6,7 @@ PR 2 (archive): §6 — branch chore/fix-spa-router-basename-archive
 
 ## 1. Phase 1 — Implement the wouter base wrapper
 
-- [ ] 1.0 Worktree setup: `git worktree add -b feature/fix-spa-router-basename /Users/pablo/development/personal/kaiord-routerfix-impl main`. Run `pnpm install` and rebuild workspace deps.
+- [ ] 1.0 Worktree setup: `git worktree add -b feature/fix-spa-router-basename <WORKTREE_DIR>/kaiord-routerfix-impl main` (replace `<WORKTREE_DIR>` with your local worktree parent directory). Run `pnpm install` and rebuild workspace deps.
 - [ ] 1.1 Create `packages/workout-spa-editor/src/router-base.ts` exporting `computeRouterBase(baseUrl: string): string`. Body: `return baseUrl.replace(/\/$/, "")`. One-line, zero dependencies, pure.
 - [ ] 1.2 Edit `packages/workout-spa-editor/src/main.tsx`:
   - Import `Router` from `wouter`.
@@ -69,7 +69,7 @@ PR 2 (archive): §6 — branch chore/fix-spa-router-basename-archive
 - [ ] 5.3 Ensure CI green (including the new `e2e-prod-base` job).
 - [ ] 5.4 Squash merge.
 - [ ] 5.5 Verify in production: navigate to `kaiord.com/editor/`, observe URL becomes `kaiord.com/editor/calendar`, refresh, confirm calendar view re-renders without the blue 404.
-- [ ] 5.6 After merge: clean local worktree (`git worktree remove /Users/pablo/development/personal/kaiord-routerfix-impl`) and delete local branch.
+- [ ] 5.6 After merge: clean local worktree (`git worktree remove <WORKTREE_DIR>/kaiord-routerfix-impl`) and delete local branch.
 
 ## 6. Phase 2 — Archive
 

--- a/openspec/specs/spa-quality-gates/spec.md
+++ b/openspec/specs/spa-quality-gates/spec.md
@@ -107,4 +107,3 @@ The rule supersedes the file-local audit at `packages/workout-spa-editor/src/com
 
 - **WHEN** `node scripts/check-no-pii-leakage.mjs` runs against the SPA editor source tree on the merge commit that closes this rollout
 - **THEN** the script exits 0 with `✅ No PII / secret leakage detected.`
-


### PR DESCRIPTION
## Summary

Proposal for `fix-spa-router-basename`: aligns wouter's Router base with Vite's deploy base so `kaiord.com/editor/<route>` URLs survive refresh on GitHub Pages.

**User report (2026-04-30):** `kaiord.com/calendar` returns the landing's blue 404 on refresh — meaning the Phase 2 rafgraph fallback shipped in `cleanup-open-issues-may-2026` (PR #398) doesn't match what users actually see in the address bar. Root cause: `main.tsx` does not wrap `<App />` in wouter's `<Router base={...}>`, so wouter emits root-relative URLs (`/calendar`) that GitHub Pages cannot serve on refresh and that the rafgraph script's `/editor/*` guard does not match.

## What this proposal adds

- One-line fix in `packages/workout-spa-editor/src/main.tsx` wrapping `<App />` in `<Router base={computeRouterBase(import.meta.env.BASE_URL)}>`
- Pure helper at `packages/workout-spa-editor/src/router-base.ts` for testability
- Table-driven Vitest unit test (trailing-slash strip + wouter contract guard)
- Production-base e2e at `packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts` (gated by `E2E_PROD_BASE=1`) with custom Node static-server fixture mimicking GitHub Pages' 404 contract exactly
- Shared `scripts/inject-spa-fallback.mjs` extracted from `deploy-site.yml` so the rafgraph script is byte-identical between production and tests
- NEW capability `spa-routing` (1 requirement, 7 scenarios)

## Review history

Iterated through 3 expert-panel rounds (5 Principal/Staff perspectives each):
- Iter 1: 8.4/10 → fixed source-grep test (extracted pure helper) + capability home (new `spa-routing` instead of stretching `spa-quality-gates`)
- Iter 2: 9.5/10 → fixed Test 1 wording (response body vs rendered DOM), added Test 4 count assertion, extracted shared rafgraph helper
- Iter 3: **9.82/10** ✅ TARGET REACHED. Cosmetic polish applied.

## Test plan

- [x] `openspec validate fix-spa-router-basename --strict` passes
- [x] `pnpm lint:specs` passes (28/28 specs)
- [ ] Implementation PR (Phase 1) lands the helper + wrapper + tests + CI job
- [ ] Production verification on `kaiord.com/editor/`
- [ ] Archive PR (Phase 2) materialises `openspec/specs/spa-routing/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added specifications and design documentation for an upcoming SPA routing fix that will address URL handling across deployment bases.
  * Documented implementation plan including router configuration updates, testing strategy, and deployment validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->