### PR TITLE
fix(spa-editor): redirect legacy /calendar, /library, /workout bookmarks to /editor/<path>

### DIFF
--- a/.changeset/fix-spa-legacy-route-redirect.md
+++ b/.changeset/fix-spa-legacy-route-redirect.md
@@ -1,0 +1,7 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+fix(spa-editor): redirect legacy SPA bookmarks (`/calendar`, `/library`, `/workout/*`) to `/editor/<path>`
+
+Pre-fix bookmarks pointing at `kaiord.com/<route>` (without the `/editor/` prefix) were dropping users on the landing's blue 404. The deploy-time rafgraph fallback now also handles a closed allowlist of legacy SPA routes — `/calendar`, `/calendar/<weekId>`, `/library`, `/workout`, `/workout/<id>` — and redirects them to `kaiord.com/editor/<path>` so the SPA loads at the intended view. Unrelated 404s (`/typo`, `/calendarx`, etc.) continue to surface the landing's blue 404 as before.

--- a/scripts/inject-spa-fallback.mjs
+++ b/scripts/inject-spa-fallback.mjs
@@ -5,9 +5,12 @@ import { resolve } from "node:path";
 // Server-driven SPA fallback for GitHub Pages-equivalent hosts:
 // - Append a redirect script to `<dir>/404.html` that captures any /editor/*
 //   deep link into a ?p= query and bounces to /editor/?p=...
+// - Also bounce a closed allowlist of legacy SPA routes (`/calendar`,
+//   `/library`, `/workout/...`) to their `/editor/<path>` equivalent so
+//   bookmarks made before the wouter base alignment fix keep working.
 // - Inject a decoder snippet at the top of `<dir>/editor/index.html` <head>
 //   that runs synchronously before React boots, restoring the original URL
-//   via history.replaceState. Non-/editor/* 404s fall through unchanged.
+//   via history.replaceState. Other 404s fall through unchanged.
 //
 // This helper is the single source of truth shared by the deploy workflow
 // (.github/workflows/deploy-site.yml) and the production-base e2e fixture
