### PR TITLE
fix(spa-editor): clean up 8 react-hooks/exhaustive-deps suppressions (closes #454)

### DIFF
--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ExtensionsTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ExtensionsTab.tsx
@@ -14,22 +14,21 @@ function toBridgeState(installed: boolean, session: boolean): BridgeState {
 export const ExtensionsTab: React.FC = () => {
   const garmin = useGarminBridge();
   const train2go = useTrain2GoStore();
+  // Destructure stable method refs so the effect/callback dep arrays
+  // reference the methods directly — exhaustive-deps is satisfied
+  // without disabling the rule.
+  const { detectExtension: detectGarmin } = garmin;
+  const { detectExtension: detectTrain2go } = train2go;
 
-  // TODO(fix-coaching-dialog-rules-of-hooks-followup): the deps array
-  // intentionally references stable method handles, not the bridge
-  // objects themselves. Re-enable exhaustive-deps as error once the
-  // bridge contexts expose stable references.
   useEffect(() => {
-    garmin.detectExtension();
-    train2go.detectExtension();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [garmin.detectExtension, train2go.detectExtension]);
+    detectGarmin();
+    detectTrain2go();
+  }, [detectGarmin, detectTrain2go]);
 
   const refreshAll = useCallback(() => {
-    garmin.detectExtension();
-    train2go.detectExtension();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [garmin.detectExtension, train2go.detectExtension]);
+    detectGarmin();
+    detectTrain2go();
+  }, [detectGarmin, detectTrain2go]);
 
   return (
     <div className="space-y-4">

--- a/packages/workout-spa-editor/src/contexts/garmin-bridge-context.tsx
+++ b/packages/workout-spa-editor/src/contexts/garmin-bridge-context.tsx
@@ -9,20 +9,34 @@ const GarminBridgeContext = createContext<GarminBridgeState | null>(null);
 export const GarminBridgeProvider = ({ children }: { children: ReactNode }) => {
   const state = useGarminBridgeActions();
 
-  // TODO(fix-coaching-dialog-rules-of-hooks-followup): explicit field
-  // dependencies are deliberate — the store mutates `state` in place
-  // and we only want to re-render on the listed slices.
-  /* eslint-disable react-hooks/exhaustive-deps */
-  const value = useMemo(
-    () => state,
+  // Field-by-field spread so the memo recomputes only when the listed
+  // slices change. `useGarminBridgeActions` returns a fresh object literal
+  // every render, so we can't depend on `state` itself without losing the
+  // memoisation. Methods (detectExtension/pushWorkout/listWorkouts/setPushing)
+  // are stable references from useCallback/useState — including them in
+  // deps is safe.
+  const value = useMemo<GarminBridgeState>(
+    () => ({
+      extensionInstalled: state.extensionInstalled,
+      sessionActive: state.sessionActive,
+      pushing: state.pushing,
+      lastError: state.lastError,
+      detectExtension: state.detectExtension,
+      pushWorkout: state.pushWorkout,
+      listWorkouts: state.listWorkouts,
+      setPushing: state.setPushing,
+    }),
     [
       state.extensionInstalled,
       state.sessionActive,
       state.pushing,
       state.lastError,
+      state.detectExtension,
+      state.pushWorkout,
+      state.listWorkouts,
+      state.setPushing,
     ]
   );
-  /* eslint-enable react-hooks/exhaustive-deps */
 
   return (
     <GarminBridgeContext.Provider value={value}>

--- a/packages/workout-spa-editor/src/hooks/useKeyboardShortcuts.ts
+++ b/packages/workout-spa-editor/src/hooks/useKeyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import type { KeyboardShortcutHandlers } from "./keyboard-shortcut-handlers";
 import {
@@ -9,13 +9,21 @@ import {
 export type { KeyboardShortcutHandlers } from "./keyboard-shortcut-handlers";
 
 export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers) {
-  // TODO(fix-coaching-dialog-rules-of-hooks-followup): the explicit
-  // per-handler deps are intentional — depending on the whole `handlers`
-  // object would re-bind listeners on every parent render.
-  /* eslint-disable react-hooks/exhaustive-deps */
+  // Latest-handlers ref: bind listeners ONCE on mount but always invoke
+  // whatever handlers were passed on the most recent render. Avoids
+  // re-binding on every parent render (which the previous explicit-deps
+  // form was trying to manage manually) and satisfies exhaustive-deps
+  // cleanly because the effect references only the ref (stable).
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
   useEffect(() => {
-    const handleKeyDown = createKeyDownHandler(handlers);
-    const handleEscape = createEscapeHandler(handlers.onClearSelection);
+    // Listeners read handlersRef.current at FIRE-TIME (not at mount-time)
+    // so handler updates from parent renders are reflected immediately.
+    const handleKeyDown = (event: KeyboardEvent) =>
+      createKeyDownHandler(handlersRef.current)(event);
+    const handleEscape = (event: KeyboardEvent) =>
+      createEscapeHandler(handlersRef.current.onClearSelection)(event);
 
     window.addEventListener("keydown", handleKeyDown);
     window.addEventListener("keydown", handleEscape);
@@ -24,20 +32,5 @@ export function useKeyboardShortcuts(handlers: KeyboardShortcutHandlers) {
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("keydown", handleEscape);
     };
-  }, [
-    handlers.onSave,
-    handlers.onUndo,
-    handlers.onRedo,
-    handlers.onMoveStepUp,
-    handlers.onMoveStepDown,
-    handlers.onCopy,
-    handlers.onCut,
-    handlers.onPaste,
-    handlers.onCreateBlock,
-    handlers.onUngroupBlock,
-    handlers.onSelectAll,
-    handlers.onDelete,
-    handlers.onClearSelection,
-  ]);
-  /* eslint-enable react-hooks/exhaustive-deps */
+  }, []);
 }

--- a/packages/workout-spa-editor/src/hooks/useToast.ts
+++ b/packages/workout-spa-editor/src/hooks/useToast.ts
@@ -1,6 +1,6 @@
 import { useCallback, useState } from "react";
 
-import { createToastItem, createVariantToast } from "./useToast.helpers";
+import { createToastItem } from "./useToast.helpers";
 import type { ToastItem, ToastOptions } from "./useToast.types";
 
 export type { ToastItem, ToastOptions };
@@ -37,18 +37,40 @@ export const useToast = () => {
     setTimeout(() => setToasts([]), 200);
   }, []);
 
-  // TODO(fix-coaching-dialog-rules-of-hooks-followup): rewrite as
-  // inline functions per the lint rule's preferred shape; the current
-  // `createVariantToast(toast, "...")` form passes a function whose
-  // dependencies the linter cannot infer.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const success = useCallback(createVariantToast(toast, "success"), [toast]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const error = useCallback(createVariantToast(toast, "error"), [toast]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const warning = useCallback(createVariantToast(toast, "warning"), [toast]);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const info = useCallback(createVariantToast(toast, "info"), [toast]);
+  // Variant helpers: inline forms so exhaustive-deps can verify deps
+  // statically. Each forwards to `toast` with the variant baked in.
+  const success = useCallback(
+    (
+      title: string,
+      description?: string,
+      options?: Omit<ToastOptions, "title" | "description" | "variant">
+    ) => toast({ title, description, variant: "success", ...options }),
+    [toast]
+  );
+  const error = useCallback(
+    (
+      title: string,
+      description?: string,
+      options?: Omit<ToastOptions, "title" | "description" | "variant">
+    ) => toast({ title, description, variant: "error", ...options }),
+    [toast]
+  );
+  const warning = useCallback(
+    (
+      title: string,
+      description?: string,
+      options?: Omit<ToastOptions, "title" | "description" | "variant">
+    ) => toast({ title, description, variant: "warning", ...options }),
+    [toast]
+  );
+  const info = useCallback(
+    (
+      title: string,
+      description?: string,
+      options?: Omit<ToastOptions, "title" | "description" | "variant">
+    ) => toast({ title, description, variant: "info", ...options }),
+    [toast]
+  );
 
   return { toasts, toast, success, error, warning, info, dismiss, dismissAll };
 };


### PR DESCRIPTION
## Summary

Resolves the 8 deferred `react-hooks/exhaustive-deps` suppressions across 4 files left by PR #426 (`fix-coaching-dialog-rules-of-hooks`). All `eslint-disable` directives and `TODO(fix-coaching-dialog-rules-of-hooks-followup)` markers removed.

## Changes

| File | Approach |
|---|---|
| `contexts/garmin-bridge-context.tsx` | Explicit field-spread `useMemo` (fixes latent staleness — `useGarminBridgeActions` returns a fresh object literal each render) |
| `components/organisms/SettingsPanel/ExtensionsTab.tsx` | Destructure `detectExtension` from each bridge so deps reference stable methods directly |
| `hooks/useToast.ts` | Inline the variant helpers (`success`/`error`/`warning`/`info`) so exhaustive-deps verifies deps statically |
| `hooks/useKeyboardShortcuts.ts` | Latest-handlers ref pattern; bind listeners once but read `handlersRef.current` at fire-time (avoids both re-binding-per-render and stale-closure bugs) |

## Test plan

- [x] `pnpm --filter @kaiord/workout-spa-editor lint` — passes (typecheck + eslint + prettier)
- [x] `pnpm --filter @kaiord/workout-spa-editor test` — 3154/3154 passes
- [x] `grep -rn "fix-coaching-dialog-rules-of-hooks-followup\\|eslint-disable.*exhaustive-deps" packages/workout-spa-editor/src` — 0 hits (only my new explanatory comments mention "exhaustive-deps")
- [x] Pre-commit + pre-push hooks — passes

## Notes on behavioral equivalence

- **garmin-bridge-context**: the old `useMemo(() => state, [slice…])` had a latent staleness bug — the closure captured `state` at factory-execution time but only re-ran on the listed slices, while methods (which DID happen to be stable) hid the bug. The new explicit field-spread guarantees consumers see fresh values for every listed slice and methods are stable refs anyway, so semantics are preserved.
- **useKeyboardShortcuts**: the naive ref pattern (capture `handlersRef.current` at mount, bind once) would introduce a stale-closure bug since `createKeyDownHandler(handlers)` captures the handlers in its returned closure. The fix reads `handlersRef.current` AT FIRE-TIME — so handler updates from parent renders are reflected immediately on the next key event, while DOM listeners are bound only once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)