### PR TITLE
fix(release): allow changesets bot "Version Packages" commit

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -11,8 +11,17 @@
 
 import { SCOPE_ENUM, TYPE_ENUM } from "./commitlint.vocab.mjs";
 
+// changesets/action commits the generated version-bump with subject
+// "Version Packages" (its built-in default). That commit is produced by
+// automation we control end-to-end; the conventional-commit type/scope
+// contract is for human authors. Allowlist that exact subject so the
+// Release workflow can land its bump commit through the husky commit-msg
+// hook.
+const CHANGESET_BOT_SUBJECT = /^Version Packages(\s|$)/;
+
 export default {
   extends: ["@commitlint/config-conventional"],
+  ignores: [(message) => CHANGESET_BOT_SUBJECT.test(message)],
   plugins: [
     {
       rules: {

--- a/openspec/changes/archive/2026-05-01-calendar-coaching-redesign/proposal.md
+++ b/openspec/changes/archive/2026-05-01-calendar-coaching-redesign/proposal.md
@@ -1,3 +1,5 @@
+> Completed: 2026-05-01
+
 ## Why
 
 The calendar week view is the home page of the SPA editor and the entry point for every coaching workflow, but its current state is broken in three compounding ways: (a) the `CoachingActivityCard` literally **overflows its container** — the word "pending" is rendered outside the card border on screens at the design width; (b) titles like "Z2/Z3 técnica" and "FASE 3 fuerza" are aggressively truncated, so the most important field on the card is the field least visible; (c) coaching activities (what the coach planned) and workouts (what the athlete did) live as two unrelated stacks in the same day column with no way to express that they describe the same session, despite this being the central question every athlete asks ("did I do what I was told?").

--- a/scripts/check-commitlint-config.test.mjs
+++ b/scripts/check-commitlint-config.test.mjs
@@ -138,4 +138,29 @@ describe("commitlint subject acceptance", () => {
       `expected 0, got ${r.code}\n${r.stderr}\n${r.stdout}`
     );
   });
+
+  // changesets/action emits a "Version Packages" commit during the Release
+  // workflow. It has no conventional-commit type and would otherwise be
+  // rejected by the husky commit-msg hook, breaking the entire release
+  // pipeline. The `ignores` predicate in commitlint.config.mjs allowlists
+  // that exact subject.
+  test("Version Packages (changesets bot) → exit 0", () => {
+    const r = runCommitlint("Version Packages");
+    if (r.skipped) return;
+    assert.equal(
+      r.code,
+      0,
+      `expected 0, got ${r.code}\n${r.stderr}\n${r.stdout}`
+    );
+  });
+
+  test("Version Packagesfoo (lookalike, no boundary) → non-zero", () => {
+    const r = runCommitlint("Version Packagesfoo");
+    if (r.skipped) return;
+    assert.notEqual(
+      r.code,
+      0,
+      "expected non-zero: only the exact bot subject is allowlisted"
+    );
+  });
 });


### PR DESCRIPTION
## Summary

The husky `commit-msg` hook (commitlint backstop) added in `guidelines-compliance-harden` PR1 rejects the changesets/action auto-generated `Version Packages` subject — that subject has no conventional-commit type/scope, so commitlint fails it with `subject-empty` + `type-empty`. This has broken the **Release workflow on every push to main since 2026-05-01T13:59Z** (commit `0768cd8` onward — 7 consecutive failures, including my own merges).

## Fix

Add an `ignores` predicate to `commitlint.config.mjs` that allowlists the exact bot subject:

```js
const CHANGESET_BOT_SUBJECT = /^Version Packages(\s|$)/;
ignores: [(message) => CHANGESET_BOT_SUBJECT.test(message)]
```

- Matches: `Version Packages`, `Version Packages\nbody`, `Version Packages something`
- Rejects: `Version Packagesfoo` (lookalike with no word boundary)

The contract: this commit is generated by automation we control end-to-end (changesets/action's built-in default). The conventional-commit type/scope rule is for human authors; bypassing it for our own bot is intentional, narrow, and tested.

## Verification

- `node --test scripts/check-commitlint-config.test.mjs` → 10/10 pass (2 new tests cover the bot subject accept + lookalike reject)
- `pnpm test:scripts` → 247/247 pass
- `pnpm lint` → clean

## Why no changeset

This is a config + scripts-only change with no public-package surface. The only consumer is the Release workflow itself, which is not a published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)