### PR TITLE
chore(scripts): close R-NoUnconditionalSkip residuals

### DIFF
--- a/.claude/skills/guidelines/testing-standards/SKILL.md
+++ b/.claude/skills/guidelines/testing-standards/SKILL.md
@@ -52,11 +52,25 @@ Always import fixtures from `@kaiord/core/test-utils`. Never re-implement fixtur
 
 ## Never skip a test
 
-Never skip a test unconditionally. If a test fails, fix the code or update the test to reflect a deliberate behavior change — never silence it. The only acceptable form of skipping is a runtime-evaluated `*.skipIf(<expr>)` whose argument depends on the environment (e.g., `process.env.X`, `typeof window !== "undefined"`).
+Never skip a test unconditionally. If a test fails, fix the code or update the test to reflect a deliberate behavior change — never silence it. The acceptable forms of skipping are:
+
+1. A runtime-evaluated `*.skipIf(<expr>)` whose argument depends on the environment (e.g., `process.env.X`, `typeof window !== "undefined"`).
+2. A `*.todo(...)` call with an immediately-preceding `// TODO(YYYY-MM-DD): reason` comment whose deadline is not yet expired (Vitest's planned-test convention with a hard deadline). When the deadline passes, CI fails until the test is implemented or the deadline is extended via PR.
 
 Enforcement: `scripts/check-no-unconditional-skip.mjs` (R-NoUnconditionalSkip).
 
-The regex-based check covers two dispatch shapes mechanically: member (`it.skip("...", fn)`) and computed-member (`it["skip"]("...", fn)`). The destructured form (`const { skip } = it; skip("...", fn)`) and re-bound form (`const my = it; my.skip("...", fn)`) are documented residual risk — vanishingly rare in practice, not detected by the regex; if a contributor introduces one in the wild, file an issue and tighten the rule. The conditional `it.skipIf(<expr>)` form is allowed only when `<expr>` contains at least one `Identifier`, `MemberExpression`, `CallExpression`, or `NewExpression` node — literal-only arguments (e.g., `skipIf(true)`, `skipIf(!!1)`, ``skipIf(`true`)``) are rejected as functionally equivalent to unconditional skip.
+The check covers four dispatch shapes mechanically:
+
+1. **Member**: `it.skip("...", fn)` / `test.only(...)` / `describe.todo(...)`.
+2. **Computed-member**: `it["skip"]("...", fn)`, `test["only"](...)`, `describe["todo"](...)`.
+3. **Destructured**: `const { skip } = it; skip("...", fn);` and renames `const { only: myOnly } = test;` (depth-1).
+4. **Re-bound**: `const my = it; my.skip("...", fn);` (depth-1).
+
+Chain re-binds (e.g., `const my = it; const { skip } = my; skip(...)`) remain documented residual risk — vanishingly rare in practice and not depth-1.
+
+The conditional `it.skipIf(<expr>)` form is allowed only when `<expr>` contains at least one `Identifier`, `MemberExpression`, `CallExpression`, or `NewExpression` node — literal-only arguments (e.g., `skipIf(true)`, `skipIf(!!1)`, ``skipIf(`true`)``) are rejected as functionally equivalent to unconditional skip. The same literal-only rejection applies to `skipIf` accessed through destructured or re-bound aliases.
+
+The `*.todo` deadline allowance is recognized only when the comment is on the line **immediately above** the call (no blank line between). The date format is strictly `YYYY-MM-DD`. Once the deadline passes, the rule fails CI with the exact expired date in the message.
 
 ## Test output capture
 

--- a/openspec/specs/spa-quality-gates/spec.md
+++ b/openspec/specs/spa-quality-gates/spec.md
@@ -151,22 +151,27 @@ The script's `ALLOWLIST` MUST be the empty Set before this change is archived.
 
 The repository SHALL contain a static-source check at `scripts/check-no-unconditional-skip.mjs` that fails on any of: `it.skip`, `test.skip`, `describe.skip`, `it.only`, `test.only`, `describe.only`, `it.todo`, `test.todo` call-expression access in any `*.test.{ts,tsx}` or `*.spec.{ts,tsx}` file under `packages/`. The rule ID is `R-NoUnconditionalSkip`. The script SHALL be tested by `scripts/check-no-unconditional-skip.test.mjs` and wired into `pnpm test:scripts`.
 
-> Note on `it.todo`: rejection is currently unconditional. The team is aware this conflicts with Vitest's planned-test workflow; a follow-up `repo-quality-gates` change may revisit this decision (Open Question 2 in the proposal). Contributors blocked by this rule SHOULD open an issue rather than work around it with an empty `it("planned", () => {})`.
-
-The check SHALL recognize and reject all four syntactic dispatch shapes (mirroring the precedent in `scripts/check-no-pii-leakage.mjs`):
+The check SHALL recognize and reject all four syntactic dispatch shapes:
 
 1. **Member dispatch**: `it.skip(...)`, `test.only(...)`, `describe.todo(...)`.
 2. **Computed-member dispatch**: `it["skip"](...)`, `test["only"](...)`, `describe["todo"](...)`.
-3. **Destructured dispatch**: `const { skip } = it; skip(...);` — the script tracks `it`/`test`/`describe` destructurings within a file and treats subsequent calls to those bound names under the same rule.
-4. **Re-bound dispatch**: `const myIt = it; myIt.skip(...);` — the script tracks `const X = it|test|describe` rebindings and treats `<X>.<method>(...)` under the same rule.
+3. **Destructured dispatch**: `const { skip } = it; skip(...);` and renames `const { only: myOnly } = test;` — the script tracks depth-1 destructurings of `skip`, `only`, `todo`, and `skipIf` from `it`/`test`/`describe` and treats subsequent calls to those bound names under the same rule.
+4. **Re-bound dispatch**: `const myIt = it; myIt.skip(...);` — the script tracks depth-1 `const X = it|test|describe` rebindings and treats `<X>.<method>(...)` under the same rule.
+
+Chain re-binds (e.g., `const my = it; const { skip } = my; skip(...)`) remain documented residual risk — vanishingly rare in practice and not depth-1.
+
+#### Allowance: `*.todo` with non-expired deadline comment
+
+The check SHALL allow `*.todo(...)` calls (across all four dispatch shapes) when the line **immediately above** the call contains a comment of the form `// TODO(YYYY-MM-DD): <reason>` whose date is not yet expired (compared against the current system date). The date format is strictly `YYYY-MM-DD`. The deadline allowance applies ONLY to `*.todo` — `*.skip` and `*.only` remain unconditionally rejected. When the deadline passes, CI fails with the expired date in the message until the test is implemented or the deadline is extended via PR.
 
 The check SHALL allow the conditional forms `it.skipIf(<expr>)`, `test.skipIf(<expr>)`, `describe.skipIf(<expr>)` ONLY when `<expr>` contains at least one AST node of kind `Identifier`, `MemberExpression`, `CallExpression`, or `NewExpression`. All other constructs (literals; template literals without `${...}` substitutions; unary, binary, or logical expressions whose every reachable leaf is a literal — e.g., `!!1`, `1 + 1`, `true && true`) SHALL be rejected as literal-only because they are functionally equivalent to an unconditional skip. `NewExpression` is included so legitimate runtime forms like `skipIf(new URL(import.meta.url).hostname === "ci")` pass; the constructor invocation contributes runtime evaluation. The check SHALL apply the same four-shape dispatch detection to `skipIf` so a contributor cannot bypass via `it["skipIf"](true)` or destructured/re-bound forms.
 
-A test that cannot run unconditionally MUST take one of the three paths in `R-NoUnconditionalSkip`:
+A test that cannot run unconditionally MUST take one of the four paths in `R-NoUnconditionalSkip`:
 
 - **Path (a) — `skipIf(<runtime-expr>)`**: env-gated or feature-detected, e.g., `describe.skipIf(!process.env.GARMIN_EMAIL)`.
 - **Path (b) — fast-path replacement**: replace the skipped block with a deterministic test that asserts only what is currently true.
 - **Path (c) — deletion**: remove the test if the behavior is no longer relevant (with reasoning in the PR description).
+- **Path (d) — `*.todo` with deadline**: only for planned tests; an immediately-preceding `// TODO(YYYY-MM-DD): reason` comment with a non-expired date.
 
 The script's `ALLOWLIST` MUST be the empty Set before this change is archived.
 
@@ -207,6 +212,30 @@ The husky `pre-commit` hook SHALL run `pnpm test:scripts` BEFORE `pnpm test`, so
 - **GIVEN** a file containing `describe.skipIf(!process.env.GARMIN_EMAIL || !process.env.GARMIN_PASSWORD)("Garmin Connect Integration", ...)`
 - **WHEN** `pnpm test:scripts` runs
 - **THEN** the process exits with code 0 and stderr does NOT contain `R-NoUnconditionalSkip` for this file
+
+#### Scenario: it.todo with non-expired deadline is allowed
+
+- **GIVEN** a file containing two adjacent lines `// TODO(2030-01-01): finish auth flow` followed by `it.todo("auth flow", () => {});`
+- **WHEN** `pnpm test:scripts` runs
+- **THEN** the process exits with code 0 and stderr does NOT contain `R-NoUnconditionalSkip` for this file
+
+#### Scenario: it.todo with expired deadline is rejected
+
+- **GIVEN** a file containing two adjacent lines `// TODO(2020-01-01): finish auth flow` followed by `it.todo("auth flow", () => {});`
+- **WHEN** `pnpm test:scripts` runs
+- **THEN** the process exits with a non-zero code and stderr contains `R-NoUnconditionalSkip`, the file path, and the literal substring `expired` and the date `2020-01-01`
+
+#### Scenario: it.todo with no deadline comment is rejected
+
+- **GIVEN** a file containing `it.todo("auth flow", () => {});` with no immediately-preceding `// TODO(YYYY-MM-DD): ...` comment
+- **WHEN** `pnpm test:scripts` runs
+- **THEN** the process exits with a non-zero code and stderr contains `R-NoUnconditionalSkip` and the message `no deadline comment`
+
+#### Scenario: deadline allowance does NOT apply to .skip
+
+- **GIVEN** a file containing `// TODO(2030-01-01): fix later` immediately followed by `it.skip("renders", () => {});`
+- **WHEN** `pnpm test:scripts` runs
+- **THEN** the process exits with a non-zero code and stderr contains `R-NoUnconditionalSkip` for the `.skip` call (the deadline allowance applies only to `.todo`)
 
 ### Requirement: Conventional-commit format gate
 

--- a/scripts/check-no-unconditional-skip.mjs
+++ b/scripts/check-no-unconditional-skip.mjs
@@ -4,34 +4,39 @@
  *
  * Rule R-NoUnconditionalSkip: rejects Vitest-style unconditional skips
  * across `it`, `test`, `describe` for `.skip`, `.only`, `.todo` methods,
- * and rejects literal-only `*.skipIf(<expr>)` calls.
+ * and rejects literal-only `*.skipIf(<expr>)` calls. Covers four dispatch
+ * shapes (member, computed-member, destructured, re-bound). Allows
+ * `*.todo` only when an immediately-preceding `// TODO(YYYY-MM-DD): reason`
+ * comment carries a non-expired deadline.
  *
  * The signature determines the verdict:
  *
  *   it.skip("name", fn)   ← Vitest unconditional         REJECT
  *   it.only("name", fn)   ← Vitest single-test focus     REJECT
- *   it.todo("name")       ← Vitest unimplemented         REJECT
+ *   it.todo("name")       ← Vitest unimplemented         REJECT (unless deadline comment)
  *
  *   test.skip(cond, reason) ← Playwright runtime         ALLOW
  *   test.skip()             ← Playwright mid-body skip   ALLOW
- *   test.skip(true, "...")  ← Playwright unconditional   ALLOW (separate code smell, not this rule)
+ *   test.skip(true, "...")  ← Playwright unconditional   ALLOW (separate code smell)
  *
  *   it.skipIf(process.env.X)("name", fn)  ← runtime cond ALLOW
  *   it.skipIf(true)("name", fn)           ← literal-only REJECT
  *
- * The first-argument shape decides:
- *   - String literal as first arg              → Vitest unconditional → REJECT
- *   - Anything else (expression, no args, ...) → Playwright/runtime   → ALLOW
+ *   // TODO(2026-08-01): finish auth flow                ← deadline allowance
+ *   it.todo("auth flow", () => {});                      ALLOW (non-expired)
+ *
+ *   // TODO(2024-01-01): finish auth flow                ← expired
+ *   it.todo("auth flow", () => {});                      REJECT (deadline past)
  *
  * Four dispatch shapes covered:
- *   1. Member dispatch         it.skip("...", fn)
- *   2. Computed-member         it["skip"]("...", fn)
+ *   1. Member dispatch        it.skip("...", fn)
+ *   2. Computed-member        it["skip"]("...", fn)
+ *   3. Destructured           const { skip } = it; skip("...", fn)
+ *   4. Re-bound               const my = it; my.skip("...", fn)
  *
- * Destructured (`const { skip } = it; skip("...", fn)`) and re-bound
- * (`const my = it; my.skip("...", fn)`) dispatch are documented as
- * residual risk — not covered by this rule's regex implementation. They
- * are vanishingly rare in practice. If a contributor finds a case in the
- * wild, file an issue and tighten the rule.
+ * Aliases are resolved depth-1 (direct destructure or re-bind from
+ * `it|test|describe`). Chains (e.g., `const my = it; const { skip } = my;`)
+ * remain documented residual risk; vanishingly rare in practice.
  *
  * Modes:
  *   --dry-run    Emit violations as JSON on stdout; exit 0.
@@ -50,39 +55,32 @@ const PACKAGES_ROOT = resolve(REPO_ROOT, "packages");
 
 const TEST_FILE_RE = /\.(test|spec)\.(ts|tsx|js|mjs)$/;
 
-// Strip block + line comments before scanning so commentary mentioning
-// `it.skip(` does not trigger.
 const BLOCK_COMMENT_RE = /\/\*[\s\S]*?\*\//g;
 const LINE_COMMENT_RE = /(^|[^:])\/\/[^\n]*/g;
 
-// Vitest unconditional pattern: <it|test|describe>.<skip|only|todo>("...
 const MEMBER_VITEST_RE =
   /\b(it|test|describe)\.(skip|only|todo)\s*\(\s*(['"`])/g;
-
-// Computed-member equivalent: <it|test|describe>["skip"|"only"|"todo"]("...
 const COMPUTED_VITEST_RE =
   /\b(it|test|describe)\s*\[\s*['"](skip|only|todo)['"]\s*\]\s*\(\s*(['"`])/g;
-
-// skipIf pattern: <it|test|describe>.skipIf(<expr>)
 const MEMBER_SKIPIF_RE = /\b(it|test|describe)\.skipIf\s*\(/g;
 const COMPUTED_SKIPIF_RE =
   /\b(it|test|describe)\s*\[\s*['"]skipIf['"]\s*\]\s*\(/g;
 
-// Pure-literal expressions for skipIf-arg rejection. We accept a node only
-// if it contains at least one Identifier, MemberExpression, CallExpression,
-// or NewExpression. Approximation (regex, not AST):
-//
-//   - The argument string after stripping whitespace + parens consists
-//     ENTIRELY of literal-shape tokens: bool/null/undefined keywords,
-//     numeric literals, string literals (any quote style), and operators
-//     `! && || + - * / ( ) , `, possibly with surrounding whitespace.
-//
-// If a non-literal token (any letter sequence not in the literal-keyword
-// set, any backtick template with `${...}`) is present, the call is
-// runtime-evaluated → ALLOW.
+// `const { skip, only: myOnly } = it;` — destructure from it/test/describe
+const DESTRUCTURE_RE =
+  /\bconst\s*\{\s*([^}]+)\s*\}\s*=\s*(it|test|describe)\b/g;
+
+// `const my = it;` — re-bind it/test/describe to a new identifier
+const REBIND_RE =
+  /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*(it|test|describe)\b\s*;?\s*(?:\/\/|$|[\r\n])/gm;
+
+// `// TODO(YYYY-MM-DD): reason` — deadline allowance for .todo
+const DEADLINE_COMMENT_RE =
+  /^\s*\/\/\s*TODO\s*\(\s*(\d{4}-\d{2}-\d{2})\s*\)\s*:?/;
+
 const LITERAL_KEYWORDS = new Set(["true", "false", "null", "undefined"]);
 
-// R-NoUnconditionalSkip: drained in PR4 of guidelines-compliance-harden.
+// R-NoUnconditionalSkip: must remain empty. Re-seeding requires an OpenSpec amendment.
 export const ALLOWLIST = new Set([]);
 
 function relForRule(file) {
@@ -90,8 +88,6 @@ function relForRule(file) {
 }
 
 function stripComments(src) {
-  // Preserve line numbers by replacing comments with whitespace of equal
-  // length and preserving any newlines they contained.
   let out = src.replace(BLOCK_COMMENT_RE, (m) => m.replace(/[^\n]/g, " "));
   out = out.replace(
     LINE_COMMENT_RE,
@@ -108,20 +104,17 @@ function lineOf(src, idx) {
   return line;
 }
 
-// Scan forward from `(` to find balanced `)`; return the inner argument
-// string (without the parens). Quotes are honored at a basic level.
 function captureBalanced(src, openParenIdx) {
   let depth = 0;
   let i = openParenIdx;
   let out = "";
   let quote = null;
-  let templateDepth = 0; // ${...} inside backticks
+  let templateDepth = 0;
   for (; i < src.length; i++) {
     const c = src[i];
     if (quote) {
       out += c;
       if (c === "\\") {
-        // Skip next char
         if (i + 1 < src.length) {
           out += src[i + 1];
           i++;
@@ -163,16 +156,10 @@ function captureBalanced(src, openParenIdx) {
 }
 
 function looksLiteralOnly(arg) {
-  // Strip strings (replaced with whitespace, NOT identifier-shaped chars)
-  // and backtick templates without ${...} (whitespace). If any backtick
-  // template contains ${...}, the call is runtime-evaluated → return false.
   let s = arg;
-
-  // Replace "..." and '...' string literals with spaces of equal length.
   s = s.replace(/"([^"\\]|\\.)*"/g, (m) => " ".repeat(m.length));
   s = s.replace(/'([^'\\]|\\.)*'/g, (m) => " ".repeat(m.length));
 
-  // Walk backtick templates manually so we can detect ${...}.
   let out = "";
   let i = 0;
   while (i < s.length) {
@@ -199,11 +186,7 @@ function looksLiteralOnly(arg) {
         }
         j++;
       }
-      if (hasInterp) {
-        // Template literal with substitution → runtime
-        return false;
-      }
-      // Replace the entire `...` block with spaces of equal length.
+      if (hasInterp) return false;
       out += " ".repeat(j - i + 1);
       i = j + 1;
       continue;
@@ -213,9 +196,6 @@ function looksLiteralOnly(arg) {
   }
   s = out;
 
-  // Any letter sequence not in LITERAL_KEYWORDS implies an identifier
-  // reference / call → runtime. (After stripping string + template
-  // literals to whitespace, only structural identifiers remain.)
   const idTokens = s.match(/[A-Za-z_$][\w$]*/g) ?? [];
   for (const tok of idTokens) {
     if (!LITERAL_KEYWORDS.has(tok)) return false;
@@ -223,36 +203,155 @@ function looksLiteralOnly(arg) {
   return true;
 }
 
+// Resolve aliases declared via destructure or re-bind in this file.
+// Returns:
+//   destructuredAliases: Map<localName, { origin: "skip"|"only"|"todo"|"skipIf", root: "it"|"test"|"describe" }>
+//   reboundAliases: Map<localName, "it"|"test"|"describe">
+function findAliases(cleaned) {
+  const destructured = new Map();
+  const rebound = new Map();
+
+  for (const m of cleaned.matchAll(DESTRUCTURE_RE)) {
+    const bindings = m[1];
+    const root = m[2];
+    for (const part of bindings.split(",")) {
+      const trimmed = part.trim();
+      const match = trimmed.match(
+        /^(skip|only|todo|skipIf)\s*(?::\s*([A-Za-z_$][\w$]*))?\s*$/
+      );
+      if (!match) continue;
+      const origin = match[1];
+      const local = match[2] ?? match[1];
+      destructured.set(local, { origin, root });
+    }
+  }
+
+  for (const m of cleaned.matchAll(REBIND_RE)) {
+    const local = m[1];
+    const root = m[2];
+    if (local === root) continue; // const it = it (no-op)
+    if (destructured.has(local) || ["it", "test", "describe"].includes(local)) {
+      continue;
+    }
+    rebound.set(local, root);
+  }
+
+  return { destructured, rebound };
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Find a `// TODO(YYYY-MM-DD)` deadline comment immediately preceding the
+// given source position. "Immediately preceding" = the last non-empty line
+// before the call's line. Returns the parsed Date, or null if no comment
+// found / malformed / line too far away.
+function findDeadlineComment(originalSource, callIdx) {
+  // Walk back to find the start of the call's line.
+  let lineStart = callIdx;
+  while (lineStart > 0 && originalSource[lineStart - 1] !== "\n") lineStart--;
+
+  // Walk back further to find the end of the previous non-empty line.
+  let prevLineEnd = lineStart - 1; // points at \n of previous line
+  while (prevLineEnd >= 0 && originalSource[prevLineEnd] === "\n") {
+    prevLineEnd--;
+  }
+  if (prevLineEnd < 0) return null;
+
+  // Walk back to the start of that previous line.
+  let prevLineStart = prevLineEnd;
+  while (prevLineStart > 0 && originalSource[prevLineStart - 1] !== "\n") {
+    prevLineStart--;
+  }
+  const prevLine = originalSource.slice(prevLineStart, prevLineEnd + 1);
+
+  // Adjacency: only the line immediately above counts. If there were blank
+  // lines between, prevLineEnd would have skipped past them — so the comment
+  // must be on the line directly above (no blanks). Reject if the call's
+  // line and the previous line are not contiguous (blank lines between).
+  // Detect by checking that lineStart - 1 is the newline at prevLineEnd.
+  if (lineStart - 1 !== prevLineEnd + 1 && lineStart - 1 !== prevLineEnd) {
+    return null;
+  }
+
+  const m = prevLine.match(DEADLINE_COMMENT_RE);
+  if (!m) return null;
+  const dateStr = m[1];
+  const parsed = new Date(`${dateStr}T23:59:59Z`);
+  if (Number.isNaN(parsed.valueOf())) return null;
+  return { date: parsed, dateStr };
+}
+
+function isTodoDeadlineNonExpired(originalSource, callIdx) {
+  const found = findDeadlineComment(originalSource, callIdx);
+  if (!found) return { ok: false, reason: "no deadline comment" };
+  const now = new Date();
+  if (found.date.valueOf() < now.valueOf()) {
+    return {
+      ok: false,
+      reason: `deadline ${found.dateStr} has expired (today is ${now.toISOString().slice(0, 10)})`,
+    };
+  }
+  return { ok: true, dateStr: found.dateStr };
+}
+
 function checkFile(file, source) {
   const violations = [];
   const cleaned = stripComments(source);
   const rel = relForRule(file);
 
-  // 1. Vitest unconditional pattern (member dispatch)
+  // 1. Member dispatch: it.skip("...", fn) etc.
   for (const m of cleaned.matchAll(MEMBER_VITEST_RE)) {
+    const method = m[2];
+    if (method === "todo") {
+      const verdict = isTodoDeadlineNonExpired(source, m.index);
+      if (verdict.ok) continue;
+      const line = lineOf(cleaned, m.index);
+      violations.push({
+        rule: "R-NoUnconditionalSkip",
+        file: rel,
+        line,
+        detail: `${m[1]}.todo(<string>) — ${verdict.reason}. Add an immediately-preceding "// TODO(YYYY-MM-DD): reason" comment with a non-expired deadline, or remove the .todo.`,
+      });
+      continue;
+    }
     const line = lineOf(cleaned, m.index);
     violations.push({
       rule: "R-NoUnconditionalSkip",
       file: rel,
       line,
-      detail: `${m[1]}.${m[2]}(<string>, fn) is an unconditional Vitest skip. Convert to ${m[1]}.skipIf(<runtime-expr>) or fix the underlying issue.`,
+      detail: `${m[1]}.${method}(<string>, fn) is an unconditional Vitest skip. Convert to ${m[1]}.skipIf(<runtime-expr>) or fix the underlying issue.`,
     });
   }
 
-  // 2. Vitest unconditional pattern (computed-member dispatch)
+  // 2. Computed-member dispatch: it["skip"]("...", fn) etc.
   for (const m of cleaned.matchAll(COMPUTED_VITEST_RE)) {
+    const method = m[2];
+    if (method === "todo") {
+      const verdict = isTodoDeadlineNonExpired(source, m.index);
+      if (verdict.ok) continue;
+      const line = lineOf(cleaned, m.index);
+      violations.push({
+        rule: "R-NoUnconditionalSkip",
+        file: rel,
+        line,
+        detail: `${m[1]}["todo"](<string>) — ${verdict.reason}. Add an immediately-preceding "// TODO(YYYY-MM-DD): reason" comment, or remove the .todo.`,
+      });
+      continue;
+    }
     const line = lineOf(cleaned, m.index);
     violations.push({
       rule: "R-NoUnconditionalSkip",
       file: rel,
       line,
-      detail: `${m[1]}["${m[2]}"](<string>, fn) is an unconditional Vitest skip via computed-member dispatch.`,
+      detail: `${m[1]}["${method}"](<string>, fn) is an unconditional Vitest skip via computed-member dispatch.`,
     });
   }
 
   // 3. skipIf with literal-only argument (member dispatch)
   for (const m of cleaned.matchAll(MEMBER_SKIPIF_RE)) {
-    const openParen = m.index + m[0].length - 1; // position of `(`
+    const openParen = m.index + m[0].length - 1;
     const { inner } = captureBalanced(cleaned, openParen);
     if (looksLiteralOnly(inner)) {
       const line = lineOf(cleaned, m.index);
@@ -277,6 +376,100 @@ function checkFile(file, source) {
         line,
         detail: `${m[1]}["skipIf"](${inner.trim()}) — argument must contain at least one runtime-evaluated node.`,
       });
+    }
+  }
+
+  // 5. Destructured + re-bound dispatch shapes
+  const { destructured, rebound } = findAliases(cleaned);
+
+  // 5a. Destructured: `const { skip } = it; skip("...", fn);`
+  for (const [localName, { origin, root }] of destructured.entries()) {
+    const callRe = new RegExp(`(?<![.\\w$])${escapeRe(localName)}\\s*\\(`, "g");
+    for (const m of cleaned.matchAll(callRe)) {
+      const openParen = m.index + m[0].length - 1;
+      const { inner } = captureBalanced(cleaned, openParen);
+      const line = lineOf(cleaned, m.index);
+      if (origin === "skipIf") {
+        if (looksLiteralOnly(inner)) {
+          violations.push({
+            rule: "R-NoUnconditionalSkip",
+            file: rel,
+            line,
+            detail: `${localName}(${inner.trim()}) — destructured from \`${root}.skipIf\`; argument must be runtime-evaluated, literal-only is rejected.`,
+          });
+        }
+        continue;
+      }
+      // skip / only / todo via destructured alias
+      const firstArgChar = inner.trim().charAt(0);
+      const isStringLiteralFirstArg =
+        firstArgChar === '"' || firstArgChar === "'" || firstArgChar === "`";
+      if (!isStringLiteralFirstArg) continue;
+      if (origin === "todo") {
+        const verdict = isTodoDeadlineNonExpired(source, m.index);
+        if (verdict.ok) continue;
+        violations.push({
+          rule: "R-NoUnconditionalSkip",
+          file: rel,
+          line,
+          detail: `${localName}(<string>) — destructured from \`${root}.todo\`; ${verdict.reason}. Add a "// TODO(YYYY-MM-DD): reason" comment or remove the call.`,
+        });
+        continue;
+      }
+      violations.push({
+        rule: "R-NoUnconditionalSkip",
+        file: rel,
+        line,
+        detail: `${localName}(<string>, fn) — destructured from \`${root}.${origin}\`; unconditional Vitest skip via destructured dispatch.`,
+      });
+    }
+  }
+
+  // 5b. Re-bound: `const my = it; my.skip("...", fn);`
+  for (const [localName, root] of rebound.entries()) {
+    // Match `<local>.<skip|only|todo>(<string>` (member dispatch via re-bind)
+    const memberRe = new RegExp(
+      `(?<![.\\w$])${escapeRe(localName)}\\.(skip|only|todo)\\s*\\(\\s*(['"\`])`,
+      "g"
+    );
+    for (const m of cleaned.matchAll(memberRe)) {
+      const method = m[1];
+      const line = lineOf(cleaned, m.index);
+      if (method === "todo") {
+        const verdict = isTodoDeadlineNonExpired(source, m.index);
+        if (verdict.ok) continue;
+        violations.push({
+          rule: "R-NoUnconditionalSkip",
+          file: rel,
+          line,
+          detail: `${localName}.todo(<string>) — re-bound from \`${root}\`; ${verdict.reason}.`,
+        });
+        continue;
+      }
+      violations.push({
+        rule: "R-NoUnconditionalSkip",
+        file: rel,
+        line,
+        detail: `${localName}.${method}(<string>, fn) — re-bound from \`${root}\`; unconditional Vitest skip via re-bound dispatch.`,
+      });
+    }
+    // Match `<local>.skipIf(<expr>)` (re-bound skipIf)
+    const skipIfRe = new RegExp(
+      `(?<![.\\w$])${escapeRe(localName)}\\.skipIf\\s*\\(`,
+      "g"
+    );
+    for (const m of cleaned.matchAll(skipIfRe)) {
+      const openParen = m.index + m[0].length - 1;
+      const { inner } = captureBalanced(cleaned, openParen);
+      if (looksLiteralOnly(inner)) {
+        const line = lineOf(cleaned, m.index);
+        violations.push({
+          rule: "R-NoUnconditionalSkip",
+          file: rel,
+          line,
+          detail: `${localName}.skipIf(${inner.trim()}) — re-bound from \`${root}.skipIf\`; literal-only argument is rejected.`,
+        });
+      }
     }
   }
 

--- a/scripts/check-no-unconditional-skip.test.mjs
+++ b/scripts/check-no-unconditional-skip.test.mjs
@@ -301,3 +301,200 @@ describe("scope", () => {
     assert.equal(ALLOWLIST.size, 0);
   });
 });
+
+describe("destructured dispatch (REJECT)", () => {
+  test("rejects const { skip } = it; skip('name', fn);", () => {
+    write("a/x.test.ts", `const { skip } = it;\nskip("renders", () => {});\n`);
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+    assert.equal(v[0].rule, "R-NoUnconditionalSkip");
+    assert.match(v[0].detail, /destructured/);
+  });
+
+  test("rejects const { only: myOnly } = test; myOnly('name', fn);", () => {
+    write(
+      "a/x.test.ts",
+      `const { only: myOnly } = test;\nmyOnly("focused", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+    assert.match(v[0].detail, /test\.only/);
+  });
+
+  test("rejects destructured todo without deadline comment", () => {
+    write("a/x.test.ts", `const { todo } = it;\ntodo("planned", () => {});\n`);
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+    assert.match(v[0].detail, /no deadline comment|TODO\(/);
+  });
+
+  test("rejects destructured skipIf with literal-only argument", () => {
+    write(
+      "a/x.test.ts",
+      `const { skipIf } = it;\nskipIf(true)("blocked", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+    assert.match(v[0].detail, /skipIf/);
+  });
+
+  test("allows destructured skipIf with runtime expression", () => {
+    write(
+      "a/x.test.ts",
+      `const { skipIf } = it;\nskipIf(process.env.X)("conditional", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 0);
+  });
+
+  test("ignores destructure from a non-test source", () => {
+    write("a/x.test.ts", `const { skip } = lodash;\nskip(arr, 5);\n`);
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 0);
+  });
+});
+
+describe("re-bound dispatch (REJECT)", () => {
+  test("rejects const my = it; my.skip('name', fn);", () => {
+    write("a/x.test.ts", `const my = it;\nmy.skip("renders", () => {});\n`);
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+    assert.match(v[0].detail, /re-bound/);
+  });
+
+  test("rejects const t = test; t.only('name', fn);", () => {
+    write("a/x.test.ts", `const t = test;\nt.only("focused", () => {});\n`);
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+  });
+
+  test("rejects re-bound skipIf with literal-only argument", () => {
+    write(
+      "a/x.test.ts",
+      `const my = it;\nmy.skipIf(true)("blocked", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+    assert.match(v[0].detail, /re-bound/);
+  });
+
+  test("allows re-bound skipIf with runtime expression", () => {
+    write(
+      "a/x.test.ts",
+      `const my = it;\nmy.skipIf(process.env.X)("conditional", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 0);
+  });
+});
+
+describe("it.todo deadline allowance", () => {
+  test("allows it.todo with non-expired deadline comment", () => {
+    write(
+      "a/x.test.ts",
+      `// TODO(2030-01-01): finish auth flow\nit.todo("auth flow", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 0);
+  });
+
+  test("rejects it.todo with expired deadline comment", () => {
+    write(
+      "a/x.test.ts",
+      `// TODO(2020-01-01): finish auth flow\nit.todo("auth flow", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+    assert.match(v[0].detail, /expired/);
+  });
+
+  test("rejects it.todo with no comment", () => {
+    write("a/x.test.ts", `it.todo("name", () => {});\n`);
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+    assert.match(v[0].detail, /no deadline comment/);
+  });
+
+  test("rejects it.todo with comment but no date", () => {
+    write("a/x.test.ts", `// TODO: finish later\nit.todo("name", () => {});\n`);
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+    assert.match(v[0].detail, /no deadline comment/);
+  });
+
+  test("rejects it.todo when deadline comment is two lines above (not adjacent)", () => {
+    write(
+      "a/x.test.ts",
+      `// TODO(2030-01-01): finish auth flow\n\nit.todo("auth flow", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 1);
+    assert.match(v[0].detail, /no deadline comment/);
+  });
+
+  test("allows test.todo with non-expired deadline comment", () => {
+    write(
+      "a/x.test.ts",
+      `// TODO(2030-12-31): refactor flow\ntest.todo("refactor", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 0);
+  });
+
+  test("does NOT apply deadline allowance to .skip", () => {
+    write(
+      "a/x.test.ts",
+      `// TODO(2030-01-01): fix later\nit.skip("renders", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    // .skip is rejected unconditionally; the deadline allowance only
+    // applies to .todo (Vitest planned-test convention).
+    assert.equal(v.length, 1);
+    assert.match(v[0].detail, /unconditional Vitest skip/);
+  });
+
+  test("allows destructured todo with non-expired deadline", () => {
+    write(
+      "a/x.test.ts",
+      `const { todo } = it;\n// TODO(2030-01-01): fix later\ntodo("auth flow", () => {});\n`
+    );
+
+    const v = runCheck({ packagesRoot: sandbox });
+
+    assert.equal(v.length, 0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the two residual concerns flagged on PR #419 and listed as deferred follow-ups in `design.md` of the archived `guidelines-compliance-harden`.

## What this PR does

### 1. Destructured + re-bound dispatch detection

`scripts/check-no-unconditional-skip.mjs` now catches all four dispatch shapes (was: two):

```ts
// REJECTED — destructured (with optional rename)
const { skip } = it;            skip("renders", () => {});
const { only: myOnly } = test;  myOnly("focused", () => {});
const { skipIf } = it;          skipIf(true)("blocked", () => {});

// REJECTED — re-bound
const my = it;  my.skip("renders", () => {});
const t = test; t.only("focused", () => {});
const my = it;  my.skipIf(true)("blocked", () => {});
```

Aliases are resolved depth-1 directly from `it`/`test`/`describe`. Chains like `const my = it; const { skip } = my; skip(...)` remain documented residual risk (rare in practice).

### 2. `*.todo` deadline allowance

A new path (d) in `R-NoUnconditionalSkip`: a `*.todo(...)` call is allowed when the line **immediately above** carries `// TODO(YYYY-MM-DD): reason` with a non-expired date. The allowance applies ONLY to `.todo` — `.skip` and `.only` stay unconditionally rejected.

```ts
// TODO(2030-01-01): finish auth flow
it.todo("auth flow", () => {});                  // ✅ allowed (non-expired)

// TODO(2020-01-01): finish auth flow
it.todo("auth flow", () => {});                  // ❌ REJECTED — deadline passed

it.todo("auth flow", () => {});                  // ❌ REJECTED — no deadline comment

// TODO(2030-01-01): fix later
it.skip("renders", () => {});                    // ❌ REJECTED — allowance only applies to .todo
```

When a deadline passes, CI fails with the expired date in the message until the test is implemented or the deadline is extended via PR.

## Validation

- ✅ 48/48 unit tests pass (was 30; +18 new for destructured/re-bound/deadline cases)
- ✅ `pnpm test:scripts` clean
- ✅ `pnpm -r build` clean
- ✅ `pnpm lint` clean (R-AllowlistsEmpty in error mode; R-NoUnconditionalSkip ALLOWLIST stays empty)
- ✅ `pnpm lint:specs` 29/29 pass

## Spec changes

- `openspec/specs/spa-quality-gates/spec.md`: R-NoUnconditionalSkip requirement updated to enumerate four shapes mechanically (was: two with two as residual risk); path (d) added to the test-cannot-run-unconditionally list; 4 new scenarios for the deadline allowance.
- `.claude/skills/guidelines/testing-standards/SKILL.md`: same updates in the human-facing guidelines.

## Changeset

**NO changeset** — root tooling only (script + spec + SKILL.md); no published `@kaiord/*` package's behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)