### PR TITLE
feat(spa-editor): profile-snapshot push pipeline (bridge-popup-redesign PR2/7)

### DIFF
--- a/.changeset/bridge-popup-redesign-spa-push-pipeline.md
+++ b/.changeset/bridge-popup-redesign-spa-push-pipeline.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Add SPA-side foundation for the bridge popup profile-snapshot push: pure mapper from domain `Profile` to `ProfileSnapshot`, push adapter with content-fingerprint de-duplication via `@kaiord/core`'s `fingerprintSnapshot`, Dexie v6 schema migration that backfills `pendingClear: false` and `lastSuccessfulFingerprint: null` on existing bridge rows, and an extension of the R-PIIInterpolation guard to the bridge adapter directory. The trigger wiring (active-profile mutation effect, bridge-VERIFIED transition, profile-deletion clear) lands in a follow-up commit on the same PR.

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-registry-helpers.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-registry-helpers.ts
@@ -27,7 +27,7 @@ export function parseManifestFromPing(
   if (!response.ok || !response.data) return null;
   const result = bridgeManifestSchema.safeParse(response.data);
   if (!result.success) {
-    console.warn(`Bridge ${extensionId}: invalid manifest`);
+    console.warn("Bridge: invalid manifest", { extensionId });
     return null;
   }
   return {

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-types.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-types.ts
@@ -24,6 +24,22 @@ export type RegisteredBridge = {
    * transition). Undefined for bridges never marked removed.
    */
   removedAt?: number;
+  /**
+   * Content fingerprint of the most recent successful `profile-snapshot`
+   * push to this bridge (FNV-1a 32-bit hex via `fingerprintSnapshot`
+   * from `@kaiord/core`). The SPA skips a push whose fingerprint
+   * matches this value, so consecutive pushes of identical content
+   * collapse to one transport call. `null` / `undefined` means no
+   * successful push has been recorded yet.
+   */
+  lastSuccessfulFingerprint?: string | null;
+  /**
+   * Right-to-be-forgotten flag: set when the user deletes the active
+   * profile while this bridge is UNAVAILABLE. The next VERIFIED
+   * transition emits `profile-snapshot-clear` BEFORE any fresh snapshot
+   * push, then clears the flag.
+   */
+  pendingClear?: boolean;
 };
 
 export type BridgePersistedRow = Omit<RegisteredBridge, never>;

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
@@ -7,6 +7,16 @@
 
 import Dexie from "dexie";
 
+import {
+  backfillBridgeSnapshotState,
+  backfillUsageRow,
+} from "./dexie-migrations";
+
+export {
+  backfillBridgeSnapshotState,
+  backfillUsageRow,
+} from "./dexie-migrations";
+
 const CORE_V1 = {
   workouts: "id, date, [date+state], [source+sourceId], sport, *tags",
   templates: "id, sport, *tags",
@@ -67,22 +77,19 @@ export class KaiordDatabase extends Dexie {
     // All new tables are empty on first load; no existing rows are mutated.
     // Forward-only: opening an older bundle against a v5 DB raises VersionError.
     this.version(5).stores(CORE_V5);
-  }
-}
-
-export function backfillUsageRow(row: Record<string, unknown>): void {
-  if (typeof row.inputTokens === "number") return;
-  const total = typeof row.totalTokens === "number" ? row.totalTokens : 0;
-  row.inputTokens = total;
-  row.outputTokens = 0;
-  row.legacy = true;
-
-  if (Array.isArray(row.entries)) {
-    row.entries = row.entries.map((entry: Record<string, unknown>) => {
-      if (typeof entry.inputTokens === "number") return entry;
-      const tokens = typeof entry.tokens === "number" ? entry.tokens : 0;
-      return { ...entry, inputTokens: tokens, outputTokens: 0 };
-    });
+    // v6 — bridge profile-snapshot push: backfills `pendingClear: false`
+    // and `lastSuccessfulFingerprint: null` on existing bridge rows so
+    // the snapshot pusher's de-dup and right-to-be-forgotten paths can
+    // assume well-defined state. Stores config is unchanged (the new
+    // fields are non-indexed); the upgrade only touches data.
+    this.version(6)
+      .stores(CORE_V5)
+      .upgrade(async (tx) => {
+        await tx
+          .table("bridges")
+          .toCollection()
+          .modify(backfillBridgeSnapshotState);
+      });
   }
 }
 

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-migrations.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-migrations.ts
@@ -1,0 +1,36 @@
+/**
+ * Dexie Migration Helpers
+ *
+ * Pure row-level upgrade functions. Co-located with `dexie-database.ts`
+ * but split out so the database class stays under the per-file line cap.
+ */
+
+export function backfillUsageRow(row: Record<string, unknown>): void {
+  if (typeof row.inputTokens === "number") return;
+  const total = typeof row.totalTokens === "number" ? row.totalTokens : 0;
+  row.inputTokens = total;
+  row.outputTokens = 0;
+  row.legacy = true;
+
+  if (Array.isArray(row.entries)) {
+    row.entries = row.entries.map((entry: Record<string, unknown>) => {
+      if (typeof entry.inputTokens === "number") return entry;
+      const tokens = typeof entry.tokens === "number" ? entry.tokens : 0;
+      return { ...entry, inputTokens: tokens, outputTokens: 0 };
+    });
+  }
+}
+
+/**
+ * v5 → v6: defaults `pendingClear` and `lastSuccessfulFingerprint` on
+ * existing bridge rows so the profile-snapshot pusher can rely on
+ * well-defined state.
+ */
+export function backfillBridgeSnapshotState(
+  row: Record<string, unknown>
+): void {
+  if (typeof row.pendingClear !== "boolean") row.pendingClear = false;
+  if (row.lastSuccessfulFingerprint === undefined) {
+    row.lastSuccessfulFingerprint = null;
+  }
+}

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v6-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v6-migration.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Forward migration v5 → v6 — bridge snapshot-state backfill.
+ *
+ * Existing bridge rows MUST gain `pendingClear: false` and
+ * `lastSuccessfulFingerprint: null` defaults so the snapshot pusher's
+ * de-dup and right-to-be-forgotten paths can rely on well-defined
+ * state. All other rows MUST round-trip byte-identically.
+ */
+import "fake-indexeddb/auto";
+
+import Dexie from "dexie";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { backfillBridgeSnapshotState, KaiordDatabase } from "./dexie-database";
+
+const dbName = (suffix: string) => `kaiord-test-v6-${suffix}-${Date.now()}`;
+
+const seedV5 = async (name: string): Promise<void> => {
+  const v5 = new Dexie(name);
+  v5.version(1).stores({ bridges: "extensionId, status, lastSeen" });
+  v5.version(5).stores({ bridges: "extensionId, status, lastSeen" });
+  await v5.open();
+  await v5.table("bridges").bulkPut([
+    {
+      extensionId: "ext-legacy-verified",
+      id: "garmin-bridge",
+      name: "Garmin",
+      version: "7.0.0",
+      protocolVersion: 1,
+      capabilities: ["write:workouts"],
+      status: "verified",
+      lastSeen: "2026-04-30T00:00:00.000Z",
+      failCount: 0,
+    },
+    {
+      extensionId: "ext-legacy-unavailable",
+      id: "train2go-bridge",
+      name: "Train2Go",
+      version: "7.0.0",
+      protocolVersion: 1,
+      capabilities: ["read:training-plan"],
+      status: "unavailable",
+      lastSeen: "2026-04-29T12:00:00.000Z",
+      failCount: 3,
+    },
+  ]);
+  v5.close();
+};
+
+describe("Dexie v5 → v6 migration", () => {
+  let name: string;
+
+  beforeEach(() => {
+    name = dbName("backfill");
+  });
+
+  afterEach(async () => {
+    await Dexie.delete(name);
+  });
+
+  it("backfills pendingClear=false and lastSuccessfulFingerprint=null on existing bridges", async () => {
+    await seedV5(name);
+
+    const v6 = new KaiordDatabase(name);
+    await v6.open();
+    const rows = await v6.table("bridges").toArray();
+    v6.close();
+
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.pendingClear).toBe(false);
+      expect(row.lastSuccessfulFingerprint).toBeNull();
+    }
+  });
+
+  it("preserves existing fields verbatim", async () => {
+    await seedV5(name);
+
+    const v6 = new KaiordDatabase(name);
+    await v6.open();
+    const verified = await v6.table("bridges").get("ext-legacy-verified");
+    v6.close();
+
+    expect(verified).toMatchObject({
+      extensionId: "ext-legacy-verified",
+      id: "garmin-bridge",
+      name: "Garmin",
+      version: "7.0.0",
+      protocolVersion: 1,
+      capabilities: ["write:workouts"],
+      status: "verified",
+      lastSeen: "2026-04-30T00:00:00.000Z",
+      failCount: 0,
+    });
+  });
+});
+
+describe("backfillBridgeSnapshotState", () => {
+  it("sets defaults on a row missing both fields", () => {
+    const row: Record<string, unknown> = { extensionId: "ext-1" };
+
+    backfillBridgeSnapshotState(row);
+
+    expect(row.pendingClear).toBe(false);
+    expect(row.lastSuccessfulFingerprint).toBeNull();
+  });
+
+  it("preserves an existing pendingClear=true value", () => {
+    const row: Record<string, unknown> = {
+      extensionId: "ext-1",
+      pendingClear: true,
+      lastSuccessfulFingerprint: "deadbeef",
+    };
+
+    backfillBridgeSnapshotState(row);
+
+    expect(row.pendingClear).toBe(true);
+    expect(row.lastSuccessfulFingerprint).toBe("deadbeef");
+  });
+});

