### PR TITLE
feat(spa-editor): icon-only CoachingSyncButton with relative-time tooltip (PR-B)

### DIFF
--- a/openspec/changes/calendar-coaching-redesign-completion/tasks.md
+++ b/openspec/changes/calendar-coaching-redesign-completion/tasks.md
@@ -32,11 +32,11 @@ PR independence — explicit dependency map:
 
 ## 2. PR-B — CoachingSyncButton refresh (issue #431, TDD red → green)
 
-- [ ] 2.1 Write failing tests for `formatRelativeTime(date: Date | undefined, now: Date): string` at `packages/workout-spa-editor/src/utils/format-relative-time.test.ts` covering the seven branches in design D17 (`undefined` → `"never synced"`, `<60_000` → `"just now"`, minutes, hours, `yesterday` (cross-day under 48h), days, ISO-fallback for older). Use injected `now` so no fake-timers are needed.
-- [ ] 2.2 Implement `format-relative-time.ts`. All seven branches return literal-string outputs (never interpolated user data) so the PII-toast lint passes.
-- [ ] 2.3 Write failing tests for `CoachingSyncButton` connected-state asserting: `aria-label="Sync <Label>"`, no visible text label, `title` reads `"<Label> · <relative-time>"`, the spinner replaces the icon in place during sync (button disabled), and `prefers-reduced-motion: reduce` collapses the spinner to a static glyph (mock `window.matchMedia`). Cover the `lastSyncedAt === undefined` → `"never synced"` branch.
-- [ ] 2.4 Update `CoachingSyncButton.tsx` to icon-only chrome with the slate color tokens per spec; reuse the existing tooltip primitive used elsewhere in `CalendarHeader`. The not-connected branch is unchanged.
-- [ ] 2.5 Run `pnpm --filter @kaiord/workout-spa-editor test` and `pnpm lint` — clean.
+- [x] 2.1 `format-relative-time.test.ts` covers all 7 branches with injected `now` (no fake timers). 9 tests.
+- [x] 2.2 `format-relative-time.ts` implements the helper with literal-string outputs only (R-PIIInterpolation green).
+- [x] 2.3 `CoachingSyncButton.test.tsx` rewritten covering: `aria-label="Sync <Label>"`, no visible text, `title` matches `<Label> · <relative-time>`, spinner-replaces-icon-in-place during sync (button disabled), `prefers-reduced-motion: reduce` static glyph, `lastSyncedAt === undefined` → `"never synced"`. 9 tests.
+- [x] 2.4 `CoachingSyncButton.tsx` rewritten with icon-only chrome (lucide `RefreshCw` / `Loader2`), 32×32 button, slate tokens. Tooltip composer + reduced-motion subscription extracted to `coaching-sync-button-tooltip.ts` to stay under the 80-line file cap. `CoachingSource` and `CoachingSyncState` ports gain `lastSyncedAt: string | undefined`; `use-train2go-source.ts` reads it via `coachingSyncState.getBySourceAndProfile`; `CalendarHeader` threads it through to the button.
+- [x] 2.5 `pnpm --filter @kaiord/workout-spa-editor test` — 3150/3150 (12 new tests vs PR-A baseline). `pnpm --filter @kaiord/workout-spa-editor lint` — clean. Build clean.
 
 ## 3. PR-C — CoachingActivityDialog match/split actions (issue #432, TDD red → green)
 

--- a/packages/workout-spa-editor/src/adapters/train2go/use-train2go-source.ts
+++ b/packages/workout-spa-editor/src/adapters/train2go/use-train2go-source.ts
@@ -52,6 +52,14 @@ export function useTrain2GoSource(
     );
   }, [activeProfileId, start, end]);
 
