### PR TITLE
chore(ci): fan build artifacts to consumer jobs

### DIFF
--- a/.changeset/happy-plants-sort.md
+++ b/.changeset/happy-plants-sort.md
@@ -1,0 +1,15 @@
+---
+---
+
+ci: build packages once per workflow run and fan dist out to consumer jobs.
+
+Refactors `.github/workflows/ci.yml` so the `build` job is the sole producer of
+`packages/*/dist/` per CI run; every consumer job (`lint`, `typecheck`, `test`,
+`test-cli`, `test-frontend`, `round-trip`, `e2e-frontend`, `e2e-prod-base`) now
+downloads the `build-artifacts` artifact via a new
+`.github/actions/consume-build-artifacts` composite action instead of running
+`pnpm -r build` from scratch. Bundle analysis (`@codecov/vite-plugin`) moved to
+its own dedicated `bundle-analysis` job. Branch-protection summary jobs gain
+build-awareness so a build failure cannot land on main.
+
+Tooling-only — no package version bumps.

--- a/.github/actions/consume-build-artifacts/action.yml
+++ b/.github/actions/consume-build-artifacts/action.yml
@@ -26,10 +26,17 @@ runs:
       run: rm -rf packages/*/dist
 
     - name: Download build artifacts
+      # actions/upload-artifact uses the least-common-ancestor of the
+      # configured `path:` glob set as the artifact root. With our
+      # upload paths (packages/*/dist/, packages/*/package.json), the
+      # LCA is `packages/` — so the artifact internal structure is
+      # `core/dist/...`, `core/package.json`, etc. (NO leading
+      # `packages/`). Extracting to `path: packages` re-introduces the
+      # prefix so consumers see `packages/core/dist/...` as expected.
       uses: actions/download-artifact@v7
       with:
         name: build-artifacts
-        path: .
+        path: packages
 
     - name: Verify dist exists and contains no symlinks
       # SECURITY: input is materialized into env first so a future

--- a/.github/actions/consume-build-artifacts/action.yml
+++ b/.github/actions/consume-build-artifacts/action.yml
@@ -1,0 +1,66 @@
+# The single chokepoint where a consumer job receives the run-scoped
+# build artifact. See openspec/specs/ci-build-fanout/spec.md. The
+# consumer enumeration is hardcoded in
+# scripts/check-ci-fanout-invariants.mjs; adding a new consumer
+# requires updating that whitelist alongside the consumer's YAML.
+name: "Consume build artifacts"
+description: "Wipe stale dist, download build-artifacts, verify result."
+
+inputs:
+  expected-packages:
+    description: "Space-separated list of package names whose packages/<name>/dist/ MUST exist after download. Default covers all publishable packages."
+    required: false
+    default: "core fit tcx zwo garmin garmin-connect cli mcp ai"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Wipe stale dist (artifact is source of truth)
+      # INVARIANT: every package under packages/*/ is in the upload glob
+      # (packages/*/dist/). Wiping packages/*/dist before download is
+      # safe because the subsequent download re-creates every required
+      # dist/ directory; the Verify step fails fast if any expected one
+      # is missing. The wipe neutralises setup-pnpm's TypeScript-cache
+      # restore so it cannot leak files into a hybrid filesystem.
+      shell: bash
+      run: rm -rf packages/*/dist
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v7
+      with:
+        name: build-artifacts
+        path: .
+
+    - name: Verify dist exists and contains no symlinks
+      # SECURITY: input is materialized into env first so a future
+      # caller passing `core; rm -rf /` becomes a literal token in
+      # the array, not a shell metacharacter.
+      shell: bash
+      env:
+        EXPECTED: ${{ inputs.expected-packages }}
+      run: |
+        read -ra pkgs <<< "$EXPECTED"
+        missing=0
+        for pkg in "${pkgs[@]}"; do
+          if [ ! -d "packages/$pkg/dist" ]; then
+            echo "::error::Artifact 'build-artifacts' from job 'build' did not land packages/$pkg/dist."
+            echo "::error::Possible causes: (1) artifact expired (>30 days); (2) build-job upload step failed silently; (3) workflow misconfiguration."
+            echo "::error::Inspect the run's Artifacts panel; if missing, push an empty commit to rebuild:"
+            echo "::error::  git commit --allow-empty -m 'chore(ci): re-trigger build'"
+            missing=1
+          fi
+        done
+        [ $missing -eq 0 ] || exit 1
+        # CORRECTNESS: scan INSIDE every packages/*/dist for symlinks.
+        # The earlier `-path 'packages/*/dist' -type d -prune` form was
+        # wrong — it pruned the dist roots and so missed symlinks within
+        # them, defeating the entire check. -mindepth 0 keeps the dist
+        # root itself in scope (defends against root-symlink attacks:
+        # `packages/foo/dist -> /attacker-controlled`); do NOT
+        # "tighten" to -mindepth 1 — that silently loses root coverage.
+        symlinks=$(find packages/*/dist -mindepth 0 -type l -print 2>/dev/null | head -5)
+        if [ -n "$symlinks" ]; then
+          echo "::error::Symlinks under packages/*/dist/ are forbidden (potential malicious build):"
+          echo "$symlinks"
+          exit 1
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,14 +500,13 @@ jobs:
 
       - name: Verify build outputs
         # Verify every package whose dist/ a downstream consumer reads.
-        # `test` matrix has a garmin-bridge leg; `test-frontend`,
-        # `e2e-frontend`, and `e2e-prod-base` consume `workout-spa-editor/dist`.
-        # If any of these silently produces an empty dist/, fail at the
-        # build job rather than fanning out to consumer verify-step
-        # failures (which would surface the same error N times in less
-        # actionable form).
+        # `test-frontend`, `e2e-frontend`, and `e2e-prod-base` consume
+        # `workout-spa-editor/dist` (the SPA's vite build). The bridges
+        # (`garmin-bridge`, `train2go-bridge`) are raw Chrome-extension
+        # source — they have no `build` script and produce no dist/, so
+        # they are intentionally excluded.
         run: |
-          for pkg in core fit tcx zwo garmin garmin-connect cli mcp ai garmin-bridge train2go-bridge workout-spa-editor; do
+          for pkg in core fit tcx zwo garmin garmin-connect cli mcp ai workout-spa-editor; do
             if [ ! -d "packages/$pkg/dist" ]; then
               echo "::error::@kaiord/$pkg build output not found"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,8 +499,15 @@ jobs:
         run: pnpm -r build
 
       - name: Verify build outputs
+        # Verify every package whose dist/ a downstream consumer reads.
+        # `test` matrix has a garmin-bridge leg; `test-frontend`,
+        # `e2e-frontend`, and `e2e-prod-base` consume `workout-spa-editor/dist`.
+        # If any of these silently produces an empty dist/, fail at the
+        # build job rather than fanning out to consumer verify-step
+        # failures (which would surface the same error N times in less
+        # actionable form).
         run: |
-          for pkg in core fit tcx zwo garmin garmin-connect cli mcp ai; do
+          for pkg in core fit tcx zwo garmin garmin-connect cli mcp ai garmin-bridge train2go-bridge workout-spa-editor; do
             if [ ! -d "packages/$pkg/dist" ]; then
               echo "::error::@kaiord/$pkg build output not found"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,8 +204,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: always() && needs.detect-changes.outputs.should-test == 'true'
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -223,8 +223,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Build packages (required for type checking)
-        run: pnpm -r build
+      - name: Consume build artifacts
+        uses: ./.github/actions/consume-build-artifacts
 
       - name: Run linting (ESLint + Prettier)
         run: pnpm lint
@@ -393,8 +393,8 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: always() && needs.detect-changes.outputs.should-test == 'true'
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -402,16 +402,16 @@ jobs:
       - name: Setup pnpm with caching
         uses: ./.github/actions/setup-pnpm
 
-      - name: Build packages (required for type checking)
-        run: pnpm -r build
+      - name: Consume build artifacts
+        uses: ./.github/actions/consume-build-artifacts
 
       - name: Run TypeScript type checking
         run: pnpm -r exec tsc --noEmit
 
   test:
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: always() && needs.detect-changes.outputs.should-test == 'true'
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -437,8 +437,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Build dependencies
-        run: pnpm -r build
+      - name: Consume build artifacts
+        uses: ./.github/actions/consume-build-artifacts
 
       - name: Run tests with coverage
         run: pnpm --filter @kaiord/${{ matrix.package }} test:coverage
@@ -483,7 +483,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: always() && needs.detect-changes.outputs.should-test == 'true'
+    # Actor check is redundant with detect-changes' own gate (line ~31),
+    # but kept as belt-and-braces; if detect-changes' gate ever moves,
+    # build still skips bot commits. Default success() over needs:
+    # propagates the skip to consumers via their own needs:[..., build].
+    if: github.actor != 'github-actions[bot]' && needs.detect-changes.outputs.should-test == 'true'
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -512,12 +516,14 @@ jobs:
           path: |
             packages/*/dist/
             packages/*/package.json
-          retention-days: 7
+          # 30 days covers the typical PR review cycle so "Re-run failed
+          # jobs only" stays usable; spec floor 14, ceiling 90.
+          retention-days: 30
 
   test-frontend:
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: always() && needs.detect-changes.outputs.should-test == 'true'
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -531,11 +537,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Build dependencies
-        # CODECOV_TOKEN enables bundle analysis upload for SPA (only on the minimum supported Node version)
-        env:
-          CODECOV_TOKEN: ${{ matrix.node-version == '22.18.0' && secrets.CODECOV_TOKEN || '' }}
-        run: pnpm -r build
+      - name: Consume build artifacts
+        uses: ./.github/actions/consume-build-artifacts
+        with:
+          expected-packages: "core fit tcx zwo garmin garmin-connect cli mcp ai workout-spa-editor"
 
       - name: Run frontend tests with coverage
         run: pnpm --filter @kaiord/workout-spa-editor test:coverage
@@ -564,8 +569,8 @@ jobs:
 
   test-cli:
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: always() && needs.detect-changes.outputs.should-test == 'true'
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -579,8 +584,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Build all packages (CLI depends on all adapters)
-        run: pnpm -r build
+      - name: Consume build artifacts
+        uses: ./.github/actions/consume-build-artifacts
 
       - name: Run CLI tests with coverage
         run: pnpm --filter @kaiord/cli test:coverage
@@ -609,8 +614,8 @@ jobs:
 
   round-trip:
     runs-on: ubuntu-latest
-    needs: detect-changes
-    if: always() && needs.detect-changes.outputs.should-test == 'true'
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -622,8 +627,8 @@ jobs:
       - name: Setup pnpm with caching
         uses: ./.github/actions/setup-pnpm
 
-      - name: Build dependencies
-        run: pnpm -r build
+      - name: Consume build artifacts
+        uses: ./.github/actions/consume-build-artifacts
 
       - name: Run round-trip tests
         run: |
@@ -661,8 +666,10 @@ jobs:
   e2e-frontend:
     runs-on: ubuntu-latest
     needs: [detect-changes, build]
+    # needs.build.result success check is redundant with default success()
+    # over needs:, but kept explicit since this clause uses if: | multi-line
+    # and the frontend-changed gate is the load-bearing narrowing.
     if: |
-      needs.build.result == 'success' &&
       needs.detect-changes.outputs.should-test == 'true' &&
       needs.detect-changes.outputs.frontend-changed == 'true'
     strategy:
@@ -678,8 +685,10 @@ jobs:
         with:
           node-version: "22.18.0"
 
-      - name: Build dependencies
-        run: pnpm -r build
+      - name: Consume build artifacts
+        uses: ./.github/actions/consume-build-artifacts
+        with:
+          expected-packages: "core fit tcx zwo garmin garmin-connect cli mcp ai workout-spa-editor"
 
       - name: Install Playwright browsers
         run: pnpm --filter @kaiord/workout-spa-editor exec playwright install --with-deps chromium
@@ -699,7 +708,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-changes, build]
     if: |
-      needs.build.result == 'success' &&
       needs.detect-changes.outputs.should-test == 'true' &&
       needs.detect-changes.outputs.frontend-changed == 'true'
     steps:
@@ -711,8 +719,10 @@ jobs:
         with:
           node-version: "22.18.0"
 
-      - name: Build dependencies
-        run: pnpm -r build
+      - name: Consume build artifacts
+        uses: ./.github/actions/consume-build-artifacts
+        with:
+          expected-packages: "core fit tcx zwo garmin garmin-connect cli mcp ai workout-spa-editor"
 
       - name: Install Playwright browsers
         run: pnpm --filter @kaiord/workout-spa-editor exec playwright install --with-deps chromium
@@ -730,63 +740,143 @@ jobs:
           path: packages/workout-spa-editor/playwright-report/
           retention-days: 30
 
+  # Bundle-size analysis (Codecov Vite plugin). The plugin instruments
+  # vite build via a Vite plugin hook, so it cannot consume the
+  # packages/*/dist artifact and is intentionally NOT a build consumer.
+  # See openspec/specs/ci-build-fanout/spec.md "Bundle-analysis exception".
+  bundle-analysis:
+    name: bundle-analysis
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.should-test == 'true' &&
+      needs.detect-changes.outputs.frontend-changed == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm with caching
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: "22.18.0"
+
+      - name: Build SPA with Codecov bundle plugin
+        # Step-level fork-PR skip: secrets.* is not reliably evaluable in
+        # job-level if:. Materialize the secret into env first, then
+        # guard at step level via env. On fork PRs env is empty → step
+        # is skipped, the job exits zero with no upload.
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: env.CODECOV_TOKEN != ''
+        run: pnpm --filter @kaiord/workout-spa-editor build
+
   # Summary jobs for branch protection
-  # These jobs have fixed names that match branch protection requirements
+  # These jobs have fixed names that match branch protection requirements.
+  # They retain `if: always()` legitimately because they observe consumer
+  # status — they are NOT consumers themselves and are correctly excluded
+  # from the consumer enumeration in scripts/check-ci-fanout-invariants.mjs.
+  #
+  # Four-state logic per Decision 12 (spec "Branch-protection summary jobs
+  # reflect build status"):
+  #   build=skipped → consumer=skipped → green (docs-only PR; intentional).
+  #   build=failure → consumer=skipped → red, naming build as upstream cause.
+  #   build=success + consumer=success → green.
+  #   build=success + consumer=skipped → red (workflow misconfiguration).
   lint-summary:
     name: lint
     runs-on: ubuntu-latest
-    needs: lint
+    needs: [build, lint]
     if: always()
     steps:
-      - name: Check lint status
+      - name: Check lint status (with build awareness)
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ] && [ "${{ needs.lint.result }}" != "skipped" ]; then
-            echo "Lint failed"
+          build_result="${{ needs.build.result }}"
+          lint_result="${{ needs.lint.result }}"
+          if [ "$build_result" = "skipped" ]; then
+            echo "Build skipped (docs-only); lint correctly not run."
+            exit 0
+          fi
+          if [ "$build_result" = "failure" ]; then
+            echo "::error::Build failed; lint did not run. Fix the build error and re-run."
             exit 1
           fi
-          echo "Lint passed or skipped"
+          if [ "$lint_result" != "success" ]; then
+            echo "::error::Build succeeded but lint did not. Lint result: $lint_result"
+            exit 1
+          fi
+          echo "Lint passed."
 
   test-summary:
     name: test
     runs-on: ubuntu-latest
-    needs: test
+    needs: [build, test]
     if: always()
     steps:
-      - name: Check test status
+      - name: Check test status (with build awareness)
         run: |
-          if [ "${{ needs.test.result }}" != "success" ] && [ "${{ needs.test.result }}" != "skipped" ]; then
-            echo "Tests failed"
+          build_result="${{ needs.build.result }}"
+          test_result="${{ needs.test.result }}"
+          if [ "$build_result" = "skipped" ]; then
+            echo "Build skipped (docs-only); test correctly not run."
+            exit 0
+          fi
+          if [ "$build_result" = "failure" ]; then
+            echo "::error::Build failed; test did not run. Fix the build error and re-run."
             exit 1
           fi
-          echo "Tests passed or skipped"
+          if [ "$test_result" != "success" ]; then
+            echo "::error::Build succeeded but test did not. Test result: $test_result"
+            exit 1
+          fi
+          echo "Tests passed."
 
   round-trip-summary:
     name: round-trip
     runs-on: ubuntu-latest
-    needs: round-trip
+    needs: [build, round-trip]
     if: always()
     steps:
-      - name: Check round-trip status
+      - name: Check round-trip status (with build awareness)
         run: |
-          if [ "${{ needs.round-trip.result }}" != "success" ] && [ "${{ needs.round-trip.result }}" != "skipped" ]; then
-            echo "Round-trip tests failed"
+          build_result="${{ needs.build.result }}"
+          rt_result="${{ needs.round-trip.result }}"
+          if [ "$build_result" = "skipped" ]; then
+            echo "Build skipped (docs-only); round-trip correctly not run."
+            exit 0
+          fi
+          if [ "$build_result" = "failure" ]; then
+            echo "::error::Build failed; round-trip did not run. Fix the build error and re-run."
             exit 1
           fi
-          echo "Round-trip tests passed or skipped"
+          if [ "$rt_result" != "success" ]; then
+            echo "::error::Build succeeded but round-trip did not. Round-trip result: $rt_result"
+            exit 1
+          fi
+          echo "Round-trip tests passed."
 
   test-frontend-summary:
     name: test-frontend
     runs-on: ubuntu-latest
-    needs: test-frontend
+    needs: [build, test-frontend]
     if: always()
     steps:
-      - name: Check frontend test status
+      - name: Check frontend test status (with build awareness)
         run: |
-          if [ "${{ needs.test-frontend.result }}" != "success" ] && [ "${{ needs.test-frontend.result }}" != "skipped" ]; then
-            echo "Frontend tests failed"
+          build_result="${{ needs.build.result }}"
+          tf_result="${{ needs.test-frontend.result }}"
+          if [ "$build_result" = "skipped" ]; then
+            echo "Build skipped (docs-only); test-frontend correctly not run."
+            exit 0
+          fi
+          if [ "$build_result" = "failure" ]; then
+            echo "::error::Build failed; test-frontend did not run. Fix the build error and re-run."
             exit 1
           fi
-          echo "Frontend tests passed or skipped"
+          if [ "$tf_result" != "success" ]; then
+            echo "::error::Build succeeded but test-frontend did not. Test-frontend result: $tf_result"
+            exit 1
+          fi
+          echo "Frontend tests passed."
 
   notify-failure:
     name: Notify on Failure

--- a/openspec/changes/ci-artifact-fanout/.openspec.yaml
+++ b/openspec/changes/ci-artifact-fanout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-03

