### PR TITLE
feat(spa-editor): density toggle + week label + ESLint layer guards

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -282,5 +282,90 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    // SPA hexagonal layering: ports / application / adapters / hooks /
+    // components. Matches the convention used by @kaiord/core. Files in
+    // a higher layer must not bypass the layer below them.
+    files: ["packages/workout-spa-editor/src/**/*.{ts,tsx}"],
+    plugins: { boundaries },
+    settings: {
+      "boundaries/elements": [
+        {
+          type: "spa-ports",
+          pattern: "packages/workout-spa-editor/src/ports/**",
+        },
+        {
+          type: "spa-application",
+          pattern: "packages/workout-spa-editor/src/application/**",
+        },
+        {
+          type: "spa-adapters",
+          pattern: "packages/workout-spa-editor/src/adapters/**",
+        },
+        {
+          type: "spa-hooks",
+          pattern: "packages/workout-spa-editor/src/hooks/**",
+        },
+        {
+          type: "spa-components",
+          pattern: "packages/workout-spa-editor/src/components/**",
+        },
+      ],
+    },
+    rules: {
+      "boundaries/element-types": [
+        "error",
+        {
+          default: "allow",
+          rules: [
+            {
+              from: "spa-ports",
+              disallow: ["spa-adapters"],
+              message:
+                "Ports must not depend on adapters. Ports define interfaces only.",
+            },
+            {
+              from: "spa-application",
+              disallow: ["spa-adapters"],
+              message:
+                "Application use cases must not depend on adapters. Inject through ports instead.",
+            },
+            {
+              from: "spa-components",
+              disallow: ["spa-adapters"],
+              message:
+                "Components must not import from adapters directly. Go through hooks (which compose use cases with injected ports).",
+            },
+          ],
+        },
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          // MatchSuggestion type lives in src/application/match-suggestion.ts.
+          // Redeclaring elsewhere bypasses the single-source-of-truth contract
+          // between the auto-match heuristic (producer) and the banner UI
+          // (consumer). The canonical file is exempted in the override below.
+          selector: "TSTypeAliasDeclaration[id.name='MatchSuggestion']",
+          message:
+            "MatchSuggestion is owned by application/match-suggestion.ts. Import it from there instead of redeclaring.",
+        },
+        {
+          selector: "TSInterfaceDeclaration[id.name='MatchSuggestion']",
+          message:
+            "MatchSuggestion is owned by application/match-suggestion.ts. Import it from there instead of redeclaring.",
+        },
+      ],
+    },
+  },
+  {
+    // Canonical owner of MatchSuggestion — re-enable the type alias
+    // declaration that the no-restricted-syntax rule above forbids
+    // everywhere else.
+    files: ["packages/workout-spa-editor/src/application/match-suggestion.ts"],
+    rules: {
+      "no-restricted-syntax": "off",
+    },
+  },
   ...adapterBoundaryRules()
 );

--- a/packages/workout-spa-editor/e2e/calendar-navigation.spec.ts
+++ b/packages/workout-spa-editor/e2e/calendar-navigation.spec.ts
@@ -22,7 +22,7 @@ test.describe("Calendar Navigation", () => {
     await page.goto("/calendar/2026-W15");
     await expect(page.getByTestId("week-navigation")).toBeVisible();
     await expect(
-      page.getByTestId("week-navigation").getByText("2026 W15")
+      page.getByTestId("week-navigation").getByText(/· W15/)
     ).toBeVisible();
   });
 
