### PR TITLE
test(spa-editor): zones-sync Playwright e2e + shared orchestrator (closes #478)

### DIFF
--- a/.changeset/train2go-zones-sync-e2e-and-shared-orchestrator.md
+++ b/.changeset/train2go-zones-sync-e2e-and-shared-orchestrator.md
@@ -1,0 +1,13 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Train2Go zones-sync — Playwright e2e + shared orchestrator (closes #478).
+
+- New `packages/workout-spa-editor/e2e/zones-sync.spec.ts` covers the three user-visible flows the unit tests can't fully exercise in a real browser: (a) toggle-off auto-sync MUST NOT issue `read-details`, (b) toggle-on with empty profile silently fills every threshold/physio value, (c) toggle-on with a manual FTP opens the `ZonesConflictDialog` with the diff. Stable across 5/5 runs in `pnpm exec playwright test --project=chromium`.
+- New helpers `e2e/helpers/train2go-bridge-stub.ts` + `train2go-bridge-stub-page-script.ts` install a self-contained Train2Go bridge stub via `addInitScript`: stubs `chrome.runtime.sendMessage`, posts `KAIORD_BRIDGE_ANNOUNCE` (and re-posts on `KAIORD_BRIDGE_DISCOVER`), tracks every action call so tests can assert what fired (`read-details`) and what didn't.
+- **Architectural fix**: lift the zones-sync orchestrator out of per-source instances into a single `Train2GoZonesSyncProvider` mounted at app root (inside `AppToastProvider`). Before this, the calendar header's sync button and the `LinkedAccountRow`'s mounted dialog used different orchestrator instances — clicking sync on the calendar set `pending` on instance A while the dialog was mounted under instance B. The provider now owns the state and renders the dialog itself, so any trigger surfaces the dialog regardless of which page is open. The calendar's call site (via the registry's `useTrain2GoSource` factory) and the Profile Manager's row both consume the same context.
+- `useTrain2GoSource` no longer creates its own orchestrator; it reads from the new context. The `Train2GoSource.zonesSync` field is preserved for backwards compatibility (some tests reference it).
+- `LinkedAccountRow` no longer renders `ZonesConflictDialog` (the provider does). `useLinkedAccountRow` no longer returns `zonesSync`.
+
+This closes the integration gap that PR 3 (#474) shipped — the per-instance orchestrator design passed all 16 unit tests because each one tested in isolation, but the dialog never appeared in the calendar-triggered flow that PR 3 was supposed to wire up.

--- a/packages/workout-spa-editor/e2e/helpers/train2go-bridge-stub-page-script.ts
+++ b/packages/workout-spa-editor/e2e/helpers/train2go-bridge-stub-page-script.ts
@@ -1,0 +1,86 @@
+/**
+ * Page-side init script for the Train2Go bridge stub.
+ *
+ * Playwright serialises `installStubScript` via `.toString()` and runs
+ * it in the page context before the SPA boots — references to other
+ * module-level functions in this file are NOT available there, so the
+ * whole body is intentionally self-contained.
+ */
+export type T2GStubScriptArgs = {
+  extensionId: string;
+  bridgeId: string;
+  caps: readonly string[];
+  payload: unknown;
+};
+
+// eslint-disable-next-line max-lines-per-function -- self-contained on purpose; Playwright `.toString()` serialisation precludes referencing module-level helpers from inside.
+export const installStubScript = (args: T2GStubScriptArgs): void => {
+  type Call = { action: string; payload: unknown };
+  const calls: Call[] = [];
+  (window as unknown as Record<string, unknown>).__T2G_STUB_CALLS__ = calls;
+  // BridgeManifest shape (`id` etc.) — the wire announcement adds
+  // `type`, `bridgeId`, `extensionId` on top of these same fields.
+  const m = {
+    id: args.bridgeId,
+    name: "Train2Go (stub)",
+    version: "0.0.0-stub",
+    protocolVersion: 1,
+    capabilities: args.caps,
+  };
+  const ann = {
+    type: "KAIORD_BRIDGE_ANNOUNCE",
+    bridgeId: args.bridgeId,
+    extensionId: args.extensionId,
+    ...m,
+  };
+  const wrap = (data: unknown) => ({ ok: true, protocolVersion: 1, data });
+  const responses: Record<string, () => unknown> = {
+    ping: () =>
+      wrap({
+        ...m,
+        sessionActive: true,
+        userId: "99999",
+        userName: "Test User",
+      }),
+    "read-week": () => wrap({ activities: [] }),
+    "read-day": () => wrap({ activities: [] }),
+    "read-details": () => wrap(args.payload),
+    "open-train2go": () => wrap(null),
+    // Snapshot push hooks fire on every mount; respond no-op so stub
+    // calls don't fall through to the "Unknown action" error path.
+    "profile-snapshot": () => wrap(null),
+    "profile-snapshot-clear": () => wrap(null),
+  };
+  (window as unknown as Record<string, unknown>).chrome = {
+    runtime: {
+      lastError: null,
+      sendMessage: (
+        _id: string,
+        msg: Record<string, unknown>,
+        cb?: (r: unknown) => void
+      ): void => {
+        const action = String(msg?.action ?? "");
+        calls.push({ action, payload: msg });
+        const r = responses[action]?.() ?? {
+          ok: false,
+          protocolVersion: 1,
+          error: `Unknown action: ${action}`,
+        };
+        if (cb) setTimeout(() => cb(r), 0);
+      },
+    },
+  };
+  // Two complementary triggers handle the race between React mount
+  // (when bridge-discovery attaches its listener) and our addInitScript:
+  // listen for DISCOVER, AND post repeatedly during the first 6 seconds.
+  const post = (): void => void window.postMessage(ann, "*");
+  window.addEventListener("message", (e: MessageEvent) => {
+    if (
+      e.source === window &&
+      (e.data as { type?: string } | null)?.type === "KAIORD_BRIDGE_DISCOVER"
+    )
+      post();
+  });
+  for (const delayMs of [0, 250, 500, 1000, 2000, 4000, 6000])
+    setTimeout(post, delayMs);
+};

--- a/packages/workout-spa-editor/e2e/helpers/train2go-bridge-stub.ts
+++ b/packages/workout-spa-editor/e2e/helpers/train2go-bridge-stub.ts
@@ -1,0 +1,86 @@
+/**
+ * Playwright helper: install a fake Train2Go bridge in the page context.
+ *
+ * The real bridge is a Chrome extension — Playwright Chromium runs without
+ * the extension loaded, so `chrome.runtime` is undefined and the SPA's
+ * bridge-discovery handshake never completes. This helper paves over both:
+ *
+ *   1. Stubs `chrome.runtime.sendMessage(extensionId, msg, callback)` to
+ *      route action calls into a deterministic per-test response map.
+ *   2. Posts `{ type: "KAIORD_BRIDGE_ANNOUNCE", ... }` on `window` so the
+ *      SPA's `bridgeDiscovery` handler verifies and registers the stub.
+ *   3. Tracks every action call on `window.__T2G_STUB_CALLS__` so tests can
+ *      assert which actions fired (and which did NOT, e.g. `read-details`
+ *      in the toggle-off flow).
+ *
+ * The action responses mirror what `parseDetailsHtml` would produce against
+ * the sanitized fixture at `packages/train2go-bridge/test/fixtures/
+ * details-active.html` — values are derived from that fixture so any future
+ * shape drift in the parser is caught by the e2e in addition to its
+ * dedicated unit tests.
+ */
+import type { Page } from "@playwright/test";
+
+import { installStubScript } from "./train2go-bridge-stub-page-script";
+
+export const TRAIN2GO_EXTENSION_ID = "train2go-stub-ext";
+export const TRAIN2GO_BRIDGE_ID = "train2go-bridge";
+
+/**
+ * Parsed shape that `parseDetailsHtml` emits for the sanitized
+ * `details-active.html` fixture (verified by the bridge's own unit tests).
+ * Kept alongside the stub so the e2e and the bridge can drift in lockstep.
+ */
+export const FIXTURE_ZONES_PAYLOAD = {
+  physiological: { weight: 83, bpmMax: 187 },
+  paces: {
+    cycling: { z4Upper: 268, z5Lower: 269 },
+    running: { z4Upper: { min: 4, sec: 10 } },
+    swimming: { z4Upper: { min: 1, sec: 32 } },
+  },
+  hrZones: {
+    cycling: { z4Upper: 174 },
+    running: { z4Upper: 168 },
+  },
+} as const;
+
+export type T2GStubOptions = {
+  /** Override the manifest capabilities. Defaults include training-zones. */
+  capabilities?: readonly string[];
+  /** Override the zones payload returned for `read-details`. */
+  zonesPayload?: unknown;
+};
+
+const DEFAULT_CAPS = ["read:training-plan", "read:training-zones"] as const;
+
+/**
+ * Install the bridge stub. Call BEFORE `page.goto(...)` so the
+ * `addInitScript` runs before the SPA boots and bridge-discovery starts.
+ */
+export const installTrain2GoBridgeStub = async (
+  page: Page,
+  options: T2GStubOptions = {}
+): Promise<void> => {
+  await page.addInitScript(installStubScript, {
+    extensionId: TRAIN2GO_EXTENSION_ID,
+    bridgeId: TRAIN2GO_BRIDGE_ID,
+    caps: options.capabilities ?? DEFAULT_CAPS,
+    payload: options.zonesPayload ?? FIXTURE_ZONES_PAYLOAD,
+  });
+};
+
+/** Returns the action names recorded by the stub since page load (or last clear). */
+export const getBridgeCallActions = async (page: Page): Promise<string[]> =>
+  page.evaluate(() => {
+    const calls =
+      ((window as unknown as Record<string, unknown>).__T2G_STUB_CALLS__ as
+        | { action: string }[]
+        | undefined) ?? [];
+    return calls.map((c) => c.action);
+  });
+
+/** Reset the call tracker (useful when an action fires during navigation). */
+export const clearBridgeCalls = (page: Page): Promise<void> =>
+  page.evaluate(() => {
+    (window as unknown as Record<string, unknown>).__T2G_STUB_CALLS__ = [];
+  });

--- a/packages/workout-spa-editor/e2e/zones-sync.spec.ts
+++ b/packages/workout-spa-editor/e2e/zones-sync.spec.ts
@@ -1,0 +1,310 @@
+/**
+ * Train2Go zones-sync — end-to-end spec covering the three user-visible
+ * flows from `openspec/changes/archive/2026-05-03-train2go-zones-sync/`:
+ *
+ *   (a) toggle-off-link        → manual sync MUST NOT issue `read-details`
+ *   (b) toggle-on, empty       → silent fills, no conflict dialog
+ *   (c) toggle-on, manual FTP  → conflict dialog opens with the diff
+ *
+ * Closes #478. Bridge stub at `helpers/train2go-bridge-stub.ts` paves over
+ * the missing Chrome extension (Playwright Chromium runs unloaded), so the
+ * SPA's `bridgeDiscovery` handshake completes against a deterministic
+ * in-page fake.
+ */
+import { expect, test } from "./fixtures/base";
+import { clearDexie, getWeekDates, getWeekId } from "./helpers/seed-dexie";
+import {
+  FIXTURE_ZONES_PAYLOAD,
+  getBridgeCallActions,
+  installTrain2GoBridgeStub,
+} from "./helpers/train2go-bridge-stub";
+
+const PROFILE_ID = "zones-sync-e2e-profile";
+const NOW_ISO = "2026-04-28T10:00:00.000Z";
+
+type SyncZonesFlag = boolean;
+type CyclingFtp = number | undefined;
+
+const seedProfile = async (
+  page: import("@playwright/test").Page,
+  syncZones: SyncZonesFlag,
+  ftp: CyclingFtp
+): Promise<void> => {
+  await page.evaluate(
+    async ({ profileId, ts, syncZonesFlag, cyclingFtp }) => {
+      type Db = {
+        table: (n: string) => {
+          put: (r: unknown) => Promise<unknown>;
+          clear: () => Promise<unknown>;
+        };
+      };
+      const db = (window as unknown as Record<string, unknown>)
+        .__KAIORD_DB__ as Db;
+      await db.table("profiles").clear();
+      await db.table("meta").put({ key: "activeProfileId", value: profileId });
+      await db.table("profiles").put({
+        id: profileId,
+        name: "E2E Test User",
+        sportZones:
+          cyclingFtp !== undefined
+            ? {
+                cycling: {
+                  thresholds: { ftp: cyclingFtp },
+                  heartRateZones: { method: "manual", zones: [] },
+                },
+              }
+            : {},
+        linkedAccounts: [
+          {
+            source: "train2go",
+            externalUserId: "99999",
+            externalUserName: "Test User",
+            linkedAt: ts,
+            syncZones: syncZonesFlag,
+          },
+        ],
+        createdAt: ts,
+        updatedAt: ts,
+      });
+
+      // Seed an out-of-week dummy workout so `hasAnyWorkouts` is true
+      // and the FirstVisitState onboarding panel does NOT render — the
+      // CalendarHeader (which owns the Sync button) only mounts when the
+      // calendar has at least one workout somewhere in the database.
+      type DbWithBulk = Db & {
+        table: (n: string) => {
+          put: (r: unknown) => Promise<unknown>;
+          clear: () => Promise<unknown>;
+          bulkPut?: (r: unknown[]) => Promise<unknown>;
+        };
+      };
+      const dbb = (window as unknown as Record<string, unknown>)
+        .__KAIORD_DB__ as DbWithBulk;
+      await dbb.table("workouts").put({
+        id: "zones-sync-dummy-workout",
+        date: "2020-01-01",
+        state: "raw",
+        sport: "cycling",
+        source: "manual",
+        sourceId: "dummy",
+        planId: null,
+        raw: { description: "x", duration: { value: 600, unit: "s" } },
+        krd: null,
+        lastProcessingError: null,
+        feedback: null,
+        aiMeta: null,
+        garminPushId: null,
+        tags: [],
+        previousState: null,
+        createdAt: ts,
+        modifiedAt: null,
+        updatedAt: ts,
+      });
+    },
+    {
+      profileId: PROFILE_ID,
+      ts: NOW_ISO,
+      syncZonesFlag: syncZones,
+      cyclingFtp: ftp,
+    }
+  );
+};
+
+const navigateToWeek = async (
+  page: import("@playwright/test").Page
+): Promise<void> => {
+  const weekId = getWeekId(getWeekDates(0)[2]);
+  await page.goto(`/calendar/${weekId}`);
+};
+
+const waitForSyncButton = async (
+  page: import("@playwright/test").Page
+): Promise<void> => {
+  const syncBtn = page.getByRole("button", { name: /^sync train2go$/i });
+  await syncBtn.waitFor({ state: "visible", timeout: 15_000 });
+};
+
+test.describe("Train2Go zones-sync — auto-sync flows", () => {
+  test.beforeEach(async ({ page }) => {
+    await installTrain2GoBridgeStub(page);
+    await page.goto("/calendar");
+    await page.waitForFunction(
+      () =>
+        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
+      { timeout: 10_000 }
+    );
+    await clearDexie(page);
+  });
+
+  test("(a) toggle-off — auto-sync does NOT issue read-details", async ({
+    page,
+  }) => {
+    // Arrange: linked account with syncZones flag OFF.
+    await seedProfile(page, false, undefined);
+    await navigateToWeek(page);
+    await waitForSyncButton(page);
+
+    // Wait for read-week to settle (the auto-sync hook fires it on
+    // calendar mount). With syncZones=false the fan-out check returns
+    // false BEFORE read-details would queue.
+    await page.waitForFunction(
+      () => {
+        const calls =
+          ((window as unknown as Record<string, unknown>).__T2G_STUB_CALLS__ as
+            | { action: string }[]
+            | undefined) ?? [];
+        return calls.some((c) => c.action === "read-week");
+      },
+      { timeout: 10_000 }
+    );
+
+    // One extra tick to let any racing fan-out queue if it were going to.
+    await page.waitForTimeout(200);
+
+    // Assert: read-details was NEVER called.
+    const actions = await getBridgeCallActions(page);
+    expect(actions).toContain("read-week");
+    expect(actions).not.toContain("read-details");
+  });
+
+  test("(b) toggle-on with empty profile — silent fills, no dialog", async ({
+    page,
+  }) => {
+    // Arrange: linked account with syncZones=true, profile has NO
+    // pre-existing thresholds.
+    await seedProfile(page, true, undefined);
+    await navigateToWeek(page);
+    await waitForSyncButton(page);
+
+    // The auto-sync hook fires on calendar mount → runs syncZones after
+    // read-week → reads every Kaiord field empty → writes silently.
+    // Wait for read-details to land (the marker for fan-out completion).
+    await page.waitForFunction(
+      () => {
+        const calls =
+          ((window as unknown as Record<string, unknown>).__T2G_STUB_CALLS__ as
+            | { action: string }[]
+            | undefined) ?? [];
+        return calls.some((c) => c.action === "read-details");
+      },
+      { timeout: 10_000 }
+    );
+
+    // Wait for the orchestrator's profile.put to settle. Polling Dexie
+    // is more deterministic than a fixed sleep because the put is
+    // sequenced after the readZones promise.
+    await page.waitForFunction(
+      ({ profileId }) => {
+        type Db = {
+          table: (n: string) => {
+            get: (id: string) => Promise<
+              | {
+                  sportZones?: { cycling?: { thresholds?: { ftp?: number } } };
+                }
+              | undefined
+            >;
+          };
+        };
+        const db = (window as unknown as Record<string, unknown>)
+          .__KAIORD_DB__ as Db;
+        return db
+          .table("profiles")
+          .get(profileId)
+          .then((p) => p?.sportZones?.cycling?.thresholds?.ftp === 268);
+      },
+      { profileId: PROFILE_ID },
+      { timeout: 10_000 }
+    );
+
+    // Assert: dialog NOT visible (no conflicts → orchestrator stays idle).
+    await expect(page.getByTestId("zones-conflict-dialog")).not.toBeVisible();
+
+    // Assert: the persisted profile got every fixture-derived value.
+    const profile = await page.evaluate(async (id) => {
+      type Db = {
+        table: (n: string) => { get: (k: string) => Promise<unknown> };
+      };
+      const db = (window as unknown as Record<string, unknown>)
+        .__KAIORD_DB__ as Db;
+      return (await db.table("profiles").get(id)) as {
+        bodyWeight?: number;
+        maxHeartRate?: number;
+        sportZones: {
+          cycling?: { thresholds: { ftp?: number; lthr?: number } };
+          running?: {
+            thresholds: { lthr?: number; thresholdPace?: number };
+          };
+          swimming?: { thresholds: { thresholdPace?: number } };
+        };
+      };
+    }, PROFILE_ID);
+
+    expect(profile.bodyWeight).toBe(FIXTURE_ZONES_PAYLOAD.physiological.weight);
+    expect(profile.maxHeartRate).toBe(
+      FIXTURE_ZONES_PAYLOAD.physiological.bpmMax
+    );
+    expect(profile.sportZones.cycling?.thresholds.ftp).toBe(268);
+    expect(profile.sportZones.cycling?.thresholds.lthr).toBe(174);
+    expect(profile.sportZones.running?.thresholds.lthr).toBe(168);
+    // Running pace 4:10 = 250 sec, swim CSS 1:32 = 92 sec.
+    expect(profile.sportZones.running?.thresholds.thresholdPace).toBe(250);
+    expect(profile.sportZones.swimming?.thresholds.thresholdPace).toBe(92);
+  });
+
+  test("(c) toggle-on with manual FTP — conflict dialog opens", async ({
+    page,
+  }) => {
+    // Arrange: linked account with syncZones=true, profile has a manual
+    // FTP=200 that disagrees with the fixture's 268.
+    await seedProfile(page, true, 200);
+    await navigateToWeek(page);
+    await waitForSyncButton(page);
+
+    // The auto-sync hook fires on calendar mount → runs syncZones →
+    // detects FTP conflict (200 vs 268) → orchestrator stashes pending
+    // → provider renders ZonesConflictDialog.
+    // Assert: ZonesConflictDialog opens with the FTP row.
+    const dialog = page.getByTestId("zones-conflict-dialog");
+    await expect(dialog).toBeVisible({ timeout: 10_000 });
+    await expect(
+      page.getByTestId("zones-conflict-row-cycling.thresholds.ftp")
+    ).toBeVisible();
+
+    // The static label map keys "cycling.thresholds.ftp" → "FTP".
+    await expect(dialog).toContainText("FTP");
+    // Both old and new values render as React children.
+    await expect(dialog).toContainText("200");
+    await expect(dialog).toContainText("268");
+
+    // Assert: profile FTP is STILL 200 (conflict, not silently overwritten).
+    const ftpBeforeDecision = await page.evaluate(async (id) => {
+      type Db = {
+        table: (n: string) => { get: (k: string) => Promise<unknown> };
+      };
+      const db = (window as unknown as Record<string, unknown>)
+        .__KAIORD_DB__ as Db;
+      const p = (await db.table("profiles").get(id)) as {
+        sportZones: { cycling?: { thresholds: { ftp?: number } } };
+      };
+      return p.sportZones.cycling?.thresholds.ftp;
+    }, PROFILE_ID);
+    expect(ftpBeforeDecision).toBe(200);
+
+    // Act: cancel the dialog → leaves manual value intact.
+    await page.getByRole("button", { name: /^cancel$/i }).click();
+    await expect(dialog).not.toBeVisible();
+
+    const ftpAfterCancel = await page.evaluate(async (id) => {
+      type Db = {
+        table: (n: string) => { get: (k: string) => Promise<unknown> };
+      };
+      const db = (window as unknown as Record<string, unknown>)
+        .__KAIORD_DB__ as Db;
+      const p = (await db.table("profiles").get(id)) as {
+        sportZones: { cycling?: { thresholds: { ftp?: number } } };
+      };
+      return p.sportZones.cycling?.thresholds.ftp;
+    }, PROFILE_ID);
+    expect(ftpAfterCancel).toBe(200);
+  });
+});

--- a/packages/workout-spa-editor/src/App.analytics.test.tsx
+++ b/packages/workout-spa-editor/src/App.analytics.test.tsx
@@ -18,7 +18,9 @@ import {
   SettingsDialogProvider,
   ThemeProvider,
 } from "./contexts";
+import { PersistenceProvider } from "./contexts/persistence-context";
 import { ToastContextProvider } from "./contexts/ToastContext";
+import { createInMemoryPersistence } from "./test-utils/in-memory-persistence";
 import { useWorkoutStore } from "./store/workout-store";
 
 type RenderArgs = {
@@ -31,19 +33,21 @@ function renderAtPath({ path, analytics }: RenderArgs) {
 
   const result = render(
     <AnalyticsProvider analytics={analytics}>
-      <ThemeProvider>
-        <SettingsDialogProvider>
-          <GarminBridgeProvider>
-            <ToastProvider>
-              <ToastContextProvider>
-                <Router hook={hook}>
-                  <App />
-                </Router>
-              </ToastContextProvider>
-            </ToastProvider>
-          </GarminBridgeProvider>
-        </SettingsDialogProvider>
-      </ThemeProvider>
+      <PersistenceProvider persistence={createInMemoryPersistence()}>
+        <ThemeProvider>
+          <SettingsDialogProvider>
+            <GarminBridgeProvider>
+              <ToastProvider>
+                <ToastContextProvider>
+                  <Router hook={hook}>
+                    <App />
+                  </Router>
+                </ToastContextProvider>
+              </ToastProvider>
+            </GarminBridgeProvider>
+          </SettingsDialogProvider>
+        </ThemeProvider>
+      </PersistenceProvider>
     </AnalyticsProvider>
   );
 

--- a/packages/workout-spa-editor/src/adapters/train2go/use-train2go-source.test.tsx
+++ b/packages/workout-spa-editor/src/adapters/train2go/use-train2go-source.test.tsx
@@ -13,6 +13,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PersistenceProvider } from "../../contexts/persistence-context";
 import { ToastContextProvider } from "../../contexts/ToastContext";
+import { Train2GoZonesSyncProvider } from "../../contexts/train2go-zones-sync-context";
 import { createInMemoryPersistence } from "../../test-utils/in-memory-persistence";
 
 const mockSync = vi.fn(async () => ({
@@ -72,7 +73,9 @@ import { useTrain2GoSource } from "./use-train2go-source";
 
 const wrap = (children: ReactNode) => (
   <PersistenceProvider persistence={createInMemoryPersistence()}>
-    <ToastContextProvider>{children}</ToastContextProvider>
+    <ToastContextProvider>
+      <Train2GoZonesSyncProvider>{children}</Train2GoZonesSyncProvider>
+    </ToastContextProvider>
   </PersistenceProvider>
 );
 

--- a/packages/workout-spa-editor/src/adapters/train2go/use-train2go-source.ts
+++ b/packages/workout-spa-editor/src/adapters/train2go/use-train2go-source.ts
@@ -5,13 +5,17 @@
  * Activities come from a useLiveQuery over the persisted
  * coachingActivities table; sync/expand/connect delegate to application
  * use cases (extracted to use-train2go-actions.ts to stay under lint).
+ *
+ * Zones-sync state is owned by `Train2GoZonesSyncProvider` (one
+ * instance per app), so multiple consumers of this factory all share
+ * the same `pending` state and the same dialog mount.
  */
 
 import { useCallback, useMemo } from "react";
 
 import { useAnalytics } from "../../contexts";
 import { usePersistence } from "../../contexts/persistence-context";
-import { useToastContext } from "../../contexts/ToastContext";
+import { useTrain2GoZonesSync } from "../../contexts/train2go-zones-sync-context";
 import { useTrain2GoStore } from "../../store/train2go-store";
 import type { CoachingSource } from "../../types/coaching-source";
 import { bridgeDiscovery } from "../bridge/bridge-discovery";
@@ -26,7 +30,6 @@ import {
   useTrain2GoSyncState,
 } from "./use-train2go-data";
 import type { ZonesSyncOrchestrator } from "./use-zones-sync-orchestrator";
-import { useZonesSyncOrchestrator } from "./use-zones-sync-orchestrator";
 
 export type Train2GoSource = CoachingSource & {
   zonesSync: ZonesSyncOrchestrator;
@@ -43,14 +46,13 @@ export function useTrain2GoSource(
 ): Train2GoSource {
   const store = useTrain2GoStore();
   const persistence = usePersistence();
-  const toasts = useToastContext();
   const analytics = useAnalytics();
+  const zonesSync = useTrain2GoZonesSync();
 
   const transport = useMemo(
     () => createTrain2GoCoachingTransport(getExtensionId),
     []
   );
-  const zonesSync = useZonesSyncOrchestrator(persistence, transport, toasts);
   const activities = useCoachingActivities(persistence, activeProfileId, days);
   const lastSyncedAt = useTrain2GoSyncState(persistence, activeProfileId);
 

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialog.bootstrap.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialog.bootstrap.test.tsx
@@ -21,6 +21,7 @@ import { CoachingRegistryBootstrap } from "../../../contexts/coaching-registry-b
 import { useCoachingSourceFactories } from "../../../contexts/coaching-registry-context";
 import { PersistenceProvider } from "../../../contexts/persistence-context";
 import { ToastContextProvider } from "../../../contexts/ToastContext";
+import { Train2GoZonesSyncProvider } from "../../../contexts/train2go-zones-sync-context";
 import { useCoachingActivities } from "../../../hooks/use-coaching-activities";
 import { createInMemoryPersistence } from "../../../test-utils/in-memory-persistence";
 import type { CoachingActivity } from "../../../types/coaching-activity";
@@ -78,14 +79,16 @@ describe("CoachingActivityDialog (bootstrap-real smoke)", () => {
     render(
       <PersistenceProvider persistence={createInMemoryPersistence()}>
         <ToastContextProvider>
-          <CoachingRegistryBootstrap>
-            <TestProbe onFactoryCount={(n) => (factoryCount = n)} />
-            <CoachingActivityDialog
-              activity={baseActivity}
-              onClose={vi.fn()}
-              expandActivity={vi.fn()}
-            />
-          </CoachingRegistryBootstrap>
+          <Train2GoZonesSyncProvider>
+            <CoachingRegistryBootstrap>
+              <TestProbe onFactoryCount={(n) => (factoryCount = n)} />
+              <CoachingActivityDialog
+                activity={baseActivity}
+                onClose={vi.fn()}
+                expandActivity={vi.fn()}
+              />
+            </CoachingRegistryBootstrap>
+          </Train2GoZonesSyncProvider>
         </ToastContextProvider>
       </PersistenceProvider>
     );

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/LinkedAccountRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/LinkedAccountRow.tsx
@@ -5,10 +5,14 @@
  * toggle. The toggle is gated on TWO conditions: the row is currently
  * `linked`, AND the discovered Train2Go bridge advertises
  * `read:training-zones`. Older bridges never see the control.
+ *
+ * The conflict dialog itself lives at app root via
+ * `Train2GoZonesSyncProvider` so its visibility is decoupled from the
+ * Profile Manager being open — clicking sync from the calendar header
+ * still surfaces the dialog.
  */
 import { useTrain2GoSupportsZones } from "../../../../hooks/use-train2go-supports-zones";
 import type { Profile } from "../../../../types/profile";
-import { ZonesConflictDialog } from "../../ZonesConflictDialog/ZonesConflictDialog";
 import { RowInfo } from "./RowInfo";
 import { SyncZonesToggle } from "./SyncZonesToggle";
 import type { SourceMeta } from "./use-linked-account-row";
@@ -22,13 +26,8 @@ export function LinkedAccountRow({
   sourceMeta: SourceMeta;
 }) {
   const linked = profile.linkedAccounts.find((a) => a.source === sourceMeta.id);
-  const {
-    busy,
-    handleConnect,
-    handleDisconnect,
-    handleToggleSyncZones,
-    zonesSync,
-  } = useLinkedAccountRow(profile, sourceMeta);
+  const { busy, handleConnect, handleDisconnect, handleToggleSyncZones } =
+    useLinkedAccountRow(profile, sourceMeta);
   const supportsZones = useTrain2GoSupportsZones();
 
   return (
@@ -65,12 +64,6 @@ export function LinkedAccountRow({
           onChange={handleToggleSyncZones}
         />
       ) : null}
-      <ZonesConflictDialog
-        open={zonesSync.pending !== null}
-        conflicts={zonesSync.pending?.conflicts ?? []}
-        onConfirm={zonesSync.confirmDecisions}
-        onCancel={zonesSync.cancel}
-      />
     </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/use-linked-account-row.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/use-linked-account-row.ts
@@ -87,6 +87,5 @@ export const useLinkedAccountRow = (
     handleConnect,
     handleDisconnect,
     handleToggleSyncZones,
-    zonesSync: t2gSource.zonesSync,
   };
 };

--- a/packages/workout-spa-editor/src/components/providers/AppToastProvider.tsx
+++ b/packages/workout-spa-editor/src/components/providers/AppToastProvider.tsx
@@ -4,6 +4,7 @@ import {
   ToastContextProvider,
   useToastContext,
 } from "../../contexts/ToastContext";
+import { Train2GoZonesSyncProvider } from "../../contexts/train2go-zones-sync-context";
 import { Toast, ToastProvider } from "../atoms/Toast";
 
 function ToastRenderer() {
@@ -33,7 +34,7 @@ export function AppToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastProvider>
       <ToastContextProvider>
-        {children}
+        <Train2GoZonesSyncProvider>{children}</Train2GoZonesSyncProvider>
         <ToastRenderer />
       </ToastContextProvider>
     </ToastProvider>

--- a/packages/workout-spa-editor/src/contexts/train2go-zones-sync-context.tsx
+++ b/packages/workout-spa-editor/src/contexts/train2go-zones-sync-context.tsx
@@ -1,0 +1,66 @@
+/**
+ * Train2GoZonesSyncProvider — single source of truth for the
+ * zones-sync orchestrator across the app.
+ *
+ * Before this lived in a context, every call site of `useTrain2GoSource`
+ * created its own `useZonesSyncOrchestrator` instance. Two consumers
+ * (the calendar header's sync button and the Profile Manager's
+ * Linked Account row) ended up with disjoint state — clicking sync on
+ * the calendar set `pending` on instance A, while the dialog was
+ * mounted under instance B and never saw it. Lifting the orchestrator
+ * into one provider fixes that integration gap, and rendering the
+ * dialog INSIDE the provider lets it appear regardless of which
+ * trigger fired.
+ */
+import { createContext, type ReactNode, useContext, useMemo } from "react";
+
+import { bridgeDiscovery } from "../adapters/bridge/bridge-discovery";
+import { createTrain2GoCoachingTransport } from "../adapters/train2go/train2go-coaching-transport";
+import {
+  useZonesSyncOrchestrator,
+  type ZonesSyncOrchestrator,
+} from "../adapters/train2go/use-zones-sync-orchestrator";
+import { ZonesConflictDialog } from "../components/organisms/ZonesConflictDialog/ZonesConflictDialog";
+import { usePersistence } from "./persistence-context";
+import { useToastContext } from "./ToastContext";
+
+const Ctx = createContext<ZonesSyncOrchestrator | null>(null);
+
+const getExtensionId = (): string =>
+  bridgeDiscovery.getExtensionId("train2go-bridge") ?? "";
+
+export const Train2GoZonesSyncProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const persistence = usePersistence();
+  const toasts = useToastContext();
+  const transport = useMemo(
+    () => createTrain2GoCoachingTransport(getExtensionId),
+    []
+  );
+  const orchestrator = useZonesSyncOrchestrator(persistence, transport, toasts);
+
+  return (
+    <Ctx.Provider value={orchestrator}>
+      {children}
+      <ZonesConflictDialog
+        open={orchestrator.pending !== null}
+        conflicts={orchestrator.pending?.conflicts ?? []}
+        onConfirm={orchestrator.confirmDecisions}
+        onCancel={orchestrator.cancel}
+      />
+    </Ctx.Provider>
+  );
+};
+
+export const useTrain2GoZonesSync = (): ZonesSyncOrchestrator => {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    throw new Error(
+      "useTrain2GoZonesSync must be used within Train2GoZonesSyncProvider"
+    );
+  }
+  return ctx;
+};


### PR DESCRIPTION
## Summary

Implements the deferred Playwright e2e for the `train2go-zones-sync` flow that was filed as a follow-up issue (#478) when the change archived. While building it, the e2e exposed a real architectural bug shipped in PR #474 — fixed in the same commit because the e2e can't pass without it.

## Architectural fix (the real one)

The orchestrator state lived inside `useTrain2GoSource`, which is called as a factory hook by both the CoachingRegistry (for the calendar header) and `useLinkedAccountRow` (for the Profile Manager). Each call created a **fresh orchestrator instance**. The dialog mounted inside `LinkedAccountRow` consumed instance B; clicking the calendar's sync button updated instance A's `pending` state — so the dialog never saw conflicts unless the Profile Manager happened to also trigger sync.

The fix: lift the orchestrator into `<Train2GoZonesSyncProvider>` mounted at app root (inside `AppToastProvider` so it has `usePersistence` + `useToastContext`). Both trigger sites consume the same context, and the provider renders `<ZonesConflictDialog>` itself so visibility is decoupled from which page is open. `useTrain2GoSource` no longer creates its own orchestrator; `LinkedAccountRow` no longer renders the dialog.

## E2E (`zones-sync.spec.ts`)

Three tests against the spec scenarios from `openspec/changes/archive/2026-05-03-train2go-zones-sync/`:
- **(a) toggle-off** → auto-sync MUST NOT issue `read-details`. Asserts the call tracker contains `read-week` but not `read-details`.
- **(b) toggle-on with empty profile** → silent fills land, no dialog. Asserts `bodyWeight=83`, `maxHeartRate=187`, cycling FTP=268, cycling LTHR=174, running LTHR=168, running pace=250s, swimming CSS=92s — every value derived from the sanitized fixture.
- **(c) toggle-on with manual FTP** → `ZonesConflictDialog` opens with the FTP row showing `200 → 268`; cancel → 200 stays. Verified via `data-testid` selectors.

Bridge stub at `e2e/helpers/train2go-bridge-stub.ts` paves over the missing Chrome extension (Playwright Chromium runs unloaded). Stable across **5/5 iterations** at ~2.2s per run.

## The diagnostic that took longest to spot

The bridge announcement uses `bridgeId` while the bridge ping response uses `id` — they're separate fields by design (announcement is for routing; ping returns the manifest). My initial stub reused the same object for both, which made `bridgeManifestSchema.safeParse` reject (`id` missing). bridge-discovery silently ignored the bridge. Comment in the stub flags this for future me.

## Test plan

- [x] `pnpm test` — 3203 unit tests pass (was 3203; 3 wrapper tests updated to add `Train2GoZonesSyncProvider`)
- [x] `pnpm exec playwright test e2e/zones-sync.spec.ts` — 3/3 pass, stable 5/5 iterations
- [x] `pnpm lint` — clean
- [x] `pnpm test:scripts` — 315 mechanical guards pass
- [x] `pnpm lint:specs` — 34/34 pass

## Closes

- #478 (Playwright e2e for zones-sync)
- The latent integration bug from #474 (per-instance orchestrator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)