--- a/openspec/changes/ci-artifact-fanout/design.md
+++ b/openspec/changes/ci-artifact-fanout/design.md
@@ -1,0 +1,254 @@
+## Context
+
+The PR-time CI workflow (`.github/workflows/ci.yml`) has 10+ jobs that need compiled package output (`packages/*/dist/`) before they can run their actual checks: lint (matrix ×2), typecheck, build, test (matrix 9 packages × 2 Node versions), test-cli (×2), test-frontend (×2), round-trip (×2 packages), e2e-frontend (×4 shards), e2e-prod-base. Every one of those jobs currently runs `pnpm -r build` from a clean checkout.
+
+The `build` job at `ci.yml:483-515` already uploads `packages/*/dist/` and `packages/*/package.json` as a `build-artifacts` artifact (retention 7 days). No consumer reads it, so it is dead weight. There is also a `setup-pnpm` composite cache for TypeScript output keyed by `hashFiles('packages/*/tsconfig.json', 'packages/*/src/**/*.ts')`, but the global key invalidates the entire cache on any source-file change, so it is essentially a no-op on real PRs and is left untouched here.
+
+The change re-wires the existing producer/consumer relationship: keep the `build` job as the single producer; make every consumer depend on it and download the artifact instead of compiling.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Run `pnpm -r build` exactly once per CI run for non-docs PRs.
+- Preserve existing behavior on docs-only PRs (the `should-test == false` short-circuit still skips everything).
+- Preserve existing matrix coverage (Node `22.18.0` and `24.x` for jobs that have it today).
+- Fail fast: if `build` fails, downstream jobs are skipped, not run with stale or rebuilt output.
+- Zero changes to package source, exports, or runtime behavior.
+- Zero new external tools or dependencies.
+
+**Non-Goals:**
+
+- Adopting Turborepo, Nx, or any task-graph runner.
+- Removing or rewriting the per-package change-detection bash in `detect-changes`.
+- Cross-run caching (the artifact is scoped to a single workflow run, by design — that is what makes it correct).
+- Changing the `setup-pnpm` composite action's TypeScript dist cache (left as-is).
+- Replacing the matrix Node-version testing model.
+- Changing the release workflow (`release.yml`), the failure-bot workflow, or any other workflow file.
+
+## Decisions
+
+### Decision 1: Reuse the existing `build-artifacts` artifact name and paths
+
+**Choice**: Keep the upload step at `ci.yml:508-515` as-is. Consumers download the same artifact name (`build-artifacts`).
+
+**Why**: It is already there and already correct (`packages/*/dist/` + `packages/*/package.json`). Renaming would create churn with no benefit.
+
+**Alternatives considered**:
+
+- Use `actions/cache` keyed by commit SHA — rejected. The artifact mechanism is simpler, has built-in run-scoping (no risk of cross-run collisions), and does not consume the cache quota.
+- Split per-package artifacts — rejected. The download-everything model is simpler and the total artifact size is small (we ship JS + `.d.ts`, no native bindings).
+
+### Decision 2: Single artifact serves both Node-version matrix legs
+
+**Choice**: One artifact, produced by the `build` job on its single Node version. Both Node `22.18.0` and Node `24.x` matrix legs of consumer jobs download the same artifact.
+
+**Why**: Our packages compile to portable JS + `.d.ts` via `tsup`/`tsc`. There are no native bindings shipped in `dist/`, no Node-version-specific code paths in build output. The `package.json` `engines` field is what enforces runtime compatibility — that is unaffected. The Node-version matrix exists to validate **runtime** behavior (test execution under different Node versions), not to validate that compilation produces different output.
+
+**Alternatives considered**:
+
+- Build the artifact under each Node version in the matrix — rejected. Doubles `build` job time for no observable benefit; the artifacts would be byte-identical for our build configuration.
+
+**Verification**: a one-shot diff during rollout (Decision 7) confirms output is byte-identical across Node 22 and Node 24 builds. If the diff is non-empty for any package, this decision must be revisited before merge.
+
+### Decision 3: Consumers gain `needs: [detect-changes, build]` AND drop `if: always()`
+
+**Choice**: Every consumer job's `needs:` includes both `detect-changes` (for the `should-test` gate) and `build` (for the artifact dependency). Additionally, each consumer's existing `if: always() && needs.detect-changes.outputs.should-test == 'true'` clause MUST be rewritten to drop `always() &&`, becoming simply `if: needs.detect-changes.outputs.should-test == 'true'`.
+
+**Why**: GitHub Actions' default `if:` for a job with `needs:` is implicit `success()` over the union of upstream jobs — i.e., a job is skipped if any upstream failed or was skipped. The `always()` function explicitly defeats that default and forces the job to run regardless of upstream status. Today, every consumer carries `if: always() && …` (see `ci.yml:208, 397, 414, 520, 568, 613`). Adding `needs: build` to a consumer with `always()` would NOT short-circuit on build failure; the job would still run, fail to find the artifact, and produce a noisy unrelated error. This directly contradicts the "Build failure short-circuits consumers" spec requirement.
+
+**Why was `always()` there in the first place?** Historical: `always()` was the simplest expression that ensured consumers ran even if `detect-changes` produced no should-test=true output (e.g., bot commits where `detect-changes` is skipped via `if: github.actor != 'github-actions[bot]'`). After the rewrite, the desired behavior is exactly the opposite: bot commits and docs-only PRs SHOULD skip consumers, and a failed `build` SHOULD skip consumers. Default `success()` semantics give us all three for free.
+
+**`if:` clauses are otherwise preserved** so the `should-test == 'true'` gate continues to work; `e2e-frontend` and `e2e-prod-base` keep their `frontend-changed == 'true'` gate (they currently use `if: |` multi-line with `needs.build.result == 'success'` explicitly — that explicit success check is redundant once `always()` is dropped, but harmless).
+
+**Verification**: spec scenario "Consumer if-clause does not contain always" + tasks step that greps `ci.yml` for `if: always() &&` in any consumer-job `if:` clause.
+
+### Decision 4: Build job inherits the docs-only gate
+
+**Choice**: Add `if: needs.detect-changes.outputs.should-test == 'true'` to the `build` job (it currently lacks this gate but the consumers all have it).
+
+**Why**: Today the build job runs on docs-only PRs even though every consumer skips. Cheap fix: add the gate. After fan-out, building on docs-only PRs would still be wasteful — and the gate is required anyway so docs-only PRs do not break (no build → consumers must already be skipped, which they are).
+
+### Decision 5 (REOPENED in iter-4): Each consumer invokes a `consume-build-artifacts` composite action
+
+**Choice (revised)**: Create `.github/actions/consume-build-artifacts/action.yml` that wraps the three-step wipe → download → verify pattern, and have each consumer invoke the composite action via a single `uses: ./.github/actions/consume-build-artifacts` step.
+
+**Why the reopen**: Iter-1 Decision 5 rejected the composite action with the rationale "two lines of YAML per consumer is cheaper than another layer of abstraction." That rationale held when the pattern was a single `download-artifact` step. After iter-2 (added `Verify dist exists`) and iter-3 (added `Wipe stale dist` and symlink rejection), the pattern is now ~25 lines per consumer — and there are 8 consumers. Inlining produces ~200 lines of duplicated, drift-prone YAML where every error message and every find-expression must be edited in 8 places. The composite action collapses this into one definition + 8 single-line invocations.
+
+**What the composite action contains**:
+
+1. `Wipe stale dist` (`rm -rf packages/*/dist`) — neutralises `setup-pnpm`'s TypeScript-cache restore.
+2. `Download build artifacts` (`actions/download-artifact@v7`, name: `build-artifacts`, path: `.`).
+3. `Verify dist exists and contains no symlinks` — fails fast with the actionable error message (artifact name, producing job, recovery path) defined in tasks §5A.
+
+**Inputs**: a single `expected-packages` input (space-separated package names) so SPA-only consumers (`e2e-frontend`, `e2e-prod-base`, `test-frontend`) can narrow the verification to just `workout-spa-editor` and surface a clearer error if the SPA dist is missing.
+
+**Why this isn't `setup-pnpm-with-artifacts`**: keeping the composite single-purpose (artifact consumption only) preserves `setup-pnpm`'s independent role and avoids the scope-creep risk of a "kitchen-sink composite." Future consumers that want pnpm setup but NOT artifact consumption (e.g., `bundle-analysis`) keep using `setup-pnpm` alone.
+
+**Alternatives considered**:
+
+- Inline the 3-step pattern in every consumer — rejected (the iter-1 position). The 8× duplication is a real maintenance liability.
+- Split into two composites (one for wipe, one for download+verify) — rejected as gratuitous.
+- Defer the composite to a follow-up PR — rejected because it materially affects the diff size and contributor experience of THIS PR. Better to land it together.
+
+### Decision 6: `e2e-frontend` already declares `needs: [detect-changes, build]`
+
+**Choice**: For `e2e-frontend` and `e2e-prod-base`, only add the `download-artifact` step and remove `pnpm -r build`. The `needs` edge already exists.
+
+**Why**: Per `ci.yml:663` and `ci.yml:700`, e2e jobs already gate on `needs.build.result == 'success'`. They just rebuild instead of consuming. Surgical change.
+
+### Decision 7: Rollout via a single PR with manual verification
+
+**Choice**: Land everything in one PR. Verify by:
+
+1. Opening the PR and confirming each consumer job downloads the artifact and runs to green.
+2. Confirming wall-clock CI time on the PR is materially lower than recent baseline PRs.
+3. Confirming a deliberately-broken-build commit (pushed to a throwaway branch) skips all consumer jobs (fail-fast verification).
+
+**Why**: The change is mechanical and same-shape across consumers; a feature flag would add complexity without buying derisk. A staged rollout (one consumer at a time) would mean N PRs of trivial diffs, each blocked on the previous merging.
+
+### Decision 8: Do not touch the existing TypeScript dist cache in `setup-pnpm`
+
+**Choice**: Leave `actions/cache` for `packages/*/dist` + `.tsbuildinfo` in `setup-pnpm/action.yml` as-is.
+
+**Why**: It is global-key-invalidated and effectively a no-op on real PRs, but it is also harmless. After fan-out, the cache becomes redundant for any job that uses `setup-pnpm` _and_ downloads the artifact (the artifact lands in the same path). Removing it is a separate cleanup that risks breaking jobs we have not audited (release workflow, eval workflow, etc.). Out of scope for this change.
+
+### Decision 9 (revised — the bundle-analysis carve-out): Bundle analysis runs in a dedicated job, not inside `test-frontend`
+
+**Choice**: Move the SPA bundle-analysis behavior (driven by `@codecov/vite-plugin`, currently coupled to the `Build dependencies` step in `test-frontend` at `ci.yml:534-538` via `CODECOV_TOKEN`) into its own dedicated job named `bundle-analysis`. The new job:
+
+1. Gates on `frontend-changed == 'true'` and `should-test == 'true'`.
+2. Pins to a single Node version (`22.18.0`, the minimum supported, to match Codecov's "upload from one Node only" rule).
+3. Runs `pnpm --filter @kaiord/workout-spa-editor build` (single-package, NOT multi-package).
+4. Carries `CODECOV_TOKEN` on its own step.
+5. Does NOT declare `build` in `needs:` — it is not an artifact consumer; it is an orthogonal in-job build for tooling that hooks `vite build`.
+
+**Why**: The Codecov Vite plugin is a Vite plugin — it instruments the build via Vite plugin hooks. Reading a pre-built `dist/` does not give the plugin the build pipeline it needs to instrument. So either (a) the SPA build runs twice in `test-frontend` (once for the artifact, once for analysis) or (b) bundle analysis is hoisted to its own job, where it is honest about being its own build. Option (b) keeps `test-frontend` clean (one job, one purpose, downloads the artifact like any other consumer) and isolates the secret.
+
+**Why this re-numbering**: in iteration 1 of design.md, this decision did not exist; iteration 1 deferred §5.4 to a tasks-time decision. Iteration 2 promotes the decision into the design and locks the spec around it. The original Decision 9 (artifact-is-environment-agnostic) is renumbered to Decision 10.
+
+**Alternatives considered**:
+
+- Keep the bundle-analysis build inside `test-frontend`, gated to `matrix.node-version == '22.18.0'` only — rejected. Couples a secret-bearing step to a matrixed test job, complicates the spec ("consumers don't rebuild" gains a multi-clause carve-out), and violates Factor V's separation of concerns.
+- Drop bundle analysis entirely — rejected. It is an active feedback loop on bundle size; removing it is out of scope for this change.
+
+### Decision 10: Artifact is environment-agnostic and carries no config
+
+**Choice**: The `build-artifacts` artifact SHALL contain only compiled package output (`packages/*/dist/`) and `packages/*/package.json`. It SHALL NOT contain environment-specific values, secrets, runtime config, or Node-version-conditional bytes. This is a 12-factor App Factor V invariant: the artifact is the Build product; config is injected at the Run stage (i.e., by the consumer job's environment).
+
+**Why**: This is the load-bearing assumption behind Decision 2 (one artifact serves both Node-version matrix legs) and behind the spec's "single artifact for all matrix legs" requirement. If any package were to introduce a Node-version-conditional build step (e.g., a `tsup` config that emits different bytes under different Node versions), or to bake an environment value into `dist/` at build time, the artifact would lose its portability and Decision 2 would no longer hold.
+
+**Trip-wires that re-open this decision**:
+
+1. A package adds a `process.env.NODE_VERSION`-conditional code path to its build script.
+2. A package adds a build-time injection of a config value (e.g., a `define:` block in a Vite/tsup config that reads from CI env vars).
+3. A package ships native bindings or platform-specific binaries in `dist/`.
+4. The pre-flight diff in tasks §1.1 is non-empty for any package.
+
+**Action if a trip-wire fires**: revisit Decision 2 — either gate the consumer matrix on the `build` job's single Node version (drop matrixed Node testing) or matrix the `build` job per Node version and produce per-version artifacts. Both are local changes; neither requires re-thinking the fan-out itself.
+
+**Alternatives considered**:
+
+- Embed a `release.json` manifest (commit SHA, build time, per-package versions, Node version) into the artifact root for consumer-side sanity checks. **Deferred** — captures Factor V's "every release has a unique ID" more explicitly, but the GitHub Actions run ID already provides that identity, and consumers downloading from the same workflow run cannot see a foreign artifact. Worth re-opening if a debugging incident demonstrates value.
+
+### Decision 11: Decision-10 trip-wires AND fan-out invariants are bound to mechanical guards
+
+**Choice**: Add two single-purpose mechanical guards with co-located tests, run via `pnpm test:scripts`:
+
+1. **`scripts/check-build-portable.mjs`** — fails CI if any of Decision 10's trip-wires appear: env-var-as-value `define:` blocks (the `JSON.stringify(process.env.X)` and unwrapped `'__X__': process.env.X` patterns), `process.env.NODE_VERSION` references in build-time code, or native bindings (`*.node`/`*.so`/`*.dylib`) under any package's `dist/`. The whitelist for `process.env.NODE_ENV` only covers comparison operands (`process.env.NODE_ENV ===` etc.), never values.
+2. **`scripts/check-ci-fanout-invariants.mjs`** — uses `js-yaml` to parse `.github/workflows/ci.yml` and fail if (a) any consumer job's `if:` clause contains `always()` (replacing the brittle grep originally proposed in tasks §4.8); (b) any consumer's `needs:` does not include `build`; (c) any non-consumer (other than the explicit `notify-failure` failure-aggregation whitelist) declares `needs: build`.
+
+Each guard has a docstring opening with `// SCOPE: <single-purpose description>. Adding new checks requires a separate guard with its own design entry in openspec/changes/<slug>/design.md.` This is a deliberate scope-creep guardrail.
+
+**Why**: Per CLAUDE.md "Mechanical guards > AI review" — invariants that gate a load-bearing decision SHALL be enforced deterministically, not by reviewer attention. Decision 10's trip-wires (portability) and Decision 3's `always()`-removal (fail-fast correctness) are both exactly that kind of invariant. A prose-only commitment to "revisit Decision 2 if a trip-wire fires" relies on someone noticing the trip-wire fired, which is exactly the failure mode the policy exists to prevent.
+
+**Scope (intentionally narrow)**:
+
+- `check-build-portable.mjs` performs greppable static checks only — the guard does NOT execute builds or compute byte-diffs. The pre-flight Node-version diff in tasks §1.1 stays as the empirical check; the mechanical guard is the structural backstop.
+- `check-ci-fanout-invariants.mjs` parses ONLY `.github/workflows/ci.yml`, ONLY for the three invariants enumerated above. It does NOT lint generic GitHub Actions style.
+
+**Cost**: ~30 lines of script + ~50 lines of test for each guard (~160 lines total). Single-purpose, low-maintenance.
+
+**Why two guards instead of one**: Conceptually distinct invariants (portability vs. CI workflow shape). Splitting them prevents the single-purpose-creep that one combined guard would invite, and it keeps the failure messages crisp ("portability trip-wire fired" vs. "fanout invariant violated").
+
+**N-guard refactor trigger**: This change ships two guards (`check-build-portable`, `check-ci-fanout-invariants`). The single-purpose discipline likely produces more guards over time (each new invariant is its own ~30-line script + test). To prevent the `scripts/` directory from sprawling: **if more than 4 mechanical guards exist that are bound to this capability** (or to closely related CI workflow capabilities), consolidate them into a guard runner with a plugin model — a single `scripts/check-ci-invariants.mjs` that loads `scripts/ci-invariants/*.mjs` plugins, where each plugin is one ~30-line check. The plugin shape becomes the new SCOPE-comment discipline. Until that threshold is hit, individual scripts remain the right shape.
+
+### Decision 12: Branch-protection summary jobs include `build` in `needs:` and treat `skipped`-due-to-build-failure as failure
+
+**Choice**: Modify the four branch-protection-required summary jobs (`lint-summary`, `test-summary`, `round-trip-summary`, `test-frontend-summary` — `ci.yml:735-789`) to:
+
+1. Add `build` to `needs:`.
+2. Replace the current "passed or skipped" whitelist with a tri-state check:
+   - `needs.build.result == 'skipped'` → exit 0 (docs-only PR, intentional skip).
+   - `needs.build.result == 'failure'` → exit 1 with a message naming `build` as the upstream cause.
+   - `needs.build.result == 'success'` → require `needs.<consumer>.result == 'success'` (skip is no longer acceptable; build succeeded so the consumer should have run and passed).
+
+**Why**: Today's summary jobs whitelist `skipped` because docs-only PRs legitimately skip consumers. After fan-out, `skipped` has a second cause: build failure. Without distinguishing the two, branch protection would let a build-broken PR merge if the only required checks are the four summary names. This is a real branch-protection bypass.
+
+**Alternatives considered**:
+
+- Add `build` itself to the branch-protection required-checks list (repo settings change, not workflow code). **Rejected as the sole fix** — it would catch build failures, but the summary jobs would still falsely report consumer success on `skipped`, leaving a confusing UI state. Doing both (require `build` in branch protection AND fix the summaries) is fine; the repo-settings change is recommended in tasks §10 as a follow-up but not blocking.
+- Have one mega-summary job that depends on `build` and all consumers. **Rejected** — would require renaming required checks, which is a coordinated repo-settings + workflow change.
+
+### Decision 13: Bump artifact `retention-days` from 7 to 30
+
+**Choice**: Increase the `retention-days` on `Upload build artifacts` from 7 to 30.
+
+**Why**: Today the value is 7 because no consumer reads the artifact. After fan-out, "Re-run failed jobs only" depends on the artifact still existing. A 7-day window is too short for the typical PR review cycle (PRs commonly sit ≥1 week awaiting review or follow-up changes). 30 days covers the long tail without an order-of-magnitude storage cost increase. The spec sets a floor of 14 and a ceiling of 90; this design picks 30 as a reasonable point in that range.
+
+**Alternatives considered**:
+
+- Keep at 7 and document the re-run-after-7-days failure mode — rejected. Predictable DX regression for no benefit.
+- Bump to 90 (GitHub default) — rejected. Storage growth is unbounded and most PRs do not need 90-day artifact retention.
+
+## Risks / Trade-offs
+
+- **[Risk]** A consumer downloads the artifact AND a stale `dist/` from the `setup-pnpm` composite's TypeScript cache co-exists, causing partial version skew. `actions/download-artifact@v7` overwrites files at the destination path BUT does NOT delete files that exist at the destination but are absent from the artifact. So a stale cached `packages/foo/dist/old-file.js` would survive a download that no longer produces it. → **Mitigation**: every consumer's pattern (tasks §5.2) is now THREE steps: (1) `Wipe stale dist` (`rm -rf packages/*/dist`), (2) `Download build artifacts`, (3) `Verify dist exists and contains no symlinks`. The wipe step is the load-bearing fix; the spec scenario "Consumer wipes stale dist before downloading" makes it a hard requirement. Decision 8 (leave the existing TypeScript cache untouched) is preserved because the wipe step neutralises the cache's effect on consumers without removing the cache itself (the cache may still help non-consumer jobs that don't download the artifact).
+
+- **[Risk]** Build job succeeds but artifact upload fails, leaving consumers without input. → **Mitigation**: `actions/upload-artifact@v7` sets the job to failed if the upload fails, which propagates via `needs:` to skip consumers. No explicit handling needed.
+
+- **[Risk]** Node-version matrix legs assume artifact compatibility (Decision 2) and someone later adds a Node-version-specific build flag. → **Mitigation**: The Decision 2 rationale is documented in this design and in a comment in `ci.yml`. If that assumption breaks, the fix is to gate the matrix on the `build` job's Node version or produce per-version artifacts; both are local changes.
+
+- **[Risk]** A consumer accidentally drops `pnpm install --frozen-lockfile` and breaks because `node_modules` is missing. → **Mitigation**: `setup-pnpm` composite always runs `pnpm install --frozen-lockfile`; the consumer pattern keeps `setup-pnpm` as the first step. The `download-artifact` step only ever lands `packages/*/dist/` and `packages/*/package.json`, never `node_modules`.
+
+- **[Trade-off]** Single-run scoping means every PR pays for one full build. Cross-run caching (Turborepo + remote cache, or `actions/cache` keyed by lockfile + source) would skip the build entirely for unchanged packages. We accept this trade-off because:
+  1. The full build is cheap (~30-90s per package, parallelisable).
+  2. Cross-run caching has correctness sharp edges (input/output declaration, env-var hashing).
+  3. The biggest win (eliminating in-run rebuilds) is captured by this change.
+
+- **[Trade-off — Factor X dev/CI parity gap]** Local dev runs `pnpm -r build` before every test command, so build and test costs are co-located per developer iteration. After this change, CI builds once and fans out, while local dev is unchanged. This widens the dev/CI parity surface: a build-stage bug that only manifests when the build step runs _adjacent to_ a particular test step will be caught locally but not in CI (because CI no longer rebuilds before each test). Today no such coupling exists — the build step is pure (`tsup`/`tsc` with deterministic inputs) and produces byte-identical output regardless of which test runs after it. The pre-flight Node-version diff in tasks §1.1 is the load-bearing verification that this remains true. If any of the Decision 9 trip-wires fire later, the parity gap becomes a real risk and the fan-out must re-matrix accordingly. We accept the present-day gap because the trip-wires are explicit and the savings are significant.
+
+  Cross-run caching can be layered on later via `turbo.json` without touching the fan-out wiring.
+
+- **[Trade-off]** Adding `needs: build` to consumers serializes the workflow: nothing runs until `build` finishes. Today, all jobs start in parallel. → Net effect is still a wall-clock reduction because the saved `pnpm -r build` per-job time (~30-90s) exceeds the build job's wall-clock contribution.
+
+- **[Risk]** Fork PRs (third-party contributors) have read-only `secrets.*` and reduced `permissions:`. → **Mitigation**: the change does not introduce any new secret-bearing step in the build path. Artifacts work normally under `pull_request` from forks because `actions/{upload,download}-artifact` operate within the workflow run and do not require write permissions on the repository. Bundle analysis (Decision 9) carries `CODECOV_TOKEN`, which is not available on fork PRs — that step is a no-op for fork PRs (existing behavior, unchanged).
+
+- **[Risk]** A compromised dependency injects code into `dist/` during `build`; consumers no longer rebuild and so cannot independently catch tampering. → **Mitigation**: this is a property of any artifact-fan-out pattern (and of any cached build). Today every consumer builds from the same lockfile, so a compromised dep produces the same `dist/` in every job — consumers do not catch it either. Net effect is unchanged. The supply-chain guarantees come from `pnpm install --frozen-lockfile`, dependency pinning, and downstream signature verification, none of which this change touches.
+
+- **[Risk]** GHSA advisories on pinned action versions (`actions/upload-artifact@v7`, `actions/download-artifact@v7`). → **Mitigation**: tasks §9.4 verifies no open advisories at merge time; the existing `dependabot.yml` (or equivalent) keeps action versions current.
+
+## Migration Plan
+
+This change has no public API impact and no migration concerns for package consumers. The CI-internal migration is:
+
+1. Add `if: needs.detect-changes.outputs.should-test == 'true'` to the `build` job.
+2. For each consumer (`lint`, `typecheck`, `test`, `test-cli`, `test-frontend`, `round-trip`, `e2e-frontend`, `e2e-prod-base`):
+   - Add `build` to `needs:`.
+   - Replace the `Build dependencies` / `Build all packages` / `Build packages (required for type checking)` step with a `Download build artifacts` step.
+3. Open PR; verify all jobs green; merge.
+
+**Rollback**: Revert the PR. The `build` job continues to upload its artifact (no consumer reads it), exactly the pre-change state.
+
+## Cross-spec interactions
+
+- **`ci-release` (release workflow)**: unaffected. `release.yml` runs on `push` to `main`, not on `pull_request`, and produces its own `pnpm -r build` step independent of `build-artifacts`. Tasks §10.4 verifies this assumption.
+- **`ci-failure-bot` (failure-issue automation)**: unaffected in shape but signal improves. Today, a build failure produces ~10 identical consumer failures, all listed in the failure issue. After fan-out, `notify-failure` (which already declares `needs: [..., build, ...]` at `ci.yml:805` and explicitly checks `needs.build.result == 'failure'`) will see exactly one failure (`build`) and several skips. The bot's "fully-green close" rule remains correct because a failed `build` keeps the workflow run in a non-green state.
+
+  Second-order effect on issue body content: pre-fan-out, the failure-issue body's `failed-jobs` JSON footer enumerated 10 jobs (`["build","lint","test","..."]`); post-fan-out it enumerates a single job (`["build"]`). This changes dedupe behavior — consecutive build breaks now dedupe more aggressively (all share the same `failed-jobs` fingerprint). That is a desirable improvement, not a regression: today the bot may open separate issues for the same root cause when the `failed-jobs` order varies; tomorrow it opens one. The `ci-failure-bot` spec does NOT need to change; its dedupe logic is content-agnostic.
+
+- **`hexagonal-arch` (project-wide architecture spec)**: not relevant. This change touches `.github/workflows/ci.yml` only — no application code, no domain layers.
+
+## Open Questions
+
+- Should the `Verify build outputs` step in the `build` job (`ci.yml:497-506`) become a hard gate (it already runs after the build, before the upload)? It is currently informational only when build itself succeeds. Tasks §10.5 tracks extending this verification to include `workout-spa-editor` and the bridge packages, since their `dist/` is consumed by `e2e-frontend` and (when fan-out lands) `test-frontend`. Tightening to a hard gate is a separate cleanup.

--- a/openspec/changes/ci-artifact-fanout/proposal.md
+++ b/openspec/changes/ci-artifact-fanout/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+CI currently runs `pnpm -r build` 30+ times on a single PR — once per job (lint, typecheck, build, test×9 packages, test-cli, test-frontend, round-trip×2, e2e-frontend×4 shards, e2e-prod-base), each across two Node versions. The `build` job already uploads `packages/*/dist/` as a `build-artifacts` artifact, but no consumer reads it, so the upload is dead weight today. Fanning the existing artifact out to consumers eliminates redundant rebuilds within a single CI run, capturing most of the wall-clock savings of a Turborepo migration without adding a new build tool.
+
+## What Changes
+
+- Refactor `.github/workflows/ci.yml` so the `build` job is the sole producer of `packages/*/dist/` per CI run; every consumer job depends on `build` and downloads the `build-artifacts` artifact instead of running `pnpm -r build`.
+- Affected consumer jobs: `lint`, `typecheck`, `test` (matrix), `test-cli`, `test-frontend`, `round-trip`, `e2e-frontend`, `e2e-prod-base`. Their `pnpm -r build` step is replaced with `actions/download-artifact` followed by a `Verify dist exists` step that fails fast with an actionable error if the artifact did not land.
+- **CRITICAL fail-fast fix**: drop `if: always() &&` from each consumer's `if:` clause. With `always()` present, `needs: build` does NOT short-circuit on build failure (the consumer would run anyway and produce noisy unrelated errors). Default GitHub Actions `success()` semantics give us correct skip-on-build-failure behavior once `always()` is removed.
+- Bump artifact retention from 7 to 30 days so "Re-run failed jobs only" remains usable across the typical PR review cycle.
+- The `build` job's existing artifact (`build-artifacts`, paths `packages/*/dist/` + `packages/*/package.json`) is reused; only `retention-days` changes.
+- Preserve the docs-only short-circuit: every consumer keeps its `needs.detect-changes.outputs.should-test == 'true'` gate. The `build` job inherits the same gate so it does not run on docs-only PRs.
+- Preserve the Node-version matrix: jobs running both `22.18.0` and `24.x` keep the matrix; the artifact is Node-version-agnostic for our packages (`tsup`/`tsc` outputs JS + `.d.ts`, no native bindings shipped in `dist/`), so a single artifact serves both Node versions.
+- **Branch-protection summary fix**: update `lint-summary`, `test-summary`, `round-trip-summary`, `test-frontend-summary` to include `build` in `needs:` and to fail when `build` failed, instead of treating `skipped` as success. Today's whitelist would let a build-broken PR merge after fan-out.
+- **Bundle-analysis carve-out**: extract the `@codecov/vite-plugin` build (currently coupled to `test-frontend`'s build step via `CODECOV_TOKEN`) into its own `bundle-analysis` job. The new job runs only on Node `22.18.0`, builds only `@kaiord/workout-spa-editor`, carries the secret on its own step, and is NOT a consumer of `build-artifacts` (it does its own in-job build because the Codecov plugin instruments `vite build`).
+- **Build-job environment hardening**: no `secrets.*` in the build job's env (other than the implicit `secrets.GITHUB_TOKEN`). Secret tokens belong on the consumer jobs that need them, never on the shared producer.
+- **Decision-9 mechanical guard**: add `scripts/check-build-portable.mjs` (with `*.test.mjs`) that fails CI if any package introduces env-var `define:` blocks, `process.env.NODE_VERSION`-conditional build code, or native bindings under `dist/`. Per CLAUDE.md "Mechanical guards > AI review."
+- **Non-consumer jobs unchanged**: `check-links`, `log-bot-skip` do not need `dist/` and SHALL NOT depend on `build`.
+- The existing `setup-pnpm` composite action's TypeScript dist cache is left untouched (out of scope).
+
+## Capabilities
+
+### New Capabilities
+
+- `ci-build-fanout`: Build packages once per CI run and fan the resulting `dist/` artifact out to every job that needs compiled output, replacing redundant per-job rebuilds.
+
+### Modified Capabilities
+
+(none — `ci-release` and `ci-failure-bot` are unaffected; this change touches the PR-time CI workflow only.)
+
+## Impact
+
+- **Code**: `.github/workflows/ci.yml` (consumer wiring, summary-job rewrites, new `bundle-analysis` job) and two new repo scripts (`scripts/check-build-portable.mjs` + test). No package source, no `setup-pnpm` composite changes, no `turbo.json`.
+- **CI minutes**: expected 30-60% reduction in PR wall-clock time for non-docs PRs. The exact saving depends on the slowest matrix leg; a hard gate of ≥30% improvement is set in tasks §10.2 (halt and investigate if not met).
+- **Public API**: none affected. No package source, exports, or runtime behavior changes.
+- **Architecture layers**: this change touches `.github/workflows/` only — no domain, application, or adapter code. Hexagonal-architecture invariants (per `openspec/specs/hexagonal-arch/spec.md`) are not relevant.
+- **Branch protection**: the four summary-job names (`lint`, `test`, `round-trip`, `test-frontend`) remain the same; their internal logic gains a `build`-status check. No repo-settings change required for this PR. A follow-up issue (tasks §13.5) tracks adding `build` itself to the required-checks list as belt-and-braces.
+- **Developer experience**: PR feedback latency drops; local `pnpm -r build` is unchanged. Missing-artifact failures now produce actionable errors via the new `Verify dist exists` step.
+- **Risk surface**: stale-artifact bugs if a consumer reads a `dist/` produced from a different commit. Mitigated because the artifact is scoped to a single workflow run (GitHub Actions artifacts are run-scoped by default) and consumers explicitly depend on the `build` job from the same run.
+- **Cross-spec interactions**: `ci-release` (release workflow) and `ci-failure-bot` are unaffected. See `design.md` "Cross-spec interactions" for the reasoning.
+- **Out of scope**: Turborepo adoption, removing the per-package change-detection bash in `detect-changes`, removing or re-keying the existing TypeScript dist cache in `setup-pnpm`.
+- **Hard follow-up (not "out of scope")**: adding `build` to branch-protection required checks. **Issue MUST be filed before this PR merges; assignee MUST be set within 30 days of merge** (tasks §13.5). The workflow-code fixes here (Decision 12 summary-job logic) close the immediate gap; the repo-settings change is the belt-and-braces commitment.

--- a/openspec/changes/ci-artifact-fanout/specs/ci-build-fanout/spec.md
+++ b/openspec/changes/ci-artifact-fanout/specs/ci-build-fanout/spec.md
@@ -1,0 +1,264 @@
+<!--
+Capability scope (lifted to `## Purpose` when this delta archives into
+`openspec/specs/ci-build-fanout/spec.md`):
+
+`ci-build-fanout` covers the producer-consumer relationship for compiled
+package output in the PR-time CI workflow, plus the invariants that keep
+that relationship correct end-to-end:
+
+  1. The build job is the sole producer of `packages/*/dist/`.
+  2. Consumer jobs download the artifact instead of rebuilding.
+  3. The build-job environment is secret-free (least privilege).
+  4. The artifact is portable across the Node-version matrix.
+  5. Bundle-analysis is a named non-consumer exception (it instruments
+     `vite build` and so cannot read pre-built dist/).
+  6. Branch-protection summary jobs reflect build status correctly,
+     distinguishing docs-only skips from build-failure skips.
+  7. Decision-9 portability trip-wires are mechanically enforced.
+  8. Artifact retention is bounded (≥14 days, ≤90 days).
+
+Non-consumer jobs (e.g., `check-links`) and failure-aggregation jobs
+(e.g., `notify-failure`) are out of scope as artifact consumers but
+named explicitly to avoid spurious `needs: build` couplings.
+-->
+
+## ADDED Requirements
+
+### Requirement: Single build per CI run
+
+The PR-time CI workflow (`.github/workflows/ci.yml`) SHALL execute `pnpm -r build` exactly once per workflow run for non-docs PRs. The `build` job SHALL be the sole producer of multi-package compiled output (`packages/*/dist/`) within the workflow.
+
+A single, named exception is permitted: a dedicated bundle-analysis job MAY run a single-package rebuild (`pnpm --filter <package> build`) when an in-job build is required by tooling that instruments the build pipeline (e.g., the Codecov Vite bundle-analysis plugin, which hooks into `vite build` and cannot read pre-built `dist/`). The bundle-analysis job is NOT a consumer and SHALL NOT declare `build` in its `needs:` list (see "Bundle-analysis exception" requirement below).
+
+#### Scenario: Consumers do not invoke pnpm -r build
+
+- **WHEN** the CI workflow runs on a PR that touches package source
+- **THEN** no consumer job (defined by the consumer-download requirement) SHALL contain a step that invokes `pnpm -r build`, `pnpm build`, or any other multi-package compilation command
+
+#### Scenario: Build job runs once
+
+- **WHEN** the CI workflow runs on a PR that touches package source
+- **THEN** the `build` job SHALL appear exactly once in the workflow run summary (it is not matrixed)
+
+### Requirement: Build job uploads compiled output as a workflow artifact
+
+The `build` job SHALL upload `packages/*/dist/` and `packages/*/package.json` as a GitHub Actions artifact named `build-artifacts` so that downstream jobs in the same workflow run can consume the compiled output without rebuilding. The upload step SHALL be the last step in the `build` job — no step with `if: always()` MAY follow it, since that would bypass GitHub Actions' default skip-on-upstream-failure semantics for downstream consumers.
+
+#### Scenario: Successful build uploads artifact
+
+- **WHEN** the `build` job completes successfully
+- **THEN** the workflow run SHALL contain an artifact named `build-artifacts` whose contents include `packages/*/dist/` and `packages/*/package.json`
+
+#### Scenario: Failed build does not upload artifact
+
+- **WHEN** the `build` job fails before reaching the upload step
+- **THEN** the workflow run SHALL NOT contain a `build-artifacts` artifact for the failing run
+
+#### Scenario: No always-step follows upload
+
+- **WHEN** the `build` job is defined in `ci.yml`
+- **THEN** no step in the `build` job AFTER `Upload build artifacts` SHALL declare `if: always()` or any expression that runs when prior steps failed
+
+### Requirement: Build job environment carries no secret tokens
+
+The `build` job SHALL NOT receive secret tokens (e.g., `CODECOV_TOKEN`, npm publish tokens, Garmin Connect credentials, AI provider keys) via its environment. Because the build artifact is shared across every consumer job, any secret available during build is implicitly trusted by all downstream jobs; constraining secret material to the consumer job that actually needs it preserves least-privilege.
+
+#### Scenario: Build job has no env-level secrets
+
+- **WHEN** the `build` job is defined in `ci.yml`
+- **THEN** neither the job-level `env:` nor any step-level `env:` within the `build` job SHALL reference `secrets.*` other than `secrets.GITHUB_TOKEN` (the implicit, unavoidable token)
+
+#### Scenario: Codecov token belongs to the consumer
+
+- **WHEN** a consumer job needs `CODECOV_TOKEN` for coverage upload or bundle analysis
+- **THEN** the token SHALL be set on the consumer job's step (or job-level `env:`), not on the `build` job
+
+### Requirement: Consumers download the artifact instead of rebuilding
+
+Every consumer job in `ci.yml` (`lint`, `typecheck`, `test`, `test-cli`, `test-frontend`, `round-trip`, `e2e-frontend`, `e2e-prod-base`) SHALL declare `build` in its `needs:` list and SHALL replace any local `pnpm -r build` step with a `actions/download-artifact` step that downloads `build-artifacts` into the workspace root. Consumers SHALL verify the artifact landed correctly before running tests, so missing-artifact failures produce actionable errors.
+
+#### Scenario: Consumer job downloads build-artifacts
+
+- **WHEN** a consumer job listed above runs after a successful `build` job
+- **THEN** the job SHALL contain a step that uses `actions/download-artifact@v7` with `name: build-artifacts` and `path: .` BEFORE any step that depends on compiled output
+
+#### Scenario: Consumer job declares build dependency
+
+- **WHEN** a consumer job listed above is defined in `ci.yml`
+- **THEN** the job's `needs:` list SHALL include `build`
+
+#### Scenario: Consumer verifies dist exists post-download
+
+- **WHEN** a consumer job downloads `build-artifacts`
+- **THEN** the job SHALL run a verification step (or composite action) that fails fast with an actionable error message if any expected `packages/<consumed-pkg>/dist/` directory is missing after the download
+
+#### Scenario: Consumer verification rejects symlinks under dist
+
+- **WHEN** a consumer job runs the post-download verification step
+- **THEN** the step SHALL fail if any `packages/<pkg>/dist/` directory contains a symlink (which would indicate either a malicious build or a misconfigured upload), exiting non-zero with a message naming the offending path
+
+#### Scenario: Consumer wipes stale dist before downloading
+
+- **WHEN** a consumer job runs the `Setup pnpm with caching` composite (which restores `packages/*/dist` from a TypeScript cache) AND then downloads `build-artifacts`
+- **THEN** the job SHALL run a `rm -rf packages/*/dist` step BETWEEN the composite and the download, so that `actions/download-artifact` writes to a clean target and no cached files survive that are absent from the run-scoped artifact
+
+### Requirement: Build failure short-circuits consumers
+
+When the `build` job fails, every consumer job SHALL be skipped rather than running with stale or freshly-rebuilt output, so that a single compilation error is reported once instead of fanning out across every consumer job. To make this effective, no consumer SHALL use `if: always()` (or any equivalent expression that overrides GitHub Actions' default `success()` skip-on-upstream-failure semantics).
+
+#### Scenario: Build failure skips downstream jobs
+
+- **WHEN** the `build` job ends with status `failure`
+- **THEN** every consumer job listed in the consumer-download requirement SHALL have status `skipped` for that workflow run
+
+#### Scenario: Consumer if-clause does not contain always
+
+- **WHEN** a consumer job declares an `if:` clause
+- **THEN** the clause SHALL NOT contain `always()`, `failure()`, or any expression that causes the job to run when `needs.build.result == 'failure'`. The clause SHALL only narrow execution further (e.g., `needs.detect-changes.outputs.should-test == 'true'`), relying on the implicit `success()` over `needs:` to short-circuit on build failure
+
+### Requirement: Branch-protection summary jobs reflect build status
+
+The branch-protection-required summary jobs (`lint-summary`, `test-summary`, `round-trip-summary`, `test-frontend-summary`) SHALL include `build` in their `needs:` list and SHALL fail when the `build` job failed, even when their own consumer dependency is `skipped`. Today these summary jobs whitelist `skipped` as "passed or skipped"; after fan-out, a failed build skips all consumers, so without this fix a build-broken PR could merge if branch protection only requires the summary names.
+
+#### Scenario: Summary fails on build failure
+
+- **WHEN** the `build` job ends with status `failure` AND the consumer that the summary tracks ends with status `skipped`
+- **THEN** the summary job SHALL exit non-zero with a message naming `build` as the upstream failure
+
+#### Scenario: Summary passes on docs-only short-circuit
+
+- **WHEN** the `build` job ends with status `skipped` (docs-only PR) AND the consumer that the summary tracks ends with status `skipped`
+- **THEN** the summary job SHALL exit zero — `skipped` is the correct outcome for docs-only PRs
+
+#### Scenario: Summary passes on all-green run
+
+- **WHEN** the `build` job ends with status `success` AND the consumer that the summary tracks ends with status `success`
+- **THEN** the summary job SHALL exit zero
+
+#### Scenario: Summary fails when build succeeded but consumer was skipped
+
+- **WHEN** the `build` job ends with status `success` AND the consumer that the summary tracks ends with status `skipped`
+- **THEN** the summary job SHALL exit non-zero with a message indicating the consumer was unexpectedly skipped — once `build` succeeded, the consumer SHALL have run; a `skipped` outcome here indicates a workflow misconfiguration (e.g., a stray `if:` clause narrowing further than intended)
+
+### Requirement: Non-consumer jobs do not declare build dependency
+
+Jobs that do not need compiled package output (e.g., `check-links`, `log-bot-skip`) SHALL NOT declare `build` in their `needs:` list. Adding spurious `needs: build` would couple unrelated checks to the build job's outcome and unnecessarily widen the fan-out blast radius.
+
+**Exception**: the existing `notify-failure` job MAY declare `build` in `needs:` because its purpose is to observe the result of upstream jobs (including `build`) for failure-issue creation, not to consume `dist/`. The exception is **explicitly named and bounded to `notify-failure`** — future failure-aggregation jobs (e.g., a hypothetical `metrics-collector`) require a spec amendment to extend this Exception, NOT an ad-hoc edit to the mechanical guard's whitelist. This keeps the spec and the guard's literal whitelist (`scripts/check-ci-fanout-invariants.mjs`) in lockstep: the guard hardcodes `notify-failure`, the spec hardcodes `notify-failure`, and any drift requires a deliberate spec change.
+
+#### Scenario: check-links has no build dependency
+
+- **WHEN** the `check-links` job is defined in `ci.yml`
+- **THEN** its `needs:` list SHALL NOT contain `build`
+
+#### Scenario: notify-failure exception is whitelisted
+
+- **WHEN** the `notify-failure` job is defined in `ci.yml`
+- **THEN** its `needs:` list MAY contain `build` because the job's purpose is failure aggregation across all upstream jobs (it inspects `needs.build.result` and other `needs.*.result` values), not artifact consumption
+
+### Requirement: Bundle-analysis exception is named and bounded
+
+If a single-package rebuild is required for tooling that instruments the build pipeline (e.g., `@codecov/vite-plugin` bundle analysis), the rebuild SHALL run in a dedicated job (e.g., `bundle-analysis`) — never inside a consumer job. The dedicated job SHALL:
+
+1. Run only on the minimum-supported Node version (currently `22.18.0`), to avoid duplicate uploads.
+2. Build only the package whose bundle is being analysed (e.g., `pnpm --filter @kaiord/workout-spa-editor build`).
+3. Carry the secret token (e.g., `CODECOV_TOKEN`) on its own step, never on the `build` job.
+4. NOT declare `build` in its `needs:` list (it is not a consumer of the artifact).
+5. Be gated by the same `should-test` and frontend-changed conditions as the related consumers.
+6. Skip cleanly on fork PRs where the secret is unavailable (the job-level or step-level `if:` SHALL evaluate `secrets.CODECOV_TOKEN != ''` so that fork PRs do not waste CI minutes building a no-op upload).
+
+#### Scenario: Bundle-analysis runs only on minimum Node version
+
+- **WHEN** the bundle-analysis job is defined
+- **THEN** the job SHALL run on exactly one Node version (the minimum supported, currently `22.18.0`)
+
+#### Scenario: Bundle-analysis builds only the analysed package
+
+- **WHEN** the bundle-analysis job runs
+- **THEN** any build step within the job SHALL use `pnpm --filter <single-package> build`, NOT `pnpm -r build`
+
+#### Scenario: Bundle-analysis is not a consumer
+
+- **WHEN** the bundle-analysis job is defined
+- **THEN** its `needs:` list SHALL NOT contain `build`
+
+#### Scenario: Bundle-analysis skips on fork PRs
+
+- **WHEN** the bundle-analysis job runs on a `pull_request` from a fork (where `secrets.CODECOV_TOKEN` is empty)
+- **THEN** the job SHALL be skipped (or exit early at its first step) rather than executing a no-op build with no upload
+
+### Requirement: Workflow trigger SHALL NOT switch to pull_request_target
+
+The PR-time CI workflow SHALL be triggered by `pull_request` (or equivalent fork-safe events), NOT by `pull_request_target`. The latter exposes `secrets.*` to fork-controlled code (because it runs against the base branch's workflow but with the head ref's payload), which would defeat the bundle-analysis fork-PR skip and could leak `CODECOV_TOKEN` (or any future secret added to a consumer) to attacker-controlled `vite.config.ts`, `tsup.config.ts`, or test harness.
+
+#### Scenario: Workflow does not use pull_request_target
+
+- **WHEN** `.github/workflows/ci.yml` is defined
+- **THEN** its `on:` block SHALL NOT contain `pull_request_target`
+
+### Requirement: Docs-only short-circuit is preserved
+
+The `build` job and every consumer SHALL gate execution on `needs.detect-changes.outputs.should-test == 'true'` so that PRs touching only documentation continue to skip the entire build-and-test pipeline.
+
+#### Scenario: Docs-only PR skips build
+
+- **WHEN** the CI workflow runs on a PR whose `detect-changes` step sets `should-test=false`
+- **THEN** the `build` job SHALL be skipped
+
+#### Scenario: Docs-only PR skips consumers
+
+- **WHEN** the CI workflow runs on a PR whose `detect-changes` step sets `should-test=false`
+- **THEN** every consumer job listed in the consumer-download requirement SHALL be skipped
+
+### Requirement: Single artifact serves all Node-version matrix legs
+
+The `build` job SHALL produce a single `build-artifacts` artifact (not matrixed) and every Node-version matrix leg of every consumer job SHALL download the same artifact. Build output is JS + `.d.ts` only and contains no Node-version-specific bytes; the matrix exists to validate runtime behavior under each Node version, not to validate compilation.
+
+#### Scenario: Test job matrix legs share one artifact
+
+- **WHEN** the `test` job runs across Node versions `22.18.0` and `24.x`
+- **THEN** both matrix legs SHALL download the artifact named `build-artifacts` produced by the single `build` job in the same workflow run
+
+#### Scenario: Build job is not matrixed
+
+- **WHEN** the `build` job is defined in `ci.yml`
+- **THEN** the `build` job SHALL NOT declare a `strategy.matrix` over Node versions
+
+### Requirement: Artifact retention is bounded by workflow run scope
+
+The `build-artifacts` artifact SHALL be scoped to a single workflow run. No CI job SHALL read a `build-artifacts` artifact from a different workflow run, branch, or PR. Retention SHALL be at least 14 days so that "Re-run failed jobs only" remains usable for the typical PR review cycle, and SHALL NOT exceed 90 days so that artifact storage stays bounded.
+
+#### Scenario: Consumer reads artifact from current run
+
+- **WHEN** a consumer job downloads `build-artifacts`
+- **THEN** the download SHALL use the default `actions/download-artifact` behavior, which reads from the current workflow run only (no `run-id` or cross-run download parameters)
+
+#### Scenario: Retention is finite and ≥ 14 days
+
+- **WHEN** the `build` job uploads `build-artifacts`
+- **THEN** the upload SHALL declare a `retention-days` value of at least 14 and at most 90
+
+### Requirement: Decision-9 trip-wires are mechanically enforced
+
+The "artifact is environment-agnostic" invariant (Decision 9 in design.md) SHALL be enforced by a mechanical guard, not by documentation alone. The guard SHALL fail CI if any package introduces:
+
+1. A `tsup.config.*` or `vite.config.*` `define:` block that reads from an environment variable (other than the standard `process.env.NODE_ENV` for production/development build modes).
+2. A `process.env.NODE_VERSION`-conditional code path inside a build script.
+3. A native binding artifact (`*.node`, `*.so`, `*.dylib`) under any package's `dist/`.
+
+The guard SHALL live under `scripts/check-build-portable.mjs` with a co-located `*.test.mjs`, consistent with existing mechanical guards (per `CLAUDE.md` "Mechanical guards > AI review").
+
+#### Scenario: Guard fails on env-var define
+
+- **WHEN** a package's `tsup.config.ts` adds `define: { __API_URL__: process.env.API_URL }`
+- **THEN** `pnpm test:scripts` SHALL fail with a message naming the offending file and the violated trip-wire
+
+#### Scenario: Guard fails on native binding in dist
+
+- **WHEN** any `packages/*/dist/` directory contains a `*.node`, `*.so`, or `*.dylib` file after `pnpm -r build`
+- **THEN** the guard SHALL fail with a message naming the file and the violated trip-wire
+
+#### Scenario: Guard passes on the current codebase
+
+- **WHEN** `pnpm test:scripts` runs on `main`
+- **THEN** the guard SHALL pass — no current package configuration violates a trip-wire

--- a/openspec/changes/ci-artifact-fanout/tasks.md
+++ b/openspec/changes/ci-artifact-fanout/tasks.md
@@ -27,7 +27,6 @@ always() drop). User preference for bundled coherent chunks in CI/refactor work.
   ```
 
   The guard MUST use the **TypeScript compiler API** (`import * as ts from 'typescript'`; `typescript` is already a workspace dep) to AST-parse `tsup.config.{ts,mts,cts}` and `vite.config.{ts,mts,cts}` files — no regex over source text. It walks every `define:` property in `defineConfig({ define: {...} })` (and bare-object equivalents) and fails if any property value is `process.env.*` (direct identifier access), `JSON.stringify(process.env.*)`, an arrow-function returning either of those, a spread of an object containing either, or a computed-property whose key uses `process.env.*`. It whitelists `process.env.NODE_ENV` only as a comparison operand (`BinaryExpression` where `process.env.NODE_ENV` is `left` or `right` and operator is `===`/`!==`/`==`/`!=`), never as a `define:` value. The guard ALSO:
-
   - Greps `packages/*/src/**/*.{ts,tsx,mjs,cjs}` for `process.env.NODE_VERSION` (no whitelist; this should never appear in build-time code).
   - Scans `packages/*/dist/` (when present) for `*.node`, `*.so`, or `*.dylib` files.
 
@@ -36,18 +35,17 @@ always() drop). User preference for bundled coherent chunks in CI/refactor work.
 - [ ] 2.2 Create `scripts/check-build-portable.test.mjs` using `node:test` with **nine cases**: (a) clean repo passes; (b) `define: { __X__: JSON.stringify(process.env.API_URL) }` fails; (c) `define: { __DEV__: process.env.NODE_ENV !== 'production' ? 'true' : 'false' }` PASSES (comparison operand); (d) `process.env.NODE_VERSION === '22'` in fixture `src/build-helper.ts` fails; (e) `dist/native.node` file fails; (f) computed property `define: { ['__X__']: process.env.API_URL }` fails; (g) spread `define: { ...{ __X__: process.env.X } }` fails; (h) template-literal-key with `process.env.X` value fails; (i) comment containing `}` inside a `define:` block does NOT cause a false negative (regression test for the AST approach vs. naive regex).
 
 - [ ] 2.3 Create `scripts/check-ci-fanout-invariants.mjs` whose docstring opens with: `// SCOPE: enforces ONLY ci.yml fanout invariants (consumer-needs-build, no always() in consumers, non-consumer build dependency, pull_request_target prohibition). Adding new checks requires a separate guard with its own design entry.` Use **`yaml@2.x`** (already in `pnpm.overrides` as `>=2.8.3`; verify with `pnpm why yaml` at workspace root) — NOT `js-yaml`, NOT `safeLoad`. Import as `import { parse } from 'yaml'`. The guard parses `.github/workflows/ci.yml` and fails if:
-
   1. Any consumer job's `if:` clause (string field on the parsed job object) contains the literal `always()`. Consumers enumerated literally: `lint`, `typecheck`, `test`, `test-cli`, `test-frontend`, `round-trip`, `e2e-frontend`, `e2e-prod-base`.
   2. Any consumer job's `needs:` (whether scalar or sequence) does NOT include `build`.
   3. Any non-consumer job declares `needs: build`. Non-consumers enumerated: `check-links`, `log-bot-skip`, `bundle-analysis`. The single whitelisted exception is `notify-failure` (per spec "Non-consumer jobs do not declare build dependency" Exception clause). The script hardcodes the literal name `notify-failure` AND the comment block: `// WHITELIST: only 'notify-failure' qualifies under the spec Exception. Adding a new job here REQUIRES amending openspec/specs/ci-build-fanout/spec.md first.`
+  4. The workflow `on:` block contains `pull_request_target` (per spec "Workflow trigger SHALL NOT switch to pull_request_target").
 
   Note for future readers: summary jobs (`lint-summary`, `test-summary`, `round-trip-summary`, `test-frontend-summary`) are NOT in the consumer list above. They observe consumer status and legitimately retain `if: always()` (per §8.5) — that is permitted because they are not consumers. Adding any of them to the consumer enumeration would be a category error.
-  4. The workflow `on:` block contains `pull_request_target` (per spec "Workflow trigger SHALL NOT switch to pull_request_target").
 
 - [ ] 2.4 Create `scripts/check-ci-fanout-invariants.test.mjs` using `node:test` with cases: (a) current `ci.yml` (post-rollout) passes; (b) injecting `if: always() && …` into `lint`'s `if:` fails with a message naming `lint`; (c) removing `build` from `test`'s `needs:` fails; (d) adding `needs: [detect-changes, build]` to `check-links` fails; (e) `notify-failure` keeping `always()` and `build` in `needs:` PASSES (whitelist); (f) injecting `pull_request_target:` into the `on:` block fails.
 
 - [ ] 2.5 Wire both guards into the root `lint` script: add `pnpm lint:build-portable` and `pnpm lint:ci-fanout` as sub-targets in `package.json` and append them to the root `lint` aggregator. Confirm `pnpm test:scripts` discovers and runs both new tests.
-- [ ] 2.6 Add `"yaml": "^2.8.3"` to root `devDependencies` in `package.json` (run `pnpm add -Dw yaml@^2.8.3`). The `pnpm.overrides` clause pins the *version* if `yaml` appears in the resolution graph, but does not *install* it. Adding it as an explicit root devDep makes the guard self-sufficient and survives unrelated dep removals.
+- [ ] 2.6 Add `"yaml": "^2.8.3"` to root `devDependencies` in `package.json` (run `pnpm add -Dw yaml@^2.8.3`). The `pnpm.overrides` clause pins the _version_ if `yaml` appears in the resolution graph, but does not _install_ it. Adding it as an explicit root devDep makes the guard self-sufficient and survives unrelated dep removals.
 - [ ] 2.7 Extend `scripts/check-ci-fanout-invariants.mjs` with **invariant 5**: no consumer job's `steps:` array contains a step whose `run:` field matches `^pnpm (-r )?build($|\s)` or any equivalent multi-package compilation command. This catches the regression where a future contributor adds back the build-from-source pattern alongside the artifact download. Add a test case (g): injecting `run: pnpm -r build` into `lint`'s steps fails the guard with a message naming the consumer + the offending step.
 
 ## 3. Gate the build job on docs-only short-circuit
@@ -264,11 +262,11 @@ always() drop). User preference for bundled coherent chunks in CI/refactor work.
 
 - [ ] 10.1 Capture at least **5** force-pushed runs of the rollout PR (n=3 is below the noise floor for GitHub-hosted runners; n=5 brings the 95% CI of the median to ~±20%, comparable to baseline variance). Compute the median end-to-end wall-clock across those 5 runs.
 - [ ] 10.2 Compare the §10.1 median against the §1.2 baseline median (also computed from at least 5 recent merged PRs). The proposal claims a 30-60% reduction in PR wall-clock for non-docs PRs. The gate is **two clauses, BOTH must hold**:
-
   1. **Magnitude floor**: median improvement ≥ **20%** (relaxed from 30% to account for runner noise; the proposal's 30-60% claim remains the expected target but the floor is the ship gate).
   2. **Directional significance**: a one-sided Mann-Whitney U test (`scipy.stats.mannwhitneyu(post_fanout, baseline, alternative='less')`, or equivalent) MUST reject the null at p<0.05. The one-sided alternative is critical — a two-sided test could reject the null for a regression as easily as for an improvement. Note: at n1=n2=5 the smallest exact one-sided p-value is ~1/252 ≈ 0.004, so p<0.05 is achievable but the test has limited power; the 20% magnitudinal floor is the dominant signal, MWU is the directional sanity check.
 
   If median improvement is between 20% and 30%, document the gap in the rollout PR description and link to a follow-up issue exploring cross-run cache adoption (Decision 8 → Turborepo path). If median improvement is <20% OR the one-sided MWU fails to reject at p<0.05, halt and investigate before merging.
+
 - [ ] 10.3 Capture per-job timings in a table (build job duration vs. saved time across consumers) with min/median/max columns for each of the 5 sample runs and include in the PR description for future audits.
 
 ## 11. Verify orthogonal workflows are unaffected
@@ -282,7 +280,6 @@ always() drop). User preference for bundled coherent chunks in CI/refactor work.
 - [ ] 12.2 Run `pnpm lint:specs` and `pnpm lint` end-to-end on the rollout branch.
 - [ ] 12.3 Add an empty changeset (`pnpm exec changeset --empty`) — this is repo-tooling-only, no package version bumps. Description: "ci: build packages once per workflow run and fan dist out to consumer jobs."
 - [ ] 12.4 **Archive spec hand-off**: when this change archives via `/opsx:archive`, the spec at `openspec/changes/ci-artifact-fanout/specs/ci-build-fanout/spec.md` is lifted to `openspec/specs/ci-build-fanout/spec.md`. The lifted spec MUST satisfy **all four** SPEC_TEMPLATE.md rules:
-
   - **(rule 1)** First non-empty line is `> Synced: YYYY-MM-DD (ci-artifact-fanout)` — the date is the archive date and the change-slug is the canonical reference.
   - **(rule 2)** Exactly one `# CI Build Fanout` H1, exactly one `## Purpose` H2 (lifted from the HTML capability-scope comment at the top of the change-delta), exactly one `## Requirements` H2.
   - **(rule 4)** The `## ADDED Requirements` change-delta header MUST be renamed to `## Requirements`. All `### Requirement: …` headers under it are preserved as-is. The HTML comment block at the top of the change-delta MUST be removed (its content is now in `## Purpose`).

--- a/openspec/changes/ci-artifact-fanout/tasks.md
+++ b/openspec/changes/ci-artifact-fanout/tasks.md
@@ -1,0 +1,302 @@
+<!-- opsx-ship: chunking
+PR 1 (ci-artifact-fanout): §1, §2, §3, §4, §5A, §5, §6, §7, §8, §9, §10, §11, §12, §13
+
+Rationale: structurally atomic refactor of .github/workflows/ci.yml plus 2
+mechanical guards + 1 composite action. Splitting would force temporarily-broken
+main (e.g., consumers reference the composite before it lands; mechanical guards
+fail before workflow shape conforms; summary-job logic depends on consumer
+always() drop). User preference for bundled coherent chunks in CI/refactor work.
+-->
+
+## 1. Pre-flight verification
+
+- [ ] 1.1 Confirm Decision 2 assumption: build `packages/core/dist` under Node `22.18.0` and Node `24.x` locally and `diff -r` the outputs. Repeat for `packages/workout-spa-editor` (the largest non-trivial bundle). Both diffs MUST be empty. Capture the result in the PR description; if non-empty, halt and revisit Decision 2 before continuing.
+- [ ] 1.2 Snapshot baseline CI wall-clock from the three most recent merged PRs touching package source (capture `build`, `lint`, `typecheck`, `test`, `test-frontend`, `e2e-frontend` durations). This is the comparison baseline for §8.2.
+- [ ] 1.3 Verify `actions/download-artifact@v7` `path: .` semantics: download an artifact uploaded with `path: packages/*/dist/` and confirm it lands files at `packages/<pkg>/dist/...`, NOT under a `build-artifacts/packages/...` subdirectory. Run a tiny throwaway workflow against a fork or test branch. Reference: this verifies the v3→v4 path-handling change applied in v7 matches what consumer steps expect.
+- [ ] 1.4 Verify no open GHSA advisories on `actions/upload-artifact@v7` and `actions/download-artifact@v7`: run `gh api -H "Accept: application/vnd.github+json" /repos/actions/upload-artifact/security-advisories | jq '[.[] | select(.state=="published")]'` and the equivalent for `download-artifact`. Both arrays MUST be empty (or contain only advisories for unrelated minor versions).
+
+## 2. Add Decision 11 mechanical guards (portability + fan-out invariants)
+
+- [ ] 2.1 Create `scripts/check-build-portable.mjs` whose docstring opens with this SCOPE comment block:
+
+  ```js
+  // SCOPE: enforces ONLY Decision 10's three trip-wires (env-var define:,
+  // NODE_VERSION conditionals, native bindings). Adding new checks
+  // requires a separate guard with its own design entry in
+  // openspec/changes/<slug>/design.md.
+  ```
+
+  The guard MUST use the **TypeScript compiler API** (`import * as ts from 'typescript'`; `typescript` is already a workspace dep) to AST-parse `tsup.config.{ts,mts,cts}` and `vite.config.{ts,mts,cts}` files — no regex over source text. It walks every `define:` property in `defineConfig({ define: {...} })` (and bare-object equivalents) and fails if any property value is `process.env.*` (direct identifier access), `JSON.stringify(process.env.*)`, an arrow-function returning either of those, a spread of an object containing either, or a computed-property whose key uses `process.env.*`. It whitelists `process.env.NODE_ENV` only as a comparison operand (`BinaryExpression` where `process.env.NODE_ENV` is `left` or `right` and operator is `===`/`!==`/`==`/`!=`), never as a `define:` value. The guard ALSO:
+
+  - Greps `packages/*/src/**/*.{ts,tsx,mjs,cjs}` for `process.env.NODE_VERSION` (no whitelist; this should never appear in build-time code).
+  - Scans `packages/*/dist/` (when present) for `*.node`, `*.so`, or `*.dylib` files.
+
+  Fails non-zero on any match with a message naming the offending file and the violated trip-wire.
+
+- [ ] 2.2 Create `scripts/check-build-portable.test.mjs` using `node:test` with **nine cases**: (a) clean repo passes; (b) `define: { __X__: JSON.stringify(process.env.API_URL) }` fails; (c) `define: { __DEV__: process.env.NODE_ENV !== 'production' ? 'true' : 'false' }` PASSES (comparison operand); (d) `process.env.NODE_VERSION === '22'` in fixture `src/build-helper.ts` fails; (e) `dist/native.node` file fails; (f) computed property `define: { ['__X__']: process.env.API_URL }` fails; (g) spread `define: { ...{ __X__: process.env.X } }` fails; (h) template-literal-key with `process.env.X` value fails; (i) comment containing `}` inside a `define:` block does NOT cause a false negative (regression test for the AST approach vs. naive regex).
+
+- [ ] 2.3 Create `scripts/check-ci-fanout-invariants.mjs` whose docstring opens with: `// SCOPE: enforces ONLY ci.yml fanout invariants (consumer-needs-build, no always() in consumers, non-consumer build dependency, pull_request_target prohibition). Adding new checks requires a separate guard with its own design entry.` Use **`yaml@2.x`** (already in `pnpm.overrides` as `>=2.8.3`; verify with `pnpm why yaml` at workspace root) — NOT `js-yaml`, NOT `safeLoad`. Import as `import { parse } from 'yaml'`. The guard parses `.github/workflows/ci.yml` and fails if:
+
+  1. Any consumer job's `if:` clause (string field on the parsed job object) contains the literal `always()`. Consumers enumerated literally: `lint`, `typecheck`, `test`, `test-cli`, `test-frontend`, `round-trip`, `e2e-frontend`, `e2e-prod-base`.
+  2. Any consumer job's `needs:` (whether scalar or sequence) does NOT include `build`.
+  3. Any non-consumer job declares `needs: build`. Non-consumers enumerated: `check-links`, `log-bot-skip`, `bundle-analysis`. The single whitelisted exception is `notify-failure` (per spec "Non-consumer jobs do not declare build dependency" Exception clause). The script hardcodes the literal name `notify-failure` AND the comment block: `// WHITELIST: only 'notify-failure' qualifies under the spec Exception. Adding a new job here REQUIRES amending openspec/specs/ci-build-fanout/spec.md first.`
+
+  Note for future readers: summary jobs (`lint-summary`, `test-summary`, `round-trip-summary`, `test-frontend-summary`) are NOT in the consumer list above. They observe consumer status and legitimately retain `if: always()` (per §8.5) — that is permitted because they are not consumers. Adding any of them to the consumer enumeration would be a category error.
+  4. The workflow `on:` block contains `pull_request_target` (per spec "Workflow trigger SHALL NOT switch to pull_request_target").
+
+- [ ] 2.4 Create `scripts/check-ci-fanout-invariants.test.mjs` using `node:test` with cases: (a) current `ci.yml` (post-rollout) passes; (b) injecting `if: always() && …` into `lint`'s `if:` fails with a message naming `lint`; (c) removing `build` from `test`'s `needs:` fails; (d) adding `needs: [detect-changes, build]` to `check-links` fails; (e) `notify-failure` keeping `always()` and `build` in `needs:` PASSES (whitelist); (f) injecting `pull_request_target:` into the `on:` block fails.
+
+- [ ] 2.5 Wire both guards into the root `lint` script: add `pnpm lint:build-portable` and `pnpm lint:ci-fanout` as sub-targets in `package.json` and append them to the root `lint` aggregator. Confirm `pnpm test:scripts` discovers and runs both new tests.
+- [ ] 2.6 Add `"yaml": "^2.8.3"` to root `devDependencies` in `package.json` (run `pnpm add -Dw yaml@^2.8.3`). The `pnpm.overrides` clause pins the *version* if `yaml` appears in the resolution graph, but does not *install* it. Adding it as an explicit root devDep makes the guard self-sufficient and survives unrelated dep removals.
+- [ ] 2.7 Extend `scripts/check-ci-fanout-invariants.mjs` with **invariant 5**: no consumer job's `steps:` array contains a step whose `run:` field matches `^pnpm (-r )?build($|\s)` or any equivalent multi-package compilation command. This catches the regression where a future contributor adds back the build-from-source pattern alongside the artifact download. Add a test case (g): injecting `run: pnpm -r build` into `lint`'s steps fails the guard with a message naming the consumer + the offending step.
+
+## 3. Gate the build job on docs-only short-circuit
+
+- [ ] 3.1 Add `if: github.actor != 'github-actions[bot]' && needs.detect-changes.outputs.should-test == 'true'` to the `build` job in `.github/workflows/ci.yml` (the `needs: detect-changes` edge already exists at `ci.yml:485`). Add a YAML comment: `# Actor check is redundant with detect-changes' own gate, but kept as belt-and-braces; if detect-changes' gate ever moves, build still skips bot commits.`
+- [ ] 3.2 Verify by pushing a docs-only branch (touching only a `*.md` file) and confirming both `detect-changes` and `build` show as skipped in the CI run.
+- [ ] 3.3 Confirm the `Upload build artifacts` step is the LAST step in the `build` job and that no step with `if: always()` follows it (per spec "No always-step follows upload").
+- [ ] 3.4 Bump `retention-days` on `Upload build artifacts` from 7 to 30 (Decision 13). Add a YAML comment `# 30 days covers the typical PR review cycle so "Re-run failed jobs only" stays usable; spec floor is 14, ceiling 90`.
+- [ ] 3.5 Audit the `build` job's `env:` and per-step `env:` blocks. Confirm no `secrets.*` reference other than `secrets.GITHUB_TOKEN` (which is implicit). Specifically: ensure `CODECOV_TOKEN` is NOT referenced in the build job (it currently only appears under `test-frontend`'s build step at `ci.yml:534-538`, which is being removed in §6).
+
+## 4. Drop `if: always()` from every consumer (CRITICAL fail-fast fix)
+
+- [ ] 4.1 In `lint` (`ci.yml:208`), rewrite `if: always() && needs.detect-changes.outputs.should-test == 'true'` to `if: needs.detect-changes.outputs.should-test == 'true'`. Drop `always() &&`.
+- [ ] 4.2 In `typecheck` (`ci.yml:397`), apply the same rewrite.
+- [ ] 4.3 In `test` (`ci.yml:414`), apply the same rewrite.
+- [ ] 4.4 In `test-cli` (`ci.yml:568`), apply the same rewrite.
+- [ ] 4.5 In `test-frontend` (`ci.yml:520`), apply the same rewrite.
+- [ ] 4.6 In `round-trip` (`ci.yml:613`), apply the same rewrite.
+- [ ] 4.7 `e2e-frontend` and `e2e-prod-base` use `if: |` multi-line clauses without `always()`; verify they still do not contain `always()` after this change.
+- [ ] 4.8 (Replaced — see §2.3.) The `always()`-in-consumers check is now enforced by the YAML-aware `scripts/check-ci-fanout-invariants.mjs` guard, NOT by a brittle grep. Remove this task slot from the gating set; the guard runs as part of `pnpm lint`.
+
+## 5A. Create the `consume-build-artifacts` composite action (Decision 5 reopened)
+
+- [ ] 5A.1 Create `.github/actions/consume-build-artifacts/action.yml` wrapping the wipe → download → verify pattern. Shape:
+
+  ```yaml
+  # The single chokepoint where a consumer job receives the run-scoped
+  # build artifact. See openspec/specs/ci-build-fanout/spec.md. The
+  # consumer enumeration is hardcoded in
+  # scripts/check-ci-fanout-invariants.mjs; adding a new consumer
+  # requires updating that whitelist alongside the consumer's YAML.
+  name: "Consume build artifacts"
+  description: "Wipe stale dist, download build-artifacts, verify result."
+  inputs:
+    expected-packages:
+      description: "Space-separated list of package names whose packages/<name>/dist/ MUST exist after download. Default covers all publishable packages."
+      required: false
+      default: "core fit tcx zwo garmin garmin-connect cli mcp ai"
+  runs:
+    using: "composite"
+    steps:
+      - name: Wipe stale dist (artifact is source of truth)
+        shell: bash
+        run: rm -rf packages/*/dist
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: build-artifacts
+          path: .
+
+      - name: Verify dist exists and contains no symlinks
+        shell: bash
+        # SECURITY: input is materialized into env first so a future
+        # caller passing `core; rm -rf /` becomes a literal token in
+        # the array, not a shell metacharacter.
+        env:
+          EXPECTED: ${{ inputs.expected-packages }}
+        run: |
+          read -ra pkgs <<< "$EXPECTED"
+          missing=0
+          for pkg in "${pkgs[@]}"; do
+            if [ ! -d "packages/$pkg/dist" ]; then
+              echo "::error::Artifact 'build-artifacts' from job 'build' did not land packages/$pkg/dist."
+              echo "::error::Possible causes: (1) artifact expired (>30 days); (2) build-job upload step failed silently; (3) workflow misconfiguration."
+              echo "::error::Inspect the run's Artifacts panel; if missing, push an empty commit to rebuild:"
+              echo "::error::  git commit --allow-empty -m 'chore(ci): re-trigger build'"
+              missing=1
+            fi
+          done
+          [ $missing -eq 0 ] || exit 1
+          # CORRECTNESS: scan INSIDE every packages/*/dist for symlinks.
+          # The earlier `-path 'packages/*/dist' -type d -prune` form
+          # was wrong — it pruned the dist roots and so missed symlinks
+          # within them, defeating the entire check. -mindepth 0 keeps
+          # the dist root itself in scope (defends against root-symlink
+          # attacks: `packages/foo/dist -> /attacker-controlled`); do
+          # NOT "tighten" to -mindepth 1 — that silently loses root
+          # coverage.
+          symlinks=$(find packages/*/dist -mindepth 0 -type l -print 2>/dev/null | head -5)
+          if [ -n "$symlinks" ]; then
+            echo "::error::Symlinks under packages/*/dist/ are forbidden (potential malicious build):"
+            echo "$symlinks"
+            exit 1
+          fi
+  ```
+
+- [ ] 5A.2 Each consumer in §5/§6/§7 invokes the composite via:
+
+  ```yaml
+  - name: Consume build artifacts
+    uses: ./.github/actions/consume-build-artifacts
+    # For SPA-only consumers (e2e-frontend, e2e-prod-base, test-frontend),
+    # narrow the expected list:
+    # with:
+    #   expected-packages: "workout-spa-editor"
+  ```
+
+- [ ] 5A.3 Add a `with: expected-packages: "workout-spa-editor"` parameter to `e2e-frontend`, `e2e-prod-base`, and `test-frontend` so a missing SPA dist fails the consumer with a clear error rather than passing because `core/dist` happens to exist.
+
+- [ ] 5A.4 Verify the composite action's `Verify dist exists` step reports the same `Artifact 'build-artifacts' from job 'build' did not land …` error that the inline form would (mirror the user-facing message exactly so contributors get the same hint regardless of consumer job).
+
+## 5. Wire the lint, typecheck, test, test-cli, round-trip jobs to consume the artifact
+
+- [ ] 5.1 In each of `lint`, `typecheck`, `test`, `test-cli`, `round-trip`, add `build` to `needs:` (where not already present).
+- [ ] 5.2 In each of `lint`, `typecheck`, `test`, `test-cli`, `round-trip`, replace the `Build packages (required for type checking)` / `Build dependencies` / `Build all packages (CLI depends on all adapters)` step with a single invocation of the composite action defined in §5A.1. The composite is the **single source of truth** for the wipe → download → verify pattern; consumers MUST NOT inline the three steps. Example for `test-cli`:
+
+  ```yaml
+  # Consume the run-scoped build artifact. The composite action wipes
+  # stale dist/, downloads build-artifacts, and verifies the result
+  # (no missing dirs, no symlinks). See .github/actions/consume-build-artifacts/.
+  - name: Consume build artifacts
+    uses: ./.github/actions/consume-build-artifacts
+  ```
+
+  For SPA-only consumers (`test-frontend`, `e2e-frontend`, `e2e-prod-base`), narrow via:
+
+  ```yaml
+  - name: Consume build artifacts
+    uses: ./.github/actions/consume-build-artifacts
+    with:
+      expected-packages: "workout-spa-editor"
+  ```
+
+- [ ] 5.3 Add a one-line YAML comment above the `Download build artifacts` step (already shown in §5.2's snippet) referencing the spec. Mirror the comment style on the `bundle-analysis` job (§6.2) and on `check-links` (§5.4).
+- [ ] 5.4 Add a YAML comment above `check-links:` (around `ci.yml:379`) that reads: `# check-links does not need compiled output; it is intentionally NOT a build consumer (see openspec/specs/ci-build-fanout/spec.md).` Same shape for `log-bot-skip` if a future reviewer might wonder.
+- [ ] 5.5 Run the full CI on the rollout PR and confirm every matrix leg of every job above downloads the artifact and passes its checks.
+
+## 6. Wire the test-frontend job and extract the bundle-analysis carve-out (Decision 9 revised)
+
+- [ ] 6.1 In `test-frontend`, add `build` to `needs:`, drop `always()` (see §4.5), and replace `Build dependencies` with the `Download build artifacts` + `Verify dist exists` steps. The `CODECOV_TOKEN` env var on the old build step is REMOVED here — bundle analysis moves to its own job in §6.2.
+- [ ] 6.2 Create a new top-level `bundle-analysis` job in `ci.yml` (placement: after `test-frontend`, before the summary jobs) with the following shape:
+
+  ```yaml
+  # Bundle-size analysis (Codecov Vite plugin). The plugin instruments
+  # vite build via a Vite plugin hook, so it cannot consume the
+  # packages/*/dist artifact and is intentionally NOT a build consumer.
+  # See openspec/specs/ci-build-fanout/spec.md "Bundle-analysis exception".
+  bundle-analysis:
+    name: bundle-analysis
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.should-test == 'true' &&
+      needs.detect-changes.outputs.frontend-changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: "22.18.0"
+      - name: Build SPA with Codecov bundle plugin
+        # Step-level fork-PR skip: secrets.* is not reliably evaluable
+        # in job-level `if:` (GitHub Actions documents this surface as
+        # context-dependent). Materialize the secret into env first,
+        # then guard at step level via env. On fork PRs, env is empty
+        # → step is skipped, the job exits zero with no upload.
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        if: env.CODECOV_TOKEN != ''
+        run: pnpm --filter @kaiord/workout-spa-editor build
+  ```
+
+  Per spec: bundle-analysis SHALL NOT declare `build` in `needs:` (it is not a consumer); it pins to one Node version; it builds only one package; it carries the secret on its own step. The **step-level** `if: env.CODECOV_TOKEN != ''` is the canonical fork-PR guard — job-level `secrets.*` evaluation is unsupported in some `if:` contexts (per GitHub Actions docs).
+
+- [ ] 6.3 Confirm `notify-failure` does NOT need to track `bundle-analysis` (failures there should not page; bundle analysis is informational signal, not a gating check). If failure-bot tracking IS desired, add it to `notify-failure`'s `needs:` list and the failure-jobs JSON assembly. Default: do not track.
+
+## 7. Wire the e2e-frontend and e2e-prod-base jobs
+
+- [ ] 7.1 In `e2e-frontend` (4 shards), keep the existing `needs: [detect-changes, build]` edge; replace the `Build dependencies` step with `Download build artifacts` + `Verify dist exists` (`packages/workout-spa-editor/dist`).
+- [ ] 7.2 In `e2e-prod-base`, keep the existing `needs: [detect-changes, build]` edge; replace the `Build dependencies` step with `Download build artifacts` + `Verify dist exists` (`packages/workout-spa-editor/dist`).
+- [ ] 7.3 Confirm Playwright finds the SPA build output (`packages/workout-spa-editor/dist/`) under the artifact-restored layout.
+
+## 8. Update branch-protection summary jobs (Decision 12)
+
+- [ ] 8.1 Modify `lint-summary` (`ci.yml:735`): add `build` to `needs:` (becomes `needs: [build, lint]`); rewrite the check step with explicit four-state logic to lock the policy from spec scenarios "Summary fails on build failure", "Summary passes on docs-only short-circuit", "Summary passes on all-green run", and "Summary fails when build succeeded but consumer was skipped":
+
+  ```yaml
+  - name: Check lint status (with build awareness)
+    run: |
+      build_result="${{ needs.build.result }}"
+      lint_result="${{ needs.lint.result }}"
+      # State 1: docs-only PR — build correctly skipped → consumer correctly skipped → green.
+      if [ "$build_result" = "skipped" ]; then
+        echo "Build skipped (docs-only); lint correctly not run."
+        exit 0
+      fi
+      # State 2: build failed — consumer correctly skipped → red, naming the upstream cause.
+      if [ "$build_result" = "failure" ]; then
+        echo "::error::Build failed; lint did not run. Fix the build error and re-run."
+        exit 1
+      fi
+      # State 3 & 4: build succeeded — consumer MUST have run and passed.
+      if [ "$lint_result" != "success" ]; then
+        echo "::error::Build succeeded but lint did not. Lint result: $lint_result"
+        exit 1
+      fi
+      echo "Lint passed."
+  ```
+
+- [ ] 8.2 Apply the same four-state pattern to `test-summary` (`ci.yml:749`), substituting `lint` → `test`.
+- [ ] 8.3 Apply the same four-state pattern to `round-trip-summary` (`ci.yml:763`), substituting `lint` → `round-trip`.
+- [ ] 8.4 Apply the same four-state pattern to `test-frontend-summary` (`ci.yml:777`), substituting `lint` → `test-frontend`.
+- [ ] 8.5 Verify `if: always()` is preserved on the four summary jobs (it is required for them to run when their consumer is skipped — that is the whole reason they exist as separate summary jobs). The §2.3 mechanical guard whitelists summary jobs explicitly so this does not violate the consumer-`always()`-prohibition.
+- [ ] 8.6 (Follow-up only — see §13.5.) Adding `build` to branch-protection required checks is a repo-settings change, not workflow code, and is tracked as a follow-up issue. The summary fixes here are sufficient for the immediate gap.
+
+## 9. Verify fail-fast and re-run behaviour
+
+- [ ] 9.1 On a throwaway branch, deliberately introduce a TypeScript error in `packages/core/src/` so the `build` job fails. Push and observe: every consumer job (`lint`, `typecheck`, `test`, `test-cli`, `test-frontend`, `round-trip`, `e2e-frontend`, `e2e-prod-base`) MUST end with status `skipped`, not `failure`. The four summary jobs MUST end with status `failure`. Discard the branch.
+- [ ] 9.2 Document the fail-fast verification result in the rollout PR description (with a link to the throwaway run).
+- [ ] 9.3 Verify "Re-run failed jobs only" works: after a successful `build` and a deliberately-failing `test`, click "Re-run failed jobs only" and confirm `test` re-runs against the same artifact (no `build` re-run; artifact still present after 1 day).
+- [ ] 9.4 Verify a docs-only PR still produces all-green: `build` skipped, all consumers skipped, all four summary jobs exit 0 (per Decision 12 scenario "Summary passes on docs-only short-circuit").
+
+## 10. Verify wall-clock improvement and reconcile thresholds
+
+- [ ] 10.1 Capture at least **5** force-pushed runs of the rollout PR (n=3 is below the noise floor for GitHub-hosted runners; n=5 brings the 95% CI of the median to ~±20%, comparable to baseline variance). Compute the median end-to-end wall-clock across those 5 runs.
+- [ ] 10.2 Compare the §10.1 median against the §1.2 baseline median (also computed from at least 5 recent merged PRs). The proposal claims a 30-60% reduction in PR wall-clock for non-docs PRs. The gate is **two clauses, BOTH must hold**:
+
+  1. **Magnitude floor**: median improvement ≥ **20%** (relaxed from 30% to account for runner noise; the proposal's 30-60% claim remains the expected target but the floor is the ship gate).
+  2. **Directional significance**: a one-sided Mann-Whitney U test (`scipy.stats.mannwhitneyu(post_fanout, baseline, alternative='less')`, or equivalent) MUST reject the null at p<0.05. The one-sided alternative is critical — a two-sided test could reject the null for a regression as easily as for an improvement. Note: at n1=n2=5 the smallest exact one-sided p-value is ~1/252 ≈ 0.004, so p<0.05 is achievable but the test has limited power; the 20% magnitudinal floor is the dominant signal, MWU is the directional sanity check.
+
+  If median improvement is between 20% and 30%, document the gap in the rollout PR description and link to a follow-up issue exploring cross-run cache adoption (Decision 8 → Turborepo path). If median improvement is <20% OR the one-sided MWU fails to reject at p<0.05, halt and investigate before merging.
+- [ ] 10.3 Capture per-job timings in a table (build job duration vs. saved time across consumers) with min/median/max columns for each of the 5 sample runs and include in the PR description for future audits.
+
+## 11. Verify orthogonal workflows are unaffected
+
+- [ ] 11.1 Confirm NO workflow other than `ci.yml` consumes `build-artifacts`, including via composite actions: run `grep -rE '(download-artifact|build-artifacts)' .github/workflows/ .github/actions/` and assert the only matches are: (a) `ci.yml` (the new consumer downloads + the producer upload), (b) `.github/actions/setup-pnpm/action.yml` (the existing TypeScript dist cache, which is unrelated to the run-scoped artifact). Any match in `release.yml`, `eval.yml`, `metrics-gate.yml`, `cws-publish.yml`, `deploy-site.yml`, `auto-merge.yml`, `changeset-bot.yml`, `security.yml`, `accessibility-evidence-refresh.yml`, `ci-issue-bot-canary.yml`, `ci-issue-bot-success.yml`, or `workout-spa-editor-e2e.yml` is unexpected — halt and investigate.
+- [ ] 11.2 Confirm `ci-failure-bot` behavior: trigger a build failure (via §9.1's throwaway branch on `main` if safely revertable, or by simulation) and verify the failure issue lists `build` exactly once, with consumers listed as skipped (not failed). If the bot's failed-jobs JSON includes skipped jobs as failures, file a separate issue — that is a `ci-failure-bot` bug, not a fan-out regression.
+
+## 12. Spec compliance and changeset
+
+- [ ] 12.1 Run `pnpm exec openspec validate ci-artifact-fanout --strict` and ensure it passes.
+- [ ] 12.2 Run `pnpm lint:specs` and `pnpm lint` end-to-end on the rollout branch.
+- [ ] 12.3 Add an empty changeset (`pnpm exec changeset --empty`) — this is repo-tooling-only, no package version bumps. Description: "ci: build packages once per workflow run and fan dist out to consumer jobs."
+- [ ] 12.4 **Archive spec hand-off**: when this change archives via `/opsx:archive`, the spec at `openspec/changes/ci-artifact-fanout/specs/ci-build-fanout/spec.md` is lifted to `openspec/specs/ci-build-fanout/spec.md`. The lifted spec MUST satisfy **all four** SPEC_TEMPLATE.md rules:
+
+  - **(rule 1)** First non-empty line is `> Synced: YYYY-MM-DD (ci-artifact-fanout)` — the date is the archive date and the change-slug is the canonical reference.
+  - **(rule 2)** Exactly one `# CI Build Fanout` H1, exactly one `## Purpose` H2 (lifted from the HTML capability-scope comment at the top of the change-delta), exactly one `## Requirements` H2.
+  - **(rule 4)** The `## ADDED Requirements` change-delta header MUST be renamed to `## Requirements`. All `### Requirement: …` headers under it are preserved as-is. The HTML comment block at the top of the change-delta MUST be removed (its content is now in `## Purpose`).
+  - **(rule 3)** Every `### Requirement:` has at least one `#### Scenario:` block — already satisfied by construction in this change-delta; `pnpm lint:specs` re-asserts post-archive.
+  - **(rule 5)** `pnpm lint:specs` passes post-archive — this is the deterministic check that catches violations of rules 1-4.
+
+  If `/opsx:archive` does not auto-perform the H1/Purpose/Requirements transformations, do them by hand and run `pnpm lint:specs` before merging the archive PR. The structural lint at `scripts/check-spec-format.mjs` will fail the build if any of the four rules above is violated.
+
+## 13. Land and follow up
+
+- [ ] 13.1 Open the rollout PR with conventional-commit subject `chore(ci): fan build artifacts to consumer jobs`. Body MUST include: (a) §1.1 byte-diff results, (b) §1.2 baseline + §10 measured wall-clock, (c) §9.1-§9.4 verification screenshots/links.
+- [ ] 13.2 After merge, monitor the next 5 PR runs on `main` for unexpected skips, stale artifacts, or matrix-leg divergence. If any consumer reports `dist/` missing, roll back per design.md Migration Plan.
+- [ ] 13.3 Open a follow-up issue: "Remove redundant TypeScript dist cache from setup-pnpm composite action" (Decision 8).
+- [ ] 13.4 Open a follow-up issue: "Extend `Verify build outputs` step in the build job to include `workout-spa-editor`, `garmin-bridge`, `train2go-bridge`" — currently it only iterates `core fit tcx zwo garmin garmin-connect cli mcp ai`, which leaves SPA + bridge dist gaps undetected.
+- [ ] 13.5 **Issue MUST be filed before this PR merges; assignee MUST be set within 30 days of merge.** Title: "Add `build` to branch-protection required-checks list". Decision 12 fixes the summary-job whitelist gap inside workflow code; adding `build` to required checks is the belt-and-braces repo-settings change tracked here. Issue references this change's PR; rollout PR description links to the issue.
+- [ ] 13.6 Verify `dependabot.yml` covers `package-ecosystem: github-actions` so that future GHSA advisories on `actions/upload-artifact@v7` and `actions/download-artifact@v7` produce auto-PRs. If the ecosystem is missing, open a follow-up issue to add it (do not block this change).
+- [ ] 13.7 Run `/opsx:archive` once the PR is merged.

--- a/openspec/changes/ci-artifact-fanout/tasks.md
+++ b/openspec/changes/ci-artifact-fanout/tasks.md
@@ -293,7 +293,19 @@ always() drop). User preference for bundled coherent chunks in CI/refactor work.
 - [ ] 13.1 Open the rollout PR with conventional-commit subject `chore(ci): fan build artifacts to consumer jobs`. Body MUST include: (a) §1.1 byte-diff results, (b) §1.2 baseline + §10 measured wall-clock, (c) §9.1-§9.4 verification screenshots/links.
 - [ ] 13.2 After merge, monitor the next 5 PR runs on `main` for unexpected skips, stale artifacts, or matrix-leg divergence. If any consumer reports `dist/` missing, roll back per design.md Migration Plan.
 - [ ] 13.3 Open a follow-up issue: "Remove redundant TypeScript dist cache from setup-pnpm composite action" (Decision 8).
+
+  > Deferred to: #482
+
 - [ ] 13.4 Open a follow-up issue: "Extend `Verify build outputs` step in the build job to include `workout-spa-editor`, `garmin-bridge`, `train2go-bridge`" — currently it only iterates `core fit tcx zwo garmin garmin-connect cli mcp ai`, which leaves SPA + bridge dist gaps undetected.
+
+  > Deferred to: #483
+
 - [ ] 13.5 **Issue MUST be filed before this PR merges; assignee MUST be set within 30 days of merge.** Title: "Add `build` to branch-protection required-checks list". Decision 12 fixes the summary-job whitelist gap inside workflow code; adding `build` to required checks is the belt-and-braces repo-settings change tracked here. Issue references this change's PR; rollout PR description links to the issue.
+
+  > Deferred to: #481
+
 - [ ] 13.6 Verify `dependabot.yml` covers `package-ecosystem: github-actions` so that future GHSA advisories on `actions/upload-artifact@v7` and `actions/download-artifact@v7` produce auto-PRs. If the ecosystem is missing, open a follow-up issue to add it (do not block this change).
+
+  > Deferred to: #484
+
 - [ ] 13.7 Run `/opsx:archive` once the PR is merged.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r test && pnpm test:scripts",
-    "lint": "pnpm -r lint && pnpm lint:archive && pnpm lint:archive-index && pnpm lint:archive-followups && pnpm lint:specs && pnpm lint:tsup-watchdog && pnpm lint:mapper-no-tests && pnpm lint:converter-has-tests && pnpm lint:husky-no-bypass && pnpm lint:package-deps && pnpm lint:architecture && pnpm lint:no-unconditional-skip && pnpm lint:no-library-dual-mount && pnpm lint:allowlists-empty && pnpm lint:icons-distinct",
+    "lint": "pnpm -r lint && pnpm lint:archive && pnpm lint:archive-index && pnpm lint:archive-followups && pnpm lint:specs && pnpm lint:tsup-watchdog && pnpm lint:mapper-no-tests && pnpm lint:converter-has-tests && pnpm lint:husky-no-bypass && pnpm lint:package-deps && pnpm lint:architecture && pnpm lint:no-unconditional-skip && pnpm lint:no-library-dual-mount && pnpm lint:allowlists-empty && pnpm lint:icons-distinct && pnpm lint:build-portable && pnpm lint:ci-fanout",
     "lint:fix": "pnpm -r lint:fix && prettier --write .",
     "lint:packages": "pnpm -r lint",
     "lint:archive": "node scripts/check-archive-dates.mjs",
@@ -69,6 +69,8 @@
     "lint:no-library-dual-mount": "node scripts/check-no-library-dual-mount.mjs",
     "lint:allowlists-empty": "node scripts/check-allowlists-empty.mjs",
     "lint:icons-distinct": "node scripts/check-extension-icons-distinct.mjs",
+    "lint:build-portable": "node scripts/check-build-portable.mjs",
+    "lint:ci-fanout": "node scripts/check-ci-fanout-invariants.mjs",
     "lint:links": "bash scripts/lint-links.sh",
     "icons:build": "node scripts/build-extension-icons.mjs",
     "popup:sync": "node scripts/sync-popup-css.mjs",
@@ -109,6 +111,7 @@
     "sharp": "^0.34.5",
     "size-limit": "^12.1.0",
     "typescript": "^6.0.3",
-    "typescript-eslint": "^8.59.1"
+    "typescript-eslint": "^8.59.1",
+    "yaml": "^2.8.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       typescript-eslint:
         specifier: ^8.59.1
         version: 8.59.1(eslint@10.2.1(jiti@2.6.1))(typescript@6.0.3)
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
 
   packages/_shared: {}
 

--- a/scripts/check-build-portable.mjs
+++ b/scripts/check-build-portable.mjs
@@ -196,7 +196,10 @@ function findDefineCalls(node, file, violations) {
     if (arg && ts.isObjectLiteralExpression(arg)) {
       // Object form: defineConfig({ define: {...} })
       inspectConfigObject(arg, file, violations);
-    } else if (arg && (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg))) {
+    } else if (
+      arg &&
+      (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg))
+    ) {
       // Factory form: defineConfig((env) => ({ define: {...} })).
       // tsup and vite both document this as a first-class pattern for
       // env-dependent config. The body is either an expression
@@ -206,7 +209,10 @@ function findDefineCalls(node, file, violations) {
       if (body) {
         if (ts.isObjectLiteralExpression(body)) {
           inspectConfigObject(body, file, violations);
-        } else if (ts.isParenthesizedExpression(body) && ts.isObjectLiteralExpression(body.expression)) {
+        } else if (
+          ts.isParenthesizedExpression(body) &&
+          ts.isObjectLiteralExpression(body.expression)
+        ) {
           inspectConfigObject(body.expression, file, violations);
         } else if (ts.isBlock(body)) {
           for (const stmt of body.statements) {
@@ -217,7 +223,11 @@ function findDefineCalls(node, file, violations) {
                 ts.isParenthesizedExpression(stmt.expression) &&
                 ts.isObjectLiteralExpression(stmt.expression.expression)
               ) {
-                inspectConfigObject(stmt.expression.expression, file, violations);
+                inspectConfigObject(
+                  stmt.expression.expression,
+                  file,
+                  violations
+                );
               }
             }
           }

--- a/scripts/check-build-portable.mjs
+++ b/scripts/check-build-portable.mjs
@@ -94,6 +94,33 @@ function valueReadsEnv(node) {
   if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
     if (node.body) return valueReadsEnv(node.body);
   }
+  if (ts.isBlock(node)) {
+    return node.statements.some(valueReadsEnv);
+  }
+  if (ts.isReturnStatement(node)) {
+    return valueReadsEnv(node.expression);
+  }
+  if (ts.isBinaryExpression(node)) {
+    // Catches `process.env.X || 'default'`, `process.env.X ?? 'd'`,
+    // `'prefix' + process.env.X`, etc. Whitelist the comparison form
+    // `process.env.NODE_ENV === 'production'` (left or right operand
+    // is the NODE_ENV access AND the operator is a comparison).
+    const isComparison =
+      node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+      node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsEqualsToken ||
+      node.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
+      node.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken;
+    if (isComparison) {
+      const leftIsNodeEnv = envName(node.left) === "NODE_ENV";
+      const rightIsNodeEnv = envName(node.right) === "NODE_ENV";
+      if (leftIsNodeEnv || rightIsNodeEnv) return false;
+    }
+    return valueReadsEnv(node.left) || valueReadsEnv(node.right);
+  }
+  if (ts.isTemplateExpression(node)) {
+    // Template literal like `` `http://${process.env.HOST}` ``.
+    return node.templateSpans.some((s) => valueReadsEnv(s.expression));
+  }
   if (ts.isConditionalExpression(node)) {
     return valueReadsEnv(node.whenTrue) || valueReadsEnv(node.whenFalse);
   }
@@ -145,6 +172,20 @@ function visitDefineProperties(defineObject, file, violations) {
   }
 }
 
+function inspectConfigObject(obj, file, violations) {
+  if (!obj || !ts.isObjectLiteralExpression(obj)) return;
+  for (const prop of obj.properties) {
+    if (
+      ts.isPropertyAssignment(prop) &&
+      ts.isIdentifier(prop.name) &&
+      prop.name.text === "define" &&
+      ts.isObjectLiteralExpression(prop.initializer)
+    ) {
+      visitDefineProperties(prop.initializer, file, violations);
+    }
+  }
+}
+
 function findDefineCalls(node, file, violations) {
   if (
     ts.isCallExpression(node) &&
@@ -153,14 +194,33 @@ function findDefineCalls(node, file, violations) {
   ) {
     const arg = node.arguments[0];
     if (arg && ts.isObjectLiteralExpression(arg)) {
-      for (const prop of arg.properties) {
-        if (
-          ts.isPropertyAssignment(prop) &&
-          ts.isIdentifier(prop.name) &&
-          prop.name.text === "define" &&
-          ts.isObjectLiteralExpression(prop.initializer)
-        ) {
-          visitDefineProperties(prop.initializer, file, violations);
+      // Object form: defineConfig({ define: {...} })
+      inspectConfigObject(arg, file, violations);
+    } else if (arg && (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg))) {
+      // Factory form: defineConfig((env) => ({ define: {...} })).
+      // tsup and vite both document this as a first-class pattern for
+      // env-dependent config. The body is either an expression
+      // (concise arrow) or a block whose return statement carries the
+      // config object.
+      const body = arg.body;
+      if (body) {
+        if (ts.isObjectLiteralExpression(body)) {
+          inspectConfigObject(body, file, violations);
+        } else if (ts.isParenthesizedExpression(body) && ts.isObjectLiteralExpression(body.expression)) {
+          inspectConfigObject(body.expression, file, violations);
+        } else if (ts.isBlock(body)) {
+          for (const stmt of body.statements) {
+            if (ts.isReturnStatement(stmt) && stmt.expression) {
+              if (ts.isObjectLiteralExpression(stmt.expression)) {
+                inspectConfigObject(stmt.expression, file, violations);
+              } else if (
+                ts.isParenthesizedExpression(stmt.expression) &&
+                ts.isObjectLiteralExpression(stmt.expression.expression)
+              ) {
+                inspectConfigObject(stmt.expression.expression, file, violations);
+              }
+            }
+          }
         }
       }
     }

--- a/scripts/check-build-portable.mjs
+++ b/scripts/check-build-portable.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// SCOPE: enforces ONLY Decision 10's three trip-wires (env-var define:,
+// NODE_VERSION conditionals, native bindings). Adding new checks
+// requires a separate guard with its own design entry in
+// openspec/changes/<slug>/design.md.
+//
+// Rule R-BuildPortable: the build-artifacts artifact (packages/*/dist)
+// MUST be byte-identical across the Node-version matrix. Trip-wires:
+//
+//   1. tsup.config.* / vite.config.* `define:` blocks whose VALUES
+//      read process.env.* (other than NODE_ENV as a comparison
+//      operand).
+//   2. process.env.NODE_VERSION references in build-time code under
+//      packages/*/src/.
+//   3. native bindings (*.node, *.so, *.dylib) under packages/*/dist.
+//
+// If any trip-wire fires, Decision 2 (one artifact for both Node legs)
+// no longer holds and the fan-out must re-matrix.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import ts from "typescript";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const PACKAGES_ROOT = resolve(REPO_ROOT, "packages");
+
+const CONFIG_FILE_RE = /^(tsup|vite)\.config\.(ts|mts|cts)$/;
+const NATIVE_BINDING_RE = /\.(node|so|dylib)$/;
+const SOURCE_FILE_RE = /\.(ts|tsx|mjs|cjs)$/;
+
+function listPackageDirs(packagesRoot) {
+  try {
+    return readdirSync(packagesRoot, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => join(packagesRoot, d.name));
+  } catch {
+    return [];
+  }
+}
+
+function findFilesMatching(rootDir, predicate, results = []) {
+  let entries;
+  try {
+    entries = readdirSync(rootDir, { withFileTypes: true });
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    if (entry.name === "node_modules" || entry.name.startsWith(".")) continue;
+    const full = join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      findFilesMatching(full, predicate, results);
+    } else if (entry.isFile() && predicate(entry.name, full)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function isProcessEnvAccess(node) {
+  if (!node) return false;
+  if (!ts.isPropertyAccessExpression(node)) return false;
+  const obj = node.expression;
+  if (!ts.isPropertyAccessExpression(obj)) return false;
+  return (
+    ts.isIdentifier(obj.expression) &&
+    obj.expression.text === "process" &&
+    ts.isIdentifier(obj.name) &&
+    obj.name.text === "env"
+  );
+}
+
+function envName(node) {
+  if (!isProcessEnvAccess(node)) return null;
+  return ts.isIdentifier(node.name) ? node.name.text : null;
+}
+
+function valueReadsEnv(node) {
+  if (!node) return false;
+  if (envName(node)) return true;
+  if (ts.isCallExpression(node)) {
+    const callee = node.expression;
+    const isJsonStringify =
+      ts.isPropertyAccessExpression(callee) &&
+      ts.isIdentifier(callee.expression) &&
+      callee.expression.text === "JSON" &&
+      ts.isIdentifier(callee.name) &&
+      callee.name.text === "stringify";
+    if (isJsonStringify && node.arguments.some(valueReadsEnv)) return true;
+  }
+  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {
+    if (node.body) return valueReadsEnv(node.body);
+  }
+  if (ts.isConditionalExpression(node)) {
+    return valueReadsEnv(node.whenTrue) || valueReadsEnv(node.whenFalse);
+  }
+  if (ts.isParenthesizedExpression(node)) return valueReadsEnv(node.expression);
+  if (ts.isObjectLiteralExpression(node)) {
+    return node.properties.some((p) => {
+      if (ts.isPropertyAssignment(p)) return valueReadsEnv(p.initializer);
+      if (ts.isSpreadAssignment(p)) return valueReadsEnv(p.expression);
+      return false;
+    });
+  }
+  return false;
+}
+
+function visitDefineProperties(defineObject, file, violations) {
+  for (const prop of defineObject.properties) {
+    if (ts.isPropertyAssignment(prop)) {
+      const computedKey =
+        prop.name && ts.isComputedPropertyName(prop.name)
+          ? prop.name.expression
+          : null;
+      if (computedKey && valueReadsEnv(computedKey)) {
+        violations.push({
+          rule: "R-BuildPortable",
+          file: relative(REPO_ROOT, file),
+          detail:
+            "Computed `define:` key reads process.env (build-time injection)",
+        });
+        continue;
+      }
+      if (valueReadsEnv(prop.initializer)) {
+        violations.push({
+          rule: "R-BuildPortable",
+          file: relative(REPO_ROOT, file),
+          detail:
+            "`define:` value reads process.env (build-time injection — Decision 10 trip-wire)",
+        });
+      }
+    } else if (ts.isSpreadAssignment(prop)) {
+      if (valueReadsEnv(prop.expression)) {
+        violations.push({
+          rule: "R-BuildPortable",
+          file: relative(REPO_ROOT, file),
+          detail:
+            "Spread into `define:` reads process.env (build-time injection)",
+        });
+      }
+    }
+  }
+}
+
+function findDefineCalls(node, file, violations) {
+  if (
+    ts.isCallExpression(node) &&
+    ts.isIdentifier(node.expression) &&
+    node.expression.text === "defineConfig"
+  ) {
+    const arg = node.arguments[0];
+    if (arg && ts.isObjectLiteralExpression(arg)) {
+      for (const prop of arg.properties) {
+        if (
+          ts.isPropertyAssignment(prop) &&
+          ts.isIdentifier(prop.name) &&
+          prop.name.text === "define" &&
+          ts.isObjectLiteralExpression(prop.initializer)
+        ) {
+          visitDefineProperties(prop.initializer, file, violations);
+        }
+      }
+    }
+  }
+  ts.forEachChild(node, (child) => findDefineCalls(child, file, violations));
+}
+
+function checkConfigFile(file, violations) {
+  const text = readFileSync(file, "utf8");
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+  findDefineCalls(sf, file, violations);
+}
+
+function checkNodeVersionInSrc(packageDir, violations) {
+  const srcDir = join(packageDir, "src");
+  try {
+    statSync(srcDir);
+  } catch {
+    return;
+  }
+  const files = findFilesMatching(srcDir, (name) => SOURCE_FILE_RE.test(name));
+  for (const file of files) {
+    const text = readFileSync(file, "utf8");
+    if (text.includes("process.env.NODE_VERSION")) {
+      violations.push({
+        rule: "R-BuildPortable",
+        file: relative(REPO_ROOT, file),
+        detail:
+          "process.env.NODE_VERSION reference in build-time code (Decision 10 trip-wire 2)",
+      });
+    }
+  }
+}
+
+function checkDistNativeBindings(packageDir, violations) {
+  const distDir = join(packageDir, "dist");
+  try {
+    statSync(distDir);
+  } catch {
+    return;
+  }
+  const files = findFilesMatching(distDir, (name) =>
+    NATIVE_BINDING_RE.test(name)
+  );
+  for (const file of files) {
+    violations.push({
+      rule: "R-BuildPortable",
+      file: relative(REPO_ROOT, file),
+      detail:
+        "Native binding shipped in dist/ (Decision 10 trip-wire 3 — non-portable)",
+    });
+  }
+}
+
+export function runCheck({ packagesRoot } = {}) {
+  const root = packagesRoot ?? PACKAGES_ROOT;
+  const violations = [];
+  for (const pkgDir of listPackageDirs(root)) {
+    const configs = readdirSync(pkgDir, { withFileTypes: true })
+      .filter((d) => d.isFile() && CONFIG_FILE_RE.test(d.name))
+      .map((d) => join(pkgDir, d.name));
+    for (const config of configs) {
+      checkConfigFile(config, violations);
+    }
+    checkNodeVersionInSrc(pkgDir, violations);
+    checkDistNativeBindings(pkgDir, violations);
+  }
+  return violations;
+}
+
+const isMain =
+  process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isMain) {
+  const violations = runCheck();
+  if (violations.length === 0) {
+    console.log("✅ No build-portability violations detected.");
+    process.exit(0);
+  }
+  console.error("❌ R-BuildPortable violations:");
+  for (const v of violations) {
+    console.error(`  [${v.rule}] ${v.file}`);
+    console.error(`    ${v.detail}`);
+  }
+  process.exit(1);
+}

--- a/scripts/check-build-portable.test.mjs
+++ b/scripts/check-build-portable.test.mjs
@@ -193,6 +193,89 @@ export default defineConfig({
   }
 });
 
+test("(j) `process.env.X || 'default'` (BinaryExpression) fails", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("binexpr");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+export default defineConfig({
+  entry: ['src/index.ts'],
+  define: { __X__: process.env.API_URL || 'http://default' },
+});
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+    assert.match(violations[0].detail, /process\.env/);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(k) template-literal value reading process.env fails", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("templit");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+export default defineConfig({
+  entry: ['src/index.ts'],
+  define: { __URL__: \`http://\${process.env.API_HOST}\` },
+});
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(l) factory-form defineConfig with arrow returning bare object fails", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("factory-arrow");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+export default defineConfig((env) => ({
+  entry: ['src/index.ts'],
+  define: { __X__: process.env.API_URL },
+}));
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(m) factory-form defineConfig with block + return fails", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("factory-block");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+export default defineConfig((env) => {
+  return {
+    entry: ['src/index.ts'],
+    define: { __X__: process.env.API_URL },
+  };
+});
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
 test("(i) comment containing } inside define block does not false-negative", () => {
   const fixtures = makeTempPackages();
   try {

--- a/scripts/check-build-portable.test.mjs
+++ b/scripts/check-build-portable.test.mjs
@@ -1,0 +1,218 @@
+// node:test suite for check-build-portable.mjs.
+//
+// Each case stages a fixture packages/ tree under a temp directory and
+// invokes runCheck({ packagesRoot }) to assert the expected violation.
+
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runCheck } from "./check-build-portable.mjs";
+
+function makeTempPackages() {
+  const root = mkdtempSync(join(tmpdir(), "build-portable-"));
+  return {
+    root,
+    addPackage(name) {
+      const pkgDir = join(root, name);
+      mkdirSync(pkgDir, { recursive: true });
+      mkdirSync(join(pkgDir, "src"), { recursive: true });
+      mkdirSync(join(pkgDir, "dist"), { recursive: true });
+      return {
+        writeConfig(filename, contents) {
+          writeFileSync(join(pkgDir, filename), contents);
+        },
+        writeSource(filename, contents) {
+          writeFileSync(join(pkgDir, "src", filename), contents);
+        },
+        writeDist(filename, contents = "") {
+          writeFileSync(join(pkgDir, "dist", filename), contents);
+        },
+      };
+    },
+    cleanup() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+test("(a) clean repo passes", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("clean");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+});
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 0);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(b) define with JSON.stringify(process.env.X) fails", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("inject");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+export default defineConfig({
+  entry: ['src/index.ts'],
+  define: { __X__: JSON.stringify(process.env.API_URL) },
+});
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+    assert.match(violations[0].detail, /process\.env/);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(c) NODE_ENV as comparison operand passes (whitelist)", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("node-env-ok");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+const isProd = process.env.NODE_ENV === 'production';
+export default defineConfig({
+  entry: ['src/index.ts'],
+  define: { __DEV__: isProd ? 'false' : 'true' },
+});
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 0);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(d) process.env.NODE_VERSION in src fails", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("node-version");
+    pkg.writeSource(
+      "build-helper.ts",
+      `if (process.env.NODE_VERSION === '22') {
+  // ...
+}
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+    assert.match(violations[0].detail, /NODE_VERSION/);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(e) native binding in dist fails", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("native");
+    pkg.writeDist("addon.node", "");
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+    assert.match(violations[0].detail, /Native binding/);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(f) computed property reading process.env fails", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("computed");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+export default defineConfig({
+  entry: ['src/index.ts'],
+  define: { ['__X__']: process.env.API_URL },
+});
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(g) spread of object containing process.env fails", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("spread");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+export default defineConfig({
+  entry: ['src/index.ts'],
+  define: { ...{ __X__: process.env.X } },
+});
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(h) template-literal key with env value fails", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("template");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+const suffix = 'BAR';
+export default defineConfig({
+  entry: ['src/index.ts'],
+  define: { [\`__FOO_\${suffix}__\`]: process.env.X },
+});
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+  } finally {
+    fixtures.cleanup();
+  }
+});
+
+test("(i) comment containing } inside define block does not false-negative", () => {
+  const fixtures = makeTempPackages();
+  try {
+    const pkg = fixtures.addPackage("comment");
+    pkg.writeConfig(
+      "tsup.config.ts",
+      `import { defineConfig } from 'tsup';
+export default defineConfig({
+  entry: ['src/index.ts'],
+  define: {
+    // comment with a } that would defeat naive regex
+    __X__: JSON.stringify(process.env.API_URL),
+  },
+});
+`
+    );
+    const violations = runCheck({ packagesRoot: fixtures.root });
+    assert.equal(violations.length, 1);
+    assert.match(violations[0].detail, /process\.env/);
+  } finally {
+    fixtures.cleanup();
+  }
+});

--- a/scripts/check-ci-fanout-invariants.mjs
+++ b/scripts/check-ci-fanout-invariants.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// SCOPE: enforces ONLY ci.yml fanout invariants — consumer-needs-build,
+// no always() in consumers, non-consumer build dependency,
+// pull_request_target prohibition, no pnpm -r build in consumer steps.
+// Adding new checks requires a separate guard with its own design entry.
+//
+// Rule R-CIFanout: keeps the artifact fan-out shape from drifting.
+// See openspec/specs/ci-build-fanout/spec.md.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+import { parse } from "yaml";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+const DEFAULT_CI_PATH = resolve(REPO_ROOT, ".github", "workflows", "ci.yml");
+
+const CONSUMERS = new Set([
+  "lint",
+  "typecheck",
+  "test",
+  "test-cli",
+  "test-frontend",
+  "round-trip",
+  "e2e-frontend",
+  "e2e-prod-base",
+]);
+
+const NON_CONSUMERS = new Set([
+  "check-links",
+  "log-bot-skip",
+  "bundle-analysis",
+]);
+
+// WHITELIST: only 'notify-failure' qualifies under the spec Exception.
+// Adding a new job here REQUIRES amending openspec/specs/ci-build-fanout/spec.md first.
+const FAILURE_AGGREGATION_WHITELIST = new Set(["notify-failure"]);
+
+const BUILD_COMMAND_RE = /^pnpm (-r )?build($|\s)/;
+
+function needsList(job) {
+  if (!job?.needs) return [];
+  if (Array.isArray(job.needs)) return job.needs;
+  return [job.needs];
+}
+
+function ifClauseText(job) {
+  if (!job || job.if == null) return "";
+  return String(job.if);
+}
+
+function checkConsumer(jobName, job, violations) {
+  const ifClause = ifClauseText(job);
+  if (ifClause.includes("always()")) {
+    violations.push({
+      rule: "R-CIFanout",
+      detail: `consumer job '${jobName}' has 'always()' in if: clause; this defeats fail-fast on build failure`,
+    });
+  }
+  if (!needsList(job).includes("build")) {
+    violations.push({
+      rule: "R-CIFanout",
+      detail: `consumer job '${jobName}' must include 'build' in needs:`,
+    });
+  }
+  for (const step of job.steps ?? []) {
+    const run = typeof step.run === "string" ? step.run : "";
+    for (const line of run.split(/\n+/)) {
+      if (BUILD_COMMAND_RE.test(line.trim())) {
+        violations.push({
+          rule: "R-CIFanout",
+          detail: `consumer job '${jobName}' has a step running '${line.trim()}'; consumers download the artifact, never rebuild`,
+        });
+        break;
+      }
+    }
+  }
+}
+
+function checkNonConsumer(jobName, job, violations) {
+  if (FAILURE_AGGREGATION_WHITELIST.has(jobName)) return;
+  if (needsList(job).includes("build")) {
+    violations.push({
+      rule: "R-CIFanout",
+      detail: `non-consumer job '${jobName}' must NOT include 'build' in needs: (only 'notify-failure' is whitelisted as a failure-aggregator)`,
+    });
+  }
+}
+
+function checkTriggers(workflow, violations) {
+  const on = workflow?.on;
+  if (!on) return;
+  if (typeof on === "string") {
+    if (on === "pull_request_target") {
+      violations.push({
+        rule: "R-CIFanout",
+        detail:
+          "workflow trigger SHALL NOT be 'pull_request_target' — exposes secrets to fork PRs",
+      });
+    }
+    return;
+  }
+  if (Array.isArray(on)) {
+    if (on.includes("pull_request_target")) {
+      violations.push({
+        rule: "R-CIFanout",
+        detail:
+          "workflow trigger SHALL NOT include 'pull_request_target' — exposes secrets to fork PRs",
+      });
+    }
+    return;
+  }
+  if (typeof on === "object" && "pull_request_target" in on) {
+    violations.push({
+      rule: "R-CIFanout",
+      detail:
+        "workflow trigger SHALL NOT include 'pull_request_target' — exposes secrets to fork PRs",
+    });
+  }
+}
+
+export function runCheck({ ciPath } = {}) {
+  const path = ciPath ?? DEFAULT_CI_PATH;
+  const text = readFileSync(path, "utf8");
+  const workflow = parse(text);
+  const violations = [];
+  checkTriggers(workflow, violations);
+  const jobs = workflow?.jobs ?? {};
+  for (const [name, job] of Object.entries(jobs)) {
+    if (CONSUMERS.has(name)) {
+      checkConsumer(name, job, violations);
+    } else if (NON_CONSUMERS.has(name)) {
+      checkNonConsumer(name, job, violations);
+    }
+  }
+  return violations;
+}
+
+const isMain =
+  process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isMain) {
+  const violations = runCheck();
+  if (violations.length === 0) {
+    console.log("✅ No ci-fanout invariant violations detected.");
+    process.exit(0);
+  }
+  console.error("❌ R-CIFanout violations:");
+  for (const v of violations) {
+    console.error(`  [${v.rule}] ${v.detail}`);
+  }
+  process.exit(1);
+}

--- a/scripts/check-ci-fanout-invariants.mjs
+++ b/scripts/check-ci-fanout-invariants.mjs
@@ -51,13 +51,20 @@ function ifClauseText(job) {
   return String(job.if);
 }
 
+// Fail-open status functions that defeat default `success()`-over-`needs:`
+// short-circuit. Any of these in a consumer's `if:` would let it run
+// even when `build` failed/skipped, breaking the fail-fast guarantee.
+const FAIL_OPEN_FUNCTIONS = ["always()", "failure()", "cancelled()"];
+
 function checkConsumer(jobName, job, violations) {
   const ifClause = ifClauseText(job);
-  if (ifClause.includes("always()")) {
-    violations.push({
-      rule: "R-CIFanout",
-      detail: `consumer job '${jobName}' has 'always()' in if: clause; this defeats fail-fast on build failure`,
-    });
+  for (const fn of FAIL_OPEN_FUNCTIONS) {
+    if (ifClause.includes(fn)) {
+      violations.push({
+        rule: "R-CIFanout",
+        detail: `consumer job '${jobName}' has '${fn}' in if: clause; fail-open status functions defeat fail-fast on build failure`,
+      });
+    }
   }
   if (!needsList(job).includes("build")) {
     violations.push({
@@ -128,6 +135,23 @@ export function runCheck({ ciPath } = {}) {
   const violations = [];
   checkTriggers(workflow, violations);
   const jobs = workflow?.jobs ?? {};
+  // Fail closed when a CONSUMER drifts (renamed or removed) — every
+  // consumer is required and silently disappearing is the bug. The fix
+  // is either rename the job back, or amend
+  // openspec/specs/ci-build-fanout/spec.md AND update this script's
+  // CONSUMERS set together.
+  //
+  // NON_CONSUMERS are NOT checked for presence: they are optional
+  // jobs that, if they exist, must not have `needs: build`. A
+  // hypothetical workflow without `check-links` is fine.
+  for (const expected of CONSUMERS) {
+    if (!(expected in jobs)) {
+      violations.push({
+        rule: "R-CIFanout",
+        detail: `enumerated consumer job '${expected}' is missing from ci.yml; rename or amend spec/script enumerations together`,
+      });
+    }
+  }
   for (const [name, job] of Object.entries(jobs)) {
     if (CONSUMERS.has(name)) {
       checkConsumer(name, job, violations);

--- a/scripts/check-ci-fanout-invariants.test.mjs
+++ b/scripts/check-ci-fanout-invariants.test.mjs
@@ -200,6 +200,43 @@ test("(f) injecting pull_request_target into on: fails", () => {
   }
 });
 
+test("(h) consumer with failure() in if: fails (fail-open status function)", () => {
+  const broken = POST_FANOUT_CI.replace(
+    "  lint:\n    runs-on: ubuntu-latest\n    needs: [detect-changes, build]\n    if: needs.detect-changes.outputs.should-test == 'true'",
+    "  lint:\n    runs-on: ubuntu-latest\n    needs: [detect-changes, build]\n    if: failure() || needs.detect-changes.outputs.should-test == 'true'"
+  );
+  const t = withTmpYml(broken);
+  try {
+    const violations = runCheck({ ciPath: t.path });
+    assert.ok(
+      violations.some(
+        (v) => /'lint'/.test(v.detail) && /failure\(\)/.test(v.detail)
+      )
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("(i) renaming a consumer fails closed", () => {
+  // Rename `lint` → `lint-renamed` in the workflow. The script's
+  // CONSUMERS enumeration still contains `lint`, so the check should
+  // fire a "missing from ci.yml" violation rather than silently
+  // skipping enforcement.
+  const broken = POST_FANOUT_CI.replace(/^  lint:$/m, "  lint-renamed:");
+  const t = withTmpYml(broken);
+  try {
+    const violations = runCheck({ ciPath: t.path });
+    assert.ok(
+      violations.some(
+        (v) => /'lint'/.test(v.detail) && /missing from ci\.yml/.test(v.detail)
+      )
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
 test("(g) consumer with pnpm -r build step fails", () => {
   const broken = POST_FANOUT_CI.replace(
     "  lint:\n    runs-on: ubuntu-latest\n    needs: [detect-changes, build]\n    if: needs.detect-changes.outputs.should-test == 'true'\n    steps:\n      - uses: ./.github/actions/consume-build-artifacts\n      - run: pnpm lint",

--- a/scripts/check-ci-fanout-invariants.test.mjs
+++ b/scripts/check-ci-fanout-invariants.test.mjs
@@ -1,0 +1,219 @@
+// node:test suite for check-ci-fanout-invariants.mjs.
+
+import { test } from "node:test";
+import { strict as assert } from "node:assert";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runCheck } from "./check-ci-fanout-invariants.mjs";
+
+const POST_FANOUT_CI = `
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo detect
+
+  build:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    steps:
+      - run: pnpm -r build
+
+  lint:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
+    steps:
+      - uses: ./.github/actions/consume-build-artifacts
+      - run: pnpm lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
+    steps:
+      - uses: ./.github/actions/consume-build-artifacts
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
+    steps:
+      - uses: ./.github/actions/consume-build-artifacts
+
+  test-cli:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
+    steps:
+      - uses: ./.github/actions/consume-build-artifacts
+
+  test-frontend:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
+    steps:
+      - uses: ./.github/actions/consume-build-artifacts
+
+  round-trip:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
+    steps:
+      - uses: ./.github/actions/consume-build-artifacts
+
+  e2e-frontend:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
+    steps:
+      - uses: ./.github/actions/consume-build-artifacts
+
+  e2e-prod-base:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build]
+    if: needs.detect-changes.outputs.should-test == 'true'
+    steps:
+      - uses: ./.github/actions/consume-build-artifacts
+
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - run: lychee
+
+  notify-failure:
+    runs-on: ubuntu-latest
+    needs: [build, lint, test]
+    if: always()
+    steps:
+      - run: echo notify
+`;
+
+function withTmpYml(yml) {
+  const dir = mkdtempSync(join(tmpdir(), "ci-fanout-"));
+  const path = join(dir, "ci.yml");
+  writeFileSync(path, yml);
+  return {
+    path,
+    cleanup() {
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+test("(a) post-rollout ci.yml passes", () => {
+  const t = withTmpYml(POST_FANOUT_CI);
+  try {
+    const violations = runCheck({ ciPath: t.path });
+    assert.equal(violations.length, 0);
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("(b) injecting always() into lint's if: fails", () => {
+  const broken = POST_FANOUT_CI.replace(
+    "  lint:\n    runs-on: ubuntu-latest\n    needs: [detect-changes, build]\n    if: needs.detect-changes.outputs.should-test == 'true'",
+    "  lint:\n    runs-on: ubuntu-latest\n    needs: [detect-changes, build]\n    if: always() && needs.detect-changes.outputs.should-test == 'true'"
+  );
+  const t = withTmpYml(broken);
+  try {
+    const violations = runCheck({ ciPath: t.path });
+    assert.ok(
+      violations.some((v) => /'lint'/.test(v.detail) && /always/.test(v.detail))
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("(c) removing build from test's needs: fails", () => {
+  const broken = POST_FANOUT_CI.replace(
+    "  test:\n    runs-on: ubuntu-latest\n    needs: [detect-changes, build]",
+    "  test:\n    runs-on: ubuntu-latest\n    needs: [detect-changes]"
+  );
+  const t = withTmpYml(broken);
+  try {
+    const violations = runCheck({ ciPath: t.path });
+    assert.ok(
+      violations.some(
+        (v) => /'test'/.test(v.detail) && /'build' in needs/.test(v.detail)
+      )
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("(d) adding build to check-links fails", () => {
+  const broken = POST_FANOUT_CI.replace(
+    "  check-links:\n    runs-on: ubuntu-latest",
+    "  check-links:\n    runs-on: ubuntu-latest\n    needs: [build]"
+  );
+  const t = withTmpYml(broken);
+  try {
+    const violations = runCheck({ ciPath: t.path });
+    assert.ok(
+      violations.some(
+        (v) =>
+          /'check-links'/.test(v.detail) &&
+          /must NOT include 'build'/.test(v.detail)
+      )
+    );
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("(e) notify-failure with always() and build in needs passes (whitelist)", () => {
+  const t = withTmpYml(POST_FANOUT_CI);
+  try {
+    const violations = runCheck({ ciPath: t.path });
+    const notifyViolations = violations.filter((v) =>
+      /notify-failure/.test(v.detail)
+    );
+    assert.equal(notifyViolations.length, 0);
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("(f) injecting pull_request_target into on: fails", () => {
+  const broken = POST_FANOUT_CI.replace(
+    "on:\n  pull_request:",
+    "on:\n  pull_request_target:\n    types: [opened]\n  pull_request:"
+  );
+  const t = withTmpYml(broken);
+  try {
+    const violations = runCheck({ ciPath: t.path });
+    assert.ok(violations.some((v) => /pull_request_target/.test(v.detail)));
+  } finally {
+    t.cleanup();
+  }
+});
+
+test("(g) consumer with pnpm -r build step fails", () => {
+  const broken = POST_FANOUT_CI.replace(
+    "  lint:\n    runs-on: ubuntu-latest\n    needs: [detect-changes, build]\n    if: needs.detect-changes.outputs.should-test == 'true'\n    steps:\n      - uses: ./.github/actions/consume-build-artifacts\n      - run: pnpm lint",
+    "  lint:\n    runs-on: ubuntu-latest\n    needs: [detect-changes, build]\n    if: needs.detect-changes.outputs.should-test == 'true'\n    steps:\n      - uses: ./.github/actions/consume-build-artifacts\n      - run: pnpm -r build\n      - run: pnpm lint"
+  );
+  const t = withTmpYml(broken);
+  try {
+    const violations = runCheck({ ciPath: t.path });
+    assert.ok(
+      violations.some(
+        (v) => /'lint'/.test(v.detail) && /pnpm -r build/.test(v.detail)
+      )
+    );
+  } finally {
+    t.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Refactors `.github/workflows/ci.yml` so the `build` job is the sole producer of `packages/*/dist/` per CI run, and every consumer job downloads the existing `build-artifacts` artifact via a new `.github/actions/consume-build-artifacts` composite action instead of running `pnpm -r build` from scratch. Today the build job uploads `build-artifacts` but no consumer reads it (dead weight).

Expected wall-clock reduction: 30–60% on non-docs PRs (gated by §10.2 Mann-Whitney U test before merge).

OpenSpec change `ci-artifact-fanout` iterated through 5 expert-panel rounds to converge at **9.54/10**. Full design, decisions, trip-wires, and task breakdown live in `openspec/changes/ci-artifact-fanout/`.

## Critical correctness fixes

- **Drop `if: always() &&`** from every consumer's `if:` clause. With `always()` present, `needs: build` does NOT short-circuit on build failure; the consumer would still run and produce noisy unrelated errors. Default GitHub Actions `success()` semantics give correct skip-on-build-failure once `always()` is removed.
- **Branch-protection summary jobs** (`lint-summary`, `test-summary`, `round-trip-summary`, `test-frontend-summary`) now include `build` in `needs:` with explicit four-state logic so a build failure cannot land on `main` via the previous "passed or skipped" whitelist.
- **Bundle analysis** (`@codecov/vite-plugin`) extracted to its own dedicated `bundle-analysis` job (Node 22.18.0 only, single-package build, step-level secret check). The Codecov plugin instruments `vite build` via a Vite plugin hook, so it cannot consume the prebuilt artifact.

## Hardening

- **Composite action** wipes stale `dist/` before download (so `setup-pnpm`'s TS-cache restore cannot leak files into a hybrid filesystem), then downloads, then verifies — failing fast if any expected `packages/*/dist/` is missing OR if any symlinks appear under `dist/` (potential malicious build).
- **Two new mechanical guards** under `scripts/`, wired into `pnpm lint`:
  - `check-build-portable.mjs` (TypeScript AST scan): fails if any `tsup.config` / `vite.config` injects `process.env` via `define:`, or if `process.env.NODE_VERSION` appears in build-time code, or if native bindings ship in `dist/`. Enforces "one artifact serves both Node-version matrix legs."
  - `check-ci-fanout-invariants.mjs` (yaml-based `ci.yml` parser): fails if any consumer has `always()` in `if:`, lacks `build` in `needs:`, has a `pnpm -r build` step, OR if a non-consumer (besides the `notify-failure` whitelist) declares `build` in `needs:`, OR if the workflow trigger ever switches to `pull_request_target`.
- **Artifact retention** bumped 7 → 30 days so "Re-run failed jobs only" remains usable across the typical PR review cycle.

## Hard follow-up

> ⚠️ **Issue MUST be filed before this PR merges; assignee MUST be set within 30 days of merge.**
>
> Add `build` to branch-protection required-checks list as belt-and-braces alongside the summary-job fixes (Decision 12). Workflow code closes the immediate gap; the repo-settings change is the additional defense.

## Test plan

- [x] Both new mechanical guards pass against the modified `ci.yml`.
- [x] All 338 script tests green (`pnpm test:scripts`).
- [x] Spec validates with `--strict` (`pnpm exec openspec validate ci-artifact-fanout --strict`).
- [x] `pnpm lint:specs` green.
- [ ] **Pre-flight (§1.1)**: Build `packages/core/dist` and `packages/workout-spa-editor/dist` under Node 22.18.0 + Node 24.x locally; `diff -r` MUST be empty (Decision 2 byte-identical assumption).
- [ ] **Pre-flight (§1.3)**: Confirm `actions/download-artifact@v7` `path: .` lands files at `packages/<pkg>/dist/...` (not nested under `build-artifacts/`).
- [ ] **Pre-flight (§1.4)**: No open GHSA advisories on `actions/{upload,download}-artifact@v7`.
- [ ] **Wall-clock (§10.1–10.3)**: 5 force-pushed runs of this PR + 5 baseline runs; median improvement ≥20% AND one-sided MWU `alternative='less'` p<0.05.
- [ ] **Fail-fast (§9.1)**: Throwaway branch with deliberate TS error in `packages/core/src/`; consumers MUST end `skipped`, summary jobs MUST end `failure`.
- [ ] **Re-run (§9.3)**: After successful build + failing test, "Re-run failed jobs only" works against the same artifact.
- [ ] **Docs-only (§9.4)**: Docs-only PR is all-green (build skipped, consumers skipped, summaries exit 0).
- [ ] **Cross-spec (§11.1)**: Grep all of `.github/workflows/` + `.github/actions/` confirms only `ci.yml` consumes `build-artifacts`.

## Structural atomicity

This is one PR rather than a chunked series because the changes are structurally interdependent: the mechanical guards must land with the workflow changes (otherwise they fail on `main`); the composite action must land with the consumer wiring (otherwise `uses:` references break); the summary-job changes must land with the consumer drops of `always()` (otherwise fail-fast breaks). Splitting would force temporarily-broken `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now builds packages once per run and shares signed build artifacts to all consumer jobs, preventing redundant rebuilds and enforcing fail-fast behavior.
  * Added automated verification and artifact-consumption checks to prevent stale or non-portable build outputs.

* **Documentation**
  * Added rollout design, proposal, spec, and task checklists describing the CI fan-out changes.

* **Tests**
  * Added automated checks and test suites to validate CI invariants and build-portability rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->