### PR TITLE
chore(ci): remove redundant TypeScript dist cache from setup-pnpm

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -52,20 +52,6 @@ runs:
           ${{ runner.os }}-node-modules-${{ inputs.node-version }}-
           ${{ runner.os }}-node-modules-
 
-    - name: Setup TypeScript build cache
-      id: cache-typescript
-      uses: actions/cache@v5
-      with:
-        path: |
-          packages/*/dist
-          packages/*/.tsbuildinfo
-          packages/*/tsconfig.tsbuildinfo
-        key: ${{ runner.os }}-typescript-${{ inputs.node-version }}-${{ hashFiles('packages/*/tsconfig.json', 'packages/*/src/**/*.ts') }}
-        restore-keys: |
-          ${{ runner.os }}-typescript-${{ inputs.node-version }}-${{ hashFiles('packages/*/tsconfig.json') }}
-          ${{ runner.os }}-typescript-${{ inputs.node-version }}-
-          ${{ runner.os }}-typescript-
-
     - name: Display cache hit status
       shell: bash
       run: |
@@ -73,7 +59,6 @@ runs:
         echo "====================="
         echo "pnpm store cache: ${{ steps.cache-pnpm-store.outputs.cache-hit == 'true' && '✅ HIT' || '❌ MISS' }}"
         echo "node_modules cache: ${{ steps.cache-node-modules.outputs.cache-hit == 'true' && '✅ HIT' || '❌ MISS' }}"
-        echo "TypeScript build cache: ${{ steps.cache-typescript.outputs.cache-hit == 'true' && '✅ HIT' || '❌ MISS' }}"
         echo "====================="
 
     - name: Install dependencies


### PR DESCRIPTION
## Summary

Closes #482. Removes the `Setup TypeScript build cache` step from `.github/actions/setup-pnpm/action.yml`.

The cache was keyed by a single global hash (`hashFiles('packages/*/tsconfig.json', 'packages/*/src/**/*.ts')`) — any source change in any package invalidated the cache for every package, making it a near-no-op on real PRs (per Decision 8 of the `ci-artifact-fanout` change).

After PR #480, every consumer of `setup-pnpm` either:
- wipes `packages/*/dist` via the `consume-build-artifacts` composite before downloading the run-scoped artifact (cache restore wasted), OR
- runs its own `pnpm -r build` (cache restore overwritten), OR
- runs `pnpm --filter <pkg> build` (cache restore overwritten).

The cache restore added ~5-10s per job × ~20 CI jobs of pure overhead with zero hit benefit.

## Test plan

- [x] Removed `Setup TypeScript build cache` step + associated `Display cache hit status` line.
- [x] `pnpm store cache` and `node_modules cache` steps preserved (those still hit reliably).
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)