@@ -17,11 +20,24 @@ const REDIRECT_SCRIPT = `
 <script>
   (function () {
     var l = window.location;
-    if (l.pathname.indexOf('/editor/') === 0) {
+    var p = l.pathname;
+    if (p.indexOf('/editor/') === 0) {
       l.replace(
         l.protocol + '//' + l.host +
           '/editor/?p=' +
-          encodeURIComponent(l.pathname + l.search) +
+          encodeURIComponent(p + l.search) +
+          l.hash
+      );
+      return;
+    }
+    // Legacy bookmarks: match the SPA's top-level wouter routes at root.
+    // Allowlist is intentionally narrow so unrelated 404s still surface
+    // the landing's blue 404 page.
+    if (/^\\/(calendar(\\/|$)|library$|workout(\\/|$))/.test(p)) {
+      l.replace(
+        l.protocol + '//' + l.host +
+          '/editor/?p=' +
+          encodeURIComponent('/editor' + p + l.search) +
           l.hash
       );
     }

--- a/scripts/inject-spa-fallback.test.mjs
+++ b/scripts/inject-spa-fallback.test.mjs
@@ -70,4 +70,89 @@ describe("inject-spa-fallback", () => {
     const fourOhFour = readFileSync(join(dir, "404.html"), "utf8");
     assert.match(fourOhFour, /404 base/);
   });
+
+  it("legacy-route allowlist: simulating a /calendar visit redirects to /editor/?p=%2Feditor%2Fcalendar", () => {
+    injectSpaFallback(dir);
+
+    const fourOhFour = readFileSync(join(dir, "404.html"), "utf8");
+    const fn = extractRedirectFn(fourOhFour);
+
+    const replaced = simulateLocation(fn, "/calendar");
+
+    assert.equal(
+      replaced,
+      "https://example.test/editor/?p=" + encodeURIComponent("/editor/calendar")
+    );
+  });
+
+  it("legacy-route allowlist: /library and /workout/abc also redirect", () => {
+    injectSpaFallback(dir);
+
+    const fourOhFour = readFileSync(join(dir, "404.html"), "utf8");
+    const fn = extractRedirectFn(fourOhFour);
+
+    assert.equal(
+      simulateLocation(fn, "/library"),
+      "https://example.test/editor/?p=" + encodeURIComponent("/editor/library")
+    );
+    assert.equal(
+      simulateLocation(fn, "/workout/abc"),
+      "https://example.test/editor/?p=" +
+        encodeURIComponent("/editor/workout/abc")
+    );
+  });
+
+  it("does NOT redirect arbitrary 404s that aren't in the allowlist", () => {
+    injectSpaFallback(dir);
+
+    const fourOhFour = readFileSync(join(dir, "404.html"), "utf8");
+    const fn = extractRedirectFn(fourOhFour);
+
+    assert.equal(simulateLocation(fn, "/typo-here"), null);
+    assert.equal(simulateLocation(fn, "/some/random/path"), null);
+    // /calendarx should NOT match — must be exact /calendar or /calendar/<rest>
+    assert.equal(simulateLocation(fn, "/calendarx"), null);
+  });
+
+  it("/editor/* deep links keep using the existing rafgraph bounce, not the legacy path", () => {
+    injectSpaFallback(dir);
+
+    const fourOhFour = readFileSync(join(dir, "404.html"), "utf8");
+    const fn = extractRedirectFn(fourOhFour);
+
+    assert.equal(
+      simulateLocation(fn, "/editor/calendar"),
+      "https://example.test/editor/?p=" + encodeURIComponent("/editor/calendar")
+    );
+  });
 });
+
+// --- helpers ---
+
+// Extract the IIFE body from the injected redirect <script> so we can run it
+// against a synthetic window.location and verify behaviour.
+function extractRedirectFn(html) {
+  const match = html.match(
+    /<script>\s*\(function \(\) \{([\s\S]*?)\}\)\(\);\s*<\/script>/
+  );
+  if (!match) throw new Error("could not extract redirect IIFE");
+  return new Function("window", `${match[1]}`);
+}
+
+function simulateLocation(fn, pathname) {
+  let replacedTo = null;
+  const fakeWindow = {
+    location: {
+      protocol: "https:",
+      host: "example.test",
+      pathname,
+      search: "",
+      hash: "",
+      replace: (url) => {
+        replacedTo = url;
+      },
+    },
+  };
+  fn(fakeWindow);
+  return replacedTo;
+}


### PR DESCRIPTION
## Summary

Follow-up UX patch to PR #404. After the wouter base alignment, bookmarks pointing at `kaiord.com/<route>` (without the `/editor/` prefix) still hit the landing's blue 404 because the rafgraph fallback only handled `/editor/*` paths.

This PR extends the deploy-time rafgraph script in `scripts/inject-spa-fallback.mjs` with a **closed allowlist** of legacy SPA routes:

- `/calendar` and `/calendar/<weekId>`
- `/library`
- `/workout` and `/workout/<id>`

These are bounced through the same `?p=` round-trip rafgraph already uses for `/editor/*` deep refreshes, ending up at `kaiord.com/editor/<path>` with the SPA loaded.

**Unrelated 404s (`/typo`, `/calendarx`, `/random/path`) keep surfacing the landing's blue 404** — the allowlist is intentionally narrow. Verified by tests.

## Test plan

- [x] `pnpm test:scripts` — 107 tests pass (4 new behavioural tests for the allowlist)
- [ ] Deploy to prod after merge
- [ ] Verify `kaiord.com/calendar` redirects to `kaiord.com/editor/calendar` and the calendar view renders

## Verification approach

The new tests don't string-match the regex source — they extract the injected IIFE from `404.html` and execute it against a synthetic `window.location` stub, asserting the `replace()` URL the script generates for each test pathname. This guards against accidental regex regressions that would silently break legacy redirects or hijack random 404s into the SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)