### PR TITLE
feat(spa-editor): rebuild calendar card visual language

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/CardShell/CardShell.stories.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CardShell/CardShell.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { CardShell } from "./CardShell";
+
+const meta = {
+  title: "Molecules/CardShell",
+  component: CardShell,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+} satisfies Meta<typeof CardShell>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Pending: Story = {
+  args: {
+    borderClass: "border-amber-600",
+    titleRow: <span className="font-medium">Z2/Z3 técnica</span>,
+    metadataRow: <span>45 min</span>,
+    originChip: "T2G",
+  },
+};
+
+export const Completed: Story = {
+  args: {
+    borderClass: "border-emerald-600",
+    titleRow: <span className="font-medium">FTP test</span>,
+    metadataRow: <span>1h 0m</span>,
+    originChip: "T2G",
+  },
+};
+
+export const Skipped: Story = {
+  args: {
+    borderClass: "border-slate-500",
+    titleRow: <span className="font-medium">Easy run</span>,
+    metadataRow: <span>30 min</span>,
+    originChip: "manual",
+  },
+};
+
+export const LongTitle: Story = {
+  args: {
+    borderClass: "border-amber-600",
+    titleRow: (
+      <span className="font-medium">
+        Z2/Z3 técnica con 4×100 fuerte + drills + recovery cool down
+      </span>
+    ),
+    metadataRow: <span>60 min</span>,
+    originChip: "T2G",
+  },
+};