@@ -63,25 +63,25 @@ test.describe("Calendar Navigation", () => {
 
   test("Click prev week changes URL", async ({ page }) => {
     await page.goto("/calendar/2026-W15");
-    await expect(page.getByText("2026 W15")).toBeVisible();
+    await expect(page.getByText(/· W15/)).toBeVisible();
 
     await page.getByRole("button", { name: "Previous week" }).click();
     await page.waitForURL(/\/calendar\/2026-W14/);
-    await expect(page.getByText("2026 W14")).toBeVisible();
+    await expect(page.getByText(/· W14/)).toBeVisible();
   });
 
   test("Click next week changes URL", async ({ page }) => {
     await page.goto("/calendar/2026-W15");
-    await expect(page.getByText("2026 W15")).toBeVisible();
+    await expect(page.getByText(/· W15/)).toBeVisible();
 
     await page.getByRole("button", { name: "Next week" }).click();
     await page.waitForURL(/\/calendar\/2026-W16/);
-    await expect(page.getByText("2026 W16")).toBeVisible();
+    await expect(page.getByText(/· W16/)).toBeVisible();
   });
 
   test('Click "Today" navigates to current week', async ({ page }) => {
     await page.goto("/calendar/2026-W01");
-    await expect(page.getByText("2026 W01")).toBeVisible();
+    await expect(page.getByText(/· W01/)).toBeVisible();
 
     await page.getByRole("button", { name: "Today" }).click();
 

--- a/packages/workout-spa-editor/src/components/molecules/DensityToggle/DensityToggle.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/DensityToggle/DensityToggle.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { DensityToggle } from "./DensityToggle";
+
+describe("DensityToggle", () => {
+  it("renders 'Switch to comfortable view' + aria-checked=true when current is compact", () => {
+    render(<DensityToggle density="compact" onToggle={vi.fn()} />);
+
+    const btn = screen.getByRole("switch", {
+      name: "Switch to comfortable view",
+    });
+    expect(btn.getAttribute("aria-checked")).toBe("true");
+    expect(btn.getAttribute("title")).toBe("Switch to comfortable view");
+  });
+
+  it("renders 'Switch to compact view' + aria-checked=false when current is comfortable", () => {
+    render(<DensityToggle density="comfortable" onToggle={vi.fn()} />);
+
+    const btn = screen.getByRole("switch", { name: "Switch to compact view" });
+    expect(btn.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("calls onToggle with the next density when clicked", async () => {
+    const onToggle = vi.fn();
+    render(<DensityToggle density="compact" onToggle={onToggle} />);
+
+    await userEvent.click(screen.getByTestId("density-toggle"));
+
+    expect(onToggle).toHaveBeenCalledWith("comfortable");
+  });
+
+  it("calls onToggle with 'compact' when current is comfortable", async () => {
+    const onToggle = vi.fn();
+    render(<DensityToggle density="comfortable" onToggle={onToggle} />);
+
+    await userEvent.click(screen.getByTestId("density-toggle"));
+
+    expect(onToggle).toHaveBeenCalledWith("compact");
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/DensityToggle/DensityToggle.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/DensityToggle/DensityToggle.tsx
@@ -15,7 +15,14 @@ import type { CalendarDensity } from "../../../types/user-preferences";
 
 export type DensityToggleProps = {
   density: CalendarDensity;
-  onToggle: (next: CalendarDensity) => void;
+  /**
+   * Allowed to return a Promise (e.g. when wired through
+   * useSetCalendarDensity, which awaits a Dexie write). The component
+   * swallows rejection because density-write failures (concurrent
+   * profile-delete, infrastructure error) are non-fatal — the
+   * underlying live-query keeps the UI consistent.
+   */
+  onToggle: (next: CalendarDensity) => void | Promise<void>;
 };
 
 const nextDensity = (current: CalendarDensity): CalendarDensity =>
@@ -25,6 +32,16 @@ export function DensityToggle({ density, onToggle }: DensityToggleProps) {
   const next = nextDensity(density);
   const label = `Switch to ${next} view`;
   const Icon = next === "compact" ? LayoutGrid : List;
+  const handleClick = () => {
+    const result = onToggle(next);
+    if (result && typeof result.then === "function") {
+      result.catch(() => {
+        // Density-write failure is non-fatal — the live-query
+        // observation in the consumer leaves the persisted state
+        // truthful and the UI stays consistent on the next render.
+      });
+    }
+  };
   return (
     <button
       type="button"
@@ -33,7 +50,7 @@ export function DensityToggle({ density, onToggle }: DensityToggleProps) {
       aria-label={label}
       title={label}
       data-testid="density-toggle"
-      onClick={() => onToggle(next)}
+      onClick={handleClick}
       className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
     >
       <Icon className="h-4 w-4" />

--- a/packages/workout-spa-editor/src/components/molecules/DensityToggle/DensityToggle.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/DensityToggle/DensityToggle.tsx
@@ -1,0 +1,42 @@
+/**
+ * Density toggle for the calendar — switches between compact (denser
+ * cards, just a status icon) and comfortable (status text visible,
+ * MatchedSessionCard renders both Plan and Actual rows).
+ *
+ * Uses the WAI-ARIA Switch pattern (role=switch, aria-checked) per APG
+ * §3.27 — density is a binary on/off state, not an action toggle.
+ * Icon reflects the NEXT state (the action it will perform), so the
+ * visual cue and the `aria-label` "Switch to <next> view" agree.
+ */
+
+import { LayoutGrid, List } from "lucide-react";
+
+import type { CalendarDensity } from "../../../types/user-preferences";
+
+export type DensityToggleProps = {
+  density: CalendarDensity;
+  onToggle: (next: CalendarDensity) => void;
+};
+
+const nextDensity = (current: CalendarDensity): CalendarDensity =>
+  current === "compact" ? "comfortable" : "compact";
+
+export function DensityToggle({ density, onToggle }: DensityToggleProps) {
+  const next = nextDensity(density);
+  const label = `Switch to ${next} view`;
+  const Icon = next === "compact" ? LayoutGrid : List;
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={density === "compact"}
+      aria-label={label}
+      title={label}
+      data-testid="density-toggle"
+      onClick={() => onToggle(next)}
+      className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-200 dark:hover:bg-slate-800"
+    >
+      <Icon className="h-4 w-4" />
+    </button>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/CalendarHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarHeader.tsx
@@ -1,11 +1,14 @@
 /**
- * CalendarHeader — top-of-page banners + batch cost confirmation +
- * week navigation row. Kept out of CalendarPage so its render
- * function stays under the max-lines-per-function rule.
+ * Top-of-page banners + batch cost confirmation + week navigation row +
+ * density toggle. Kept out of CalendarPage so each render function
+ * stays under the per-function line cap.
  */
 
 import type { useCoachingActivities } from "../../hooks/use-coaching-activities";
+import type { CalendarDensity } from "../../types/user-preferences";
+import { formatWeekLabel } from "../../utils/format-week-label";
 import { CoachingSyncButton } from "../molecules/CoachingCard/CoachingSyncButton";
+import { DensityToggle } from "../molecules/DensityToggle/DensityToggle";
 import { WeekNavigation } from "../molecules/WorkoutCard/WeekNavigation";
 import { BatchCostConfirmation } from "../organisms/BatchCostConfirmation";
 import { CalendarEmptyBanners } from "./CalendarEmptyBanners";
@@ -14,9 +17,16 @@ import type { useCalendarState } from "./use-calendar-state";
 export type CalendarHeaderProps = {
   state: ReturnType<typeof useCalendarState>;
   coaching: ReturnType<typeof useCoachingActivities>;
+  density?: CalendarDensity;
+  onDensityChange?: (next: CalendarDensity) => void;
 };
 
-export function CalendarHeader({ state: s, coaching }: CalendarHeaderProps) {
+export function CalendarHeader({
+  state: s,
+  coaching,
+  density,
+  onDensityChange,
+}: CalendarHeaderProps) {
   return (
     <>
       <CalendarEmptyBanners
@@ -44,9 +54,12 @@ export function CalendarHeader({ state: s, coaching }: CalendarHeaderProps) {
       <div className="flex items-center justify-between">
         <WeekNavigation
           weekId={s.data.weekId}
-          weekLabel={s.data.weekId.replace("-W", " W")}
+          weekLabel={formatWeekLabel(s.data.weekId)}
         />
-        <div className="flex gap-2">
+        <div className="flex items-center gap-2">
+          {density && onDensityChange && (
+            <DensityToggle density={density} onToggle={onDensityChange} />
+          )}
           {coaching.syncSources
             .filter((src) => src.linked)
             .map((src) => (

--- a/packages/workout-spa-editor/src/components/pages/CalendarPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPage.tsx
@@ -18,6 +18,7 @@ import { useCoachingActivities } from "../../hooks/use-coaching-activities";
 import { useCoachingAutoSync } from "../../hooks/use-coaching-auto-sync";
 import type { MatchedSessionWithMetadata as PageMatchedSession } from "../../hooks/use-matched-sessions";
 import { useMatchedSessions } from "../../hooks/use-matched-sessions";
+import { useSetCalendarDensity } from "../../hooks/use-set-calendar-density";
 import { useUserPreferences } from "../../hooks/use-user-preferences";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { CoachingActivity } from "../../types/coaching-activity";
@@ -63,12 +64,19 @@ export default function CalendarPage() {
     coaching.expandActivity(activity);
   };
 
+  const handleDensityChange = useSetCalendarDensity(profileId);
+
   if (!s.data.isValidWeek) return <Redirect to="/calendar" />;
   if (s.data.hydration === "pending") return <CalendarSkeleton />;
 
   return (
     <div className="space-y-4" data-testid="calendar-page">
-      <CalendarHeader state={s} coaching={coaching} />
+      <CalendarHeader
+        state={s}
+        coaching={coaching}
+        density={prefs?.calendarDensity}
+        onDensityChange={handleDensityChange}
+      />
       <CalendarWeekGrid
         days={s.data.days}
         matchedByDay={buckets.matchedByDay}

--- a/packages/workout-spa-editor/src/hooks/use-set-calendar-density.ts
+++ b/packages/workout-spa-editor/src/hooks/use-set-calendar-density.ts
@@ -1,0 +1,36 @@
+/**
+ * Wires the `setCalendarDensity` use case with Dexie-backed adapters
+ * and an injected clock. Returned callback persists the density and
+ * the live-query subscription on the underlying user_preferences
+ * table re-fires the consuming components.
+ *
+ * Lives in the hooks layer so components don't reach across into
+ * adapters directly — preserves the layering enforced by the eslint
+ * boundary rule.
+ */
+
+import { useCallback } from "react";
+
+import { db } from "../adapters/dexie/dexie-database";
+import { createDexiePersistence } from "../adapters/dexie/dexie-persistence-adapter";
+import { createDexieUserPreferencesRepository } from "../adapters/dexie/dexie-user-preferences-repository";
+import { setCalendarDensity } from "../application/set-calendar-density";
+import type { CalendarDensity } from "../types/user-preferences";
+
+export function useSetCalendarDensity(profileId: string | null) {
+  return useCallback(
+    async (next: CalendarDensity): Promise<void> => {
+      if (!profileId) return;
+      const persistence = createDexiePersistence(db);
+      await setCalendarDensity(
+        { profileId, density: next },
+        {
+          clock: () => new Date().toISOString(),
+          repository: createDexieUserPreferencesRepository(db),
+          profileRepository: persistence.profiles,
+        }
+      );
+    },
+    [profileId]
+  );
+}

--- a/packages/workout-spa-editor/src/utils/format-week-label.test.ts
+++ b/packages/workout-spa-editor/src/utils/format-week-label.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { formatWeekLabel } from "./format-week-label";
+
+describe("formatWeekLabel", () => {
+  it("formats a same-month week", () => {
+    expect(formatWeekLabel("2026-W18")).toBe("Apr 27 – May 3 · W18");
+  });
+
+  it("formats a same-year cross-month week", () => {
+    expect(formatWeekLabel("2026-W19")).toBe("May 4 – May 10 · W19");
+  });
+
+  it("formats a cross-year week with year disambiguation", () => {
+    expect(formatWeekLabel("2026-W01")).toBe(
+      "Dec 29, 2025 – Jan 4, 2026 · W01"
+    );
+  });
+
+  it("falls back to the raw weekId on invalid input", () => {
+    expect(formatWeekLabel("not-a-week")).toBe("not-a-week");
+  });
+
+  it("is deterministic", () => {
+    expect(formatWeekLabel("2026-W18")).toBe(formatWeekLabel("2026-W18"));
+  });
+});

--- a/packages/workout-spa-editor/src/utils/format-week-label.ts
+++ b/packages/workout-spa-editor/src/utils/format-week-label.ts
@@ -1,0 +1,43 @@
+/**
+ * Human-readable week label: "Apr 27 – May 3 · W18".
+ *
+ * Same-month weeks abbreviate the second month; cross-year weeks include
+ * both years to disambiguate. Falls back to the raw weekId when the
+ * input is malformed (the calendar's invalid-week handling redirects
+ * before reaching this function in production).
+ */
+
+import { parseWeekId } from "./week-utils";
+
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+const fmt = (yyyymmdd: string): { y: number; m: string; d: number } => {
+  const [y, m, d] = yyyymmdd.split("-").map(Number) as [number, number, number];
+  return { y, m: MONTHS[m - 1] ?? "", d };
+};
+
+export function formatWeekLabel(weekId: string): string {
+  const range = parseWeekId(weekId);
+  if (!range) return weekId;
+  const start = fmt(range.start);
+  const end = fmt(range.end);
+  const weekNum = weekId.split("-W")[1] ?? "";
+
+  if (start.y !== end.y) {
+    return `${start.m} ${start.d}, ${start.y} – ${end.m} ${end.d}, ${end.y} · W${weekNum}`;
+  }
+  return `${start.m} ${start.d} – ${end.m} ${end.d} · W${weekNum}`;
+}


### PR DESCRIPTION
## Summary

PR 4 of 4 for the calendar-coaching-redesign change (#409 spec, #410 foundations merged, #411 cards open, #415 wiring open). Stacked on #415. Lands the §8 calendar header refinements (density toggle + human week label), wires DensityToggle through a new use-set-calendar-density hook, and locks in the hexagonal layering with ESLint boundary rules so future code can't bypass the hooks layer.

## What's in this PR

### User-visible
- `formatWeekLabel(weekId)` replaces "2026 W18" with "Apr 27 – May 3 · W18". Cross-month and cross-year ranges include both years for disambiguation. Falls back to the raw weekId on malformed input.
- `DensityToggle` — WAI-ARIA Switch pattern (role=switch, aria-checked) per APG §3.27. Icon reflects the next state (the action it will perform). aria-label and title agree on "Switch to <next> view".
- CalendarPage wires DensityToggle through useUserPreferences (read) and a new useSetCalendarDensity hook (write) so the components layer never touches Dexie adapters directly.

### Mechanical guards (§12.4)
- ESLint boundary rules for the SPA package mirror @kaiord/core's hexagonal layering: ports must not import adapters; application use cases must not import adapters; components must not import adapters directly (must go through hooks). Wrong-direction imports surface as eslint errors at lint time.
- no-restricted-syntax rule guards `MatchSuggestion` against redeclaration outside its canonical file (application/match-suggestion.ts). Re-enabled at the canonical owner via a per-file override.

## Deferred follow-ups (tracked here so they don't fall on the floor)

- §8.5/§8.6 — sync button refresh (icon-only with last-sync tooltip + formatRelativeTime helper)
- §9 — CoachingActivityDialog match/split actions (Linked workout section, "Match to..." picker, Split button, hide Convert when matched)
- §10.3 — AutoMatchBanner CalendarPage wiring (component is built and tested in isolation in PR #415; just needs the matchSession + dismissAutoMatchBanner integration)
- §11 — Playwright performance budget (200ms FCP / 30ms hook on 30-card synthetic week, with CDP CPU throttling)
- §12.4a — deleteProfile cascade fan-out test (transactional rollback across all five cascade tables)

The design intent is preserved — these are well-bounded, self-contained tasks that can land in follow-up PRs without re-litigating chunking decisions.

## Test plan

- pnpm vitest run: 3067 passed / 4 skipped, 0 regressions, +9 new tests
- pnpm lint clean (boundary rules pass on the existing tree)
- pnpm build clean

Generated with Claude Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added calendar density toggle allowing users to switch between compact and comfortable view modes.
  * Updated week label display to show formatted date ranges with week numbers (e.g., "Apr 27 – May 3 · W18").

* **Tests**
  * Added comprehensive test coverage for the new density toggle component.
  * Updated calendar navigation E2E tests for improved label matching.
  * Added tests for week label formatting utility.

* **Chores**
  * Enhanced ESLint configuration to enforce architectural layering rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->