--- a/packages/workout-spa-editor/src/lib/profile-snapshot/profile-to-snapshot.test.ts
+++ b/packages/workout-spa-editor/src/lib/profile-snapshot/profile-to-snapshot.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+
+import type { Profile } from "../../types/profile";
+
+import { profileToSnapshot } from "./profile-to-snapshot";
+
+const FIXED_NOW = new Date("2026-05-01T08:30:00.000Z");
+
+const baseProfile: Profile = {
+  id: "11111111-1111-4111-8111-111111111111",
+  name: "Pablo",
+  bodyWeight: 72,
+  sportZones: {
+    cycling: {
+      thresholds: { ftp: 270, lthr: 168 },
+      heartRateZones: { method: "manual", zones: [] },
+      powerZones: { method: "manual", zones: [] },
+    },
+    running: {
+      thresholds: { lthr: 170, thresholdPace: 4.25, paceUnit: "min_per_km" },
+      heartRateZones: { method: "manual", zones: [] },
+      paceZones: { method: "manual", zones: [] },
+    },
+    swimming: {
+      thresholds: { thresholdPace: 1.45, paceUnit: "min_per_100m" },
+      heartRateZones: { method: "manual", zones: [] },
+      paceZones: { method: "manual", zones: [] },
+    },
+  },
+  linkedAccounts: [],
+  createdAt: FIXED_NOW.toISOString(),
+  updatedAt: FIXED_NOW.toISOString(),
+};
+
+describe("profileToSnapshot", () => {
+  it("derives a baseline cycling snapshot", () => {
+    const snapshot = profileToSnapshot(baseProfile, "cycling", FIXED_NOW);
+
+    expect(snapshot.schemaVersion).toBe(1);
+    expect(snapshot.profile.name).toBe("Pablo");
+    expect(snapshot.profile.bodyWeight).toBe(72);
+    expect(snapshot.activeSport).toBe("cycling");
+    expect(snapshot.thresholds.cycling?.ftp).toBe(270);
+    expect(snapshot.heartRate?.lthr).toBe(168);
+    expect(snapshot.generatedAt).toBe(FIXED_NOW.toISOString());
+  });
+
+  it("converts running pace from min/km to seconds/km", () => {
+    const snapshot = profileToSnapshot(baseProfile, "running", FIXED_NOW);
+
+    expect(snapshot.thresholds.running?.thresholdPaceSecPerKm).toBe(255);
+    expect(snapshot.thresholds.running?.lthr).toBe(170);
+    expect(snapshot.heartRate?.lthr).toBe(170);
+  });
+
+  it("converts swimming pace from min/100m to seconds/100m", () => {
+    const snapshot = profileToSnapshot(baseProfile, "swimming", FIXED_NOW);
+
+    expect(snapshot.thresholds.swimming?.cssPaceSecPer100m).toBe(87);
+    expect(snapshot.activeSport).toBe("swimming");
+  });
+
+  it("omits bodyWeight when undefined on the profile", () => {
+    const profile: Profile = { ...baseProfile, bodyWeight: undefined };
+
+    const snapshot = profileToSnapshot(profile, "cycling", FIXED_NOW);
+
+    expect(snapshot.profile.bodyWeight).toBeUndefined();
+  });
+
+  it("omits activeSport when caller passes undefined", () => {
+    const snapshot = profileToSnapshot(baseProfile, undefined, FIXED_NOW);
+
+    expect(snapshot.activeSport).toBeUndefined();
+  });
+
+  it("omits a sport's thresholds when no values are present", () => {
+    const profile: Profile = {
+      ...baseProfile,
+      sportZones: {
+        cycling: undefined,
+        running: undefined,
+        swimming: undefined,
+      },
+    };
+
+    const snapshot = profileToSnapshot(profile, undefined, FIXED_NOW);
+
+    expect(snapshot.thresholds.cycling).toBeUndefined();
+    expect(snapshot.thresholds.running).toBeUndefined();
+    expect(snapshot.thresholds.swimming).toBeUndefined();
+  });
+
+  it("emits ISO datetime for generatedAt", () => {
+    const snapshot = profileToSnapshot(baseProfile, "cycling", FIXED_NOW);
+
+    expect(snapshot.generatedAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+    );
+  });
+});

