### PR TITLE
ci(deploy-site): fix smoke probe + add scripts/inject-spa-fallback.mjs to triggers

### DIFF
--- a/.changeset/fix-deploy-site-smoke-and-trigger.md
+++ b/.changeset/fix-deploy-site-smoke-and-trigger.md
@@ -1,0 +1,16 @@
+---
+"@kaiord/workout-spa-editor": none
+---
+
+ci(deploy-site): fix smoke probe + add scripts/inject-spa-fallback.mjs to trigger paths
+
+The smoke step was failing on every deploy (visible since `cleanup-open-issues-may-2026` Phase 2 landed) because it fetched `/editor/calendar` with curl and expected the SPA bundle marker in the response body. With the rafgraph fallback that body is `404.html` plus a JS `window.location.replace` round-trip — a redirect curl cannot execute. The check could never pass.
+
+Replace the JS-dependent probe with two mechanical curl checks:
+
+1. `/editor/` returns 200 carrying the SPA bundle marker (entry script tag).
+2. `/404.html` returns 200 carrying the rafgraph redirect script (`indexOf('/editor/')`).
+
+Together those prove the deep-route fallback contract end-to-end without needing JS execution. Real-browser correctness of the redirect itself is covered by the `e2e-prod-base` Playwright job.
+
+Also adds `scripts/inject-spa-fallback.mjs` to the deploy workflow's trigger paths so future changes to the rafgraph injection script automatically redeploy.

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -161,24 +161,36 @@ jobs:
           echo "  - $EDITOR_URL (expect marker: $MARKER)"
           echo "  - $NOT_FOUND_URL (expect rafgraph redirect script)"
           for i in $(seq 1 10); do
-            EDITOR_BODY=$(curl -sL --max-time 15 "$EDITOR_URL" || true)
-            NOT_FOUND_BODY=$(curl -sL --max-time 15 "$NOT_FOUND_URL" || true)
+            EDITOR_TMP=$(mktemp)
+            NOT_FOUND_TMP=$(mktemp)
+            # `--http-status` would be cleaner but isn't in older curl; capture
+            # the code via -w and the body via -o for portability. -L follows
+            # any HTTP-level redirect so we score the final response.
+            EDITOR_CODE=$(curl -sL --max-time 15 -o "$EDITOR_TMP" -w "%{http_code}" "$EDITOR_URL" || echo "000")
+            NOT_FOUND_CODE=$(curl -sL --max-time 15 -o "$NOT_FOUND_TMP" -w "%{http_code}" "$NOT_FOUND_URL" || echo "000")
+            EDITOR_BODY=$(cat "$EDITOR_TMP" 2>/dev/null || true)
+            NOT_FOUND_BODY=$(cat "$NOT_FOUND_TMP" 2>/dev/null || true)
+            rm -f "$EDITOR_TMP" "$NOT_FOUND_TMP"
             EDITOR_OK=0
             NOT_FOUND_OK=0
-            echo "$EDITOR_BODY" | grep -qF "$MARKER" && EDITOR_OK=1
-            # Match the rafgraph guard literally; it must contain the /editor/ pathname
-            # check so the redirect only fires for SPA-related 404s.
-            echo "$NOT_FOUND_BODY" | grep -qF "indexOf('/editor/')" && NOT_FOUND_OK=1
+            # /editor/ is the SPA entry — must serve 200 + the bundle marker.
+            [ "$EDITOR_CODE" = "200" ] && echo "$EDITOR_BODY" | grep -qF "$MARKER" && EDITOR_OK=1
+            # /404.html is itself a real artefact (GitHub Pages serves it as
+            # a regular file with status 200); Pages then ALSO uses its body
+            # for the not-found fallback. We assert 200 + that the rafgraph
+            # guard literal is present so the redirect only fires for
+            # SPA-related 404s.
+            [ "$NOT_FOUND_CODE" = "200" ] && echo "$NOT_FOUND_BODY" | grep -qF "indexOf('/editor/')" && NOT_FOUND_OK=1
             if [ "$EDITOR_OK" = "1" ] && [ "$NOT_FOUND_OK" = "1" ]; then
-              echo "✅ Attempt $i: SPA bundle present at /editor/ AND rafgraph redirect present at /404.html"
+              echo "✅ Attempt $i: SPA bundle present at /editor/ (200) AND rafgraph redirect present at /404.html (200)"
               exit 0
             fi
-            echo "Attempt $i: editor=$EDITOR_OK 404=$NOT_FOUND_OK; retrying in 10s"
+            echo "Attempt $i: editor=$EDITOR_OK (code=$EDITOR_CODE) 404=$NOT_FOUND_OK (code=$NOT_FOUND_CODE); retrying in 10s"
             sleep 10
           done
           echo "❌ Smoke failed after 10 retries:"
-          echo "    /editor/ marker present:        $EDITOR_OK (expect 1)"
-          echo "    /404.html rafgraph script ok:   $NOT_FOUND_OK (expect 1)"
+          echo "    /editor/ status=$EDITOR_CODE (expect 200), marker present: $EDITOR_OK"
+          echo "    /404.html status=$NOT_FOUND_CODE (expect 200), rafgraph script: $NOT_FOUND_OK"
           exit 1
 
       # Rollback: use workflow_dispatch on last known-good main commit SHA,

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -14,6 +14,7 @@ on:
       - "packages/garmin/**"
       - "styles/**"
       - ".github/workflows/deploy-site.yml"
+      - "scripts/inject-spa-fallback.mjs"
   workflow_dispatch:
 
 permissions:
@@ -144,22 +145,40 @@ jobs:
             echo "❌ Missing build marker or page URL; cannot run smoke."
             exit 1
           fi
+          # The deep-route fallback works in two pieces:
+          #   1. /editor/index.html serves the SPA bundle (positive marker)
+          #   2. /404.html carries the rafgraph redirect script that bounces
+          #      /editor/* (and the legacy SPA route allowlist) into /editor/?p=…
+          # We probe both pieces directly. This sidesteps the prior smoke's
+          # design flaw, which fetched /editor/calendar with curl and expected
+          # the SPA bundle in the response body — but that bundle only appears
+          # after a JS-driven `window.location.replace` round-trip that curl
+          # cannot execute.
           # Pages CDN propagation is eventually consistent; retry up to 10x at 10s.
-          # The deep route /editor/calendar must serve the SPA bundle (positive marker)
-          # and never the landing's 404 markup (negative marker).
-          URL="${PAGE_URL%/}/editor/calendar"
-          echo "Smoke target: $URL"
-          echo "Looking for marker: $MARKER"
+          EDITOR_URL="${PAGE_URL%/}/editor/"
+          NOT_FOUND_URL="${PAGE_URL%/}/404.html"
+          echo "Smoke targets:"
+          echo "  - $EDITOR_URL (expect marker: $MARKER)"
+          echo "  - $NOT_FOUND_URL (expect rafgraph redirect script)"
           for i in $(seq 1 10); do
-            BODY=$(curl -sL --max-time 15 "$URL" || true)
-            if echo "$BODY" | grep -qF "$MARKER"; then
-              echo "✅ Attempt $i: SPA bundle served at deep route"
+            EDITOR_BODY=$(curl -sL --max-time 15 "$EDITOR_URL" || true)
+            NOT_FOUND_BODY=$(curl -sL --max-time 15 "$NOT_FOUND_URL" || true)
+            EDITOR_OK=0
+            NOT_FOUND_OK=0
+            echo "$EDITOR_BODY" | grep -qF "$MARKER" && EDITOR_OK=1
+            # Match the rafgraph guard literally; it must contain the /editor/ pathname
+            # check so the redirect only fires for SPA-related 404s.
+            echo "$NOT_FOUND_BODY" | grep -qF "indexOf('/editor/')" && NOT_FOUND_OK=1
+            if [ "$EDITOR_OK" = "1" ] && [ "$NOT_FOUND_OK" = "1" ]; then
+              echo "✅ Attempt $i: SPA bundle present at /editor/ AND rafgraph redirect present at /404.html"
               exit 0
             fi
-            echo "Attempt $i: marker not found yet; retrying in 10s"
+            echo "Attempt $i: editor=$EDITOR_OK 404=$NOT_FOUND_OK; retrying in 10s"
             sleep 10
           done
-          echo "❌ Smoke failed after 10 retries — deep route did not serve the SPA bundle."
+          echo "❌ Smoke failed after 10 retries:"
+          echo "    /editor/ marker present:        $EDITOR_OK (expect 1)"
+          echo "    /404.html rafgraph script ok:   $NOT_FOUND_OK (expect 1)"
           exit 1
 
       # Rollback: use workflow_dispatch on last known-good main commit SHA,


### PR DESCRIPTION
## Summary

Closes both deploy-pipeline nits surfaced during the `fix-spa-router-basename` rollout (PRs #403, #404, #406, #408):

### Nit 1: deploy workflow trigger paths missed `scripts/`

`.github/workflows/deploy-site.yml` only triggered on changes under `packages/...` (and the workflow itself + `styles/`), so PR #406's edit to `scripts/inject-spa-fallback.mjs` did NOT trigger an automatic redeploy. We had to dispatch one manually. Add `scripts/inject-spa-fallback.mjs` to the trigger paths.

### Nit 2: smoke step has been failing on every deploy since rafgraph landed

The smoke step fetched `${PAGE_URL}/editor/calendar` with curl and expected the SPA bundle marker in the response body. With the rafgraph fallback that body is the landing's `404.html` plus a JS `window.location.replace` round-trip — a redirect curl cannot execute. So every deploy since `cleanup-open-issues-may-2026` Phase 2 (PR #398) marked as failed even though Pages artefacts uploaded fine.

Replace the JS-dependent probe with two mechanical curl checks against the deployed artefact:

1. `/editor/` returns 200 carrying the SPA bundle marker (entry script tag present at the SPA entry).
2. `/404.html` returns 200 carrying the rafgraph redirect script (`indexOf('/editor/')` literal present).

Together these prove the deep-route fallback contract end-to-end without needing JS execution. Real-browser correctness of the redirect itself is covered by the `e2e-prod-base` Playwright job introduced in PR #404.

## Validation

- [x] Sanity-checked both new probes against live prod: `/editor/` returns the marker `src=\"/editor/assets/index-3u2n8Jav.js\"`, `/404.html` returns `if (p.indexOf('/editor/') === 0) {`. Both grep matches succeed.
- [x] `pnpm test:scripts` — green
- [ ] After merge: deploy will trigger automatically (workflow file changed); the new smoke step should pass on first run, ending the streak of false-failure deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment smoke tests for SPA fallback verification.
  * Updated workflow triggers to include injection script changes.

* **Documentation**
  * Added specification for profile deletion with multi-table transaction safety requirements and regression testing guidelines.
  * Reformatted specification markdown for consistency across calendar-coaching redesign specs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->