### PR TITLE
test(spa-editor): Playwright E2E for Train2Go-click coaching dialog (closes #450)

### DIFF
--- a/packages/workout-spa-editor/e2e/coaching-dialog-train2go.spec.ts
+++ b/packages/workout-spa-editor/e2e/coaching-dialog-train2go.spec.ts
@@ -61,7 +61,16 @@ test.describe("Coaching activity dialog — Train2Go click path", () => {
     const RECORD_ID = `${PROFILE_ID}:${SOURCE}:${SOURCE_ID}`;
     const VIEW_MODEL_ID = `${SOURCE}:${SOURCE_ID}`;
     await page.evaluate(
-      async ({ profileId, activityId, source, sourceId, day, ts, title, description }) => {
+      async ({
+        profileId,
+        activityId,
+        source,
+        sourceId,
+        day,
+        ts,
+        title,
+        description,
+      }) => {
         type Db = {
           table: (n: string) => {
             put: (r: unknown) => Promise<unknown>;
@@ -79,7 +88,9 @@ test.describe("Coaching activity dialog — Train2Go click path", () => {
           createdAt: ts,
           updatedAt: ts,
         });
-        await db.table("meta").put({ key: "activeProfileId", value: profileId });
+        await db
+          .table("meta")
+          .put({ key: "activeProfileId", value: profileId });
 
         await db.table("coachingActivities").put({
           id: activityId,
@@ -156,8 +167,6 @@ test.describe("Coaching activity dialog — Train2Go click path", () => {
     await expect(
       page.getByRole("alert", { name: /something went wrong/i })
     ).not.toBeVisible();
-    await expect(
-      page.getByText(/something went wrong/i)
-    ).not.toBeVisible();
+    await expect(page.getByText(/something went wrong/i)).not.toBeVisible();
   });
 });

--- a/packages/workout-spa-editor/e2e/coaching-dialog-train2go.spec.ts
+++ b/packages/workout-spa-editor/e2e/coaching-dialog-train2go.spec.ts
@@ -1,0 +1,163 @@
+/**
+ * E2E spec for the original Rules-of-Hooks repro (issue #450, deferred from
+ * the `fix-coaching-dialog-rules-of-hooks` change).
+ *
+ * Pre-fix bug: clicking a Train2Go-loaded coaching activity card crashed
+ * with "rendered more hooks than during the previous render" and surfaced
+ * the RouteErrorBoundary fallback ("Something went wrong" + role="alert").
+ *
+ * This spec seeds the calendar with a Train2Go-sourced coaching activity
+ * whose `description` is pre-materialised (so `expandActivity` is a no-op
+ * and the test does not need a live Train2Go bridge fixture), navigates
+ * to the week, clicks the card, and asserts:
+ *
+ *   1. CoachingActivityDialog opens (data-testid="coaching-activity-dialog").
+ *   2. The materialised description renders (NOT the loading placeholder).
+ *   3. RouteErrorBoundary's RouteErrorFallback ("Something went wrong"
+ *      role="alert") is NOT rendered anywhere on the page.
+ */
+
+import { expect, test } from "@playwright/test";
+
+import { clearDexie, getWeekDates, getWeekId } from "./helpers/seed-dexie";
+import { disableOnboardingTutorial } from "./test-setup";
+
+const PROFILE_ID = "t2g-click-profile";
+const ACTIVITY_TITLE = "Tempo intervals";
+const ACTIVITY_DESCRIPTION =
+  "20 min warm-up, 4 × 8 min @ tempo with 3 min recovery, 15 min cool-down";
+
+test.describe("Coaching activity dialog — Train2Go click path", () => {
+  test.beforeEach(async ({ page }) => {
+    await disableOnboardingTutorial(page);
+  });
+
+  test("clicking a T2G activity opens dialog with description; no error boundary", async ({
+    page,
+  }) => {
+    // 1. Boot the SPA so Dexie is initialised.
+    await page.goto("/calendar");
+    await page.waitForFunction(
+      () =>
+        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
+      { timeout: 10_000 }
+    );
+    await clearDexie(page);
+
+    // 2. Pick a deterministic day inside the visible week.
+    const weekDates = getWeekDates(0);
+    const visibleDay = weekDates[2]; // Wednesday — avoids the today-pill edge.
+    const weekId = getWeekId(visibleDay);
+    const now = new Date(visibleDay + "T08:00:00Z").toISOString();
+
+    // 3. Seed the active profile and a Train2Go coaching activity whose
+    // description is already materialised (so the dialog does NOT trigger
+    // expandActivity → bridge call).
+    const SOURCE = "train2go";
+    const SOURCE_ID = "t2g-act-1";
+    // Persisted CoachingActivityRecord.id (Dexie row primary key) includes
+    // the profile prefix; the view-model `CoachingActivity.id` (rendered
+    // into the data-testid) drops the prefix and is `${source}:${sourceId}`.
+    const RECORD_ID = `${PROFILE_ID}:${SOURCE}:${SOURCE_ID}`;
+    const VIEW_MODEL_ID = `${SOURCE}:${SOURCE_ID}`;
+    await page.evaluate(
+      async ({ profileId, activityId, source, sourceId, day, ts, title, description }) => {
+        type Db = {
+          table: (n: string) => {
+            put: (r: unknown) => Promise<unknown>;
+            bulkPut: (r: unknown[]) => Promise<unknown>;
+          };
+        };
+        const db = (window as unknown as Record<string, unknown>)
+          .__KAIORD_DB__ as Db;
+
+        await db.table("profiles").put({
+          id: profileId,
+          name: "T2G Test",
+          sportZones: {},
+          linkedAccounts: [{ source: "train2go", externalId: "t2g-acct-1" }],
+          createdAt: ts,
+          updatedAt: ts,
+        });
+        await db.table("meta").put({ key: "activeProfileId", value: profileId });
+
+        await db.table("coachingActivities").put({
+          id: activityId,
+          profileId,
+          source,
+          sourceId,
+          date: day,
+          sport: "running",
+          title,
+          status: "pending",
+          description,
+          duration: "60 min",
+          fetchedAt: ts,
+        });
+
+        // Seed an out-of-week dummy workout so `hasAnyWorkouts` is true
+        // and the FirstVisitState onboarding panel does not render. The
+        // panel intercepts pointer events at narrow viewports and would
+        // block the card click being tested here.
+        await db.table("workouts").put({
+          id: "t2g-click-dummy-workout",
+          date: "2020-01-01",
+          state: "raw",
+          sport: "cycling",
+          source: "manual",
+          sourceId: "dummy",
+          planId: null,
+          raw: { description: "x", duration: { value: 600, unit: "s" } },
+          krd: null,
+          lastProcessingError: null,
+          feedback: null,
+          aiMeta: null,
+          garminPushId: null,
+          tags: [],
+          previousState: null,
+          createdAt: ts,
+          modifiedAt: null,
+          updatedAt: ts,
+        });
+      },
+      {
+        profileId: PROFILE_ID,
+        activityId: RECORD_ID,
+        source: SOURCE,
+        sourceId: SOURCE_ID,
+        day: visibleDay,
+        ts: now,
+        title: ACTIVITY_TITLE,
+        description: ACTIVITY_DESCRIPTION,
+      }
+    );
+
+    // 4. Navigate to the seeded week and locate the card.
+    await page.goto(`/calendar/${weekId}`);
+    const card = page.getByTestId(`coaching-card-${VIEW_MODEL_ID}`);
+    await card.waitFor({ timeout: 10_000 });
+    await card.scrollIntoViewIfNeeded();
+    await expect(card).toBeVisible();
+
+    // 5. Click the card — the regression: pre-fix this triggered
+    // "rendered more hooks than during the previous render" and the
+    // RouteErrorBoundary fallback.
+    await card.click();
+
+    // 6. Dialog opens, description renders, no loading placeholder, no
+    // error fallback.
+    const dialog = page.getByTestId("coaching-activity-dialog");
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+    await expect(dialog).toContainText(ACTIVITY_TITLE);
+    await expect(dialog).toContainText(ACTIVITY_DESCRIPTION);
+    await expect(
+      page.getByTestId("coaching-dialog-description-loading")
+    ).not.toBeVisible();
+    await expect(
+      page.getByRole("alert", { name: /something went wrong/i })
+    ).not.toBeVisible();
+    await expect(
+      page.getByText(/something went wrong/i)
+    ).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Adds the Playwright E2E spec deferred from `fix-coaching-dialog-rules-of-hooks` (issue #450). Covers the original repro: clicking a Train2Go-loaded coaching activity card opens `CoachingActivityDialog` with the materialised description and does NOT surface the `RouteErrorBoundary` fallback.

Closes the user-trust gap on the coaching-data-ingest path — the fix landed via unit + integration smoke tests in PR #426; this spec is the missing E2E gate that detects the regression class end-to-end.

## What

- **`packages/workout-spa-editor/e2e/coaching-dialog-train2go.spec.ts`** — single spec, 5 browsers (chromium / firefox / webkit / Mobile Chrome / Mobile Safari).

## Approach

Pre-seed Dexie with a `CoachingActivityRecord` whose `description` is already populated, so `expandActivity` is a no-op and the spec needs no Train2Go bridge fixture (otherwise the spec would need to either drive the bridge against a stub Train2Go endpoint or stub the WebExtension messaging — both heavier than warranted for this regression class).

The seeded profile carries `linkedAccounts: [{ source: "train2go", … }]` so `useCoachingAutoSync` targets the source; the bridge call fails (no extension installed in playwright) but `syncWeek` returns `transport-error` early without touching the seeded row.

## Non-obvious fixtures

| Fixture | Why |
|---|---|
| `disableOnboardingTutorial(page)` (existing helper) | The "Welcome to Kaiord" tutorial dialog otherwise intercepts clicks at every viewport. |
| Out-of-week dummy workout (`date: "2020-01-01"`) | Sets `hasAnyWorkouts = true` so `FirstVisitState` does not render. That panel intercepts pointer events at narrow viewports (Mobile Chrome / Mobile Safari) and would block the card click. |
| `card.scrollIntoViewIfNeeded()` before click | The mobile viewports push the calendar below the fold; explicit scroll keeps the click reliable. |

## Activity ID note

The persisted `CoachingActivityRecord.id` is `${profileId}:${source}:${sourceId}` (composite Dexie key) but the view-model `CoachingActivity.id` rendered into the `data-testid` is `${source}:${sourceId}` (drops the profile prefix per `coaching-record-to-activity.converter.ts:21`). The spec uses both: `RECORD_ID` for the seed, `VIEW_MODEL_ID` for the testid lookup.

## Test plan

- [x] `pnpm exec playwright test coaching-dialog-train2go.spec.ts` — 5/5 browsers pass
- [x] Pre-commit + pre-push hooks (typecheck + scripts test + prettier) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test coverage for coaching activity card interactions in the calendar UI, validating that clicking a coaching card properly opens its dialog, displays activity details, and handles content loading without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->