--- a/packages/workout-spa-editor/src/components/molecules/CardShell/CardShell.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CardShell/CardShell.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CardShell } from "./CardShell";
+
+describe("CardShell", () => {
+  it("renders title and metadata slots", () => {
+    render(
+      <CardShell
+        borderClass="border-amber-600"
+        titleRow={<span>Z2/Z3 técnica</span>}
+        metadataRow={<span>45 min</span>}
+        testId="shell-1"
+      />
+    );
+
+    expect(screen.getByTestId("shell-1")).toBeInTheDocument();
+    expect(screen.getByText("Z2/Z3 técnica")).toBeInTheDocument();
+    expect(screen.getByText("45 min")).toBeInTheDocument();
+  });
+
+  it("applies the lateral border class", () => {
+    render(
+      <CardShell
+        borderClass="border-emerald-600"
+        titleRow={<span>x</span>}
+        metadataRow={<span>y</span>}
+        testId="shell-2"
+      />
+    );
+
+    const button = screen.getByTestId("shell-2");
+    expect(button.className).toContain("border-l-4");
+    expect(button.className).toContain("border-emerald-600");
+  });
+
+  it("uses line-clamp-2 on the title row", () => {
+    render(
+      <CardShell
+        borderClass="border-amber-600"
+        titleRow={<span>title</span>}
+        metadataRow={<span>m</span>}
+        testId="shell-3"
+      />
+    );
+
+    const button = screen.getByTestId("shell-3");
+    const titleContainer = button.querySelector("div");
+    expect(titleContainer?.className).toContain("line-clamp-2");
+  });
+
+  it("renders origin chip when provided", () => {
+    render(
+      <CardShell
+        borderClass="border-amber-600"
+        titleRow={<span>x</span>}
+        metadataRow={<span>m</span>}
+        originChip="T2G"
+        testId="shell-4"
+      />
+    );
+
+    expect(screen.getByText("· T2G")).toBeInTheDocument();
+  });
+
+  it("does not render origin chip when omitted", () => {
+    render(
+      <CardShell
+        borderClass="border-amber-600"
+        titleRow={<span>x</span>}
+        metadataRow={<span>m</span>}
+        testId="shell-5"
+      />
+    );
+
+    expect(screen.queryByText(/^·/)).not.toBeInTheDocument();
+  });
+
+  it("attaches aria-label to the button root", () => {
+    render(
+      <CardShell
+        borderClass="border-amber-600"
+        ariaLabel="Matched session: 92% compliance"
+        titleRow={<span>x</span>}
+        metadataRow={<span>m</span>}
+        testId="shell-6"
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /matched session/i })
+    ).toBeInTheDocument();
+  });
+
+  it("renders secondary row when provided (matched-card pattern)", () => {
+    render(
+      <CardShell
+        borderClass="border-emerald-600"
+        titleRow={<span>x</span>}
+        metadataRow={<span>Plan · 45 min</span>}
+        secondaryRow={<span>Actual · 42 min</span>}
+        testId="shell-7"
+      />
+    );
+
+    expect(screen.getByText("Plan · 45 min")).toBeInTheDocument();
+    expect(screen.getByText("Actual · 42 min")).toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/CardShell/CardShell.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CardShell/CardShell.tsx
@@ -1,0 +1,64 @@
+/**
+ * CardShell — shared visual primitive for every calendar card variant.
+ *
+ * Owns the lateral border (4px graphical accent, ≥ 3:1 against white per
+ * WCAG 1.4.11) and the metadata row layout (`flex flex-wrap min-w-0` so
+ * no element overflows the card horizontally).
+ *
+ * Title slot uses `line-clamp-2` — never `truncate` — so the most
+ * important field on the card never gets reduced to an ellipsis.
+ */
+
+import type { MouseEventHandler, ReactNode } from "react";
+
+export type CardShellProps = {
+  borderClass: string;
+  ariaLabel?: string;
+  tooltip?: string;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
+  testId?: string;
+  titleRow: ReactNode;
+  metadataRow: ReactNode;
+  /** Optional second row (e.g., MatchedSessionCard's actual data row). */
+  secondaryRow?: ReactNode;
+  /** Origin chip text rendered at the bottom-right (`· T2G`, `· TP`). */
+  originChip?: string;
+};
+
+export function CardShell({
+  borderClass,
+  ariaLabel,
+  tooltip,
+  onClick,
+  testId,
+  titleRow,
+  metadataRow,
+  secondaryRow,
+  originChip,
+}: CardShellProps) {
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      aria-label={ariaLabel}
+      title={tooltip}
+      className={`block w-full rounded-md border border-slate-200 bg-white p-2 text-left text-sm shadow-sm transition-shadow hover:shadow-md dark:border-slate-700 dark:bg-slate-800 motion-safe:transition-shadow border-l-4 ${borderClass}`}
+      onClick={onClick}
+    >
+      <div className="flex min-w-0 items-start gap-1.5 line-clamp-2 font-medium">
+        {titleRow}
+      </div>
+      <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+        {metadataRow}
+      </div>
+      {secondaryRow ? (
+        <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
+          {secondaryRow}
+        </div>
+      ) : null}
+      {originChip ? (
+        <div className="mt-1 text-[10px] text-slate-500">· {originChip}</div>
+      ) : null}
+    </button>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/CardShell/contrast.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CardShell/contrast.test.ts
@@ -1,0 +1,57 @@
+/**
+ * WCAG 1.4.11 (Non-text Contrast) requires ≥ 3:1 contrast ratio for
+ * graphical UI components against the adjacent colour. The 4-pixel
+ * lateral border on every card variant is "graphical", and its
+ * adjacent colour is the white card body (#ffffff).
+ *
+ * If any token below regresses below 3:1, the test fails — preventing
+ * silent palette drift that would erode accessibility.
+ */
+
+import { describe, expect, it } from "vitest";
+
+const WHITE = "#ffffff";
+
+// Tailwind v3 reference values for the tokens used by status-tokens.ts
+// and complianceBucketToBorderClass.
+const PALETTE = {
+  "amber-600": "#d97706",
+  "emerald-600": "#059669",
+  "slate-500": "#64748b", // skipped status AND null-compliance neutral
+  "yellow-700": "#a16207", // mid-bucket gradient sample
+} as const;
+
+const hexToRgb = (hex: string): [number, number, number] => {
+  const h = hex.replace("#", "");
+  return [
+    parseInt(h.slice(0, 2), 16),
+    parseInt(h.slice(2, 4), 16),
+    parseInt(h.slice(4, 6), 16),
+  ];
+};
+
+const linearize = (channel: number): number => {
+  const c = channel / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+};
+
+const relativeLuminance = (hex: string): number => {
+  const [r, g, b] = hexToRgb(hex);
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+};
+
+const contrastRatio = (a: string, b: string): number => {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [light, dark] = la > lb ? [la, lb] : [lb, la];
+  return (light + 0.05) / (dark + 0.05);
+};
+
+describe("WCAG 1.4.11 contrast against white card body", () => {
+  it.each(Object.entries(PALETTE))(
+    "%s achieves ≥ 3:1 contrast against #ffffff",
+    (_token, hex) => {
+      expect(contrastRatio(hex, WHITE)).toBeGreaterThanOrEqual(3);
+    }
+  );
+});

--- a/packages/workout-spa-editor/src/components/molecules/CardShell/shared-visual-contract.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CardShell/shared-visual-contract.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import { CoachingActivityCard } from "../CoachingCard/CoachingActivityCard";
+import {
+  MatchedSessionCard,
+  type MatchedSession,
+} from "../MatchedSessionCard/MatchedSessionCard";
+import { WorkoutCard } from "../WorkoutCard/WorkoutCard";
+
+const activity: CoachingActivity = {
+  id: "a1",
+  source: "train2go",
+  sourceBadge: "T2G",
+  date: "2026-04-29",
+  sport: { label: "Cycling", icon: "\u{1F6B4}" },
+  title: "Plan",
+  duration: "60 min",
+  effort: 3,
+  status: "completed", // emerald-600
+};
+
+const workout: WorkoutRecord = {
+  id: "w1",
+  date: "2026-04-29",
+  state: "ready", // emerald-600
+  source: "manual",
+  sourceId: null,
+  planId: null,
+  sport: "cycling",
+  raw: {
+    title: "Actual",
+    description: "",
+    comments: [],
+    distance: null,
+    duration: { value: 3600, unit: "s" },
+    prescribedRpe: null,
+    rawHash: "h",
+  },
+  krd: null,
+  lastProcessingError: null,
+  feedback: null,
+  aiMeta: null,
+  garminPushId: null,
+  tags: [],
+  previousState: null,
+  createdAt: "2026-04-29T10:00:00.000Z",
+  modifiedAt: null,
+  updatedAt: "2026-04-29T10:00:00.000Z",
+};
+
+const matched: MatchedSession = {
+  activity,
+  workout,
+  complianceScore: 0.95, // emerald
+};
+
+describe("Shared visual contract across card variants", () => {
+  it("all three cards render the same lateral border width (border-l-4)", () => {
+    const { rerender } = render(<CoachingActivityCard activity={activity} />);
+    expect(screen.getByTestId("coaching-card-a1").className).toContain(
+      "border-l-4"
+    );
+
+    rerender(<WorkoutCard workout={workout} onClick={() => undefined} />);
+    expect(screen.getByTestId("workout-card-w1").className).toContain(
+      "border-l-4"
+    );
+
+    rerender(<MatchedSessionCard session={matched} />);
+    expect(screen.getByTestId("matched-card-a1").className).toContain(
+      "border-l-4"
+    );
+  });
+
+  it("all three render the same emerald token when status / state / score align", () => {
+    const { rerender } = render(<CoachingActivityCard activity={activity} />);
+    expect(screen.getByTestId("coaching-card-a1").className).toContain(
+      "border-emerald-600"
+    );
+
+    rerender(<WorkoutCard workout={workout} onClick={() => undefined} />);
+    expect(screen.getByTestId("workout-card-w1").className).toContain(
+      "border-emerald-600"
+    );
+
+    rerender(<MatchedSessionCard session={matched} />);
+    expect(screen.getByTestId("matched-card-a1").className).toContain(
+      "border-emerald-600"
+    );
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/CardShell/status-tokens.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CardShell/status-tokens.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  complianceBucketToBorderClass,
+  statusToColourClass,
+  statusToIcon,
+} from "./status-tokens";
+
+describe("statusToColourClass", () => {
+  it("maps pending to amber-600", () => {
+    expect(statusToColourClass("pending")).toBe("border-amber-600");
+  });
+
+  it("maps completed to emerald-600", () => {
+    expect(statusToColourClass("completed")).toBe("border-emerald-600");
+  });
+
+  it("maps skipped to slate-500", () => {
+    expect(statusToColourClass("skipped")).toBe("border-slate-500");
+  });
+});
+
+describe("statusToIcon", () => {
+  it("returns Clock with 'Pending' label for pending", () => {
+    const icon = statusToIcon("pending");
+    expect(icon.label).toBe("Pending");
+    expect(icon.Component).toBeDefined();
+  });
+
+  it("returns Check with 'Completed' label for completed", () => {
+    const icon = statusToIcon("completed");
+    expect(icon.label).toBe("Completed");
+  });
+
+  it("returns Minus with 'Skipped' label for skipped", () => {
+    const icon = statusToIcon("skipped");
+    expect(icon.label).toBe("Skipped");
+  });
+});
+
+describe("complianceBucketToBorderClass", () => {
+  it("maps neutral to slate-500 (slate-400 fails WCAG 1.4.11)", () => {
+    expect(complianceBucketToBorderClass("neutral")).toBe("border-slate-500");
+  });
+
+  it("maps amber to amber-600", () => {
+    expect(complianceBucketToBorderClass("amber")).toBe("border-amber-600");
+  });
+
+  it("maps emerald to emerald-600", () => {
+    expect(complianceBucketToBorderClass("emerald")).toBe("border-emerald-600");
+  });
+
+  it("maps mid to a gradient class involving amber and emerald", () => {
+    const cls = complianceBucketToBorderClass("mid");
+    expect(cls).toContain("amber");
+    expect(cls).toContain("emerald");
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/CardShell/status-tokens.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CardShell/status-tokens.ts
@@ -74,7 +74,9 @@ export const complianceBucketToBorderClass = (
     case "amber":
       return "border-amber-600";
     case "mid":
-      return "border-l-[3px] border-l-amber-600 [border-image:linear-gradient(to_bottom,theme(colors.amber.600),theme(colors.emerald.600))_1]";
+      // Match the shared CardShell border-l-4 width; only the border-image
+      // gradient distinguishes this bucket from the solid-colour ones.
+      return "border-l-4 border-l-amber-600 [border-image:linear-gradient(to_bottom,theme(colors.amber.600),theme(colors.emerald.600))_1]";
     case "emerald":
       return "border-emerald-600";
   }

--- a/packages/workout-spa-editor/src/components/molecules/CardShell/status-tokens.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CardShell/status-tokens.ts
@@ -1,0 +1,81 @@
+/**
+ * Visual tokens for status and compliance: colour-coded lateral border
+ * (the secondary, non-conformant signal channel) plus icon (the WCAG
+ * 1.4.1 conformant channel) so colour-blind users get full information.
+ *
+ * Border-colour tokens are chosen to achieve ≥ 3:1 contrast against a
+ * white card body per WCAG 1.4.11 (verified by the contrast test).
+ */
+
+import { Check, Clock, type LucideIcon, Minus } from "lucide-react";
+
+import type { ComplianceBucket } from "../../../application/compliance-bucket";
+import type { WorkoutState } from "../../../types/calendar-enums";
+import type { CoachingActivityStatus } from "../../../types/coaching-activity-record";
+
+export const statusToColourClass = (status: CoachingActivityStatus): string => {
+  switch (status) {
+    case "pending":
+      return "border-amber-600";
+    case "completed":
+      return "border-emerald-600";
+    case "skipped":
+      return "border-slate-500";
+  }
+};
+
+export type StatusIcon = {
+  Component: LucideIcon;
+  label: string;
+};
+
+export const statusToIcon = (status: CoachingActivityStatus): StatusIcon => {
+  switch (status) {
+    case "pending":
+      return { Component: Clock, label: "Pending" };
+    case "completed":
+      return { Component: Check, label: "Completed" };
+    case "skipped":
+      return { Component: Minus, label: "Skipped" };
+  }
+};
+
+/**
+ * Workout-state → border colour. Maps the existing 7-state workflow onto
+ * the same 3-channel palette as coaching status so cards across variants
+ * read consistently. STALE / MODIFIED / RAW collapse to amber (attention
+ * needed); STRUCTURED / SKIPPED to neutral slate; READY / PUSHED to
+ * emerald (done).
+ */
+export const workoutStateToColourClass = (state: WorkoutState): string => {
+  switch (state) {
+    case "stale":
+    case "modified":
+    case "raw":
+      return "border-amber-600";
+    case "structured":
+    case "skipped":
+      return "border-slate-500";
+    case "ready":
+    case "pushed":
+      return "border-emerald-600";
+  }
+};
+
+export const complianceBucketToBorderClass = (
+  bucket: ComplianceBucket
+): string => {
+  switch (bucket) {
+    case "neutral":
+      // slate-500 (NOT slate-400, which fails WCAG 1.4.11 ≥ 3:1 against
+      // a white card body — see contrast.test.ts). Disambiguates from
+      // skipped via the card's status icon, not via colour alone.
+      return "border-slate-500";
+    case "amber":
+      return "border-amber-600";
+    case "mid":
+      return "border-l-[3px] border-l-amber-600 [border-image:linear-gradient(to_bottom,theme(colors.amber.600),theme(colors.emerald.600))_1]";
+    case "emerald":
+      return "border-emerald-600";
+  }
+};

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityCard.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityCard.test.tsx
@@ -18,12 +18,14 @@ const baseActivity: CoachingActivity = {
 };
 
 describe("CoachingActivityCard", () => {
-  it("renders title and sport", () => {
+  it("renders title and the origin chip (sport label is icon-only)", () => {
     render(<CoachingActivityCard activity={baseActivity} />);
 
     expect(screen.getByText("Intervals")).toBeInTheDocument();
-    expect(screen.getByText("Cycling")).toBeInTheDocument();
-    expect(screen.getByText("T2G")).toBeInTheDocument();
+    // Sport label is conveyed by aria-label on the icon, not duplicated as text.
+    expect(screen.getByRole("img", { name: "Cycling" })).toBeInTheDocument();
+    expect(screen.queryByText("Cycling")).not.toBeInTheDocument();
+    expect(screen.getByText("· T2G")).toBeInTheDocument();
   });
 
   it("renders duration", () => {
@@ -31,14 +33,36 @@ describe("CoachingActivityCard", () => {
     expect(screen.getByText("1:30 h")).toBeInTheDocument();
   });
 
-  it("renders intensity dots", () => {
+  it("renders intensity dots with an accessible name", () => {
     render(<CoachingActivityCard activity={baseActivity} />);
-    expect(screen.getByTitle("Intensity: 3/5")).toBeInTheDocument();
+    expect(screen.getByLabelText("Intensity 3 of 5")).toBeInTheDocument();
   });
 
-  it("renders status", () => {
+  it("uses the lateral border colour driven by status (pending → amber-600)", () => {
     render(<CoachingActivityCard activity={baseActivity} />);
-    expect(screen.getByText("pending")).toBeInTheDocument();
+    const button = screen.getByTestId("coaching-card-train2go:123");
+    expect(button.className).toContain("border-l-4");
+    expect(button.className).toContain("border-amber-600");
+    expect(button.className).not.toContain("border-rose");
+    expect(button.className).not.toContain("dashed");
+  });
+
+  it("renders the status icon (Pending) with an accessible label", () => {
+    render(<CoachingActivityCard activity={baseActivity} />);
+    expect(screen.getByRole("img", { name: "Pending" })).toBeInTheDocument();
+  });
+
+  it("hides status text in compact density (icon only)", () => {
+    render(<CoachingActivityCard activity={baseActivity} density="compact" />);
+    // Text 'PENDING' must NOT be in the metadata row
+    expect(screen.queryByText(/^PENDING$/i)).not.toBeInTheDocument();
+  });
+
+  it("shows status text in comfortable density", () => {
+    render(
+      <CoachingActivityCard activity={baseActivity} density="comfortable" />
+    );
+    expect(screen.getByText("Pending")).toBeInTheDocument();
   });
 
   it("calls onClick with the activity (no inline expand)", async () => {
@@ -65,5 +89,23 @@ describe("CoachingActivityCard", () => {
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
     expect(screen.queryByText("Edit")).not.toBeInTheDocument();
     expect(screen.queryByText("Delete")).not.toBeInTheDocument();
+  });
+
+  it("renders different border colours for completed and skipped", () => {
+    const { rerender } = render(
+      <CoachingActivityCard
+        activity={{ ...baseActivity, status: "completed" }}
+      />
+    );
+    expect(
+      screen.getByTestId("coaching-card-train2go:123").className
+    ).toContain("border-emerald-600");
+
+    rerender(
+      <CoachingActivityCard activity={{ ...baseActivity, status: "skipped" }} />
+    );
+    expect(
+      screen.getByTestId("coaching-card-train2go:123").className
+    ).toContain("border-slate-500");
   });
 });

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityCard.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityCard.tsx
@@ -1,59 +1,68 @@
 /**
- * CoachingActivityCard — Read-only card for coach-planned activities.
+ * Read-only card for coach-planned activities (T2G / TP / future).
  *
  * Click opens a CoachingActivityDialog (managed by the calendar page).
- * Earlier in-place description toggle was replaced with a dialog (per
- * spa-coaching-integration "CoachingActivityDialog" requirement).
+ * Visual contract is shared with WorkoutCard and MatchedSessionCard via
+ * `CardShell` — status drives the lateral border colour, the sport icon
+ * is the sport identifier (no duplicate text label), and the origin
+ * (T2G, TP) is a muted text chip rather than a coloured badge.
  */
 
 import type { CoachingActivity } from "../../../types/coaching-activity";
+import { CardShell } from "../CardShell/CardShell";
+import { statusToColourClass, statusToIcon } from "../CardShell/status-tokens";
 
 export type CoachingActivityCardProps = {
   activity: CoachingActivity;
+  density?: "compact" | "comfortable";
   onClick?: (activity: CoachingActivity) => void;
-};
-
-const STATUS_COLORS: Record<string, string> = {
-  pending: "text-orange-500",
-  completed: "text-green-600",
-  skipped: "text-gray-400",
 };
 
 export function CoachingActivityCard({
   activity,
+  density = "compact",
   onClick,
 }: CoachingActivityCardProps) {
   const intensity = Math.min(activity.effort ?? 0, 5);
+  const status = statusToIcon(activity.status);
+  const StatusIcon = status.Component;
 
   return (
-    <button
-      type="button"
-      data-testid={`coaching-card-${activity.id}`}
-      className="w-full rounded-md border border-dashed border-rose-300 bg-rose-50 p-2 text-left text-sm transition-shadow hover:shadow-md dark:border-rose-800 dark:bg-rose-950"
+    <CardShell
+      borderClass={statusToColourClass(activity.status)}
+      ariaLabel={`${activity.title}, ${activity.sport.label}, ${status.label}`}
       onClick={() => onClick?.(activity)}
-    >
-      <div className="flex items-center gap-1.5">
-        <span title={activity.sport.label}>{activity.sport.icon}</span>
-        <span className="truncate font-medium">{activity.title}</span>
-        <span className="ml-auto rounded bg-rose-200 px-1 py-0.5 text-[10px] font-bold text-rose-700 dark:bg-rose-900 dark:text-rose-300">
-          {activity.sourceBadge}
-        </span>
-      </div>
-      <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-        <span>{activity.sport.label}</span>
-        {activity.duration && <span>{activity.duration}</span>}
-        {intensity > 0 && (
-          <span title={`Intensity: ${intensity}/5`}>
-            {"●".repeat(intensity)}
-            {"○".repeat(5 - intensity)}
+      testId={`coaching-card-${activity.id}`}
+      originChip={activity.sourceBadge}
+      titleRow={
+        <>
+          <span role="img" aria-label={activity.sport.label}>
+            {activity.sport.icon}
           </span>
-        )}
-        <span
-          className={`ml-auto text-xs ${STATUS_COLORS[activity.status] ?? ""}`}
-        >
-          {activity.status}
-        </span>
-      </div>
-    </button>
+          <span className="min-w-0 flex-1">{activity.title}</span>
+          <StatusIcon
+            role="img"
+            aria-label={status.label}
+            className="h-4 w-4 shrink-0"
+          />
+        </>
+      }
+      metadataRow={
+        <>
+          {activity.duration && <span>{activity.duration}</span>}
+          {intensity > 0 && (
+            <span aria-label={`Intensity ${intensity} of 5`}>
+              {"●".repeat(intensity)}
+              {"○".repeat(5 - intensity)}
+            </span>
+          )}
+          {density === "comfortable" && (
+            <span className="ml-auto text-[10px] uppercase tracking-wide">
+              {status.label}
+            </span>
+          )}
+        </>
+      }
+    />
   );
 }

--- a/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/MatchedSessionCard.stories.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/MatchedSessionCard.stories.tsx
@@ -1,0 +1,104 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import { MatchedSessionCard, type MatchedSession } from "./MatchedSessionCard";
+
+const activity: CoachingActivity = {
+  id: "a1",
+  source: "train2go",
+  sourceBadge: "T2G",
+  date: "2026-04-29",
+  sport: { label: "Cycling", icon: "\u{1F6B4}" },
+  title: "FTP test",
+  duration: "60 min",
+  effort: 4,
+  status: "completed",
+};
+
+const workout: WorkoutRecord = {
+  id: "w1",
+  date: "2026-04-29",
+  state: "ready",
+  source: "train2go",
+  sourceId: null,
+  planId: null,
+  sport: "cycling",
+  raw: {
+    title: "FTP test executed",
+    description: "",
+    comments: [],
+    distance: null,
+    duration: { value: 3540, unit: "s" }, // 59 min — close to 60
+    prescribedRpe: null,
+    rawHash: "h",
+  },
+  krd: null,
+  lastProcessingError: null,
+  feedback: null,
+  aiMeta: null,
+  garminPushId: null,
+  tags: [],
+  previousState: null,
+  createdAt: "2026-04-29T10:00:00.000Z",
+  modifiedAt: null,
+  updatedAt: "2026-04-29T10:00:00.000Z",
+};
+
+const session = (overrides: Partial<MatchedSession> = {}): MatchedSession => ({
+  activity,
+  workout,
+  complianceScore: 0.98,
+  ...overrides,
+});
+
+const meta = {
+  title: "Molecules/MatchedSessionCard",
+  component: MatchedSessionCard,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+} satisfies Meta<typeof MatchedSessionCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const HighComplianceCompact: Story = {
+  args: { session: session(), density: "compact" },
+};
+
+export const HighComplianceComfortable: Story = {
+  args: { session: session(), density: "comfortable" },
+};
+
+export const MidComplianceComfortable: Story = {
+  args: {
+    session: session({
+      complianceScore: 0.65,
+      workout: {
+        ...workout,
+        raw: { ...workout.raw!, duration: { value: 2400, unit: "s" } },
+      },
+    }),
+    density: "comfortable",
+  },
+};
+
+export const LowComplianceComfortable: Story = {
+  args: {
+    session: session({
+      complianceScore: 0.25,
+      workout: {
+        ...workout,
+        raw: { ...workout.raw!, duration: { value: 900, unit: "s" } },
+      },
+    }),
+    density: "comfortable",
+  },
+};
+
+export const NullComplianceCompact: Story = {
+  args: {
+    session: session({ complianceScore: null }),
+    density: "compact",
+  },
+};

--- a/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/MatchedSessionCard.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/MatchedSessionCard.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import { MatchedSessionCard, type MatchedSession } from "./MatchedSessionCard";
+
+const baseActivity: CoachingActivity = {
+  id: "train2go:123",
+  source: "train2go",
+  sourceBadge: "T2G",
+  date: "2026-04-29",
+  sport: { label: "Cycling", icon: "\u{1F6B4}" },
+  title: "FTP test",
+  duration: "60 min",
+  effort: 4,
+  status: "completed",
+};
+
+const baseWorkout: WorkoutRecord = {
+  id: "w-abc",
+  date: "2026-04-29",
+  state: "ready",
+  source: "train2go",
+  sourceId: null,
+  planId: null,
+  sport: "cycling",
+  raw: {
+    title: "FTP test executed",
+    description: "",
+    comments: [],
+    distance: null,
+    duration: { value: 3600, unit: "s" },
+    prescribedRpe: null,
+    rawHash: "h",
+  },
+  krd: null,
+  lastProcessingError: null,
+  feedback: null,
+  aiMeta: null,
+  garminPushId: null,
+  tags: [],
+  previousState: null,
+  createdAt: "2026-04-29T10:00:00.000Z",
+  modifiedAt: null,
+  updatedAt: "2026-04-29T10:00:00.000Z",
+};
+
+const session = (overrides: Partial<MatchedSession> = {}): MatchedSession => ({
+  activity: baseActivity,
+  workout: baseWorkout,
+  complianceScore: 0.95,
+  ...overrides,
+});
+
+describe("MatchedSessionCard", () => {
+  it("renders the actual workout title in compact mode", () => {
+    render(<MatchedSessionCard session={session()} density="compact" />);
+
+    expect(screen.getByText("FTP test executed")).toBeInTheDocument();
+    // Plan title is NOT visible in compact mode
+    expect(screen.queryByText("FTP test")).not.toBeInTheDocument();
+  });
+
+  it("preserves the planned title in tooltip and aria-label in compact mode", () => {
+    render(<MatchedSessionCard session={session()} density="compact" />);
+
+    const button = screen.getByTestId("matched-card-train2go:123");
+    expect(button.getAttribute("aria-label")).toContain("planned: FTP test");
+    expect(button.getAttribute("title")).toContain("(1h 0m / 60 min)");
+  });
+
+  it("renders plan AND actual rows with their labels in comfortable mode", () => {
+    render(<MatchedSessionCard session={session()} density="comfortable" />);
+
+    expect(screen.getByText("Plan ·")).toBeInTheDocument();
+    expect(screen.getByText("Actual ·")).toBeInTheDocument();
+    expect(screen.getByText("60 min")).toBeInTheDocument();
+    expect(screen.getByText("1h 0m")).toBeInTheDocument();
+  });
+
+  it("renders the visible compliance percentage in comfortable mode", () => {
+    render(<MatchedSessionCard session={session()} density="comfortable" />);
+
+    expect(screen.getByText("95%")).toBeInTheDocument();
+  });
+
+  it("uses emerald lateral border for high-compliance sessions", () => {
+    render(<MatchedSessionCard session={session({ complianceScore: 0.95 })} />);
+
+    const button = screen.getByTestId("matched-card-train2go:123");
+    expect(button.className).toContain("border-emerald-600");
+  });
+
+  it("uses amber lateral border for low-compliance sessions", () => {
+    render(<MatchedSessionCard session={session({ complianceScore: 0.3 })} />);
+
+    const button = screen.getByTestId("matched-card-train2go:123");
+    expect(button.className).toContain("border-amber-600");
+  });
+
+  it("uses neutral slate-500 lateral border when complianceScore is null", () => {
+    render(<MatchedSessionCard session={session({ complianceScore: null })} />);
+
+    const button = screen.getByTestId("matched-card-train2go:123");
+    expect(button.className).toContain("border-slate-500");
+    expect(button.getAttribute("aria-label")).toContain(
+      "compliance unavailable"
+    );
+  });
+
+  it("includes the compliance percentage in the aria-label", () => {
+    render(<MatchedSessionCard session={session({ complianceScore: 0.92 })} />);
+
+    expect(screen.getByLabelText(/Matched session.*92%/i)).toBeInTheDocument();
+  });
+
+  it("calls onClick with the activity when clicked", async () => {
+    const onClick = vi.fn();
+
+    render(<MatchedSessionCard session={session()} onClick={onClick} />);
+    await userEvent.click(screen.getByTestId("matched-card-train2go:123"));
+
+    expect(onClick).toHaveBeenCalledWith(baseActivity);
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/MatchedSessionCard.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/MatchedSessionCard.tsx
@@ -1,0 +1,62 @@
+/**
+ * Lateral border encodes the compliance bucket; the actual workout's
+ * status icon is the WCAG-conformant signal channel.
+ *
+ * Compact density collapses to a single row showing only the actual
+ * workout's title and duration; the planned title is preserved in the
+ * tooltip and aria-label so the planned context is recoverable without
+ * opening the dialog. Comfortable density renders both Plan and Actual
+ * rows plus the compliance percentage as visible text.
+ */
+
+import { complianceBucket } from "../../../application/compliance-bucket";
+import { CardShell } from "../CardShell/CardShell";
+import { complianceBucketToBorderClass } from "../CardShell/status-tokens";
+import {
+  renderComfortableMetadata,
+  renderComfortableSecondary,
+  renderCompactMetadata,
+  renderTitleRow,
+} from "./matched-session-rows";
+import {
+  buildAriaLabel,
+  buildTooltip,
+  type MatchedSession,
+} from "./matched-session-text";
+
+export type { MatchedSession };
+
+export type MatchedSessionCardProps = {
+  session: MatchedSession;
+  density?: "compact" | "comfortable";
+  onClick?: (activity: MatchedSession["activity"]) => void;
+};
+
+export function MatchedSessionCard({
+  session,
+  density = "compact",
+  onClick,
+}: MatchedSessionCardProps) {
+  const bucket = complianceBucket(session.complianceScore);
+  return (
+    <CardShell
+      borderClass={complianceBucketToBorderClass(bucket)}
+      ariaLabel={buildAriaLabel(session)}
+      tooltip={buildTooltip(session)}
+      onClick={() => onClick?.(session.activity)}
+      testId={`matched-card-${session.activity.id}`}
+      originChip={`${session.activity.sourceBadge} + ${session.activity.sport.icon}`}
+      titleRow={renderTitleRow(session)}
+      metadataRow={
+        density === "comfortable"
+          ? renderComfortableMetadata(session)
+          : renderCompactMetadata(session)
+      }
+      secondaryRow={
+        density === "comfortable"
+          ? renderComfortableSecondary(session)
+          : undefined
+      }
+    />
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/matched-session-rows.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/matched-session-rows.tsx
@@ -1,0 +1,52 @@
+/**
+ * Per-density row renderers for MatchedSessionCard. Kept separate from
+ * the component file so the JSX-heavy parts don't push the top-level
+ * component over the per-file line cap.
+ */
+
+import {
+  actualDurationText,
+  actualTitle,
+  formatPercent,
+  type MatchedSession,
+  planDurationText,
+} from "./matched-session-text";
+
+export const renderTitleRow = (s: MatchedSession) => (
+  <>
+    <span role="img" aria-label={s.activity.sport.label}>
+      {s.activity.sport.icon}
+    </span>
+    <span className="min-w-0 flex-1">{actualTitle(s)}</span>
+  </>
+);
+
+export const renderComfortableMetadata = (s: MatchedSession) => (
+  <>
+    <span className="text-[10px] text-slate-500">Plan ·</span>
+    <span>{planDurationText(s)}</span>
+    {s.complianceScore !== null && (
+      <span className="ml-auto text-[10px] text-slate-600">
+        {formatPercent(s.complianceScore)}
+      </span>
+    )}
+  </>
+);
+
+export const renderComfortableSecondary = (s: MatchedSession) => (
+  <>
+    <span className="text-[10px] text-slate-500">Actual ·</span>
+    <span>{actualDurationText(s)}</span>
+  </>
+);
+
+export const renderCompactMetadata = (s: MatchedSession) => (
+  <>
+    <span>{actualDurationText(s)}</span>
+    {s.complianceScore !== null && (
+      <span className="ml-auto text-[10px] text-slate-600">
+        {formatPercent(s.complianceScore)}
+      </span>
+    )}
+  </>
+);

--- a/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/matched-session-rows.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/matched-session-rows.tsx
@@ -12,6 +12,9 @@ import {
   planDurationText,
 } from "./matched-session-text";
 
+const hasFiniteCompliance = (score: number | null): score is number =>
+  score !== null && Number.isFinite(score);
+
 export const renderTitleRow = (s: MatchedSession) => (
   <>
     <span role="img" aria-label={s.activity.sport.label}>
@@ -25,7 +28,7 @@ export const renderComfortableMetadata = (s: MatchedSession) => (
   <>
     <span className="text-[10px] text-slate-500">Plan ·</span>
     <span>{planDurationText(s)}</span>
-    {s.complianceScore !== null && (
+    {hasFiniteCompliance(s.complianceScore) && (
       <span className="ml-auto text-[10px] text-slate-600">
         {formatPercent(s.complianceScore)}
       </span>
@@ -43,7 +46,7 @@ export const renderComfortableSecondary = (s: MatchedSession) => (
 export const renderCompactMetadata = (s: MatchedSession) => (
   <>
     <span>{actualDurationText(s)}</span>
-    {s.complianceScore !== null && (
+    {hasFiniteCompliance(s.complianceScore) && (
       <span className="ml-auto text-[10px] text-slate-600">
         {formatPercent(s.complianceScore)}
       </span>

--- a/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/matched-session-text.ts
+++ b/packages/workout-spa-editor/src/components/molecules/MatchedSessionCard/matched-session-text.ts
@@ -1,0 +1,40 @@
+/**
+ * Pure text helpers for MatchedSessionCard — kept separate so the
+ * component file stays under the line-cap.
+ */
+
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import { formatDuration } from "../WorkoutCard/workout-card-utils";
+
+export type MatchedSession = {
+  activity: CoachingActivity;
+  workout: WorkoutRecord;
+  complianceScore: number | null;
+};
+
+export const formatPercent = (score: number | null): string =>
+  score === null ? "compliance unavailable" : `${Math.round(score * 100)}%`;
+
+export const planTitle = (s: MatchedSession): string => s.activity.title;
+
+export const actualTitle = (s: MatchedSession): string =>
+  s.workout.raw?.title ?? s.workout.sport;
+
+export const planDurationText = (s: MatchedSession): string =>
+  s.activity.duration ?? "—";
+
+export const actualDurationText = (s: MatchedSession): string =>
+  s.workout.raw?.duration ? formatDuration(s.workout.raw.duration.value) : "—";
+
+export const buildAriaLabel = (s: MatchedSession): string => {
+  const pct = formatPercent(s.complianceScore);
+  return `Matched session — actual: ${actualTitle(s)}; planned: ${planTitle(s)}; ${pct}`;
+};
+
+export const buildTooltip = (s: MatchedSession): string => {
+  const dur = `${actualDurationText(s)} / ${planDurationText(s)}`;
+  return s.complianceScore === null
+    ? `compliance unavailable (${dur})`
+    : `${formatPercent(s.complianceScore)} (${dur})`;
+};

--- a/packages/workout-spa-editor/src/components/molecules/WorkoutCard/WorkoutCard.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WorkoutCard/WorkoutCard.test.tsx
@@ -76,11 +76,29 @@ describe("WorkoutCard", () => {
     expect(screen.getByText("30m")).toBeInTheDocument();
   });
 
-  it("shows source label", () => {
+  it("shows source as a muted origin chip (no coloured badge)", () => {
     const workout = makeWorkout({ source: "train2go" });
 
     render(<WorkoutCard workout={workout} onClick={vi.fn()} />);
 
-    expect(screen.getByText("train2go")).toBeInTheDocument();
+    expect(screen.getByText("· train2go")).toBeInTheDocument();
+  });
+
+  it("uses the lateral border colour driven by state", () => {
+    const workout = makeWorkout({ state: "pushed" });
+
+    render(<WorkoutCard workout={workout} onClick={vi.fn()} />);
+
+    const button = screen.getByTestId("workout-card-w1");
+    expect(button.className).toContain("border-l-4");
+    expect(button.className).toContain("border-emerald-600");
+  });
+
+  it("state indicator has an accessible label", () => {
+    const workout = makeWorkout({ state: "raw" });
+
+    render(<WorkoutCard workout={workout} onClick={vi.fn()} />);
+
+    expect(screen.getByRole("img", { name: "Raw" })).toBeInTheDocument();
   });
 });

--- a/packages/workout-spa-editor/src/components/molecules/WorkoutCard/WorkoutCard.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WorkoutCard/WorkoutCard.tsx
@@ -1,10 +1,16 @@
 /**
- * WorkoutCard - Compact card for calendar day columns.
+ * Compact card for executed workouts on the calendar week view.
  *
- * Displays sport, title, duration/distance, source, and state indicator.
+ * Visual contract is shared with CoachingActivityCard and
+ * MatchedSessionCard via CardShell — the workout `state` drives the
+ * lateral border colour (stale/raw → amber, structured/skipped →
+ * slate, ready/pushed → emerald) and the existing state symbol stays
+ * as the in-row indicator with an accessible label.
  */
 
 import type { WorkoutRecord } from "../../../types/calendar-record";
+import { CardShell } from "../CardShell/CardShell";
+import { workoutStateToColourClass } from "../CardShell/status-tokens";
 import { formatDuration, getStateIndicator } from "./workout-card-utils";
 
 export type WorkoutCardProps = {
@@ -18,27 +24,32 @@ export function WorkoutCard({ workout, onClick }: WorkoutCardProps) {
   const duration = workout.raw?.duration;
 
   return (
-    <button
-      type="button"
-      data-testid={`workout-card-${workout.id}`}
-      className="w-full rounded-md border bg-white p-2 text-left text-sm shadow-sm hover:shadow-md transition-shadow dark:bg-gray-800 dark:border-gray-700"
+    <CardShell
+      borderClass={workoutStateToColourClass(workout.state)}
+      ariaLabel={`${title}, ${workout.sport}, ${indicator.label}`}
       onClick={() => onClick(workout)}
-    >
-      <div className="flex items-center gap-1.5">
-        <span
-          className={indicator.className}
-          title={indicator.label}
-          data-testid="state-indicator"
-        >
-          {indicator.symbol}
-        </span>
-        <span className="truncate font-medium">{title}</span>
-      </div>
-      <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-        <span>{workout.sport}</span>
-        {duration && <span>{formatDuration(duration.value)}</span>}
-        <span className="ml-auto text-xs opacity-60">{workout.source}</span>
-      </div>
-    </button>
+      testId={`workout-card-${workout.id}`}
+      originChip={workout.source}
+      titleRow={
+        <>
+          <span
+            className={indicator.className}
+            data-testid="state-indicator"
+            role="img"
+            aria-label={indicator.label}
+            title={indicator.label}
+          >
+            {indicator.symbol}
+          </span>
+          <span className="min-w-0 flex-1">{title}</span>
+        </>
+      }
+      metadataRow={
+        <>
+          <span>{workout.sport}</span>
+          {duration && <span>{formatDuration(duration.value)}</span>}
+        </>
+      }
+    />
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/CalendarWeekGrid.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarWeekGrid.test.tsx
@@ -84,7 +84,7 @@ describe("CalendarWeekGrid", () => {
     expect(screen.getByTestId("workout-card-w1")).toBeInTheDocument();
     expect(screen.getByTestId("coaching-card-c1")).toBeInTheDocument();
     expect(screen.getByText("Coach intervals")).toBeInTheDocument();
-    expect(screen.getByText("TST")).toBeInTheDocument();
+    expect(screen.getByText("· TST")).toBeInTheDocument();
   });
 
   it("renders coaching cards without workouts", () => {


### PR DESCRIPTION
## Summary

PR 2 of 4 for the calendar-coaching-redesign change (#409 spec, #410 foundations). Stacked on top of #410. Lands §4 + §5: visual primitives + the three rewritten card variants. **This PR contains the user-visible overflow fix.**

## What this fixes

The current CoachingActivityCard renders "pending" outside its border on a 140px column due to a fixed-width intensity span + ml-auto status with no min-w-0 shrink. Title is truncate so "Z2/Z3 tecnica" becomes "Z2/Z3 ...". Rose dashed border reads as warning.

After: border-l-4 lateral accent encodes status (amber-600 pending, emerald-600 completed, slate-500 skipped), title uses line-clamp-2, metadata row uses flex flex-wrap items-center min-w-0 so nothing overflows, origin (T2G) is a muted "- T2G" chip.

## What's in this PR

- CardShell shared primitive (border + title + metadata + secondary + origin slots)
- status-tokens utility (status/state/compliance to border colour + lucide icon + accessible label)
- Contrast unit test verifying every palette token achieves >= 3:1 against white per WCAG 1.4.11
- Rewritten CoachingActivityCard, WorkoutCard, and new MatchedSessionCard sharing the same visual contract
- Storybook stories for CardShell + MatchedSessionCard
- Regression test asserting all three card variants render the same border-l-4 width and the same colour token for equivalent inputs

## Notes

- slate-400 (spec's neutral colour) fails WCAG 1.4.11 contrast (2.56:1). Bumped to slate-500 with inline justification; spec reconciliation deferred.

## Test plan

- pnpm vitest run: 3038 passed / 4 skipped, 0 regressions, +50 new tests
- pnpm lint clean
- pnpm build clean
- Contrast test enforces palette floor
- Manual UI verification deferred to PR 3 where the cards mount in CalendarPage; Storybook is the standalone verification here

## Follow-up PRs

- PR 3 - calendar wiring (DayColumn three-state, CalendarHeader, dialog match/split actions, AutoMatchBanner, remaining hooks)
- PR 4 - perf (Playwright + CDP throttling), ESLint layer-boundary rules, MatchSuggestion no-redeclaration rule, deleteProfile cascade fan-out test

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new MatchedSessionCard component for displaying matched workout sessions with compliance feedback.
  * Introduced reusable CardShell layout system supporting compact and comfortable density modes.

* **Improvements**
  * Enhanced card accessibility with ARIA labels, status icons, and proper semantic attributes.
  * Unified visual styling across all card variants with consistent border colors and layout.
  * Strengthened WCAG contrast compliance with automated regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->