### PR TITLE
feat(spa-editor): map full Z1-Z5 zone bands from T2G payload (PR 2/4)

### DIFF
--- a/.changeset/train2go-spa-mapper-bands.md
+++ b/.changeset/train2go-spa-mapper-bands.md
@@ -1,0 +1,23 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+SPA mapper now consumes the new full-Z1-Z5-band Train2Go payload shape and writes the full HR / power / pace zone arrays to the persisted profile. Band-level entries flow through the existing `IncomingMap` / `reconcile` / `commitConflictResolution` pipeline as ~60 new band-level `FieldKey` entries.
+
+**HR fallback chain** (D-FB1): per sport, `payload.hrZones.<sport>` (Specific) wins when present; `payload.hrZones.generic` (Karvonen) is the fallback; otherwise the sport's HR bands are not touched. A triathlete with only cycling Specific configured gets running and swimming HR bands populated from the Generic block.
+
+**Cycling power conversion** (D-FB6): watts → %FTP via `Math.round(watts / z4Upper * 100)`. The divisor is `payload.paces.cycling.z4Upper` (T2G's view of FTP), NEVER the persisted profile's FTP — mixing sources distorts %. When `z4Upper` is absent or zero, cycling power band writes are skipped entirely.
+
+**Pace inversion** (D-FB7): T2G `lower` is the SLOWER edge (larger seconds) → maps to `maxPace`; T2G `upper` is the FASTER edge (smaller seconds) → maps to `minPace`. The Kaiord `minPace <= maxPace` invariant follows from this unconditional assignment.
+
+**Power-zone count mismatch** (D-FB3): Kaiord's `DEFAULT_POWER_ZONES` defines 7 zones (Z1=Active Recovery..Z7=Neuromuscular Power) but T2G emits 5. The mapper writes a 5-element array; pre-existing Z6/Z7 entries are NOT preserved (T2G is the source of truth at sync time per the design).
+
+**Per-band conflict policy**: when the persisted sport-kind table is empty (zones array missing OR length === 0), all bands are silent-fills. When the table is populated, per-band conflicts surface as `{<sport>.<kind>.zN.<bound>}` rows in the existing dialog. `commitConflictResolution` accepts band-level decisions; merge: accepted bands take T2G; rejected bands keep pre-sync values.
+
+**bpmRest flow-through-but-not-persisted** (D-FB8): the new `physiological.bpmRest` field flows through the validated payload but the SPA mapper does NOT write it to the profile in this change — Kaiord has no `restingHeartRate` consumer field yet. Pinned by a deep-diff test.
+
+UI label-map changes for the new ~60 band-level keys are auto-generated at module-load time from a hardcoded cross-product (`Cycling HR Z2 max`-style) — never interpolates an external string. PR 3 polishes the label format and adds dedicated dialog tests; this PR just keeps the dialog rendering correct values for the new keys.
+
+Type: `ZonesPayload` Zod schema extended with `physiological.bpmRest`, `paces.cycling.z1..z5: { lower, upper }`, `paces.{running,swimming}.z1..z5: { lower:{min,sec}, upper:{min,sec} }`, `hrZones.generic.z1..z5`, `hrZones.{cycling,running,swimming}.z1..z5`. Backwards-compat: existing convenience scalars (`z4Upper`, `z5Lower`) are preserved; older bridge payloads with only `z4Upper` continue to work for threshold-scalar writes.
+
+12 new unit tests in `sync-zones-bands.test.ts` cover the HR fallback chain, watts→%FTP, pace inversion, re-sync stability, bpmRest non-persistence, power-zone count mismatch, and band-level merge.

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-fields.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-fields.ts
@@ -61,7 +61,8 @@ export const readHrBand = (
   band: Band,
   bound: HrBound
 ): number | undefined => {
-  const z = profile.sportZones[sport]?.heartRateZones?.zones?.[BAND_INDEX[band]];
+  const z =
+    profile.sportZones[sport]?.heartRateZones?.zones?.[BAND_INDEX[band]];
   return z ? (bound === "minBpm" ? z.minBpm : z.maxBpm) : undefined;
 };
 

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-fields.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-fields.ts
@@ -1,0 +1,85 @@
+/**
+ * Band-level FieldKey ↔ Profile zone-array accessors.
+ */
+import type { HeartRateZone, PowerZone, Profile } from "../../types/profile";
+import {
+  DEFAULT_HEART_RATE_ZONES,
+  DEFAULT_POWER_ZONES,
+} from "../../types/profile";
+import type { PaceZone } from "../../types/sport-zones";
+
+export type Sport = "cycling" | "running" | "swimming";
+export type Band = "z1" | "z2" | "z3" | "z4" | "z5";
+export type HrBound = "minBpm" | "maxBpm";
+export type PowerBound = "minPercent" | "maxPercent";
+export type PaceBound = "minPace" | "maxPace";
+
+export const BAND_INDEX: Record<Band, number> = {
+  z1: 0,
+  z2: 1,
+  z3: 2,
+  z4: 3,
+  z5: 4,
+};
+
+const PACE_UNIT = {
+  running: "min_per_km" as const,
+  swimming: "min_per_100m" as const,
+};
+
+export const cloneOrSeedHrZones = (
+  existing: HeartRateZone[] | undefined
+): HeartRateZone[] =>
+  existing && existing.length === 5
+    ? existing.map((z) => ({ ...z }))
+    : DEFAULT_HEART_RATE_ZONES.map((z) => ({ ...z }));
+
+export const cloneOrSeedPowerZones = (
+  existing: PowerZone[] | undefined
+): PowerZone[] =>
+  existing && existing.length >= 5
+    ? existing.slice(0, 5).map((z) => ({ ...z }))
+    : DEFAULT_POWER_ZONES.slice(0, 5).map((z) => ({ ...z }));
+
+export const seedPaceZones = (
+  sport: "running" | "swimming",
+  existing: PaceZone[] | undefined
+): PaceZone[] =>
+  existing && existing.length === 5
+    ? existing.map((z) => ({ ...z }))
+    : DEFAULT_HEART_RATE_ZONES.map((z) => ({
+        zone: z.zone,
+        name: z.name,
+        minPace: 0,
+        maxPace: 0,
+        unit: PACE_UNIT[sport],
+      }));
+
+export const readHrBand = (
+  profile: Profile,
+  sport: Sport,
+  band: Band,
+  bound: HrBound
+): number | undefined => {
+  const z = profile.sportZones[sport]?.heartRateZones?.zones?.[BAND_INDEX[band]];
+  return z ? (bound === "minBpm" ? z.minBpm : z.maxBpm) : undefined;
+};
+
+export const readPowerBand = (
+  profile: Profile,
+  band: Band,
+  bound: PowerBound
+): number | undefined => {
+  const z = profile.sportZones.cycling?.powerZones?.zones?.[BAND_INDEX[band]];
+  return z ? (bound === "minPercent" ? z.minPercent : z.maxPercent) : undefined;
+};
+
+export const readPaceBand = (
+  profile: Profile,
+  sport: "running" | "swimming",
+  band: Band,
+  bound: PaceBound
+): number | undefined => {
+  const z = profile.sportZones[sport]?.paceZones?.zones?.[BAND_INDEX[band]];
+  return z ? (bound === "minPace" ? z.minPace : z.maxPace) : undefined;
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-key.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-key.ts
@@ -1,0 +1,55 @@
+/**
+ * Parse a band-level FieldKey into its components. Returns null for
+ * threshold-scalar keys (the legacy 7).
+ */
+import type { FieldKey } from "../../types/coaching-zones";
+import type {
+  Band,
+  HrBound,
+  PaceBound,
+  PowerBound,
+  Sport,
+} from "./sync-zones-band-fields";
+
+export type ParsedBandKey =
+  | { kind: "hr"; sport: Sport; band: Band; bound: HrBound }
+  | { kind: "power"; band: Band; bound: PowerBound }
+  | {
+      kind: "pace";
+      sport: "running" | "swimming";
+      band: Band;
+      bound: PaceBound;
+    }
+  | null;
+
+const HR_BAND_RE =
+  /^(cycling|running|swimming)\.heartRateZones\.(z[1-5])\.(minBpm|maxBpm)$/;
+const POWER_BAND_RE = /^cycling\.powerZones\.(z[1-5])\.(minPercent|maxPercent)$/;
+const PACE_BAND_RE =
+  /^(running|swimming)\.paceZones\.(z[1-5])\.(minPace|maxPace)$/;
+
+export const parseBandKey = (field: FieldKey): ParsedBandKey => {
+  const hr = HR_BAND_RE.exec(field);
+  if (hr) {
+    return {
+      kind: "hr",
+      sport: hr[1] as Sport,
+      band: hr[2] as Band,
+      bound: hr[3] as HrBound,
+    };
+  }
+  const pw = POWER_BAND_RE.exec(field);
+  if (pw) {
+    return { kind: "power", band: pw[1] as Band, bound: pw[2] as PowerBound };
+  }
+  const pace = PACE_BAND_RE.exec(field);
+  if (pace) {
+    return {
+      kind: "pace",
+      sport: pace[1] as "running" | "swimming",
+      band: pace[2] as Band,
+      bound: pace[3] as PaceBound,
+    };
+  }
+  return null;
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-key.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-key.ts
@@ -24,7 +24,8 @@ export type ParsedBandKey =
 
 const HR_BAND_RE =
   /^(cycling|running|swimming)\.heartRateZones\.(z[1-5])\.(minBpm|maxBpm)$/;
-const POWER_BAND_RE = /^cycling\.powerZones\.(z[1-5])\.(minPercent|maxPercent)$/;
+const POWER_BAND_RE =
+  /^cycling\.powerZones\.(z[1-5])\.(minPercent|maxPercent)$/;
 const PACE_BAND_RE =
   /^(running|swimming)\.paceZones\.(z[1-5])\.(minPace|maxPace)$/;
 

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-mappers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-mappers.ts
@@ -79,9 +79,7 @@ export const setCyclingPowerBands = (
   }
 };
 
-type RunSwimPaces = NonNullable<
-  NonNullable<ZonesPayload["paces"]>["running"]
->;
+type RunSwimPaces = NonNullable<NonNullable<ZonesPayload["paces"]>["running"]>;
 
 const minSecToSeconds = (ms: { min: number; sec: number }): number =>
   ms.min * 60 + ms.sec;

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-mappers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-mappers.ts
@@ -1,0 +1,105 @@
+/**
+ * Per-band entry generators for `mapPayloadToIncoming`. Each function
+ * mutates the IncomingMap in place with `{sport}.{kind}.zN.{bound}`
+ * entries derived from the raw payload bands.
+ *
+ * Conventions:
+ *   - HR: per-sport fallback chain — Specific → Generic → skip
+ *     (D-FB1). Resolution is the caller's responsibility; this module
+ *     just writes the bands it's given.
+ *   - Power: watts → %FTP via `Math.round(watts / z4Upper * 100)`.
+ *     The divisor MUST be `payload.paces.cycling.z4Upper` (T2G's view
+ *     of FTP), NEVER the persisted FTP (D-FB6). Skipped when z4Upper
+ *     is absent or zero.
+ *   - Pace: `{min, sec}` → integer seconds with inversion (D-FB7) —
+ *     T2G `lower` (slower) → `maxPace`; T2G `upper` (faster) →
+ *     `minPace`. The Kaiord `minPace <= maxPace` invariant follows
+ *     from this unconditional assignment.
+ */
+import type {
+  BandFieldKey,
+  FieldKey,
+  ZonesPayload,
+} from "../../types/coaching-zones";
+
+export type IncomingMap = Map<FieldKey, number>;
+
+const BANDS = ["z1", "z2", "z3", "z4", "z5"] as const;
+
+type BpmBands = {
+  z1?: { lower: number; upper: number };
+  z2?: { lower: number; upper: number };
+  z3?: { lower: number; upper: number };
+  z4?: { lower: number; upper: number };
+  z5?: { lower: number; upper: number };
+};
+
+const setIfPositive = (
+  map: IncomingMap,
+  key: FieldKey,
+  value: number | undefined
+): void => {
+  if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+    map.set(key, value);
+  }
+};
+
+export const setHrBands = (
+  map: IncomingMap,
+  sport: "cycling" | "running" | "swimming",
+  bands: BpmBands | undefined
+): void => {
+  if (!bands) return;
+  for (const band of BANDS) {
+    const b = bands[band];
+    if (!b) continue;
+    const minKey = `${sport}.heartRateZones.${band}.minBpm` as BandFieldKey;
+    const maxKey = `${sport}.heartRateZones.${band}.maxBpm` as BandFieldKey;
+    setIfPositive(map, minKey, b.lower);
+    setIfPositive(map, maxKey, b.upper);
+  }
+};
+
+type CyclingPaces = NonNullable<NonNullable<ZonesPayload["paces"]>["cycling"]>;
+
+export const setCyclingPowerBands = (
+  map: IncomingMap,
+  cycling: CyclingPaces | undefined
+): void => {
+  if (!cycling) return;
+  const ftp = cycling.z4Upper;
+  if (typeof ftp !== "number" || ftp <= 0) return;
+  for (const band of BANDS) {
+    const b = cycling[band];
+    if (!b) continue;
+    const minKey = `cycling.powerZones.${band}.minPercent` as BandFieldKey;
+    const maxKey = `cycling.powerZones.${band}.maxPercent` as BandFieldKey;
+    setIfPositive(map, minKey, Math.round((b.lower / ftp) * 100));
+    setIfPositive(map, maxKey, Math.round((b.upper / ftp) * 100));
+  }
+};
+
+type RunSwimPaces = NonNullable<
+  NonNullable<ZonesPayload["paces"]>["running"]
+>;
+
+const minSecToSeconds = (ms: { min: number; sec: number }): number =>
+  ms.min * 60 + ms.sec;
+
+export const setPaceBands = (
+  map: IncomingMap,
+  sport: "running" | "swimming",
+  bands: RunSwimPaces | undefined
+): void => {
+  if (!bands) return;
+  for (const band of BANDS) {
+    const b = bands[band];
+    if (!b) continue;
+    const minKey = `${sport}.paceZones.${band}.minPace` as BandFieldKey;
+    const maxKey = `${sport}.paceZones.${band}.maxPace` as BandFieldKey;
+    // Inversion (D-FB7): T2G `upper` (faster) → minPace;
+    // T2G `lower` (slower) → maxPace.
+    setIfPositive(map, minKey, minSecToSeconds(b.upper));
+    setIfPositive(map, maxKey, minSecToSeconds(b.lower));
+  }
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-writes.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-writes.ts
@@ -68,7 +68,10 @@ export const writePaceBand = (
   bound: PaceBound,
   value: number
 ): Profile => {
-  const zones = seedPaceZones(sport, profile.sportZones[sport]?.paceZones?.zones);
+  const zones = seedPaceZones(
+    sport,
+    profile.sportZones[sport]?.paceZones?.zones
+  );
   if (bound === "minPace") zones[BAND_INDEX[band]].minPace = value;
   else zones[BAND_INDEX[band]].maxPace = value;
   const method = profile.sportZones[sport]?.paceZones?.method ?? "manual";

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-writes.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-writes.ts
@@ -1,0 +1,76 @@
+/**
+ * Band-level write helpers. Each returns a fresh Profile with the
+ * targeted band's bound updated; the array is cloned-or-seeded to 5
+ * entries so the index-based mutate is safe.
+ */
+import type { Profile } from "../../types/profile";
+import type {
+  Band,
+  HrBound,
+  PaceBound,
+  PowerBound,
+  Sport,
+} from "./sync-zones-band-fields";
+import {
+  BAND_INDEX,
+  cloneOrSeedHrZones,
+  cloneOrSeedPowerZones,
+  seedPaceZones,
+} from "./sync-zones-band-fields";
+
+const mergeSport = (profile: Profile, sport: Sport, patch: object): Profile => {
+  const existing = profile.sportZones[sport];
+  const base = existing ?? {
+    thresholds: {},
+    heartRateZones: { method: "manual", zones: [] },
+  };
+  return {
+    ...profile,
+    sportZones: { ...profile.sportZones, [sport]: { ...base, ...patch } },
+  };
+};
+
+export const writeHrBand = (
+  profile: Profile,
+  sport: Sport,
+  band: Band,
+  bound: HrBound,
+  value: number
+): Profile => {
+  const zones = cloneOrSeedHrZones(
+    profile.sportZones[sport]?.heartRateZones?.zones
+  );
+  if (bound === "minBpm") zones[BAND_INDEX[band]].minBpm = value;
+  else zones[BAND_INDEX[band]].maxBpm = value;
+  const method = profile.sportZones[sport]?.heartRateZones?.method ?? "manual";
+  return mergeSport(profile, sport, { heartRateZones: { method, zones } });
+};
+
+export const writePowerBand = (
+  profile: Profile,
+  band: Band,
+  bound: PowerBound,
+  value: number
+): Profile => {
+  const zones = cloneOrSeedPowerZones(
+    profile.sportZones.cycling?.powerZones?.zones
+  );
+  if (bound === "minPercent") zones[BAND_INDEX[band]].minPercent = value;
+  else zones[BAND_INDEX[band]].maxPercent = value;
+  const method = profile.sportZones.cycling?.powerZones?.method ?? "manual";
+  return mergeSport(profile, "cycling", { powerZones: { method, zones } });
+};
+
+export const writePaceBand = (
+  profile: Profile,
+  sport: "running" | "swimming",
+  band: Band,
+  bound: PaceBound,
+  value: number
+): Profile => {
+  const zones = seedPaceZones(sport, profile.sportZones[sport]?.paceZones?.zones);
+  if (bound === "minPace") zones[BAND_INDEX[band]].minPace = value;
+  else zones[BAND_INDEX[band]].maxPace = value;
+  const method = profile.sportZones[sport]?.paceZones?.method ?? "manual";
+  return mergeSport(profile, sport, { paceZones: { method, zones } });
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-bands.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-bands.test.ts
@@ -1,0 +1,388 @@
+/**
+ * `syncZones` band-level paths — full Z1-Z5 zone tables, HR fallback
+ * chain, watts→%FTP conversion, pace inversion, and per-band conflicts.
+ *
+ * Companion to `sync-zones.test.ts` (which covers the threshold-scalar
+ * paths). Tests here verify the full-bands change (PR 2) end-to-end:
+ * mapper builds the IncomingMap, reconcile splits silent-fills vs
+ * conflicts at band granularity, commitConflictResolution merges per
+ * decision.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { createInMemoryProfileRepository } from "../../test-utils/in-memory-profile-repository";
+import type {
+  ConflictDecision,
+  FieldKey,
+  ZonesPayload,
+} from "../../types/coaching-zones";
+import type { Profile } from "../../types/profile";
+import type { CoachingTransport } from "./coaching-transport-port";
+import { commitConflictResolution } from "./commit-conflict-resolution";
+import { syncZones } from "./sync-zones";
+import { mapPayloadToIncoming } from "./sync-zones-payload-mapper";
+
+const PROFILE_ID = "00000000-0000-0000-0000-000000000002";
+const NOW = "2026-05-04T10:00:00.000Z";
+
+const makeProfile = (overrides: Partial<Profile> = {}): Profile => ({
+  id: PROFILE_ID,
+  name: "Pablo",
+  sportZones: {},
+  linkedAccounts: [
+    {
+      source: "train2go",
+      externalUserId: "99999",
+      externalUserName: "Pablo",
+      linkedAt: NOW,
+      syncZones: true,
+    },
+  ],
+  createdAt: NOW,
+  updatedAt: NOW,
+  ...overrides,
+});
+
+const makeTransport = (
+  readZones?: CoachingTransport["readZones"]
+): CoachingTransport => ({
+  source: "train2go",
+  ping: vi.fn(async () => ({
+    sessionActive: true,
+    externalUserId: "99999",
+    externalUserName: "Pablo",
+  })),
+  openExternal: vi.fn(async () => undefined),
+  readWeek: vi.fn(async () => []),
+  readDay: vi.fn(async () => []),
+  ...(readZones ? { readZones } : {}),
+});
+
+const HR_GENERIC_BANDS = {
+  z1: { lower: 107, upper: 133 },
+  z2: { lower: 134, upper: 147 },
+  z3: { lower: 148, upper: 160 },
+  z4: { lower: 161, upper: 174 },
+  z5: { lower: 175, upper: 187 },
+};
+
+const HR_RUNNING_BANDS = {
+  z1: { lower: 100, upper: 130 },
+  z2: { lower: 131, upper: 145 },
+  z3: { lower: 146, upper: 157 },
+  z4: { lower: 158, upper: 168 },
+  z5: { lower: 169, upper: 180 },
+};
+
+const POWER_BANDS = {
+  z1: { lower: 111, upper: 149 },
+  z2: { lower: 150, upper: 203 },
+  z3: { lower: 204, upper: 239 },
+  z4: { lower: 240, upper: 268 },
+  z5: { lower: 269, upper: 386 },
+};
+
+const RUN_PACE_BANDS = {
+  z4: {
+    lower: { min: 4, sec: 44 },
+    upper: { min: 4, sec: 10 },
+  },
+};
+
+const PAYLOAD_TRIATHLETE: ZonesPayload = {
+  physiological: { weight: 83, bpmMax: 187, bpmRest: 51 },
+  paces: {
+    cycling: {
+      ...POWER_BANDS,
+      z4Upper: 268,
+      z5Lower: 269,
+    },
+    running: {
+      ...RUN_PACE_BANDS,
+      z4Upper: { min: 4, sec: 10 },
+    },
+  },
+  hrZones: {
+    generic: HR_GENERIC_BANDS,
+    cycling: { ...HR_GENERIC_BANDS, z4Upper: 174 },
+    running: { ...HR_RUNNING_BANDS, z4Upper: 168 },
+  },
+};
+
+describe("syncZones full-bands — HR fallback chain", () => {
+  it("should write running and swimming HR bands from Generic when only cycling Specific is present (4.7a)", async () => {
+    // Arrange
+    const repo = createInMemoryProfileRepository();
+    await repo.put(makeProfile());
+    const transport = makeTransport(async () => PAYLOAD_TRIATHLETE);
+
+    // Act
+    const result = await syncZones(PROFILE_ID, transport, repo);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const persisted = await repo.getById(PROFILE_ID);
+    expect(persisted?.sportZones.cycling?.heartRateZones.zones[3]).toMatchObject({
+      minBpm: 161,
+      maxBpm: 174,
+    });
+    expect(persisted?.sportZones.running?.heartRateZones.zones[3]).toMatchObject({
+      minBpm: 158,
+      maxBpm: 168,
+    });
+    // Swimming has no Specific block → falls back to Generic.
+    expect(persisted?.sportZones.swimming?.heartRateZones.zones[3]).toMatchObject({
+      minBpm: 161,
+      maxBpm: 174,
+    });
+  });
+
+  it("should NOT touch a sport's HR bands when both Specific and Generic are absent (4.7j)", async () => {
+    // Arrange
+    const repo = createInMemoryProfileRepository();
+    await repo.put(makeProfile());
+    const payload: ZonesPayload = {
+      physiological: { weight: 83 },
+      hrZones: { cycling: { z4Upper: 174, ...HR_GENERIC_BANDS } },
+    };
+    const transport = makeTransport(async () => payload);
+
+    // Act
+    await syncZones(PROFILE_ID, transport, repo);
+
+    // Assert
+    const persisted = await repo.getById(PROFILE_ID);
+    // Cycling has Specific → present.
+    expect(persisted?.sportZones.cycling?.heartRateZones.zones).toHaveLength(5);
+    // Running and swimming have neither Specific nor Generic → untouched.
+    expect(persisted?.sportZones.running).toBeUndefined();
+    expect(persisted?.sportZones.swimming).toBeUndefined();
+  });
+});
+
+describe("syncZones full-bands — cycling power watts→%FTP", () => {
+  it("should convert cycling watts bands to %FTP using payload.paces.cycling.z4Upper as divisor (4.7f)", async () => {
+    // Arrange
+    const repo = createInMemoryProfileRepository();
+    await repo.put(makeProfile());
+    const transport = makeTransport(async () => PAYLOAD_TRIATHLETE);
+
+    // Act
+    await syncZones(PROFILE_ID, transport, repo);
+
+    // Assert — Z4: 240W..268W with FTP=268 → 90%..100% (exact integer)
+    const persisted = await repo.getById(PROFILE_ID);
+    const z4 = persisted?.sportZones.cycling?.powerZones?.zones[3];
+    expect(z4?.minPercent).toBe(90);
+    expect(z4?.maxPercent).toBe(100);
+    // Z1: 111W..149W with FTP=268 → 41%..56%.
+    const z1 = persisted?.sportZones.cycling?.powerZones?.zones[0];
+    expect(z1?.minPercent).toBe(41);
+    expect(z1?.maxPercent).toBe(56);
+  });
+
+  it("should skip cycling power band writes when payload.paces.cycling.z4Upper is absent (4.7h)", async () => {
+    // Arrange
+    const repo = createInMemoryProfileRepository();
+    await repo.put(makeProfile());
+    const payloadNoFtp: ZonesPayload = {
+      paces: {
+        cycling: { ...POWER_BANDS },
+      },
+    };
+    const transport = makeTransport(async () => payloadNoFtp);
+
+    // Act
+    await syncZones(PROFILE_ID, transport, repo);
+
+    // Assert
+    const persisted = await repo.getById(PROFILE_ID);
+    expect(persisted?.sportZones.cycling?.powerZones).toBeUndefined();
+  });
+});
+
+describe("syncZones full-bands — running pace inversion", () => {
+  it("should map T2G upper (faster) to minPace and lower (slower) to maxPace (4.7g)", async () => {
+    // Arrange
+    const repo = createInMemoryProfileRepository();
+    await repo.put(makeProfile());
+    const transport = makeTransport(async () => PAYLOAD_TRIATHLETE);
+
+    // Act
+    await syncZones(PROFILE_ID, transport, repo);
+
+    // Assert — Z4 lower 4:44 (slower) → maxPace 284s; upper 4:10 (faster) → minPace 250s
+    const persisted = await repo.getById(PROFILE_ID);
+    const z4 = persisted?.sportZones.running?.paceZones?.zones[3];
+    expect(z4?.minPace).toBe(250);
+    expect(z4?.maxPace).toBe(284);
+    expect(z4?.unit).toBe("min_per_km");
+    expect(z4!.minPace).toBeLessThanOrEqual(z4!.maxPace);
+  });
+});
+
+describe("syncZones full-bands — re-sync stability (round-trip)", () => {
+  it("should produce zero conflicts when re-syncing identical T2G data (4.7r/4.7s)", async () => {
+    // Arrange
+    const repo = createInMemoryProfileRepository();
+    await repo.put(makeProfile());
+    const transport = makeTransport(async () => PAYLOAD_TRIATHLETE);
+    // First sync — silent-fills the empty profile.
+    await syncZones(PROFILE_ID, transport, repo);
+
+    // Act — second sync against identical data.
+    const result = await syncZones(PROFILE_ID, transport, repo);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.applied).toEqual([]);
+    expect(result.conflicts).toEqual([]);
+  });
+});
+
+describe("syncZones full-bands — bpmRest flow-through-but-not-persisted", () => {
+  it("should NOT add a restingHeartRate field after sync even when bpmRest is in the payload (4.7p)", async () => {
+    // Arrange
+    const repo = createInMemoryProfileRepository();
+    await repo.put(makeProfile());
+    const transport = makeTransport(async () => PAYLOAD_TRIATHLETE);
+
+    // Act
+    await syncZones(PROFILE_ID, transport, repo);
+
+    // Assert
+    const persisted = await repo.getById(PROFILE_ID);
+    expect(persisted).toBeDefined();
+    if (!persisted) return;
+    const allKeys = collectKeys(persisted);
+    expect(allKeys.has("restingHeartRate")).toBe(false);
+    expect(allKeys.has("bpmRest")).toBe(false);
+    expect(allKeys.has("bpm_rest")).toBe(false);
+  });
+});
+
+describe("syncZones full-bands — power-zone count mismatch", () => {
+  it("should write a 5-element array (NOT 7) replacing Kaiord defaults (4.7q)", async () => {
+    // Arrange
+    const repo = createInMemoryProfileRepository();
+    await repo.put(makeProfile());
+    const transport = makeTransport(async () => PAYLOAD_TRIATHLETE);
+
+    // Act
+    await syncZones(PROFILE_ID, transport, repo);
+
+    // Assert
+    const persisted = await repo.getById(PROFILE_ID);
+    const zones = persisted?.sportZones.cycling?.powerZones?.zones;
+    expect(zones?.length).toBe(5);
+  });
+});
+
+describe("commitConflictResolution full-bands — band-level merge", () => {
+  it("should accept Z4 maxBpm and reject Z2 maxBpm — merged array reflects both decisions (4.7l)", async () => {
+    // Arrange
+    const repo = createInMemoryProfileRepository();
+    // Pre-sync profile with HR Z2 different (will produce a conflict).
+    await repo.put(
+      makeProfile({
+        sportZones: {
+          cycling: {
+            thresholds: {},
+            heartRateZones: {
+              method: "manual",
+              zones: [
+                { zone: 1, name: "Recovery", minBpm: 107, maxBpm: 133 },
+                { zone: 2, name: "Aerobic", minBpm: 131, maxBpm: 145 },
+                { zone: 3, name: "Tempo", minBpm: 148, maxBpm: 160 },
+                { zone: 4, name: "Threshold", minBpm: 161, maxBpm: 170 },
+                { zone: 5, name: "VO2 Max", minBpm: 175, maxBpm: 187 },
+              ],
+            },
+          },
+        },
+      })
+    );
+
+    // Act — accept Z4 maxBpm (170 → 174), reject Z2 maxBpm (145 → 147)
+    const decisions = {
+      "cycling.heartRateZones.z4.maxBpm": "accept",
+      "cycling.heartRateZones.z2.maxBpm": "reject",
+    } as Record<FieldKey, ConflictDecision>;
+    await commitConflictResolution(
+      PROFILE_ID,
+      decisions,
+      repo,
+      PAYLOAD_TRIATHLETE
+    );
+
+    // Assert
+    const persisted = await repo.getById(PROFILE_ID);
+    const zones = persisted?.sportZones.cycling?.heartRateZones.zones;
+    expect(zones?.[3].maxBpm).toBe(174); // accepted
+    expect(zones?.[1].maxBpm).toBe(145); // rejected — pre-sync value
+  });
+});
+
+describe("mapPayloadToIncoming — direct unit tests for the band paths", () => {
+  it("should NOT include any band-level entry derived from payload.physiological.bpmRest (D-FB8)", () => {
+    // Arrange
+    const payload: ZonesPayload = {
+      physiological: { bpmRest: 51 },
+    };
+
+    // Act
+    const map = mapPayloadToIncoming(payload);
+
+    // Assert — bpmRest must not flow into the IncomingMap.
+    for (const key of map.keys()) {
+      expect(key.toLowerCase()).not.toContain("rest");
+    }
+  });
+
+  it("should emit Z1-Z5 minBpm/maxBpm entries for each sport when Generic is the only HR source", () => {
+    // Arrange
+    const payload: ZonesPayload = {
+      hrZones: { generic: HR_GENERIC_BANDS },
+    };
+
+    // Act
+    const map = mapPayloadToIncoming(payload);
+
+    // Assert
+    expect(map.get("cycling.heartRateZones.z1.minBpm")).toBe(107);
+    expect(map.get("cycling.heartRateZones.z5.maxBpm")).toBe(187);
+    expect(map.get("running.heartRateZones.z3.minBpm")).toBe(148);
+    expect(map.get("swimming.heartRateZones.z4.maxBpm")).toBe(174);
+  });
+
+  it("should compute power-band percentages exactly (no tolerance) using T2G's z4Upper as divisor", () => {
+    // Arrange
+    const payload: ZonesPayload = {
+      paces: {
+        cycling: { ...POWER_BANDS, z4Upper: 268 },
+      },
+    };
+
+    // Act
+    const map = mapPayloadToIncoming(payload);
+
+    // Assert
+    expect(map.get("cycling.powerZones.z1.minPercent")).toBe(41);
+    expect(map.get("cycling.powerZones.z4.maxPercent")).toBe(100);
+  });
+});
+
+const collectKeys = (node: unknown, acc: Set<string> = new Set()): Set<string> => {
+  if (node === null || typeof node !== "object") return acc;
+  if (Array.isArray(node)) {
+    for (const child of node) collectKeys(child, acc);
+    return acc;
+  }
+  for (const key of Object.keys(node as Record<string, unknown>)) {
+    acc.add(key);
+    collectKeys((node as Record<string, unknown>)[key], acc);
+  }
+  return acc;
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-bands.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-bands.test.ts
@@ -123,16 +123,22 @@ describe("syncZones full-bands — HR fallback chain", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     const persisted = await repo.getById(PROFILE_ID);
-    expect(persisted?.sportZones.cycling?.heartRateZones.zones[3]).toMatchObject({
+    expect(
+      persisted?.sportZones.cycling?.heartRateZones.zones[3]
+    ).toMatchObject({
       minBpm: 161,
       maxBpm: 174,
     });
-    expect(persisted?.sportZones.running?.heartRateZones.zones[3]).toMatchObject({
+    expect(
+      persisted?.sportZones.running?.heartRateZones.zones[3]
+    ).toMatchObject({
       minBpm: 158,
       maxBpm: 168,
     });
     // Swimming has no Specific block → falls back to Generic.
-    expect(persisted?.sportZones.swimming?.heartRateZones.zones[3]).toMatchObject({
+    expect(
+      persisted?.sportZones.swimming?.heartRateZones.zones[3]
+    ).toMatchObject({
       minBpm: 161,
       maxBpm: 174,
     });
@@ -374,7 +380,10 @@ describe("mapPayloadToIncoming — direct unit tests for the band paths", () => 
   });
 });
 
-const collectKeys = (node: unknown, acc: Set<string> = new Set()): Set<string> => {
+const collectKeys = (
+  node: unknown,
+  acc: Set<string> = new Set()
+): Set<string> => {
   if (node === null || typeof node !== "object") return acc;
   if (Array.isArray(node)) {
     for (const child of node) collectKeys(child, acc);

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-helpers.ts
@@ -46,10 +46,7 @@ const isTableEmpty = (
   return false;
 };
 
-const isBandKeyInEmptyTable = (
-  profile: Profile,
-  field: FieldKey
-): boolean => {
+const isBandKeyInEmptyTable = (profile: Profile, field: FieldKey): boolean => {
   const slot = tableSlotKey(field);
   if (!slot) return false;
   const [sport, kind] = slot.split(".") as [

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-helpers.ts
@@ -5,12 +5,59 @@
  * fresh profile with silent fills already applied; conflicts are NOT
  * written here — the caller (`syncZones`) returns them to the UI for
  * per-row confirmation.
+ *
+ * For band-level FieldKeys (`<sport>.<kind>.zN.<bound>`), reconcile
+ * operates at TABLE granularity for empty-detection: when the
+ * persisted sport-kind table is empty (zones array missing OR
+ * length === 0), ALL bands of that table are silent-fills regardless
+ * of incoming values. Once the table has data, per-band comparisons
+ * apply (conflicts on differing values, no-op on matching).
  */
 import type { ZonesReconciliation } from "../../types/coaching-zones";
-import type { ConflictItem, WrittenField } from "../../types/coaching-zones";
+import type {
+  ConflictItem,
+  FieldKey,
+  WrittenField,
+} from "../../types/coaching-zones";
 import type { Profile } from "../../types/profile";
 import type { IncomingMap } from "./sync-zones-payload-mapper";
 import { readField, writeField } from "./sync-zones-profile-fields";
+
+const BAND_KEY_RE =
+  /^(cycling|running|swimming)\.(heartRateZones|powerZones|paceZones)\.z[1-5]\.(minBpm|maxBpm|minPercent|maxPercent|minPace|maxPace)$/;
+
+const tableSlotKey = (field: FieldKey): string | null => {
+  const m = BAND_KEY_RE.exec(field);
+  return m ? `${m[1]}.${m[2]}` : null;
+};
+
+const isTableEmpty = (
+  profile: Profile,
+  sport: "cycling" | "running" | "swimming",
+  kind: "heartRateZones" | "powerZones" | "paceZones"
+): boolean => {
+  const sportConfig = profile.sportZones[sport];
+  if (!sportConfig) return true;
+  const config = (sportConfig as Record<string, unknown>)[kind] as
+    | { zones?: unknown[] }
+    | undefined;
+  if (!config) return true;
+  if (!Array.isArray(config.zones) || config.zones.length === 0) return true;
+  return false;
+};
+
+const isBandKeyInEmptyTable = (
+  profile: Profile,
+  field: FieldKey
+): boolean => {
+  const slot = tableSlotKey(field);
+  if (!slot) return false;
+  const [sport, kind] = slot.split(".") as [
+    "cycling" | "running" | "swimming",
+    "heartRateZones" | "powerZones" | "paceZones",
+  ];
+  return isTableEmpty(profile, sport, kind);
+};
 
 export const reconcile = (
   profile: Profile,
@@ -20,6 +67,16 @@ export const reconcile = (
   const conflicts: ConflictItem[] = [];
   let next = profile;
   for (const [field, value] of incoming) {
+    // For band-level keys, "empty table" is silent-fill regardless of
+    // any seeded zero defaults that writeField may have introduced.
+    // Snapshot the empty state against the ORIGINAL profile (before
+    // any writes from this reconcile pass) so the first band-write
+    // doesn't flip the table's empty-status mid-pass.
+    if (isBandKeyInEmptyTable(profile, field)) {
+      next = writeField(next, field, value);
+      applied.push({ field, value });
+      continue;
+    }
     const current = readField(next, field);
     if (current === undefined) {
       next = writeField(next, field, value);

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-payload-mapper.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-payload-mapper.ts
@@ -1,24 +1,26 @@
 /**
  * `ZonesPayload` (raw bridge shape) → Kaiord-domain `IncomingMap`.
  *
- * Mapping conventions are fixed by design D5/D6:
- *   - cycling FTP: z4Upper wins; z5Lower fallback only when z4Upper is
- *     absent OR === 0 (semantically "not set" for a watt threshold).
- *   - per-sport LTHR: 1:1 from `hrZones.<sport>.z4Upper`.
- *   - running/swimming threshold pace: minutes:seconds → integer seconds.
- *   - bodyWeight + maxHeartRate: from the `physiological` block ONLY
- *     (the ping payload's weight/bpm_max is NOT consulted by zones-sync).
+ * Per design D5/D6 (threshold scalars) and D-FB1/D-FB6/D-FB7 (full
+ * band tables). Per-sport HR fallback chain is implemented here;
+ * watts→%FTP and pace inversion live in `sync-zones-band-mappers.ts`.
  */
-import type { FieldKey, ZonesPayload } from "../../types/coaching-zones";
+import type { HrBandBlock, ZonesPayload } from "../../types/coaching-zones";
+import type { IncomingMap } from "./sync-zones-band-mappers";
+import {
+  setCyclingPowerBands,
+  setHrBands,
+  setPaceBands,
+} from "./sync-zones-band-mappers";
 
-export type IncomingMap = Map<FieldKey, number>;
+export type { IncomingMap } from "./sync-zones-band-mappers";
 
 const minSecToSeconds = (ms: { min: number; sec: number }): number =>
   ms.min * 60 + ms.sec;
 
 const setIfPositive = (
   map: IncomingMap,
-  key: FieldKey,
+  key: Parameters<IncomingMap["set"]>[0],
   value: number | undefined
 ): void => {
   if (typeof value === "number" && Number.isFinite(value) && value > 0) {
@@ -36,8 +38,21 @@ const pickFtp = (
   return cycling.z5Lower;
 };
 
-export const mapPayloadToIncoming = (payload: ZonesPayload): IncomingMap => {
-  const out: IncomingMap = new Map();
+const hasAnyBand = (block: HrBandBlock | undefined): boolean =>
+  Boolean(block && (block.z1 || block.z2 || block.z3 || block.z4 || block.z5));
+
+const resolveHrBands = (
+  payload: ZonesPayload,
+  sport: "cycling" | "running" | "swimming"
+): HrBandBlock | undefined => {
+  const specific = payload.hrZones?.[sport];
+  if (hasAnyBand(specific)) return specific;
+  const generic = payload.hrZones?.generic;
+  if (hasAnyBand(generic)) return generic;
+  return undefined;
+};
+
+const setThresholdScalars = (out: IncomingMap, payload: ZonesPayload): void => {
   setIfPositive(out, "bodyWeight", payload.physiological?.weight);
   setIfPositive(out, "heartRate.max", payload.physiological?.bpmMax);
   setIfPositive(out, "cycling.thresholds.ftp", pickFtp(payload.paces?.cycling));
@@ -59,5 +74,20 @@ export const mapPayloadToIncoming = (payload: ZonesPayload): IncomingMap => {
   if (swimZ4) {
     out.set("swimming.thresholds.cssPaceSecPer100m", minSecToSeconds(swimZ4));
   }
+};
+
+const setBandEntries = (out: IncomingMap, payload: ZonesPayload): void => {
+  for (const sport of ["cycling", "running", "swimming"] as const) {
+    setHrBands(out, sport, resolveHrBands(payload, sport));
+  }
+  setCyclingPowerBands(out, payload.paces?.cycling);
+  setPaceBands(out, "running", payload.paces?.running);
+  setPaceBands(out, "swimming", payload.paces?.swimming);
+};
+
+export const mapPayloadToIncoming = (payload: ZonesPayload): IncomingMap => {
+  const out: IncomingMap = new Map();
+  setThresholdScalars(out, payload);
+  setBandEntries(out, payload);
   return out;
 };

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-profile-fields.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-profile-fields.ts
@@ -1,53 +1,59 @@
 /**
- * `FieldKey` ↔ `Profile` field accessors.
- *
- * `FieldKey` is the logical contract used by the use case + UI; the
- * actual storage paths are an implementation detail. These helpers
- * encapsulate that mapping so adding a new `FieldKey` is a single-file
- * change (here + the union in `coaching-zones.ts`).
+ * `FieldKey` ↔ `Profile` field accessors. Routes to threshold-scalar
+ * helpers (`sync-zones-threshold-fields.ts`) or band-level helpers
+ * (`sync-zones-band-fields.ts`/`sync-zones-band-writes.ts`) based on
+ * the FieldKey shape.
  */
-import type { FieldKey } from "../../types/coaching-zones";
+import type { FieldKey, ThresholdFieldKey } from "../../types/coaching-zones";
 import type { Profile } from "../../types/profile";
+import {
+  readHrBand,
+  readPaceBand,
+  readPowerBand,
+} from "./sync-zones-band-fields";
+import type { ParsedBandKey } from "./sync-zones-band-key";
+import { parseBandKey } from "./sync-zones-band-key";
+import {
+  writeHrBand,
+  writePaceBand,
+  writePowerBand,
+} from "./sync-zones-band-writes";
+import { readThreshold, writeThreshold } from "./sync-zones-threshold-fields";
+
+const readBandField = (
+  profile: Profile,
+  parsed: NonNullable<ParsedBandKey>
+): number | undefined => {
+  if (parsed.kind === "hr") {
+    return readHrBand(profile, parsed.sport, parsed.band, parsed.bound);
+  }
+  if (parsed.kind === "power") {
+    return readPowerBand(profile, parsed.band, parsed.bound);
+  }
+  return readPaceBand(profile, parsed.sport, parsed.band, parsed.bound);
+};
+
+const writeBandField = (
+  profile: Profile,
+  parsed: NonNullable<ParsedBandKey>,
+  value: number
+): Profile => {
+  if (parsed.kind === "hr") {
+    return writeHrBand(profile, parsed.sport, parsed.band, parsed.bound, value);
+  }
+  if (parsed.kind === "power") {
+    return writePowerBand(profile, parsed.band, parsed.bound, value);
+  }
+  return writePaceBand(profile, parsed.sport, parsed.band, parsed.bound, value);
+};
 
 export const readField = (
   profile: Profile,
   field: FieldKey
 ): number | undefined => {
-  switch (field) {
-    case "bodyWeight":
-      return profile.bodyWeight;
-    case "heartRate.max":
-      return profile.maxHeartRate;
-    case "cycling.thresholds.ftp":
-      return profile.sportZones.cycling?.thresholds.ftp;
-    case "cycling.thresholds.lthr":
-      return profile.sportZones.cycling?.thresholds.lthr;
-    case "running.thresholds.lthr":
-      return profile.sportZones.running?.thresholds.lthr;
-    case "running.thresholds.thresholdPaceSecPerKm":
-      return profile.sportZones.running?.thresholds.thresholdPace;
-    case "swimming.thresholds.cssPaceSecPer100m":
-      return profile.sportZones.swimming?.thresholds.thresholdPace;
-  }
-};
-
-const setSportThreshold = (
-  profile: Profile,
-  sport: "cycling" | "running" | "swimming",
-  patch: { ftp?: number; lthr?: number; thresholdPace?: number }
-): Profile => {
-  const existing = profile.sportZones[sport];
-  const thresholds = { ...(existing?.thresholds ?? {}), ...patch };
-  const sportConfig = existing
-    ? { ...existing, thresholds }
-    : {
-        thresholds,
-        heartRateZones: { method: "manual", zones: [] },
-      };
-  return {
-    ...profile,
-    sportZones: { ...profile.sportZones, [sport]: sportConfig },
-  };
+  const parsed = parseBandKey(field);
+  if (parsed) return readBandField(profile, parsed);
+  return readThreshold(profile, field as ThresholdFieldKey);
 };
 
 export const writeField = (
@@ -55,20 +61,7 @@ export const writeField = (
   field: FieldKey,
   value: number
 ): Profile => {
-  switch (field) {
-    case "bodyWeight":
-      return { ...profile, bodyWeight: value };
-    case "heartRate.max":
-      return { ...profile, maxHeartRate: value };
-    case "cycling.thresholds.ftp":
-      return setSportThreshold(profile, "cycling", { ftp: value });
-    case "cycling.thresholds.lthr":
-      return setSportThreshold(profile, "cycling", { lthr: value });
-    case "running.thresholds.lthr":
-      return setSportThreshold(profile, "running", { lthr: value });
-    case "running.thresholds.thresholdPaceSecPerKm":
-      return setSportThreshold(profile, "running", { thresholdPace: value });
-    case "swimming.thresholds.cssPaceSecPer100m":
-      return setSportThreshold(profile, "swimming", { thresholdPace: value });
-  }
+  const parsed = parseBandKey(field);
+  if (parsed) return writeBandField(profile, parsed, value);
+  return writeThreshold(profile, field as ThresholdFieldKey, value);
 };

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-threshold-fields.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-threshold-fields.ts
@@ -1,0 +1,68 @@
+/**
+ * Threshold-scalar FieldKey accessors (the legacy 7 keys). Band-level
+ * keys are handled separately in `sync-zones-band-fields.ts` /
+ * `sync-zones-band-writes.ts`.
+ */
+import type { ThresholdFieldKey } from "../../types/coaching-zones";
+import type { Profile } from "../../types/profile";
+
+export const readThreshold = (
+  profile: Profile,
+  field: ThresholdFieldKey
+): number | undefined => {
+  switch (field) {
+    case "bodyWeight":
+      return profile.bodyWeight;
+    case "heartRate.max":
+      return profile.maxHeartRate;
+    case "cycling.thresholds.ftp":
+      return profile.sportZones.cycling?.thresholds.ftp;
+    case "cycling.thresholds.lthr":
+      return profile.sportZones.cycling?.thresholds.lthr;
+    case "running.thresholds.lthr":
+      return profile.sportZones.running?.thresholds.lthr;
+    case "running.thresholds.thresholdPaceSecPerKm":
+      return profile.sportZones.running?.thresholds.thresholdPace;
+    case "swimming.thresholds.cssPaceSecPer100m":
+      return profile.sportZones.swimming?.thresholds.thresholdPace;
+  }
+};
+
+const setSportThreshold = (
+  profile: Profile,
+  sport: "cycling" | "running" | "swimming",
+  patch: { ftp?: number; lthr?: number; thresholdPace?: number }
+): Profile => {
+  const existing = profile.sportZones[sport];
+  const thresholds = { ...(existing?.thresholds ?? {}), ...patch };
+  const sportConfig = existing
+    ? { ...existing, thresholds }
+    : { thresholds, heartRateZones: { method: "manual", zones: [] } };
+  return {
+    ...profile,
+    sportZones: { ...profile.sportZones, [sport]: sportConfig },
+  };
+};
+
+export const writeThreshold = (
+  profile: Profile,
+  field: ThresholdFieldKey,
+  value: number
+): Profile => {
+  switch (field) {
+    case "bodyWeight":
+      return { ...profile, bodyWeight: value };
+    case "heartRate.max":
+      return { ...profile, maxHeartRate: value };
+    case "cycling.thresholds.ftp":
+      return setSportThreshold(profile, "cycling", { ftp: value });
+    case "cycling.thresholds.lthr":
+      return setSportThreshold(profile, "cycling", { lthr: value });
+    case "running.thresholds.lthr":
+      return setSportThreshold(profile, "running", { lthr: value });
+    case "running.thresholds.thresholdPaceSecPerKm":
+      return setSportThreshold(profile, "running", { thresholdPace: value });
+    case "swimming.thresholds.cssPaceSecPer100m":
+      return setSportThreshold(profile, "swimming", { thresholdPace: value });
+  }
+};

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/field-labels-bands.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/field-labels-bands.ts
@@ -1,0 +1,82 @@
+/**
+ * Band-level FieldKey label and unit cross-products. Generated at
+ * module-load time from a small set of hardcoded label parts; never
+ * interpolates an external string. PR 3 will polish the label format.
+ */
+import type { BandFieldKey } from "../../../types/coaching-zones";
+
+const SPORT_LABEL = {
+  cycling: "Cycling",
+  running: "Running",
+  swimming: "Swimming",
+} as const;
+
+const KIND_LABEL = {
+  heartRateZones: "HR",
+  powerZones: "Power",
+  paceZones: "Pace",
+} as const;
+
+const BOUND_LABEL = {
+  minBpm: "min",
+  maxBpm: "max",
+  minPercent: "min",
+  maxPercent: "max",
+  minPace: "min",
+  maxPace: "max",
+} as const;
+
+const SPORTS = ["cycling", "running", "swimming"] as const;
+const BANDS = ["z1", "z2", "z3", "z4", "z5"] as const;
+
+const buildLabel = (field: BandFieldKey): string => {
+  const [sport, kind, band, bound] = field.split(".") as [
+    keyof typeof SPORT_LABEL,
+    keyof typeof KIND_LABEL,
+    `z${1 | 2 | 3 | 4 | 5}`,
+    keyof typeof BOUND_LABEL,
+  ];
+  return `${SPORT_LABEL[sport]} ${KIND_LABEL[kind]} ${band.toUpperCase()} ${BOUND_LABEL[bound]}`;
+};
+
+export const buildBandLabels = (): Record<BandFieldKey, string> => {
+  const out: Partial<Record<BandFieldKey, string>> = {};
+  for (const band of BANDS) {
+    for (const sport of SPORTS) {
+      const minHr = `${sport}.heartRateZones.${band}.minBpm` as BandFieldKey;
+      const maxHr = `${sport}.heartRateZones.${band}.maxBpm` as BandFieldKey;
+      out[minHr] = buildLabel(minHr);
+      out[maxHr] = buildLabel(maxHr);
+    }
+    out[`cycling.powerZones.${band}.minPercent`] = buildLabel(
+      `cycling.powerZones.${band}.minPercent` as BandFieldKey
+    );
+    out[`cycling.powerZones.${band}.maxPercent`] = buildLabel(
+      `cycling.powerZones.${band}.maxPercent` as BandFieldKey
+    );
+    for (const sport of ["running", "swimming"] as const) {
+      const minPc = `${sport}.paceZones.${band}.minPace` as BandFieldKey;
+      const maxPc = `${sport}.paceZones.${band}.maxPace` as BandFieldKey;
+      out[minPc] = buildLabel(minPc);
+      out[maxPc] = buildLabel(maxPc);
+    }
+  }
+  return out as Record<BandFieldKey, string>;
+};
+
+export const buildBandUnits = (): Record<BandFieldKey, string> => {
+  const out: Partial<Record<BandFieldKey, string>> = {};
+  for (const band of BANDS) {
+    for (const sport of SPORTS) {
+      out[`${sport}.heartRateZones.${band}.minBpm`] = "bpm";
+      out[`${sport}.heartRateZones.${band}.maxBpm`] = "bpm";
+    }
+    out[`cycling.powerZones.${band}.minPercent`] = "% FTP";
+    out[`cycling.powerZones.${band}.maxPercent`] = "% FTP";
+    out[`running.paceZones.${band}.minPace`] = "/km";
+    out[`running.paceZones.${band}.maxPace`] = "/km";
+    out[`swimming.paceZones.${band}.minPace`] = "/100m";
+    out[`swimming.paceZones.${band}.maxPace`] = "/100m";
+  }
+  return out as Record<BandFieldKey, string>;
+};

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/field-labels.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/field-labels.ts
@@ -4,9 +4,12 @@
  * The conflict dialog renders these as React children (auto-escaped),
  * NEVER from any T2G-controlled string. This is the load-bearing line
  * that keeps `dangerouslySetInnerHTML` unnecessary in the dialog —
- * never widen a label by interpolating an external value.
+ * never widen a label by interpolating an external value. Band-level
+ * entries are generated at module-load time via
+ * `field-labels-bands.ts`; every string literal there is hardcoded.
  */
 import type { FieldKey } from "../../../types/coaching-zones";
+import { buildBandLabels, buildBandUnits } from "./field-labels-bands";
 
 export const FIELD_LABELS: Record<FieldKey, string> = {
   "cycling.thresholds.ftp": "FTP",
@@ -16,6 +19,7 @@ export const FIELD_LABELS: Record<FieldKey, string> = {
   "swimming.thresholds.cssPaceSecPer100m": "Swimming CSS",
   "heartRate.max": "Max HR",
   bodyWeight: "Body weight",
+  ...buildBandLabels(),
 };
 
 const PACE_FIELDS: ReadonlySet<FieldKey> = new Set([
@@ -37,9 +41,14 @@ const UNITS: Record<FieldKey, string> = {
   "swimming.thresholds.cssPaceSecPer100m": "/100m",
   "heartRate.max": "bpm",
   bodyWeight: "kg",
+  ...buildBandUnits(),
 };
+
+const PACE_BAND_RE =
+  /^(running|swimming)\.paceZones\.z[1-5]\.(minPace|maxPace)$/;
 
 export const formatFieldValue = (field: FieldKey, value: number): string => {
   if (PACE_FIELDS.has(field)) return formatPace(value, UNITS[field]);
+  if (PACE_BAND_RE.test(field)) return formatPace(value, UNITS[field]);
   return `${value} ${UNITS[field]}`.trim();
 };

--- a/packages/workout-spa-editor/src/types/coaching-zones-schema.ts
+++ b/packages/workout-spa-editor/src/types/coaching-zones-schema.ts
@@ -1,0 +1,75 @@
+/**
+ * Zod schema for `ZonesPayload` — validated bridge output. Kept
+ * separate from `coaching-zones.ts` (which holds the TS types).
+ */
+import { z } from "zod";
+
+const minSec = z.object({
+  min: z.number().int().min(0),
+  sec: z.number().int().min(0).max(59),
+});
+
+const wattsBand = z.object({
+  lower: z.number().int().nonnegative(),
+  upper: z.number().int().nonnegative(),
+});
+
+const paceBand = z.object({ lower: minSec, upper: minSec });
+
+const bpmBand = z.object({
+  lower: z.number().int().nonnegative().max(250),
+  upper: z.number().int().nonnegative().max(250),
+});
+
+const fiveBands = <T extends z.ZodTypeAny>(band: T) =>
+  z.object({
+    z1: band.optional(),
+    z2: band.optional(),
+    z3: band.optional(),
+    z4: band.optional(),
+    z5: band.optional(),
+  });
+
+const physiologicalSchema = z
+  .object({
+    weight: z.number().positive().optional(),
+    bpmMax: z.number().int().positive().max(250).optional(),
+    bpmRest: z.number().int().positive().max(250).optional(),
+  })
+  .optional();
+
+const cyclingPacesSchema = fiveBands(wattsBand)
+  .extend({
+    z4Upper: z.number().int().nonnegative().optional(),
+    z5Lower: z.number().int().nonnegative().optional(),
+  })
+  .optional();
+
+const runSwimPacesSchema = fiveBands(paceBand)
+  .extend({ z4Upper: minSec.optional() })
+  .optional();
+
+const hrSportSchema = fiveBands(bpmBand)
+  .extend({ z4Upper: z.number().int().positive().max(250).optional() })
+  .optional();
+
+const hrGenericSchema = fiveBands(bpmBand).optional();
+
+export const zonesPayloadSchema = z.object({
+  physiological: physiologicalSchema,
+  paces: z
+    .object({
+      cycling: cyclingPacesSchema,
+      running: runSwimPacesSchema,
+      swimming: runSwimPacesSchema,
+    })
+    .optional(),
+  hrZones: z
+    .object({
+      generic: hrGenericSchema,
+      cycling: hrSportSchema,
+      running: hrSportSchema,
+      swimming: hrSportSchema,
+    })
+    .optional(),
+});

--- a/packages/workout-spa-editor/src/types/coaching-zones.ts
+++ b/packages/workout-spa-editor/src/types/coaching-zones.ts
@@ -2,25 +2,29 @@
  * Coaching zones — types for the Train2Go zones-sync flow.
  *
  * Three name layers are intentional:
+ *   payload.* — raw bridge output (camelCase, 1-indexed).
+ *   incoming.* — Kaiord-shaped, post-mapper, pre-reconciliation.
+ *   profile.* — persisted Profile row in IDB.
  *
- *   payload.*   — raw bridge output (e.g., payload.paces.cycling.z4Upper).
- *                 Camelcase, 1-indexed zones. The `ZonesPayload` shape.
- *   incoming.*  — Kaiord-shaped, post-mapper, pre-reconciliation
- *                 (e.g., incoming.cycling.thresholds.ftp). Internal to
- *                 the syncZones use case.
- *   profile.*   — persisted Profile row in IDB (full Kaiord schema).
- *
- * `FieldKey` is a logical identifier the use case + UI use to label
- * conflicts and route writes; it is NOT the persisted-storage path.
+ * `FieldKey` is the logical identifier; storage paths live elsewhere.
+ * Two granularities (per D-FB5): threshold scalars + band-level keys.
  */
-import { z } from "zod";
+import type { z } from "zod";
 
-/**
- * Logical identifiers for zones-sync target fields. The UI's static
- * label map is keyed by these so T2G strings never reach React's
- * children — see `ZonesConflictDialog` (no `dangerouslySetInnerHTML`).
- */
-export type FieldKey =
+import type { zonesPayloadSchema } from "./coaching-zones-schema";
+
+export { zonesPayloadSchema } from "./coaching-zones-schema";
+
+type Sport = "cycling" | "running" | "swimming";
+type Band = "z1" | "z2" | "z3" | "z4" | "z5";
+
+type HrBoundKey = `${Sport}.heartRateZones.${Band}.${"minBpm" | "maxBpm"}`;
+type PowerBoundKey = `cycling.powerZones.${Band}.${"minPercent" | "maxPercent"}`;
+type PaceBoundKey = `${"running" | "swimming"}.paceZones.${Band}.${
+  | "minPace"
+  | "maxPace"}`;
+
+export type ThresholdFieldKey =
   | "cycling.thresholds.ftp"
   | "cycling.thresholds.lthr"
   | "running.thresholds.lthr"
@@ -29,10 +33,11 @@ export type FieldKey =
   | "heartRate.max"
   | "bodyWeight";
 
-export type WrittenField = {
-  field: FieldKey;
-  value: number;
-};
+export type BandFieldKey = HrBoundKey | PowerBoundKey | PaceBoundKey;
+
+export type FieldKey = ThresholdFieldKey | BandFieldKey;
+
+export type WrittenField = { field: FieldKey; value: number };
 
 export type ConflictItem = {
   field: FieldKey;
@@ -48,16 +53,14 @@ export type SyncZonesFailureReason =
   | "shape-mismatch"
   | "profile-deleted";
 
+export type ZonesPayload = z.infer<typeof zonesPayloadSchema>;
+export type HrBandBlock = NonNullable<ZonesPayload["hrZones"]>["cycling"];
+
 export type SyncZonesResult =
   | {
       ok: true;
       applied: WrittenField[];
       conflicts: ConflictItem[];
-      /**
-       * The validated bridge payload that produced this reconciliation.
-       * Returned so the UI can pass it back into
-       * `commitConflictResolution` without re-fetching.
-       */
       payload: ZonesPayload;
     }
   | { ok: false; reason: SyncZonesFailureReason; error?: string };
@@ -66,59 +69,3 @@ export type ZonesReconciliation = {
   applied: WrittenField[];
   conflicts: ConflictItem[];
 };
-
-const minSecSchema = z.object({
-  min: z.number().int().min(0),
-  sec: z.number().int().min(0).max(59),
-});
-
-const physiologicalSchema = z
-  .object({
-    weight: z.number().positive().optional(),
-    bpmMax: z.number().int().positive().max(250).optional(),
-  })
-  .optional();
-
-const cyclingPacesSchema = z
-  .object({
-    z4Upper: z.number().int().nonnegative().optional(),
-    z5Lower: z.number().int().nonnegative().optional(),
-  })
-  .optional();
-
-const runSwimPacesSchema = z
-  .object({
-    z4Upper: minSecSchema.optional(),
-  })
-  .optional();
-
-const hrSportSchema = z
-  .object({
-    z4Upper: z.number().int().positive().max(250).optional(),
-  })
-  .optional();
-
-/**
- * Raw-shape bridge output — the exact object `parseDetailsHtml` returns.
- * The mapper translates this to Kaiord-domain `incoming.*` shape inside
- * the syncZones use case. Keep this type aligned with the bridge parser
- * allowlist (see `packages/train2go-bridge/parser.js`).
- */
-export const zonesPayloadSchema = z.object({
-  physiological: physiologicalSchema,
-  paces: z
-    .object({
-      cycling: cyclingPacesSchema,
-      running: runSwimPacesSchema,
-      swimming: runSwimPacesSchema,
-    })
-    .optional(),
-  hrZones: z
-    .object({
-      cycling: hrSportSchema,
-      running: hrSportSchema,
-    })
-    .optional(),
-});
-
-export type ZonesPayload = z.infer<typeof zonesPayloadSchema>;

--- a/packages/workout-spa-editor/src/types/coaching-zones.ts
+++ b/packages/workout-spa-editor/src/types/coaching-zones.ts
@@ -19,7 +19,8 @@ type Sport = "cycling" | "running" | "swimming";
 type Band = "z1" | "z2" | "z3" | "z4" | "z5";
 
 type HrBoundKey = `${Sport}.heartRateZones.${Band}.${"minBpm" | "maxBpm"}`;
-type PowerBoundKey = `cycling.powerZones.${Band}.${"minPercent" | "maxPercent"}`;
+type PowerBoundKey =
+  `cycling.powerZones.${Band}.${"minPercent" | "maxPercent"}`;
 type PaceBoundKey = `${"running" | "swimming"}.paceZones.${Band}.${
   | "minPace"
   | "maxPace"}`;


### PR DESCRIPTION
PR 2 of 4 for **train2go-zones-sync-full-bands**. Consumes the new full-Z1-Z5-band payload shape from PR 1 (#495) and writes the persisted profile's HR / power / pace zone arrays.

## Behaviour

- HR fallback chain (D-FB1): Specific → Generic → skip per sport
- Cycling watts → %FTP (D-FB6): `Math.round(watts / payload.paces.cycling.z4Upper * 100)`
- Pace inversion (D-FB7): T2G upper (faster) → minPace; T2G lower (slower) → maxPace
- Power-zone count mismatch (D-FB3): T2G's 5 bands replace Kaiord's 7 defaults
- Per-band conflict policy: empty table → silent-fill; populated → conflicts; merge on accept
- bpmRest flow-through-but-not-persisted (D-FB8)

## Test plan

- [x] 3215 tests pass (+12 new in sync-zones-bands.test.ts)
- [x] Build + lint green
- [ ] CI green
- [ ] PR 3 (UI label-map polish + new e2e flows) follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded coaching zones configuration to support granular zone band management for heart rate, cycling power, and running/swimming pace.
  * Enhanced Train2Go synchronization with proper metric conversions and sport-specific zone fallback logic.
  * Improved zone conflict resolution to handle band-level zone entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->