--- a/packages/workout-spa-editor/src/lib/profile-snapshot/profile-to-snapshot.ts
+++ b/packages/workout-spa-editor/src/lib/profile-snapshot/profile-to-snapshot.ts
@@ -1,0 +1,105 @@
+/**
+ * Profile → Snapshot Mapper
+ *
+ * Pure derivation of a `ProfileSnapshot` (the cross-cutting protocol
+ * contract from `@kaiord/core`) out of the SPA's domain `Profile` plus
+ * the currently-active sport selection.
+ *
+ * The snapshot intentionally drops per-zone tables — bridges only need
+ * the threshold numbers to render the popup athlete card, not the full
+ * zone breakdown the editor uses.
+ */
+
+import type { ProfileSnapshot } from "@kaiord/core";
+
+import type { Profile } from "../../types/profile";
+
+export type ActiveSport = "cycling" | "running" | "swimming";
+
+const SCHEMA_VERSION = 1 as const;
+
+const buildCyclingThresholds = (
+  profile: Profile
+): { ftp?: number } | undefined => {
+  const ftp = profile.sportZones.cycling?.thresholds.ftp;
+  if (typeof ftp !== "number") return undefined;
+  return { ftp };
+};
+
+const buildRunningThresholds = (
+  profile: Profile
+): { thresholdPaceSecPerKm?: number; lthr?: number } | undefined => {
+  const running = profile.sportZones.running?.thresholds;
+  if (!running) return undefined;
+  const out: { thresholdPaceSecPerKm?: number; lthr?: number } = {};
+  if (typeof running.lthr === "number") out.lthr = running.lthr;
+  if (
+    typeof running.thresholdPace === "number" &&
+    running.paceUnit === "min_per_km"
+  ) {
+    out.thresholdPaceSecPerKm = Math.round(running.thresholdPace * 60);
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+};
+
+const buildSwimmingThresholds = (
+  profile: Profile
+): { cssPaceSecPer100m?: number } | undefined => {
+  const swimming = profile.sportZones.swimming?.thresholds;
+  if (!swimming) return undefined;
+  if (
+    typeof swimming.thresholdPace === "number" &&
+    swimming.paceUnit === "min_per_100m"
+  ) {
+    return { cssPaceSecPer100m: Math.round(swimming.thresholdPace * 60) };
+  }
+  return undefined;
+};
+
+const buildHeartRate = (
+  profile: Profile,
+  activeSport: ActiveSport | undefined
+): { max?: number; lthr?: number } => {
+  const out: { max?: number; lthr?: number } = {};
+  // Pick the lthr from the active sport's threshold if available; the
+  // popup shows ONE LTHR figure so picking the active sport is the most
+  // accurate choice.
+  if (activeSport) {
+    const sportLthr = profile.sportZones[activeSport]?.thresholds.lthr;
+    if (typeof sportLthr === "number") out.lthr = sportLthr;
+  }
+  // `max` HR is not modeled in the domain Profile yet; leave undefined
+  // until the SPA Profile schema gains a max-HR field. The protocol's
+  // optional `heartRate.max` keeps backward compat.
+  return out;
+};
+
+export const profileToSnapshot = (
+  profile: Profile,
+  activeSport: ActiveSport | undefined,
+  now: Date = new Date()
+): ProfileSnapshot => {
+  const thresholds: ProfileSnapshot["thresholds"] = {};
+  const cycling = buildCyclingThresholds(profile);
+  const running = buildRunningThresholds(profile);
+  const swimming = buildSwimmingThresholds(profile);
+  if (cycling) thresholds.cycling = cycling;
+  if (running) thresholds.running = running;
+  if (swimming) thresholds.swimming = swimming;
+
+  const snapshot: ProfileSnapshot = {
+    schemaVersion: SCHEMA_VERSION,
+    profile: {
+      name: profile.name,
+      ...(typeof profile.bodyWeight === "number"
+        ? { bodyWeight: profile.bodyWeight }
+        : {}),
+    },
+    ...(activeSport ? { activeSport } : {}),
+    thresholds,
+    heartRate: buildHeartRate(profile, activeSport),
+    generatedAt: now.toISOString(),
+  };
+
+  return snapshot;
+};

--- a/packages/workout-spa-editor/src/lib/profile-snapshot/snapshot-pusher-types.ts
+++ b/packages/workout-spa-editor/src/lib/profile-snapshot/snapshot-pusher-types.ts
@@ -1,0 +1,22 @@
+import type { BridgeRepository } from "../../adapters/bridge/bridge-types";
+
+export type SnapshotTransport = (
+  extensionId: string,
+  message: unknown
+) => Promise<{ ok: boolean; error?: string }>;
+
+export type SnapshotPusherDeps = {
+  readonly transport: SnapshotTransport;
+  readonly bridges: BridgeRepository;
+  readonly enqueue: <T>(args: {
+    bridgeId: string;
+    execute: () => Promise<T>;
+  }) => Promise<T>;
+};
+
+export type PushOutcome =
+  | "sent"
+  | "deduped"
+  | "rate-limited"
+  | "skipped"
+  | "failed";

--- a/packages/workout-spa-editor/src/lib/profile-snapshot/snapshot-pusher.test.ts
+++ b/packages/workout-spa-editor/src/lib/profile-snapshot/snapshot-pusher.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ProfileSnapshot } from "@kaiord/core";
+
+import type {
+  BridgeRepository,
+  RegisteredBridge,
+} from "../../adapters/bridge/bridge-types";
+
+import { createSnapshotPusher } from "./snapshot-pusher";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+const SNAPSHOT_A: ProfileSnapshot = {
+  schemaVersion: 1,
+  profile: { name: "Pablo" },
+  thresholds: { cycling: { ftp: 270 } },
+  heartRate: {},
+  generatedAt: "2026-05-01T08:00:00.000Z",
+};
+const SNAPSHOT_B: ProfileSnapshot = {
+  schemaVersion: 1,
+  profile: { name: "Pablo" },
+  thresholds: { cycling: { ftp: 280 } }, // FTP changed
+  heartRate: {},
+  generatedAt: "2026-05-01T08:00:00.000Z",
+};
+
+const verified = (
+  overrides: Partial<RegisteredBridge> = {}
+): RegisteredBridge => ({
+  extensionId: "ext-1",
+  id: "garmin-bridge",
+  name: "Garmin",
+  version: "7.1.0",
+  protocolVersion: 1,
+  capabilities: ["write:workouts"],
+  status: "verified",
+  lastSeen: "2026-05-01T07:50:00.000Z",
+  failCount: 0,
+  ...overrides,
+});
+
+const setupBridges = (
+  initial: RegisteredBridge
+): {
+  bridges: BridgeRepository;
+  store: Map<string, RegisteredBridge>;
+} => {
+  const store = new Map<string, RegisteredBridge>([
+    [initial.extensionId, initial],
+  ]);
+  return {
+    store,
+    bridges: {
+      getAll: async () => [...store.values()],
+      put: async (b) => {
+        store.set(b.extensionId, b);
+      },
+      delete: async (id) => {
+        store.delete(id);
+      },
+    },
+  };
+};
+
+const passThroughEnqueue = <T>(args: {
+  bridgeId: string;
+  execute: () => Promise<T>;
+}): Promise<T> => args.execute();
+
+describe("snapshot pusher — pushSnapshot", () => {
+  it("sends and persists fingerprint on ok ack", async () => {
+    const { bridges, store } = setupBridges(verified());
+    const transport = vi.fn().mockResolvedValue({ ok: true });
+    const pusher = createSnapshotPusher({
+      transport,
+      bridges,
+      enqueue: passThroughEnqueue,
+    });
+
+    const outcome = await pusher.pushSnapshot(
+      verified(),
+      SNAPSHOT_A,
+      PROFILE_ID
+    );
+
+    expect(outcome).toBe("sent");
+    expect(transport).toHaveBeenCalledTimes(1);
+    expect(transport.mock.calls[0][1]).toEqual({
+      action: "profile-snapshot",
+      snapshot: SNAPSHOT_A,
+    });
+    expect(store.get("ext-1")?.lastSuccessfulFingerprint).toMatch(
+      /^[0-9a-f]{8}$/
+    );
+  });
+
+  it("dedupes when fingerprint matches the persisted one", async () => {
+    const transport = vi.fn().mockResolvedValue({ ok: true });
+    const { bridges } = setupBridges(verified());
+    const pusher = createSnapshotPusher({
+      transport,
+      bridges,
+      enqueue: passThroughEnqueue,
+    });
+
+    const first = await pusher.pushSnapshot(verified(), SNAPSHOT_A, PROFILE_ID);
+    expect(first).toBe("sent");
+    const fingerprint = (await bridges.getAll())[0].lastSuccessfulFingerprint;
+
+    const second = await pusher.pushSnapshot(
+      verified({ lastSuccessfulFingerprint: fingerprint }),
+      SNAPSHOT_A,
+      PROFILE_ID
+    );
+
+    expect(second).toBe("deduped");
+    expect(transport).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-sends when content differs even if generatedAt is identical", async () => {
+    const transport = vi.fn().mockResolvedValue({ ok: true });
+    const { bridges } = setupBridges(verified());
+    const pusher = createSnapshotPusher({
+      transport,
+      bridges,
+      enqueue: passThroughEnqueue,
+    });
+
+    await pusher.pushSnapshot(verified(), SNAPSHOT_A, PROFILE_ID);
+    const fingerprint = (await bridges.getAll())[0].lastSuccessfulFingerprint;
+
+    const outcome = await pusher.pushSnapshot(
+      verified({ lastSuccessfulFingerprint: fingerprint }),
+      SNAPSHOT_B,
+      PROFILE_ID
+    );
+
+    expect(outcome).toBe("sent");
+    expect(transport).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not update fingerprint on ok:false response", async () => {
+    const transport = vi.fn().mockResolvedValue({ ok: false, error: "Boom" });
+    const { bridges, store } = setupBridges(
+      verified({ lastSuccessfulFingerprint: "deadbeef" })
+    );
+    const pusher = createSnapshotPusher({
+      transport,
+      bridges,
+      enqueue: passThroughEnqueue,
+    });
+
+    const outcome = await pusher.pushSnapshot(
+      verified({ lastSuccessfulFingerprint: "deadbeef" }),
+      SNAPSHOT_A,
+      PROFILE_ID
+    );
+
+    expect(outcome).toBe("failed");
+    expect(store.get("ext-1")?.lastSuccessfulFingerprint).toBe("deadbeef");
+  });
+
+  it("returns rate-limited when the queue rejects", async () => {
+    const transport = vi.fn();
+    const { bridges } = setupBridges(verified());
+    const pusher = createSnapshotPusher({
+      transport,
+      bridges,
+      enqueue: () =>
+        Promise.reject(
+          new Error("Rate limit reached for bridge garmin-bridge")
+        ),
+    });
+
+    const outcome = await pusher.pushSnapshot(
+      verified(),
+      SNAPSHOT_A,
+      PROFILE_ID
+    );
+
+    expect(outcome).toBe("rate-limited");
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("skips UNAVAILABLE bridges entirely", async () => {
+    const transport = vi.fn();
+    const { bridges } = setupBridges(verified({ status: "unavailable" }));
+    const pusher = createSnapshotPusher({
+      transport,
+      bridges,
+      enqueue: passThroughEnqueue,
+    });
+
+    const outcome = await pusher.pushSnapshot(
+      verified({ status: "unavailable" }),
+      SNAPSHOT_A,
+      PROFILE_ID
+    );
+
+    expect(outcome).toBe("skipped");
+    expect(transport).not.toHaveBeenCalled();
+  });
+});
+
+describe("snapshot pusher — clearSnapshot", () => {
+  it("sends profile-snapshot-clear to a VERIFIED bridge and resets state", async () => {
+    const transport = vi.fn().mockResolvedValue({ ok: true });
+    const { bridges, store } = setupBridges(
+      verified({ lastSuccessfulFingerprint: "deadbeef" })
+    );
+    const pusher = createSnapshotPusher({
+      transport,
+      bridges,
+      enqueue: passThroughEnqueue,
+    });
+
+    const outcome = await pusher.clearSnapshot(
+      verified({ lastSuccessfulFingerprint: "deadbeef" })
+    );
+
+    expect(outcome).toBe("sent");
+    expect(transport).toHaveBeenCalledWith("ext-1", {
+      action: "profile-snapshot-clear",
+    });
+    expect(store.get("ext-1")?.lastSuccessfulFingerprint).toBeNull();
+    expect(store.get("ext-1")?.pendingClear).toBe(false);
+  });
+
+  it("sets pendingClear when the bridge is UNAVAILABLE", async () => {
+    const transport = vi.fn();
+    const { bridges, store } = setupBridges(
+      verified({ status: "unavailable" })
+    );
+    const pusher = createSnapshotPusher({
+      transport,
+      bridges,
+      enqueue: passThroughEnqueue,
+    });
+
+    const outcome = await pusher.clearSnapshot(
+      verified({ status: "unavailable" })
+    );
+
+    expect(outcome).toBe("skipped");
+    expect(transport).not.toHaveBeenCalled();
+    expect(store.get("ext-1")?.pendingClear).toBe(true);
+  });
+});

--- a/packages/workout-spa-editor/src/lib/profile-snapshot/snapshot-pusher.ts
+++ b/packages/workout-spa-editor/src/lib/profile-snapshot/snapshot-pusher.ts
@@ -1,0 +1,84 @@
+/**
+ * Snapshot Pusher.
+ *
+ * Invariants: only ok:true updates the persisted fingerprint;
+ * timeout / ok:false / Unknown-action leave it unchanged. Callers
+ * fire-and-forget; rate-limit failures are silent (no toast).
+ */
+
+import { fingerprintSnapshot, type ProfileSnapshot } from "@kaiord/core";
+
+import type { RegisteredBridge } from "../../adapters/bridge/bridge-types";
+import type { PushOutcome, SnapshotPusherDeps } from "./snapshot-pusher-types";
+
+export type {
+  PushOutcome,
+  SnapshotPusherDeps,
+  SnapshotTransport,
+} from "./snapshot-pusher-types";
+
+const isVerified = (bridge: RegisteredBridge): boolean =>
+  bridge.status === "verified";
+
+const sendOnce = async (
+  deps: SnapshotPusherDeps,
+  bridge: RegisteredBridge,
+  message: unknown
+): Promise<PushOutcome> => {
+  try {
+    const response = await deps.enqueue({
+      bridgeId: bridge.id,
+      execute: () => deps.transport(bridge.extensionId, message),
+    });
+    return response.ok ? "sent" : "failed";
+  } catch {
+    return "rate-limited";
+  }
+};
+
+const buildPushSnapshot =
+  (deps: SnapshotPusherDeps) =>
+  async (
+    bridge: RegisteredBridge,
+    snapshot: ProfileSnapshot,
+    profileId: string
+  ): Promise<PushOutcome> => {
+    if (!isVerified(bridge)) return "skipped";
+    const next = fingerprintSnapshot(profileId, snapshot);
+    if (bridge.lastSuccessfulFingerprint === next) return "deduped";
+    const outcome = await sendOnce(deps, bridge, {
+      action: "profile-snapshot",
+      snapshot,
+    });
+    if (outcome === "sent") {
+      await deps.bridges.put({ ...bridge, lastSuccessfulFingerprint: next });
+    }
+    return outcome;
+  };
+
+const buildClearSnapshot =
+  (deps: SnapshotPusherDeps) =>
+  async (bridge: RegisteredBridge): Promise<PushOutcome> => {
+    if (!isVerified(bridge)) {
+      if (!bridge.pendingClear) {
+        await deps.bridges.put({ ...bridge, pendingClear: true });
+      }
+      return "skipped";
+    }
+    const outcome = await sendOnce(deps, bridge, {
+      action: "profile-snapshot-clear",
+    });
+    if (outcome === "sent") {
+      await deps.bridges.put({
+        ...bridge,
+        pendingClear: false,
+        lastSuccessfulFingerprint: null,
+      });
+    }
+    return outcome;
+  };
+
+export const createSnapshotPusher = (deps: SnapshotPusherDeps) => ({
+  pushSnapshot: buildPushSnapshot(deps),
+  clearSnapshot: buildClearSnapshot(deps),
+});

--- a/scripts/check-no-pii-leakage.mjs
+++ b/scripts/check-no-pii-leakage.mjs
@@ -128,7 +128,10 @@ function shouldScan(name) {
 
 function findFiles() {
   const out = [];
-  for (const sub of ["components", "hooks", "lib"]) {
+  // `lib` includes the new profile-snapshot push pipeline; `adapters/bridge`
+  // handles snapshot serialization and transport — both surface athlete PII
+  // (name, body weight, FTP, HR data) and MUST be subject to R-PIIInterpolation.
+  for (const sub of ["components", "hooks", "lib", "adapters/bridge"]) {
     walk(join(SPA_SRC, sub), (file) => out.push(file));
   }
   return out;


### PR DESCRIPTION
## Summary

PR 2 of 7 in the [bridge-popup-redesign](openspec/changes/bridge-popup-redesign/proposal.md) chunked rollout. Adds the SPA-side foundation for the bridge popup profile-snapshot push (openspec change §3 partial — trigger wiring deferred to a follow-up commit on this PR).

- **`packages/workout-spa-editor/src/lib/profile-snapshot/profile-to-snapshot.ts`** — pure mapper from the SPA's domain `Profile` + active sport to a `ProfileSnapshot`. Drops per-zone tables (bridges only need threshold numbers); converts running/swimming pace to seconds.
- **`packages/workout-spa-editor/src/lib/profile-snapshot/snapshot-pusher.ts`** + types module — push adapter with content-fingerprint de-dup via `@kaiord/core`'s `fingerprintSnapshot`. Only `ok:true` acks update the persisted fingerprint; transport timeout / `ok:false` validation/storage failure / pre-redesign `Unknown action` responses leave it unchanged so the next mutation re-pushes. `clearSnapshot` sets `pendingClear` when the bridge is UNAVAILABLE so the next VERIFIED transition emits the clear.
- **`RegisteredBridge`** gains `lastSuccessfulFingerprint?: string | null` and `pendingClear?: boolean` fields.
- **Dexie v6 migration** backfills `pendingClear: false` and `lastSuccessfulFingerprint: null` on existing bridge rows so the pusher can rely on well-defined defaults. Stores config is unchanged (the new fields are non-indexed); the upgrade only touches data. Backfill helpers extracted to `dexie-migrations.ts` to keep `dexie-database.ts` under the per-file line cap.
- **PII guard glob** extended to include `adapters/bridge` so any future `console.*` / `toast.*` in the bridge transport that interpolates snapshot fields fails the lint job. Fixed a pre-existing R-PIIInterpolation violation in `bridge-registry-helpers.ts` (`extensionId` moved to a structured payload, which DevTools renders separately).

## Trigger wiring (deferred to a follow-up commit on this PR)

The active-profile mutation effect, bridge-VERIFIED transition trigger, and profile-deletion clear trigger (§3.3.a–d) are intentionally a separate commit so this commit lands as a stable, reviewable foundation.

## Chunked rollout

| PR | Status |
|----|--------|
| 1 — `@kaiord/core` schema + DTO + fingerprint + fixtures | ✅ #413 merged |
| **2 (this)** — SPA push pipeline + Dexie v6 + PII guard | open |
| 3 — Bridge action handlers + T2G `storage` permission + privacy-surface guard | pending |
| 4 — Icon master + build script + distinctness guards | pending |
| 5 — Shared popup CSS + Garmin popup | pending |
| 6 — Train2Go popup + parser `coachName` extension | pending |
| 7 — Spec lint + changesets + e2e verification + `/opsx-archive` | pending |

## Test plan

- [x] 19 new unit tests (7 mapper + 8 pusher + 4 v6 migration); 49 existing bridge tests still green; 68/68 across the touched packages.
- [x] `pnpm lint` clean (tsc + eslint + prettier).
- [x] `node scripts/check-no-pii-leakage.mjs`: 0 violations across components / hooks / lib / adapters/bridge.
- [ ] CodeRabbit review.
- [ ] Full CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)