### PR TITLE
feat(openspec): machine-readable tasks.md shape + ratio invariant (closes #465)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,22 @@ is enforced by `pnpm lint:archive-followups` once the change archives —
 archives carrying too many deferrals fail the lint as overscoped (the
 change should have been split before archiving).
 
+When archiving, also add a top-level `> Tasks: <C> completed, <D> deferred`
+marker at the very top of `tasks.md`. This unlocks the **ratio invariant**
+(`deferred ≤ completed` per archive — semantically correct overscope
+detection) instead of the legacy absolute cap. The declared `deferred`
+MUST match the count of `> Deferred to: #N` markers in the file; mismatch
+fails the lint. Archives without the marker fall back to the legacy cap
+for backward compat.
+
+```text
+> Tasks: 28 completed, 5 deferred
+
+<!-- opsx-ship: chunking ... -->
+
+## 1. ...
+```
+
 ## Ports & adapters (example: FIT)
 
 - **Ports** (`ports/fit.ts`): `FitReader.readToKRD(buf)`, `FitWriter.writeFromKRD(krd)`

--- a/openspec/SPEC_TEMPLATE.md
+++ b/openspec/SPEC_TEMPLATE.md
@@ -67,4 +67,24 @@ Authoring rules:
    `scripts/check-archive-followups.mjs` (run via
    `pnpm lint:archive-followups`) once the change archives; archives
    carrying ≥ ABSOLUTE_DEFERRAL_CAP markers fail the lint as overscoped.
+7. **Tasks marker (for change `tasks.md`, NOT this template):** when
+   a change archives, the author SHOULD add a top-level `> Tasks:`
+   marker that exposes shipped/deferred counts as machine-readable
+   data. This unlocks the **ratio invariant**: `deferred ≤ completed`
+   per archive — semantically correct overscope detection that
+   replaces the absolute cap on archives carrying the marker.
+
+   ```text
+   > Tasks: 28 completed, 5 deferred
+
+   <!-- opsx-ship: chunking ... -->
+
+   ## 1. ...
+   ```
+
+   Both counts are non-negative integers; the declared `deferred`
+   MUST equal the count of `> Deferred to: #N` markers in the same
+   file (audited by `pnpm lint:archive-followups`). Tasks.md files
+   without the marker fall back to the legacy absolute-cap policy
+   (see rule 6) for backward compat with pre-v2 archives.
 -->

--- a/openspec/SPEC_TEMPLATE.md
+++ b/openspec/SPEC_TEMPLATE.md
@@ -79,12 +79,14 @@ Authoring rules:
 
    <!-- opsx-ship: chunking ... -->
 
-   ## 1. ...
-   ```
+## 1. ...
 
-   Both counts are non-negative integers; the declared `deferred`
-   MUST equal the count of `> Deferred to: #N` markers in the same
-   file (audited by `pnpm lint:archive-followups`). Tasks.md files
-   without the marker fall back to the legacy absolute-cap policy
-   (see rule 6) for backward compat with pre-v2 archives.
+```
+
+Both counts are non-negative integers; the declared `deferred`
+MUST equal the count of `> Deferred to: #N` markers in the same
+file (audited by `pnpm lint:archive-followups`). Tasks.md files
+without the marker fall back to the legacy absolute-cap policy
+(see rule 6) for backward compat with pre-v2 archives.
 -->
+```

--- a/openspec/changes/tasks-machine-readable-shape/proposal.md
+++ b/openspec/changes/tasks-machine-readable-shape/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The `archive-followups-guard` capability shipped in PR #464 with an absolute cap (≥ 6 `> Deferred to: #N` markers per archive → fail). Per design D6 of `2026-05-03-repo-hygiene-tooling`, the cap is a **proxy** for the semantically correct invariant: "deferrals MUST NOT exceed shipped tasks per archive" (i.e., a change that defers more than it ships is genuinely overscoped).
+
+The cap fails in two well-known directions:
+
+- **False positives** on healthy-but-large archives (e.g., 30 shipped + 8 deferred is a 21% deferral rate — healthy — but trips a cap-of-6).
+- **False negatives** on small overscoped archives (e.g., 2 shipped + 4 deferred is genuinely overscoped — 200% deferral — but slips under cap-of-6).
+
+Issue #465 was filed at PR-2 ship-time as the architectural prerequisite for moving to the ratio invariant: `tasks.md` has no machine-readable shape today, so the script cannot count "completed tasks" reliably. This change adds that shape and switches the lint to the ratio rule when the shape is present.
+
+## What Changes
+
+- **New `> Tasks: <C> completed, <D> deferred` marker** in `tasks.md`. Top-level Markdown blockquote (same syntactic family as `> Completed:` and `> Deferred to:`). Sits at the very top of the file, before any `<!-- opsx-ship: chunking -->` HTML comment. Counts are non-negative integers; the marker is the source of truth (no checkbox-counting heuristic).
+- **`scripts/check-archive-followups.mjs` v2:** parse the new marker. When present, enforce `D ≤ C` (ratio invariant) AND audit that the declared `D` matches the actual count of `> Deferred to: #N` markers in the same file. When absent, fall back to the legacy absolute cap of 6 (current behavior, preserves backward-compat for pre-v2 archives).
+- **Test suite extended** from 8 to 15 branches: 7 new tests for the v2 marker path (healthy ratio, overscoped ratio, declared/actual mismatch, malformed marker, zero-deferred + non-zero-completed, boundary D = C, and the legacy-cap-still-applies path with the new error message hint).
+- **`SPEC_TEMPLATE.md` ¶7 + `AGENTS.md`** document the new marker shape, placement, and semantics. Existing ¶6 (`> Deferred to:` marker) unchanged.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `archive-followups-guard`: replaces the absolute-cap-only rule with a per-archive policy: ratio invariant when `> Tasks:` marker is present, legacy cap fallback when absent. The cap is no longer the primary contract — the ratio is. The cap stays as a backward-compat safety net until every archive carries the marker (a future PR may then remove the cap).
+
+## Impact
+
+- **Affected packages**: none of `packages/**`. Pure repo-tooling change.
+- **Affected layers (hexagonal)**: none.
+- **Public API**: no changes.
+- **Persistence migration**: none. Existing archives stay marker-less and continue under the legacy cap; the new marker is opt-in for new archives going forward.
+- **Dependencies**: no new runtime or dev dependencies.
+- **Quality gates**: `pnpm lint:specs`, `pnpm lint:archive-followups`, and `pnpm test:scripts` all pass on the merged state.
+- **Risk surface**: the v2 script has more branching logic. Mitigation: 15 co-located node:test cases cover ratio mode (6 branches) + legacy cap mode (8 branches) + the missing-tasks.md edge case.
+- **Spec drift**: `archive-followups-guard` capability spec reflects the v2 contract. The archived `2026-05-03-repo-hygiene-tooling` change keeps its v1-cap requirements intact (frozen archive content); this change supersedes them in the live capability spec.
+
+## Out of scope
+
+- **Backfilling existing archives** with the `> Tasks:` marker. Existing archives stay under the legacy cap (which they already pass). The marker is opt-in for new archives. Backfill could be a future cleanup if metrics demand it.
+- **Removing the absolute cap entirely.** The cap is still useful as a safety net for pre-v2 archives. Removal is gated on every archive carrying the marker — out of scope here.
+- **Auto-generating the `> Tasks:` marker at archive time.** The `/opsx-archive` skill could compute counts from tasks.md state, but that's a skill update, not a script update. Out of scope here; the marker is author-written for now.

--- a/openspec/changes/tasks-machine-readable-shape/specs/archive-followups-guard/spec.md
+++ b/openspec/changes/tasks-machine-readable-shape/specs/archive-followups-guard/spec.md
@@ -1,43 +1,4 @@
-> Synced: 2026-05-03 (tasks-machine-readable-shape)
-
-# Archive Followups Guard
-
-## Purpose
-
-Prevents OpenSpec change archives from accumulating silent overscope debt by enforcing the deferral invariant `deferred ≤ completed` (ratio mode) on archives that carry a machine-readable `> Tasks:` marker, with a legacy absolute-cap fallback for pre-v2 archives. The guard is mechanical (lint script + co-located node:test) per the project's `feedback_mechanical_over_ai` preference and runs as a sibling of `lint:archive` and `lint:archive-index`.
-
-## Requirements
-
-### Requirement: Canonical `> Deferred to: #N` marker in archived `tasks.md`
-
-A deferred task in an archived `openspec/changes/archive/<date>-<slug>/tasks.md` SHALL annotate its deferral with a Markdown blockquote as a sibling paragraph (blank line + 2-space indent — required so prettier does not collapse the marker onto the task line):
-
-```text
-- [ ] §N.M Task title
-
-  > Deferred to: #ISSUE_NUMBER
-```
-
-`ISSUE_NUMBER` SHALL be a positive integer prefixed with `#` (zero is rejected). URLs, free-form descriptions, and multi-issue references on one line SHALL NOT be valid forms; a task deferred to multiple issues SHALL emit one marker line per issue.
-
-The marker grammar SHALL belong to the same family as the existing `> Completed: YYYY-MM-DD` marker parsed by `scripts/check-archive-dates.mjs`. A single regex `^\s*> (Completed|Deferred to): (.+)$` SHALL distinguish the two marker types.
-
-`openspec/SPEC_TEMPLATE.md` and `AGENTS.md` SHALL document the marker shape, valid forms, and placement under their authoring guidance. `pnpm lint:specs` SHALL continue to pass on these documentation updates.
-
-#### Scenario: Single-issue deferral
-
-- **WHEN** a task in `tasks.md` is checked but its scope was deferred to issue #432
-- **THEN** the line immediately after the checkbox (with a blank-line separator and 2-space indent) SHALL read `> Deferred to: #432`
-
-#### Scenario: Multi-issue deferral emits one marker per issue
-
-- **WHEN** a task was split and deferred to issues #432 and #435
-- **THEN** two marker lines SHALL appear after the checkbox: `> Deferred to: #432` and `> Deferred to: #435`
-
-#### Scenario: Marker grammar is rejected for non-canonical forms
-
-- **WHEN** a `tasks.md` contains `> Deferred to: https://github.com/owner/repo/issues/432` OR `> Deferred to: issue 432` OR `> Deferred to: #432, #435` OR `> Deferred to: #0`
-- **THEN** `pnpm lint:archive-followups` SHALL fail with a parse error naming the offending file and line
+## ADDED Requirements
 
 ### Requirement: Canonical `> Tasks:` marker for shipped/deferred counts
 
@@ -67,7 +28,7 @@ When an archive carries a well-formed `> Tasks: <C> completed, <D> deferred` mar
 1. **Audit consistency:** `<D>` MUST equal the number of `> Deferred to: #N` markers in the same file. A mismatch SHALL fail the lint with a message naming the declared count vs. the actual count.
 2. **Ratio invariant:** `<D>` MUST be ≤ `<C>`. A change that defers more tasks than it shipped is genuinely overscoped — the lint SHALL fail with a message naming both counts.
 
-A healthy-but-large archive (e.g., 30 completed / 5 deferred) SHALL pass even when 5 ≥ ABSOLUTE_DEFERRAL_CAP — the ratio is the contract for marker-bearing archives, not the cap.
+A healthy-but-large archive (e.g., 30 completed / 7 deferred) SHALL pass even when `<D>` ≥ `ABSOLUTE_DEFERRAL_CAP` — the ratio is the contract for marker-bearing archives, not the cap.
 
 #### Scenario: Healthy ratio passes despite legacy cap
 
@@ -93,6 +54,8 @@ A healthy-but-large archive (e.g., 30 completed / 5 deferred) SHALL pass even wh
 - **WHEN** the lint runs
 - **THEN** the lint SHALL pass — the invariant is `D ≤ C`, not `D < C`
 
+## MODIFIED Requirements
+
 ### Requirement: Legacy absolute-cap fallback when `> Tasks:` marker is absent
 
 When an archive's `tasks.md` does NOT carry a `> Tasks:` marker, the script SHALL fall back to the legacy absolute-cap policy: if the count of `> Deferred to: #N` markers is ≥ `ABSOLUTE_DEFERRAL_CAP` (currently 6), the lint SHALL fail. The fallback exists so pre-v2 archives that never carried the new marker continue to be policed against silent overscope.
@@ -112,24 +75,3 @@ The fail message in fallback mode SHALL hint at the upgrade path — i.e., advis
 - **GIVEN** a `tasks.md` has 6 `> Deferred to:` markers and NO `> Tasks:` marker
 - **WHEN** the lint runs
 - **THEN** the script SHALL exit non-zero with a message including `(≥ cap 6)` AND a hint to add `> Tasks: <C> completed, <D> deferred` for ratio-based checking
-
-### Requirement: Architectural mirror of `check-archive-dates.mjs`
-
-The lint script SHALL mirror the architectural pattern of `scripts/check-archive-dates.mjs`: identical entry-point check (`pathToFileURL(process.argv[1]) === import.meta.url`), exported `checkArchiveFollowups()` function returning a violation-collection structure, exit-with-code-after-collection pattern. Non-zero exits SHALL list the offending archive folder names alongside their counts.
-
-The script SHALL be wired as a sibling lint script in `package.json`:
-
-| Script                   | Behavior                                                                                       |
-| ------------------------ | ---------------------------------------------------------------------------------------------- |
-| `lint:archive`           | Existing folder-vs-Completed invariant. Unchanged.                                             |
-| `lint:archive-index`     | Existing `archive/README.md` index freshness. Unchanged.                                       |
-| `lint:archive-followups` | This. Runs `node scripts/check-archive-followups.mjs` (ratio + cap fallback per archive).      |
-
-The umbrella `pnpm lint` SHALL run all three. The husky `pre-commit` hook chain SHALL include `lint:archive-followups` so deferral-marker edits are caught locally before push.
-
-`scripts/check-archive-followups.test.mjs` SHALL be a co-located node:test suite covering: zero-deferral archive (pass + silent), legacy below-cap archive (pass + log), legacy at-cap archive (fail + cap message + marker hint), legacy malformed deferred-to marker (fail + parse error), v2 healthy ratio (pass even when ≥ cap), v2 overscoped ratio (fail), v2 declared/actual mismatch (fail), v2 malformed `> Tasks:` marker (fail + parse error), v2 zero-deferred-non-zero-completed (pass), v2 boundary D = C (pass). Test fixtures SHALL be created in temporary directories so the suite does not depend on the state of `openspec/changes/archive/`.
-
-#### Scenario: Suite covers both modes
-
-- **WHEN** `pnpm test:scripts` runs
-- **THEN** the `check-archive-followups.test.mjs` suite SHALL include at least 14 tests (the original 8 legacy-mode branches + 6 new ratio-mode branches)

--- a/openspec/changes/tasks-machine-readable-shape/tasks.md
+++ b/openspec/changes/tasks-machine-readable-shape/tasks.md
@@ -1,0 +1,41 @@
+<!-- opsx-ship: chunking
+Single PR — pure tooling + docs change, no code in packages/**.
+-->
+
+## 1. Marker grammar in SPEC_TEMPLATE + AGENTS
+
+- [x] 1.1 `openspec/SPEC_TEMPLATE.md` gains paragraph 7 documenting the `> Tasks: <C> completed, <D> deferred` marker — placement (top of `tasks.md`, before any chunking HTML comment), shape, and contract that the lint enforces ratio when present.
+- [x] 1.2 `AGENTS.md` "Spec Awareness" section updated alongside the existing `> Deferred to:` paragraph, noting the new marker, placement, and that authors SHOULD add it when archiving.
+- [x] 1.3 `pnpm lint:specs` passes.
+
+## 2. Script — ratio invariant + legacy cap fallback
+
+- [x] 2.1 `scripts/check-archive-followups.mjs` v2 parses `> Tasks: <C> completed, <D> deferred`. Per archive: marker present → ratio + audit checks (D ≤ C; declared D = actual `> Deferred to:` count); marker absent → legacy absolute-cap fallback (current behavior).
+- [x] 2.2 Malformed `> Tasks:` marker (non-numeric counts, wrong field order, partial fields) fails the lint with a parse error naming the file and line.
+- [x] 2.3 Mismatch between declared `D` and actual count of `> Deferred to: #N` in the same file fails with a clear message ("declares N deferred but tasks.md contains M lines — counts must agree").
+- [x] 2.4 `ABSOLUTE_DEFERRAL_CAP` stays exported (for legacy archives without the marker).
+
+## 3. Tests — co-located node:test branches
+
+- [x] 3.1 New: v2 healthy ratio (5 deferred / 30 completed) — pass even though 5 ≥ legacy cap.
+- [x] 3.2 New: v2 overscoped ratio (5 deferred / 2 completed) — fail with "5 deferred > 2 completed — change was overscoped" message.
+- [x] 3.3 New: v2 declared/actual mismatch — declared 3, actual 2 in body — fail with mismatch message.
+- [x] 3.4 New: v2 malformed marker (non-numeric counts) — fail with parse error.
+- [x] 3.5 New: v2 zero deferred + non-zero completed — pass.
+- [x] 3.6 New: v2 boundary D = C — pass (invariant is `D ≤ C`).
+- [x] 3.7 New: legacy at-cap archive — fail message includes hint "add > Tasks: ..." for upgrade path.
+- [x] 3.8 All 8 pre-existing tests still pass (zero deferrals, below-cap, malformed deferred-to, multi-archive, missing tasks.md). Total: 15/15 green.
+
+## 4. Live spec update
+
+- [x] 4.1 `openspec/specs/archive-followups-guard/spec.md` rewritten to reflect the v2 contract: 5 requirements (Deferred-to marker, Tasks marker, Ratio invariant, Legacy cap fallback, Architectural mirror). `> Synced:` updated to today + this change slug.
+- [x] 4.2 `npx openspec validate --specs --strict` passes.
+- [x] 4.3 `npx openspec validate tasks-machine-readable-shape --strict` passes.
+
+## 5. Validate + commit
+
+- [x] 5.1 `pnpm test:scripts` — 15 archive-followups tests pass; total scripts test suite passes.
+- [x] 5.2 `pnpm lint:archive-followups` — passes against current archive state (the existing `2026-05-01-calendar-coaching-redesign` archive at 5 deferrals, no marker, stays under legacy cap of 6).
+- [x] 5.3 `pnpm lint:specs` — 33/33 passes.
+- [x] 5.4 Pre-commit + pre-push hooks pass.
+- [ ] 5.5 PR opens; reviewer can verify (a) test coverage of both modes, (b) backward-compat (existing archives still pass), (c) the SPEC_TEMPLATE/AGENTS docs guide authors to use the marker on new archives.

--- a/openspec/specs/archive-followups-guard/spec.md
+++ b/openspec/specs/archive-followups-guard/spec.md
@@ -119,11 +119,11 @@ The lint script SHALL mirror the architectural pattern of `scripts/check-archive
 
 The script SHALL be wired as a sibling lint script in `package.json`:
 
-| Script                   | Behavior                                                                                       |
-| ------------------------ | ---------------------------------------------------------------------------------------------- |
-| `lint:archive`           | Existing folder-vs-Completed invariant. Unchanged.                                             |
-| `lint:archive-index`     | Existing `archive/README.md` index freshness. Unchanged.                                       |
-| `lint:archive-followups` | This. Runs `node scripts/check-archive-followups.mjs` (ratio + cap fallback per archive).      |
+| Script                   | Behavior                                                                                  |
+| ------------------------ | ----------------------------------------------------------------------------------------- |
+| `lint:archive`           | Existing folder-vs-Completed invariant. Unchanged.                                        |
+| `lint:archive-index`     | Existing `archive/README.md` index freshness. Unchanged.                                  |
+| `lint:archive-followups` | This. Runs `node scripts/check-archive-followups.mjs` (ratio + cap fallback per archive). |
 
 The umbrella `pnpm lint` SHALL run all three. The husky `pre-commit` hook chain SHALL include `lint:archive-followups` so deferral-marker edits are caught locally before push.
 

--- a/scripts/check-archive-followups.mjs
+++ b/scripts/check-archive-followups.mjs
@@ -2,14 +2,22 @@
 // Enforce the archive-followups invariant:
 //
 //   For each openspec/changes/archive/<dated-slug>/tasks.md,
-//   the count of `> Deferred to: #<N>` markers MUST be below
-//   ABSOLUTE_DEFERRAL_CAP. The cap encodes the contract:
-//   "deferrals MUST NOT exceed shipped tasks" (overscope guard).
+//   the count of `> Deferred to: #<N>` markers MUST satisfy the
+//   overscope contract: "deferrals MUST NOT exceed shipped tasks
+//   per archive."
 //
-//   v1 uses an absolute cap; v2 will refine to a deferral-ratio
-//   invariant once tasks.md gains a machine-readable shape.
-//   See openspec/changes/archive-followups-guard/spec.md for the
-//   sunset trigger.
+// v2 (this script) supports two modes per archive:
+//
+//   (a) Marker-present: the tasks.md carries
+//       `> Tasks: <C> completed, <D> deferred` near the top. The
+//       script enforces the ratio invariant: D ≤ C. The declared
+//       D MUST also equal the count of `> Deferred to: #N` markers
+//       in the same file (auditing consistency).
+//
+//   (b) Marker-absent (legacy): the script falls back to the v1
+//       absolute cap of 6 deferral markers. Existing pre-v2 archives
+//       continue to be policed under the cap until they're either
+//       backfilled with the marker or stay grandfathered below the cap.
 //
 // Architectural mirror of scripts/check-archive-dates.mjs:
 // same entry-point check, same exported function shape, same
@@ -23,10 +31,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
 const ARCHIVE_DIR = join(REPO_ROOT, "openspec", "changes", "archive");
 
-// v1 cap. Sunset trigger (per spec): replace with deferral-ratio
-// invariant when (a) a 3rd archive trips the cap, OR (b) tasks.md
-// gains a machine-readable shape. Lowered from 6 to 5 once the
-// calibration data justifies it.
+// Legacy cap. Applies only when the `> Tasks:` marker is absent on a
+// given archive. Future PRs MAY remove this once every archive in the
+// tree carries the marker; until then the cap grandfathers pre-v2
+// archives against silent overscope.
 export const ABSOLUTE_DEFERRAL_CAP = 6;
 
 // Markers live indented under the checkbox they annotate (per spec example
@@ -35,7 +43,21 @@ export const ABSOLUTE_DEFERRAL_CAP = 6;
 // Issue numbers MUST be POSITIVE integers (#0 rejected) — the spec contract
 // names a positive-integer GitHub issue number.
 const deferredRe = /^\s*> Deferred to: #([1-9]\d*)\s*$/gm;
-const malformedRe = /^\s*> Deferred to:(?! #[1-9]\d*\s*$).*$/gm;
+const malformedDeferredRe = /^\s*> Deferred to:(?! #[1-9]\d*\s*$).*$/gm;
+
+// `> Tasks: N completed, M deferred` lives at the top of tasks.md (after
+// any opsx-ship chunking HTML comment). Both counts are non-negative
+// integers; the marker is the SOURCE OF TRUTH for shipped/deferred
+// counts. The script does NOT count `[x]` checkboxes (which conflate
+// fully-shipped and partially-shipped tasks).
+const tasksMarkerRe = /^\s*> Tasks: (\d+) completed, (\d+) deferred\s*$/m;
+const malformedTasksRe = /^\s*> Tasks:(?! \d+ completed, \d+ deferred\s*$).*$/gm;
+
+function parseTasksMarker(src) {
+  const match = tasksMarkerRe.exec(src);
+  if (!match) return null;
+  return { completed: Number(match[1]), deferred: Number(match[2]) };
+}
 
 export function checkArchiveFollowups(archiveDir = ARCHIVE_DIR) {
   const violations = [];
@@ -54,21 +76,61 @@ export function checkArchiveFollowups(archiveDir = ARCHIVE_DIR) {
 
     const src = readFileSync(tasksPath, "utf8");
 
-    const malformed = [...src.matchAll(malformedRe)];
-    for (const m of malformed) {
+    // Reject malformed deferred-to markers (URL form, missing hash, #0, etc.).
+    for (const m of src.matchAll(malformedDeferredRe)) {
       violations.push(
         `${tasksPath}: malformed marker "${m[0].trim()}" — must be "> Deferred to: #<N>"`
       );
     }
 
-    const matches = [...src.matchAll(deferredRe)];
-    const count = matches.length;
-    if (count > 0) counts.push({ folder: entry, count });
-
-    if (count >= ABSOLUTE_DEFERRAL_CAP) {
+    // Reject malformed Tasks markers (non-numeric counts, wrong order, etc.).
+    for (const m of src.matchAll(malformedTasksRe)) {
       violations.push(
-        `${folder}: ${count} deferrals (≥ cap ${ABSOLUTE_DEFERRAL_CAP}) — change is overscoped`
+        `${tasksPath}: malformed marker "${m[0].trim()}" — must be "> Tasks: <N> completed, <M> deferred"`
       );
+    }
+
+    const deferredMatches = [...src.matchAll(deferredRe)];
+    const deferredCount = deferredMatches.length;
+    const tasksMarker = parseTasksMarker(src);
+
+    if (tasksMarker) {
+      // v2 mode: ratio invariant + audit consistency.
+      const { completed, deferred } = tasksMarker;
+      counts.push({
+        folder: entry,
+        deferred,
+        completed,
+        mode: "ratio",
+      });
+
+      if (deferred !== deferredCount) {
+        violations.push(
+          `${folder}: marker declares ${deferred} deferred but tasks.md contains ${deferredCount} "> Deferred to:" line(s) — counts must agree`
+        );
+      }
+
+      if (deferred > completed) {
+        violations.push(
+          `${folder}: ${deferred} deferred > ${completed} completed — change was overscoped (deferred more than shipped)`
+        );
+      }
+    } else {
+      // Legacy mode: absolute cap fallback.
+      if (deferredCount > 0) {
+        counts.push({
+          folder: entry,
+          deferred: deferredCount,
+          completed: null,
+          mode: "cap",
+        });
+      }
+
+      if (deferredCount >= ABSOLUTE_DEFERRAL_CAP) {
+        violations.push(
+          `${folder}: ${deferredCount} deferrals (≥ cap ${ABSOLUTE_DEFERRAL_CAP}) — change is overscoped (no Tasks marker — add "> Tasks: <C> completed, <D> deferred" for ratio-based check)`
+        );
+      }
     }
   }
 
@@ -78,10 +140,16 @@ export function checkArchiveFollowups(archiveDir = ARCHIVE_DIR) {
 if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   const { violations, counts } = checkArchiveFollowups();
 
-  for (const { folder, count } of counts) {
-    console.log(
-      `  ${folder}: ${count} deferrals (cap ${ABSOLUTE_DEFERRAL_CAP})`
-    );
+  for (const c of counts) {
+    if (c.mode === "ratio") {
+      console.log(
+        `  ${c.folder}: ${c.deferred} deferred / ${c.completed} completed (ratio mode)`
+      );
+    } else {
+      console.log(
+        `  ${c.folder}: ${c.deferred} deferrals (legacy cap ${ABSOLUTE_DEFERRAL_CAP})`
+      );
+    }
   }
 
   if (violations.length > 0) {
@@ -90,12 +158,10 @@ if (import.meta.url === pathToFileURL(process.argv[1]).href) {
     );
     for (const v of violations) console.error(`  ${v}`);
     console.error(
-      `\nA change with ${ABSOLUTE_DEFERRAL_CAP}+ "> Deferred to: #N" markers in tasks.md is overscoped.\nSplit it before archiving, or address the deferrals first.`
+      `\nWith a "> Tasks: <C> completed, <D> deferred" marker, deferrals MUST NOT exceed shipped tasks (D ≤ C).\nWithout the marker, legacy cap of ${ABSOLUTE_DEFERRAL_CAP} deferrals applies. Add the marker to opt into ratio-based checks.`
     );
     process.exit(1);
   }
 
-  console.log(
-    `openspec/changes/archive: deferrals ≤ ${ABSOLUTE_DEFERRAL_CAP - 1} per change.`
-  );
+  console.log("openspec/changes/archive: deferral invariants hold.");
 }

--- a/scripts/check-archive-followups.mjs
+++ b/scripts/check-archive-followups.mjs
@@ -51,7 +51,8 @@ const malformedDeferredRe = /^\s*> Deferred to:(?! #[1-9]\d*\s*$).*$/gm;
 // counts. The script does NOT count `[x]` checkboxes (which conflate
 // fully-shipped and partially-shipped tasks).
 const tasksMarkerRe = /^\s*> Tasks: (\d+) completed, (\d+) deferred\s*$/m;
-const malformedTasksRe = /^\s*> Tasks:(?! \d+ completed, \d+ deferred\s*$).*$/gm;
+const malformedTasksRe =
+  /^\s*> Tasks:(?! \d+ completed, \d+ deferred\s*$).*$/gm;
 
 function parseTasksMarker(src) {
   const match = tasksMarkerRe.exec(src);

--- a/scripts/check-archive-followups.test.mjs
+++ b/scripts/check-archive-followups.test.mjs
@@ -67,6 +67,10 @@ const buildDeferral = (issues) =>
     )
     .join("");
 
+const buildWithMarker = (completed, issues) =>
+  `> Tasks: ${completed} completed, ${issues.length} deferred\n\n` +
+  buildDeferral(issues);
+
 test("zero deferrals → exit 0, no count line for that archive", () => {
   const h = mkHarness((arc) =>
     writeTasks(arc, "2026-05-01-clean", ZERO_DEFERRAL)
@@ -169,6 +173,146 @@ test("multiple archives: one over-cap, one under, one zero — only the over-cap
     assert.ok(!r.stderr.includes("2026-05-06-clean"));
     assert.ok(!r.stderr.includes("2026-05-07-light"));
     assert.ok(r.stdout.includes("2026-05-07-light: 2 deferrals"));
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("v2 marker — healthy ratio (5 deferred / 30 completed) passes despite legacy cap", () => {
+  const h = mkHarness((arc) =>
+    writeTasks(
+      arc,
+      "2026-05-10-healthy-large",
+      buildWithMarker(30, [501, 502, 503, 504, 505, 506, 507])
+    )
+  );
+  try {
+    const r = h.run();
+    assert.equal(r.status, 0, r.stderr || r.stdout);
+    assert.ok(
+      r.stdout.includes(
+        "2026-05-10-healthy-large: 7 deferred / 30 completed (ratio mode)"
+      ),
+      r.stdout
+    );
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("v2 marker — overscoped ratio (5 deferred / 2 completed) fails with ratio violation", () => {
+  const h = mkHarness((arc) =>
+    writeTasks(
+      arc,
+      "2026-05-11-overscoped",
+      buildWithMarker(2, [601, 602, 603, 604, 605])
+    )
+  );
+  try {
+    const r = h.run();
+    assert.notEqual(r.status, 0);
+    assert.ok(
+      r.stderr.includes("5 deferred > 2 completed"),
+      r.stderr
+    );
+    assert.ok(r.stderr.includes("overscoped"), r.stderr);
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("v2 marker — declared/actual count mismatch fails", () => {
+  const inconsistent =
+    `> Tasks: 10 completed, 3 deferred\n\n` +
+    `## 1. Foo\n\n` +
+    `- [ ] 1.1 a\n      > Deferred to: #700\n` +
+    `- [ ] 1.2 b\n      > Deferred to: #701\n`;
+  const h = mkHarness((arc) =>
+    writeTasks(arc, "2026-05-12-mismatch", inconsistent)
+  );
+  try {
+    const r = h.run();
+    assert.notEqual(r.status, 0);
+    assert.ok(
+      r.stderr.includes("declares 3 deferred but tasks.md contains 2"),
+      r.stderr
+    );
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("v2 marker — malformed (non-numeric) fails with parse error", () => {
+  const malformed =
+    `> Tasks: ten completed, two deferred\n\n## 1. Foo\n\n- [x] 1.1 done\n`;
+  const h = mkHarness((arc) =>
+    writeTasks(arc, "2026-05-13-malformed-marker", malformed)
+  );
+  try {
+    const r = h.run();
+    assert.notEqual(r.status, 0);
+    assert.ok(r.stderr.includes("malformed marker"), r.stderr);
+    assert.ok(r.stderr.includes("> Tasks:"), r.stderr);
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("v2 marker — zero deferred + non-zero completed passes", () => {
+  const h = mkHarness((arc) =>
+    writeTasks(
+      arc,
+      "2026-05-14-clean-with-marker",
+      `> Tasks: 8 completed, 0 deferred\n\n## 1. Foo\n\n- [x] 1.1 done\n`
+    )
+  );
+  try {
+    const r = h.run();
+    assert.equal(r.status, 0, r.stderr || r.stdout);
+    assert.ok(
+      r.stdout.includes(
+        "2026-05-14-clean-with-marker: 0 deferred / 8 completed (ratio mode)"
+      ),
+      r.stdout
+    );
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("v2 marker — boundary ratio (D = C) passes", () => {
+  const h = mkHarness((arc) =>
+    writeTasks(
+      arc,
+      "2026-05-15-equal",
+      buildWithMarker(3, [801, 802, 803])
+    )
+  );
+  try {
+    const r = h.run();
+    assert.equal(r.status, 0, r.stderr || r.stdout);
+  } finally {
+    h.cleanup();
+  }
+});
+
+test("legacy cap still applies when Tasks marker is absent", () => {
+  const h = mkHarness((arc) =>
+    writeTasks(
+      arc,
+      "2026-05-16-legacy-tripped",
+      buildDeferral([901, 902, 903, 904, 905, 906])
+    )
+  );
+  try {
+    const r = h.run();
+    assert.notEqual(r.status, 0);
+    assert.ok(r.stderr.includes("2026-05-16-legacy-tripped"), r.stderr);
+    assert.ok(r.stderr.includes("≥ cap 6"), r.stderr);
+    assert.ok(
+      r.stderr.includes('add "> Tasks:'),
+      "error message should hint at the marker"
+    );
   } finally {
     h.cleanup();
   }

--- a/scripts/check-archive-followups.test.mjs
+++ b/scripts/check-archive-followups.test.mjs
@@ -211,10 +211,7 @@ test("v2 marker — overscoped ratio (5 deferred / 2 completed) fails with ratio
   try {
     const r = h.run();
     assert.notEqual(r.status, 0);
-    assert.ok(
-      r.stderr.includes("5 deferred > 2 completed"),
-      r.stderr
-    );
+    assert.ok(r.stderr.includes("5 deferred > 2 completed"), r.stderr);
     assert.ok(r.stderr.includes("overscoped"), r.stderr);
   } finally {
     h.cleanup();
@@ -243,8 +240,7 @@ test("v2 marker — declared/actual count mismatch fails", () => {
 });
 
 test("v2 marker — malformed (non-numeric) fails with parse error", () => {
-  const malformed =
-    `> Tasks: ten completed, two deferred\n\n## 1. Foo\n\n- [x] 1.1 done\n`;
+  const malformed = `> Tasks: ten completed, two deferred\n\n## 1. Foo\n\n- [x] 1.1 done\n`;
   const h = mkHarness((arc) =>
     writeTasks(arc, "2026-05-13-malformed-marker", malformed)
   );
@@ -282,11 +278,7 @@ test("v2 marker — zero deferred + non-zero completed passes", () => {
 
 test("v2 marker — boundary ratio (D = C) passes", () => {
   const h = mkHarness((arc) =>
-    writeTasks(
-      arc,
-      "2026-05-15-equal",
-      buildWithMarker(3, [801, 802, 803])
-    )
+    writeTasks(arc, "2026-05-15-equal", buildWithMarker(3, [801, 802, 803]))
   );
   try {
     const r = h.run();


### PR DESCRIPTION
## Summary

Closes #465 — the architectural prerequisite for moving the archive-followups guard from an absolute cap proxy to the semantically correct **ratio invariant** (deferrals MUST NOT exceed shipped tasks per archive).

## What

Adds the `> Tasks: <C> completed, <D> deferred` marker as the source of truth for shipped/deferred counts in archived `tasks.md`. When the marker is present, the lint enforces the ratio invariant + audits that the declared `D` matches the actual count of `> Deferred to: #N` markers in the file. When the marker is absent, the lint falls back to the legacy absolute cap of 6 (preserves backward-compat for pre-v2 archives).

## Changes

| File | Change |
|---|---|
| `scripts/check-archive-followups.mjs` | v2 — parse Tasks marker, ratio + audit-consistency checks, legacy cap fallback |
| `scripts/check-archive-followups.test.mjs` | 8 → 15 branches (7 new ratio-mode tests) |
| `openspec/SPEC_TEMPLATE.md` | ¶7 documenting the marker |
| `AGENTS.md` | Marker added alongside the existing `> Deferred to:` paragraph |
| `openspec/specs/archive-followups-guard/spec.md` | Rewritten for the v2 contract: 5 requirements |
| `openspec/changes/tasks-machine-readable-shape/` | Proposal + tasks + change-delta with ADDED + MODIFIED requirements |

## Why this fixes the false-positive/negative trap

The cap-of-6 was a proxy for the right invariant:

- **False positives** on healthy-but-large archives (e.g., 30 shipped + 8 deferred is healthy but trips the cap).
- **False negatives** on small overscoped archives (e.g., 2 shipped + 4 deferred is genuinely overscoped but slips under the cap).

With the marker, the lint computes the actual ratio — healthy-but-large archives pass at any deferral count, and small overscoped archives fail even with low absolute counts.

## Backward compatibility

Existing archives stay marker-less and continue under the legacy cap (which they already pass — the calendar-redesign archive at 5 deferrals continues to log `5 deferrals (legacy cap 6)` and pass). The marker is opt-in for new archives going forward. A future PR may remove the cap entirely once every archive carries the marker.

## Test plan

- [x] `pnpm test:scripts` — 322/322 passes (15 archive-followups branches: 8 legacy + 7 new ratio mode + missing-tasks.md edge case)
- [x] `pnpm lint:specs` — 33/33
- [x] `npx openspec validate tasks-machine-readable-shape --strict` — passes
- [x] `pnpm lint:archive-followups` — passes against current archive state
- [x] Pre-commit + pre-push hooks — all pass

## Out of scope

- Backfilling existing archives with the marker
- Removing the absolute cap entirely (gated on every archive carrying the marker)
- Auto-generating the marker at archive time via /opsx-archive (skill update, not script update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)