+  const syncStateRow = useLiveQuery(() => {
+    if (!activeProfileId) return Promise.resolve(undefined);
+    return persistence.coachingSyncState.getBySourceAndProfile(
+      TRAIN2GO,
+      activeProfileId
+    );
+  }, [activeProfileId]);
+
   const activities: CoachingActivity[] = useMemo(
     () => (records ?? []).map(toCoachingActivity),
     [records]
@@ -71,6 +79,7 @@ export function useTrain2GoSource(
     loading: store.loading,
     error: store.lastError,
     activities,
+    lastSyncedAt: syncStateRow?.lastSyncedAt,
     sync,
     expand,
     connect,

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingSyncButton.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingSyncButton.test.tsx
@@ -1,11 +1,33 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CoachingSyncButton } from "./CoachingSyncButton";
 
-describe("CoachingSyncButton", () => {
-  it("renders connect button when not connected", () => {
+const mockMatchMedia = (reduced: boolean) => {
+  const listeners = new Set<() => void>();
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: (query: string) => ({
+      matches: reduced && query.includes("prefers-reduced-motion"),
+      media: query,
+      addEventListener: (_type: string, cb: () => void) => listeners.add(cb),
+      removeEventListener: (_type: string, cb: () => void) =>
+        listeners.delete(cb),
+      dispatchEvent: () => true,
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+    }),
+  });
+};
+
+describe("CoachingSyncButton — not-connected state", () => {
+  beforeEach(() => mockMatchMedia(false));
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders connect CTA with the platform label", () => {
     render(
       <CoachingSyncButton
         connected={false}
@@ -20,7 +42,7 @@ describe("CoachingSyncButton", () => {
     expect(screen.getByText("Connect to Train2Go")).toBeInTheDocument();
   });
 
-  it("shows error when disconnected with error", () => {
+  it("shows error text alongside the connect CTA", () => {
     render(
       <CoachingSyncButton
         connected={false}
@@ -34,9 +56,8 @@ describe("CoachingSyncButton", () => {
     expect(screen.getByText("Session expired")).toBeInTheDocument();
   });
 
-  it("calls onConnect when connect button clicked", async () => {
+  it("invokes onConnect when the CTA is clicked", async () => {
     const onConnect = vi.fn();
-
     render(
       <CoachingSyncButton
         connected={false}
@@ -51,8 +72,13 @@ describe("CoachingSyncButton", () => {
 
     expect(onConnect).toHaveBeenCalledTimes(1);
   });
+});
 
-  it("renders sync button when connected", () => {
+describe("CoachingSyncButton — connected state (icon-only chrome)", () => {
+  beforeEach(() => mockMatchMedia(false));
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders an icon-only button with aria-label='Sync <Label>' and no visible text label", () => {
     render(
       <CoachingSyncButton
         connected={true}
@@ -64,10 +90,47 @@ describe("CoachingSyncButton", () => {
       />
     );
 
-    expect(screen.getByText("Sync Train2Go")).toBeInTheDocument();
+    const button = screen.getByRole("button", { name: "Sync Train2Go" });
+    expect(button).toBeInTheDocument();
+    // No visible text — only the icon is rendered.
+    expect(screen.queryByText("Sync Train2Go")).toBeNull();
   });
 
-  it("shows loading state", () => {
+  it("surfaces the relative-time tooltip via the title attribute", () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    render(
+      <CoachingSyncButton
+        connected={true}
+        loading={false}
+        error={null}
+        onSync={vi.fn()}
+        onConnect={vi.fn()}
+        label="Train2Go"
+        lastSyncedAt={fiveMinutesAgo}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Sync Train2Go" });
+    expect(button.getAttribute("title")).toMatch(/^Train2Go · \d+m ago$/);
+  });
+
+  it("surfaces 'never synced' when lastSyncedAt is undefined", () => {
+    render(
+      <CoachingSyncButton
+        connected={true}
+        loading={false}
+        error={null}
+        onSync={vi.fn()}
+        onConnect={vi.fn()}
+        label="Train2Go"
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Sync Train2Go" });
+    expect(button.getAttribute("title")).toBe("Train2Go · never synced");
+  });
+
+  it("replaces the icon with a spinner in place during sync and disables the button", () => {
     render(
       <CoachingSyncButton
         connected={true}
@@ -75,16 +138,20 @@ describe("CoachingSyncButton", () => {
         error={null}
         onSync={vi.fn()}
         onConnect={vi.fn()}
+        label="Train2Go"
       />
     );
 
-    expect(screen.getByText("Syncing...")).toBeInTheDocument();
-    expect(screen.getByRole("button")).toBeDisabled();
+    const button = screen.getByRole("button", { name: "Sync Train2Go" });
+    expect(button).toBeDisabled();
+    expect(button.getAttribute("title")).toBe("Train2Go · syncing…");
+    // Spinner uses the lucide Loader2 icon with the spin animation class.
+    const spinner = button.querySelector("svg");
+    expect(spinner?.getAttribute("class")).toMatch(/animate-spin/);
   });
 
-  it("calls onSync when sync button clicked", async () => {
+  it("invokes onSync when clicked", async () => {
     const onSync = vi.fn();
-
     render(
       <CoachingSyncButton
         connected={true}
@@ -92,11 +159,38 @@ describe("CoachingSyncButton", () => {
         error={null}
         onSync={onSync}
         onConnect={vi.fn()}
+        label="Train2Go"
       />
     );
 
-    await userEvent.click(screen.getByText("Sync Coach"));
+    await userEvent.click(
+      screen.getByRole("button", { name: "Sync Train2Go" })
+    );
 
     expect(onSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("CoachingSyncButton — prefers-reduced-motion", () => {
+  beforeEach(() => mockMatchMedia(true));
+  afterEach(() => vi.restoreAllMocks());
+
+  it("collapses the spinner to a static glyph (no animate-spin class)", () => {
+    render(
+      <CoachingSyncButton
+        connected={true}
+        loading={true}
+        error={null}
+        onSync={vi.fn()}
+        onConnect={vi.fn()}
+        label="Train2Go"
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Sync Train2Go" });
+    const spinner = button.querySelector("svg");
+    expect(spinner?.getAttribute("class")).not.toMatch(/animate-spin/);
+    // Tooltip still updates so the canonical signal is preserved.
+    expect(button.getAttribute("title")).toBe("Train2Go · syncing…");
   });
 });

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingSyncButton.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingSyncButton.tsx
@@ -1,9 +1,25 @@
 /**
  * CoachingSyncButton — Sync/Connect button for coaching platforms.
  *
- * Platform-specific logic is injected via props, not imported.
- * The calendar page wires this to the appropriate store.
+ * Connected state: 32×32 icon-only button with a relative-time tooltip
+ * ("<Label> · 5m ago", "<Label> · syncing…", "<Label> · never synced").
+ * The spinner replaces the icon in place during sync; under
+ * `prefers-reduced-motion: reduce` the spinner becomes a static glyph.
+ *
+ * Not-connected state retains the textual "Connect to <Label>" CTA per
+ * archived design D7 (low-frequency action, deserves discoverability).
+ *
+ * Color tokens are slate-based so the button does not compete with the
+ * status-color palette of the redesigned card stack. Tooltip composition
+ * + reduced-motion subscription live in coaching-sync-button-tooltip.ts.
  */
+
+import { Loader2, RefreshCw } from "lucide-react";
+
+import {
+  buildSyncTooltip,
+  usePrefersReducedMotion,
+} from "./coaching-sync-button-tooltip";
 
 export type CoachingSyncButtonProps = {
   connected: boolean;
@@ -12,7 +28,35 @@ export type CoachingSyncButtonProps = {
   onSync: () => void;
   onConnect: () => void;
   label?: string;
+  /** ISO timestamp of the last successful sync; undefined when never synced. */
+  lastSyncedAt?: string | undefined;
 };
+
+const ConnectedIconButton: React.FC<{
+  loading: boolean;
+  reducedMotion: boolean;
+  ariaLabel: string;
+  title: string;
+  onSync: () => void;
+}> = ({ loading, reducedMotion, ariaLabel, title, onSync }) => (
+  <button
+    type="button"
+    disabled={loading}
+    onClick={onSync}
+    aria-label={ariaLabel}
+    title={title}
+    className="inline-flex h-8 w-8 items-center justify-center rounded border border-slate-300 text-slate-700 hover:bg-slate-100 disabled:opacity-50 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+  >
+    {loading ? (
+      <Loader2
+        className={reducedMotion ? "h-4 w-4" : "h-4 w-4 animate-spin"}
+        aria-hidden="true"
+      />
+    ) : (
+      <RefreshCw className="h-4 w-4" aria-hidden="true" />
+    )}
+  </button>
+);
 
 export function CoachingSyncButton({
   connected,
@@ -21,14 +65,17 @@ export function CoachingSyncButton({
   onSync,
   onConnect,
   label = "Coach",
+  lastSyncedAt,
 }: CoachingSyncButtonProps) {
+  const reducedMotion = usePrefersReducedMotion();
+
   if (!connected) {
     return (
       <div className="flex items-center gap-2">
         <button
           type="button"
           onClick={onConnect}
-          className="rounded border border-rose-300 bg-rose-50 px-3 py-1 text-sm text-rose-700 hover:bg-rose-100 dark:border-rose-800 dark:bg-rose-950 dark:text-rose-300"
+          className="rounded border border-slate-300 bg-white px-3 py-1 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
         >
           Connect to {label}
         </button>
@@ -38,13 +85,12 @@ export function CoachingSyncButton({
   }
 
   return (
-    <button
-      type="button"
-      disabled={loading}
-      onClick={onSync}
-      className="rounded border border-rose-300 bg-rose-50 px-3 py-1 text-sm text-rose-700 hover:bg-rose-100 disabled:opacity-50 dark:border-rose-800 dark:bg-rose-950 dark:text-rose-300"
-    >
-      {loading ? "Syncing..." : `Sync ${label}`}
-    </button>
+    <ConnectedIconButton
+      loading={loading}
+      reducedMotion={reducedMotion}
+      ariaLabel={`Sync ${label}`}
+      title={buildSyncTooltip(label, loading, lastSyncedAt)}
+      onSync={onSync}
+    />
   );
 }

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-sync-button-tooltip.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-sync-button-tooltip.ts
@@ -1,0 +1,38 @@
+/**
+ * Tooltip composer + reduced-motion hook for `CoachingSyncButton`.
+ *
+ * Split out so the component file stays under the 80-line lint cap. All
+ * tooltip outputs are static literals composed from a fixed `<Label>`
+ * prefix and the deterministic branches of `formatRelativeTime`, so the
+ * project's R-PIIInterpolation guard remains green.
+ */
+
+import { useEffect, useState } from "react";
+
+import { formatRelativeTime } from "../../../utils/format-relative-time";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+export const usePrefersReducedMotion = (): boolean => {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(REDUCED_MOTION_QUERY);
+    const update = () => setReduced(mql.matches);
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, []);
+  return reduced;
+};
+
+export const buildSyncTooltip = (
+  label: string,
+  loading: boolean,
+  lastSyncedAt: string | undefined,
+  now: Date = new Date()
+): string => {
+  if (loading) return `${label} · syncing…`;
+  const date = lastSyncedAt ? new Date(lastSyncedAt) : undefined;
+  return `${label} · ${formatRelativeTime(date, now)}`;
+};

--- a/packages/workout-spa-editor/src/components/pages/CalendarHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarHeader.tsx
@@ -71,6 +71,7 @@ export function CalendarHeader({
                 onSync={() => src.sync(s.data.days[0])}
                 onConnect={src.connect}
                 label={src.label}
+                lastSyncedAt={src.lastSyncedAt}
               />
             ))}
         </div>

--- a/packages/workout-spa-editor/src/hooks/use-coaching-activities.ts
+++ b/packages/workout-spa-editor/src/hooks/use-coaching-activities.ts
@@ -23,6 +23,8 @@ export type CoachingSyncState = {
   connected: boolean;
   loading: boolean;
   error: string | null;
+  /** ISO timestamp of the last successful sync for the active profile. */
+  lastSyncedAt: string | undefined;
   sync: (weekStart: string) => Promise<void>;
   connect: () => Promise<void>;
 };
@@ -76,6 +78,7 @@ export function useCoachingActivities(days: string[]) {
       connected: s.connected,
       loading: s.loading,
       error: s.error,
+      lastSyncedAt: s.lastSyncedAt,
       sync: async (weekStart: string) => {
         if (!activeProfileId) return;
         await s.sync(activeProfileId, weekStart);

--- a/packages/workout-spa-editor/src/types/coaching-source.ts
+++ b/packages/workout-spa-editor/src/types/coaching-source.ts
@@ -24,6 +24,12 @@ export type CoachingSource = {
   error: string | null;
   /** Activities for the supplied (profileId, days), live-queried. */
   activities: CoachingActivity[];
+  /**
+   * ISO timestamp of the last successful sync for the active profile.
+   * `undefined` when the platform has never been synced for this profile
+   * (drives the "never synced" tooltip on `CoachingSyncButton`).
+   */
+  lastSyncedAt: string | undefined;
   sync: (profileId: string, weekStart: string) => Promise<void>;
   expand: (profileId: string, date: string) => Promise<void>;
   connect: (profileId: string) => Promise<void>;

--- a/packages/workout-spa-editor/src/utils/format-relative-time.test.ts
+++ b/packages/workout-spa-editor/src/utils/format-relative-time.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for `formatRelativeTime` — exhaustive coverage of the seven
+ * branches defined in design D17. `now` is injected so no fake timers
+ * are needed.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { formatRelativeTime } from "./format-relative-time";
+
+const NOW = new Date("2026-05-04T12:00:00.000Z");
+
+const minutesAgo = (n: number): Date => new Date(NOW.getTime() - n * 60 * 1000);
+const hoursAgo = (n: number): Date =>
+  new Date(NOW.getTime() - n * 60 * 60 * 1000);
+const daysAgo = (n: number): Date =>
+  new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+
+describe("formatRelativeTime", () => {
+  it("returns 'never synced' when date is undefined", () => {
+    expect(formatRelativeTime(undefined, NOW)).toBe("never synced");
+  });
+
+  it("returns 'just now' under one minute", () => {
+    expect(formatRelativeTime(new Date(NOW.getTime() - 30_000), NOW)).toBe(
+      "just now"
+    );
+    expect(formatRelativeTime(new Date(NOW.getTime() - 59_999), NOW)).toBe(
+      "just now"
+    );
+  });
+
+  it("returns 'Nm ago' between 1 minute and 1 hour", () => {
+    expect(formatRelativeTime(minutesAgo(1), NOW)).toBe("1m ago");
+    expect(formatRelativeTime(minutesAgo(5), NOW)).toBe("5m ago");
+    expect(formatRelativeTime(minutesAgo(59), NOW)).toBe("59m ago");
+  });
+
+  it("returns 'Nh ago' between 1 hour and 1 day", () => {
+    expect(formatRelativeTime(hoursAgo(1), NOW)).toBe("1h ago");
+    expect(formatRelativeTime(hoursAgo(12), NOW)).toBe("12h ago");
+    expect(formatRelativeTime(hoursAgo(23), NOW)).toBe("23h ago");
+  });
+
+  it("returns 'yesterday' for cross-day differences under 48h", () => {
+    // 30h ago crosses a calendar boundary AND is under 48h.
+    expect(formatRelativeTime(hoursAgo(30), NOW)).toBe("yesterday");
+  });
+
+  it("does NOT return 'yesterday' when ≥48h has elapsed even if calendar diff is 1", () => {
+    // Exactly 2 days back — falls into the days-ago branch.
+    expect(formatRelativeTime(daysAgo(2), NOW)).toBe("2d ago");
+  });
+
+  it("returns 'Nd ago' between 2 days and 1 week", () => {
+    expect(formatRelativeTime(daysAgo(3), NOW)).toBe("3d ago");
+    expect(formatRelativeTime(daysAgo(6), NOW)).toBe("6d ago");
+  });
+
+  it("returns ISO YYYY-MM-DD for anything ≥ 1 week", () => {
+    const eightDays = daysAgo(8);
+    expect(formatRelativeTime(eightDays, NOW)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(formatRelativeTime(daysAgo(30), NOW)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("formats the ISO fallback in local-calendar form (matches the date's components)", () => {
+    const stamp = daysAgo(10);
+    const expected = `${stamp.getFullYear()}-${String(
+      stamp.getMonth() + 1
+    ).padStart(2, "0")}-${String(stamp.getDate()).padStart(2, "0")}`;
+    expect(formatRelativeTime(stamp, NOW)).toBe(expected);
+  });
+});

--- a/packages/workout-spa-editor/src/utils/format-relative-time.ts
+++ b/packages/workout-spa-editor/src/utils/format-relative-time.ts
@@ -1,0 +1,55 @@
+/**
+ * formatRelativeTime — humanized relative-time helper for the
+ * CoachingSyncButton tooltip.
+ *
+ * `now` is injected (not resolved via `Date.now()` inline) so tests are
+ * deterministic without touching `vi.useFakeTimers`. Branches are
+ * evaluated top-down; the first matching branch wins. All return values
+ * are static literal strings (no user input is ever interpolated) so the
+ * project's R-PIIInterpolation guard remains green.
+ *
+ * Branch table:
+ *
+ *   undefined                           → "never synced"
+ *   diff <  60_000                       → "just now"
+ *   diff <  3_600_000   (and ≥ 1m)       → "<n>m ago"
+ *   diff < 86_400_000   (and ≥ 1h)       → "<n>h ago"
+ *   different calendar day, < 48h        → "yesterday"
+ *   diff < 604_800_000  (and ≥ 2d)       → "<n>d ago"
+ *   anything older                       → ISO YYYY-MM-DD
+ *
+ * Per design D17 of calendar-coaching-redesign-completion.
+ */
+
+const ONE_MINUTE_MS = 60 * 1000;
+const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+const TWO_DAYS_MS = 2 * ONE_DAY_MS;
+const ONE_WEEK_MS = 7 * ONE_DAY_MS;
+
+const isoDate = (d: Date): string => {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+};
+
+const sameCalendarDay = (a: Date, b: Date): boolean =>
+  a.getFullYear() === b.getFullYear() &&
+  a.getMonth() === b.getMonth() &&
+  a.getDate() === b.getDate();
+
+export const formatRelativeTime = (
+  date: Date | undefined,
+  now: Date
+): string => {
+  if (date === undefined) return "never synced";
+
+  const diff = now.getTime() - date.getTime();
+  if (diff < ONE_MINUTE_MS) return "just now";
+  if (diff < ONE_HOUR_MS) return `${Math.floor(diff / ONE_MINUTE_MS)}m ago`;
+  if (diff < ONE_DAY_MS) return `${Math.floor(diff / ONE_HOUR_MS)}h ago`;
+  if (!sameCalendarDay(date, now) && diff < TWO_DAYS_MS) return "yesterday";
+  if (diff < ONE_WEEK_MS) return `${Math.floor(diff / ONE_DAY_MS)}d ago`;
+  return isoDate(date);
+};


### PR DESCRIPTION
## Summary

PR-B of `calendar-coaching-redesign-completion`. Closes issue #431 (§8.5/§8.6 of the archived calendar-coaching-redesign change). The connected-state sync button drops the rose-coloured text label, becomes a 32×32 icon button with an `aria-label="Sync <Label>"`, and surfaces the last-sync time on hover via a `title` tooltip composed from the new `formatRelativeTime` helper.

Refs #431. Builds on PR-A (#452) — review either standalone or in series.

## What landed

```
utils/
├─ format-relative-time.ts          (NEW) — 7-branch helper, injected `now`
└─ format-relative-time.test.ts     (NEW) — 9 unit tests, every branch

components/molecules/CoachingCard/
├─ CoachingSyncButton.tsx           rewrite — icon-only, slate tokens
├─ coaching-sync-button-tooltip.ts  (NEW) — tooltip composer + reduced-motion hook
└─ CoachingSyncButton.test.tsx      9 RTL tests for the new chrome

types/coaching-source.ts            +lastSyncedAt: string | undefined
hooks/use-coaching-activities.ts    threads the field through CoachingSyncState
adapters/train2go/use-train2go-source.ts
                                    reads lastSyncedAt via useLiveQuery on
                                    coachingSyncState.getBySourceAndProfile
components/pages/CalendarHeader.tsx passes lastSyncedAt to the button
```

## Behavior

| State | Render |
|-------|--------|
| Connected, idle, recently synced | Icon-only button, `title="Train2Go · 5m ago"`, `aria-label="Sync Train2Go"` |
| Connected, idle, never synced | Same chrome, `title="Train2Go · never synced"` |
| Connected, syncing | Spinner replaces icon in place, button disabled, `title="Train2Go · syncing…"` |
| Connected, syncing, `prefers-reduced-motion: reduce` | Static loader glyph (no spin animation), tooltip text unchanged |
| Not connected | Unchanged "Connect to <Label>" CTA (slate tokens now, no rose) |

## Test plan

- [x] `pnpm --filter @kaiord/workout-spa-editor test` — 3150/3150 (12 new tests vs PR-A baseline 3138)
- [x] `pnpm --filter @kaiord/workout-spa-editor lint` — clean
- [x] `pnpm --filter @kaiord/workout-spa-editor build` — clean (only pre-existing dynamic-import warning)
- [ ] CI green
- [ ] CodeRabbit review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)