### PR TITLE
feat(spa-editor): method-aware reconcile via 6-state classifier (PR 2/6)

### DIFF
--- a/.changeset/zones-method-aware-classifier-reconcile.md
+++ b/.changeset/zones-method-aware-classifier-reconcile.md
@@ -1,0 +1,27 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+Method-aware reconcile + classifier (PR 2 of 6 of `zones-method-aware-reconcile`).
+
+**Behaviour change:** the conflict dialog no longer surfaces 30+ pseudo-conflict rows on a freshly-created profile's first sync. Tables on the seed/template/method-derived path are silent-replaced; only genuinely user-customized tables produce per-band conflicts.
+
+**Changes:**
+
+- New `classifyZoneTable(profile, sport, kind, snapshot)` returns one of six canonical states (`empty`, `default-template`, `method-derived`, `train2go-synced-clean`, `train2go-synced-edited`, `user-customized`).
+- `reconcile` rewritten to use the classifier. Strategy per state (per design D-MA4):
+  - `empty` / `default-template` / `method-derived` / `train2go-synced-clean` → silent-replace; flip method to `"train2go"`; record snapshot.
+  - `train2go-synced-edited` → per-band conflict only for bands user touched since last sync (snapshot-diff).
+  - `user-customized` → per-band conflict for every disagreeing band.
+- `commitConflictResolution` now updates `method` and `lastSyncedZonesSnapshot` per D-MA4: all-accept → method `"train2go"`; mixed → method `"user"`; all-reject → unchanged. Snapshot reflects post-merge persisted zones (not raw T2G).
+- `sync-zones-band-writes.ts` and `sync-zones-threshold-fields.ts`: replaced fallback method `"manual"` with `"custom"` (the existing canonical vocabulary).
+
+**Files:**
+
+- New: `zone-table-classifier.ts`, `zone-table-classifier-types.ts`, `zone-table-classifier-detectors.ts`, `zone-table-classifier-state-helpers.ts`.
+- New: `sync-zones-band-table-reconcile.ts`, `sync-zones-band-strategies.ts`, `sync-zones-partition.ts`.
+- New: `sync-zones-snapshot.ts`, `sync-zones-snapshot-write.ts`.
+- New: `commit-conflict-band-tables.ts`, `commit-conflict-table-apply.ts`.
+- Modified: `sync-zones-helpers.ts`, `commit-conflict-resolution.ts`, `sync-zones.ts`, `sync-zones-band-writes.ts`, `sync-zones-threshold-fields.ts`.
+
+Test coverage: 18 new cases (13 classifier states + 5 method-aware end-to-end). Total 3257 tests pass (3239 → 3257).

--- a/packages/workout-spa-editor/src/application/coaching/commit-conflict-band-tables.ts
+++ b/packages/workout-spa-editor/src/application/coaching/commit-conflict-band-tables.ts
@@ -1,0 +1,46 @@
+/**
+ * Per-table band-decision application. For each `<sport>.<kind>` table:
+ *   - All bands `accept` → method := "train2go"; persist T2G values.
+ *   - Mixed accept/reject → method := "user"; persist merged values.
+ *   - All bands `reject` → method/zones untouched.
+ *
+ * Snapshot is updated by `updateSnapshot` to reflect the POST-MERGE
+ * persisted zones (per D-MA4): accepted bands take T2G; rejected bands
+ * keep pre-sync user values.
+ */
+import type {
+  ConflictDecision,
+  FieldKey,
+} from "../../types/coaching-zones";
+import type { Profile } from "../../types/profile";
+import { applyOneTable } from "./commit-conflict-table-apply";
+import { updateSnapshot } from "./sync-zones-snapshot-write";
+import type { Sport, ZoneKind } from "./zone-table-classifier-types";
+
+export const applyBandTableDecisions = (
+  profile: Profile,
+  bandTableKeys: Map<string, FieldKey[]>,
+  decisions: Record<FieldKey, ConflictDecision>,
+  incoming: Map<FieldKey, number>,
+  source: string
+): Profile => {
+  let next = profile;
+  const replacedTables: Array<{ sport: Sport; kind: ZoneKind }> = [];
+  for (const [slot, keys] of bandTableKeys) {
+    const [sport, kind] = slot.split(".") as [Sport, ZoneKind];
+    const result = applyOneTable(next, sport, kind, keys, decisions, incoming);
+    if (result.touched) {
+      next = result.profile;
+      replacedTables.push({ sport, kind });
+    }
+  }
+  if (replacedTables.length > 0) {
+    next = updateSnapshot(
+      next,
+      source,
+      replacedTables,
+      new Date().toISOString()
+    );
+  }
+  return next;
+};

--- a/packages/workout-spa-editor/src/application/coaching/commit-conflict-band-tables.ts
+++ b/packages/workout-spa-editor/src/application/coaching/commit-conflict-band-tables.ts
@@ -8,10 +8,7 @@
  * persisted zones (per D-MA4): accepted bands take T2G; rejected bands
  * keep pre-sync user values.
  */
-import type {
-  ConflictDecision,
-  FieldKey,
-} from "../../types/coaching-zones";
+import type { ConflictDecision, FieldKey } from "../../types/coaching-zones";
 import type { Profile } from "../../types/profile";
 import { applyOneTable } from "./commit-conflict-table-apply";
 import { updateSnapshot } from "./sync-zones-snapshot-write";

--- a/packages/workout-spa-editor/src/application/coaching/commit-conflict-resolution.ts
+++ b/packages/workout-spa-editor/src/application/coaching/commit-conflict-resolution.ts
@@ -76,7 +76,12 @@ export const commitConflictResolution = async (
   if (!profile) throw new ProfileNotFoundError(profileId);
   const incoming = mapPayloadToIncoming(transportPayload);
   const { thresholdKeys, bandTableKeys } = partitionDecisions(decisions);
-  let next = applyThresholdDecisions(profile, thresholdKeys, decisions, incoming);
+  let next = applyThresholdDecisions(
+    profile,
+    thresholdKeys,
+    decisions,
+    incoming
+  );
   next = applyBandTableDecisions(
     next,
     bandTableKeys,

--- a/packages/workout-spa-editor/src/application/coaching/commit-conflict-resolution.ts
+++ b/packages/workout-spa-editor/src/application/coaching/commit-conflict-resolution.ts
@@ -1,11 +1,15 @@
 /**
  * Phase-2 of the zones-sync flow: applies the user's per-row decisions
- * from the conflict dialog.
+ * from the conflict dialog. Updates `method` and snapshot per
+ * sport-kind table per design D-MA4 of zones-method-aware-reconcile:
+ *   - All-accept     → method = "train2go"; snapshot.<sportKind> := T2G's array.
+ *   - Mixed (partial accept) → method = "user"; snapshot.<sportKind> :=
+ *     post-merge persisted zones (accepted bands take T2G; rejected
+ *     bands keep pre-sync user value).
+ *   - All-reject     → method/snapshot untouched.
  *
  * Idempotent — calling twice with the same `decisions` produces the
- * same final state. `transportPayload` is the raw bridge payload from
- * the preceding `syncZones` call; the function re-derives the
- * incoming-value map so the UI doesn't have to remember it.
+ * same final state.
  */
 import type { ProfileRepository } from "../../ports/persistence-port";
 import type {
@@ -13,31 +17,74 @@ import type {
   FieldKey,
   ZonesPayload,
 } from "../../types/coaching-zones";
+import type { Profile } from "../../types/profile";
 import { ProfileNotFoundError } from "../profile/errors";
+import { applyBandTableDecisions } from "./commit-conflict-band-tables";
 import { mapPayloadToIncoming } from "./sync-zones-payload-mapper";
 import { writeField } from "./sync-zones-profile-fields";
+import { tableKeyOfField } from "./sync-zones-snapshot";
+
+const partitionDecisions = (
+  decisions: Record<FieldKey, ConflictDecision>
+): {
+  thresholdKeys: FieldKey[];
+  bandTableKeys: Map<string, FieldKey[]>;
+} => {
+  const thresholdKeys: FieldKey[] = [];
+  const bandTableKeys = new Map<string, FieldKey[]>();
+  for (const key of Object.keys(decisions) as FieldKey[]) {
+    const tk = tableKeyOfField(key);
+    if (!tk) {
+      thresholdKeys.push(key);
+      continue;
+    }
+    const slot = `${tk.sport}.${tk.kind}`;
+    let entry = bandTableKeys.get(slot);
+    if (!entry) {
+      entry = [];
+      bandTableKeys.set(slot, entry);
+    }
+    entry.push(key);
+  }
+  return { thresholdKeys, bandTableKeys };
+};
+
+const applyThresholdDecisions = (
+  profile: Profile,
+  thresholdKeys: FieldKey[],
+  decisions: Record<FieldKey, ConflictDecision>,
+  incoming: Map<FieldKey, number>
+): Profile => {
+  let next = profile;
+  for (const key of thresholdKeys) {
+    if (decisions[key] !== "accept") continue;
+    const value = incoming.get(key);
+    if (value === undefined) continue;
+    next = writeField(next, key, value);
+  }
+  return next;
+};
 
 export const commitConflictResolution = async (
   profileId: string,
   decisions: Record<FieldKey, ConflictDecision>,
   repo: ProfileRepository,
-  transportPayload: ZonesPayload
+  transportPayload: ZonesPayload,
+  source = "train2go"
 ): Promise<void> => {
   const profile = await repo.getById(profileId);
-  if (!profile) {
-    throw new ProfileNotFoundError(profileId);
-  }
+  if (!profile) throw new ProfileNotFoundError(profileId);
   const incoming = mapPayloadToIncoming(transportPayload);
-  let next = profile;
-  let touched = false;
-  for (const key of Object.keys(decisions) as FieldKey[]) {
-    if (decisions[key] !== "accept") continue;
-    const value = incoming.get(key);
-    if (value === undefined) continue;
-    next = writeField(next, key, value);
-    touched = true;
-  }
-  if (touched) {
+  const { thresholdKeys, bandTableKeys } = partitionDecisions(decisions);
+  let next = applyThresholdDecisions(profile, thresholdKeys, decisions, incoming);
+  next = applyBandTableDecisions(
+    next,
+    bandTableKeys,
+    decisions,
+    incoming,
+    source
+  );
+  if (next !== profile) {
     await repo.put({ ...next, updatedAt: new Date().toISOString() });
   }
 };

--- a/packages/workout-spa-editor/src/application/coaching/commit-conflict-table-apply.ts
+++ b/packages/workout-spa-editor/src/application/coaching/commit-conflict-table-apply.ts
@@ -3,10 +3,7 @@
  * table. All-accept → method "train2go"; mixed → "user"; all-reject →
  * untouched (per D-MA4 of zones-method-aware-reconcile).
  */
-import type {
-  ConflictDecision,
-  FieldKey,
-} from "../../types/coaching-zones";
+import type { ConflictDecision, FieldKey } from "../../types/coaching-zones";
 import type { Profile } from "../../types/profile";
 import { writeField } from "./sync-zones-profile-fields";
 import type { Sport, ZoneKind } from "./zone-table-classifier-types";

--- a/packages/workout-spa-editor/src/application/coaching/commit-conflict-table-apply.ts
+++ b/packages/workout-spa-editor/src/application/coaching/commit-conflict-table-apply.ts
@@ -1,0 +1,61 @@
+/**
+ * `applyOneTable` — applies user decisions for a single sport-kind
+ * table. All-accept → method "train2go"; mixed → "user"; all-reject →
+ * untouched (per D-MA4 of zones-method-aware-reconcile).
+ */
+import type {
+  ConflictDecision,
+  FieldKey,
+} from "../../types/coaching-zones";
+import type { Profile } from "../../types/profile";
+import { writeField } from "./sync-zones-profile-fields";
+import type { Sport, ZoneKind } from "./zone-table-classifier-types";
+
+const setTableMethod = (
+  profile: Profile,
+  sport: Sport,
+  kind: ZoneKind,
+  method: string
+): Profile => {
+  const sportConfig = profile.sportZones[sport];
+  if (!sportConfig) return profile;
+  const tc = (sportConfig as Record<string, unknown>)[kind] as
+    | { method?: string; zones?: unknown[] }
+    | undefined;
+  if (!tc) return profile;
+  return {
+    ...profile,
+    sportZones: {
+      ...profile.sportZones,
+      [sport]: { ...sportConfig, [kind]: { ...tc, method } },
+    },
+  };
+};
+
+export const applyOneTable = (
+  profile: Profile,
+  sport: Sport,
+  kind: ZoneKind,
+  keys: FieldKey[],
+  decisions: Record<FieldKey, ConflictDecision>,
+  incoming: Map<FieldKey, number>
+): { profile: Profile; touched: boolean } => {
+  let next = profile;
+  let acceptCount = 0;
+  let rejectCount = 0;
+  for (const key of keys) {
+    if (decisions[key] === "accept") {
+      const value = incoming.get(key);
+      if (value !== undefined) {
+        next = writeField(next, key, value);
+        acceptCount++;
+      }
+    } else if (decisions[key] === "reject") {
+      rejectCount++;
+    }
+  }
+  if (acceptCount === 0) return { profile: next, touched: false };
+  const method = rejectCount > 0 ? "user" : "train2go";
+  next = setTableMethod(next, sport, kind, method);
+  return { profile: next, touched: true };
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-strategies.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-strategies.ts
@@ -1,0 +1,88 @@
+/**
+ * Per-strategy band-table reconcile helpers. Co-located with
+ * `sync-zones-band-table-reconcile.ts` so the dispatcher stays under
+ * the 80-line file cap.
+ */
+import type {
+  ConflictItem,
+  FieldKey,
+  WrittenField,
+} from "../../types/coaching-zones";
+import type { Profile } from "../../types/profile";
+import { readField, writeField } from "./sync-zones-profile-fields";
+import type { Sport, ZoneKind } from "./zone-table-classifier-types";
+
+export const setTableMethodTrainTwoGo = (
+  profile: Profile,
+  sport: Sport,
+  kind: ZoneKind
+): Profile => {
+  const sportConfig = profile.sportZones[sport];
+  if (!sportConfig) return profile;
+  const tc = (sportConfig as Record<string, unknown>)[kind] as
+    | { method?: string; zones?: unknown[] }
+    | undefined;
+  if (!tc) return profile;
+  return {
+    ...profile,
+    sportZones: {
+      ...profile.sportZones,
+      [sport]: {
+        ...sportConfig,
+        [kind]: { ...tc, method: "train2go" },
+      },
+    },
+  };
+};
+
+/**
+ * Silent-replace a band-table; skip no-op writes (re-sync of unchanged
+ * data) but always flip method to "train2go".
+ */
+export const silentReplaceTable = (
+  profile: Profile,
+  sport: Sport,
+  kind: ZoneKind,
+  incoming: Map<FieldKey, number>
+): { profile: Profile; applied: WrittenField[] } => {
+  let next = profile;
+  const applied: WrittenField[] = [];
+  for (const [field, value] of incoming) {
+    if (readField(next, field) === value) continue;
+    next = writeField(next, field, value);
+    applied.push({ field, value });
+  }
+  next = setTableMethodTrainTwoGo(next, sport, kind);
+  return { profile: next, applied };
+};
+
+export const perBandConflicts = (
+  profile: Profile,
+  incoming: Map<FieldKey, number>
+): ConflictItem[] => {
+  const conflicts: ConflictItem[] = [];
+  for (const [field, value] of incoming) {
+    const current = readField(profile, field);
+    if (current !== undefined && current !== value) {
+      conflicts.push({ field, current, incoming: value });
+    }
+  }
+  return conflicts;
+};
+
+/** Snapshot-aware conflict emission: only bands where user edited since last sync. */
+export const snapshotEditedConflicts = (
+  profile: Profile,
+  incoming: Map<FieldKey, number>,
+  snapshotByField: Map<FieldKey, number>
+): ConflictItem[] => {
+  const conflicts: ConflictItem[] = [];
+  for (const [field, value] of incoming) {
+    const current = readField(profile, field);
+    const snap = snapshotByField.get(field);
+    if (current !== undefined && current !== value && current !== snap) {
+      conflicts.push({ field, current, incoming: value });
+    }
+  }
+  return conflicts;
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-table-reconcile.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-table-reconcile.ts
@@ -1,0 +1,51 @@
+/**
+ * `reconcileBandTable` — given a classified state + incoming bands,
+ * routes to the correct strategy. Strategy implementations live in
+ * `sync-zones-band-strategies.ts`.
+ */
+import type {
+  ConflictItem,
+  FieldKey,
+  WrittenField,
+} from "../../types/coaching-zones";
+import type { Profile } from "../../types/profile";
+import {
+  perBandConflicts,
+  silentReplaceTable,
+  snapshotEditedConflicts,
+} from "./sync-zones-band-strategies";
+import type {
+  Sport,
+  ZoneKind,
+  ZoneTableState,
+} from "./zone-table-classifier-types";
+
+export type BandTableReconcileResult = {
+  profile: Profile;
+  applied: WrittenField[];
+  conflicts: ConflictItem[];
+};
+
+export const reconcileBandTable = (
+  profile: Profile,
+  state: ZoneTableState,
+  sport: Sport,
+  kind: ZoneKind,
+  tableIncoming: Map<FieldKey, number>,
+  snapshotByField: Map<FieldKey, number> | undefined
+): BandTableReconcileResult => {
+  if (
+    state === "empty" ||
+    state === "default-template" ||
+    state === "method-derived" ||
+    state === "train2go-synced-clean"
+  ) {
+    const r = silentReplaceTable(profile, sport, kind, tableIncoming);
+    return { profile: r.profile, applied: r.applied, conflicts: [] };
+  }
+  const conflicts =
+    state === "train2go-synced-edited" && snapshotByField
+      ? snapshotEditedConflicts(profile, tableIncoming, snapshotByField)
+      : perBandConflicts(profile, tableIncoming);
+  return { profile, applied: [], conflicts };
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-band-writes.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-band-writes.ts
@@ -22,7 +22,7 @@ const mergeSport = (profile: Profile, sport: Sport, patch: object): Profile => {
   const existing = profile.sportZones[sport];
   const base = existing ?? {
     thresholds: {},
-    heartRateZones: { method: "manual", zones: [] },
+    heartRateZones: { method: "custom", zones: [] },
   };
   return {
     ...profile,
@@ -42,7 +42,7 @@ export const writeHrBand = (
   );
   if (bound === "minBpm") zones[BAND_INDEX[band]].minBpm = value;
   else zones[BAND_INDEX[band]].maxBpm = value;
-  const method = profile.sportZones[sport]?.heartRateZones?.method ?? "manual";
+  const method = profile.sportZones[sport]?.heartRateZones?.method ?? "custom";
   return mergeSport(profile, sport, { heartRateZones: { method, zones } });
 };
 
@@ -57,7 +57,7 @@ export const writePowerBand = (
   );
   if (bound === "minPercent") zones[BAND_INDEX[band]].minPercent = value;
   else zones[BAND_INDEX[band]].maxPercent = value;
-  const method = profile.sportZones.cycling?.powerZones?.method ?? "manual";
+  const method = profile.sportZones.cycling?.powerZones?.method ?? "custom";
   return mergeSport(profile, "cycling", { powerZones: { method, zones } });
 };
 
@@ -74,6 +74,6 @@ export const writePaceBand = (
   );
   if (bound === "minPace") zones[BAND_INDEX[band]].minPace = value;
   else zones[BAND_INDEX[band]].maxPace = value;
-  const method = profile.sportZones[sport]?.paceZones?.method ?? "manual";
+  const method = profile.sportZones[sport]?.paceZones?.method ?? "custom";
   return mergeSport(profile, sport, { paceZones: { method, zones } });
 };

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-helpers.ts
@@ -15,10 +15,7 @@ import type {
 } from "../../types/coaching-zones";
 import type { Profile } from "../../types/profile";
 import { reconcileBandTable } from "./sync-zones-band-table-reconcile";
-import {
-  partitionIncoming,
-  reconcileThresholds,
-} from "./sync-zones-partition";
+import { partitionIncoming, reconcileThresholds } from "./sync-zones-partition";
 import type { IncomingMap } from "./sync-zones-payload-mapper";
 import {
   getSnapshotZones,

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-helpers.ts
@@ -1,86 +1,73 @@
 /**
  * `reconcile` — splits an `IncomingMap` against the persisted profile
- * into silent fills (current value absent) vs. conflicts (current value
- * differs from incoming). No-op when current === incoming. Returns a
- * fresh profile with silent fills already applied; conflicts are NOT
- * written here — the caller (`syncZones`) returns them to the UI for
- * per-row confirmation.
+ * into silent-replaces (via classifier dispatch per D-MA1) vs.
+ * per-band conflicts (user-customized or train2go-synced-edited tables).
+ * Updates the linked-account snapshot atomically per D-MA2.
  *
- * For band-level FieldKeys (`<sport>.<kind>.zN.<bound>`), reconcile
- * operates at TABLE granularity for empty-detection: when the
- * persisted sport-kind table is empty (zones array missing OR
- * length === 0), ALL bands of that table are silent-fills regardless
- * of incoming values. Once the table has data, per-band comparisons
- * apply (conflicts on differing values, no-op on matching).
+ * Threshold scalars keep their per-key path (delegated to
+ * `reconcileThresholds`); only band-level FieldKeys go through the
+ * 6-state classifier.
  */
-import type { ZonesReconciliation } from "../../types/coaching-zones";
 import type {
   ConflictItem,
-  FieldKey,
   WrittenField,
+  ZonesReconciliation,
 } from "../../types/coaching-zones";
 import type { Profile } from "../../types/profile";
+import { reconcileBandTable } from "./sync-zones-band-table-reconcile";
+import {
+  partitionIncoming,
+  reconcileThresholds,
+} from "./sync-zones-partition";
 import type { IncomingMap } from "./sync-zones-payload-mapper";
-import { readField, writeField } from "./sync-zones-profile-fields";
-
-const BAND_KEY_RE =
-  /^(cycling|running|swimming)\.(heartRateZones|powerZones|paceZones)\.z[1-5]\.(minBpm|maxBpm|minPercent|maxPercent|minPace|maxPace)$/;
-
-const tableSlotKey = (field: FieldKey): string | null => {
-  const m = BAND_KEY_RE.exec(field);
-  return m ? `${m[1]}.${m[2]}` : null;
-};
-
-const isTableEmpty = (
-  profile: Profile,
-  sport: "cycling" | "running" | "swimming",
-  kind: "heartRateZones" | "powerZones" | "paceZones"
-): boolean => {
-  const sportConfig = profile.sportZones[sport];
-  if (!sportConfig) return true;
-  const config = (sportConfig as Record<string, unknown>)[kind] as
-    | { zones?: unknown[] }
-    | undefined;
-  if (!config) return true;
-  if (!Array.isArray(config.zones) || config.zones.length === 0) return true;
-  return false;
-};
-
-const isBandKeyInEmptyTable = (profile: Profile, field: FieldKey): boolean => {
-  const slot = tableSlotKey(field);
-  if (!slot) return false;
-  const [sport, kind] = slot.split(".") as [
-    "cycling" | "running" | "swimming",
-    "heartRateZones" | "powerZones" | "paceZones",
-  ];
-  return isTableEmpty(profile, sport, kind);
-};
+import {
+  getSnapshotZones,
+  snapshotZonesToFieldMap,
+} from "./sync-zones-snapshot";
+import { updateSnapshot } from "./sync-zones-snapshot-write";
+import { classifyZoneTable } from "./zone-table-classifier";
+import type { Sport, ZoneKind } from "./zone-table-classifier-types";
 
 export const reconcile = (
   profile: Profile,
-  incoming: IncomingMap
+  incoming: IncomingMap,
+  source: string
 ): { profile: Profile } & ZonesReconciliation => {
-  const applied: WrittenField[] = [];
-  const conflicts: ConflictItem[] = [];
-  let next = profile;
-  for (const [field, value] of incoming) {
-    // For band-level keys, "empty table" is silent-fill regardless of
-    // any seeded zero defaults that writeField may have introduced.
-    // Snapshot the empty state against the ORIGINAL profile (before
-    // any writes from this reconcile pass) so the first band-write
-    // doesn't flip the table's empty-status mid-pass.
-    if (isBandKeyInEmptyTable(profile, field)) {
-      next = writeField(next, field, value);
-      applied.push({ field, value });
-      continue;
-    }
-    const current = readField(next, field);
-    if (current === undefined) {
-      next = writeField(next, field, value);
-      applied.push({ field, value });
-    } else if (current !== value) {
-      conflicts.push({ field, current, incoming: value });
-    }
+  const account = profile.linkedAccounts.find((a) => a.source === source);
+  const snapshot = account?.lastSyncedZonesSnapshot;
+  const { thresholds, tables } = partitionIncoming(incoming);
+  const thrResult = reconcileThresholds(profile, thresholds);
+  let next = thrResult.profile;
+  const applied: WrittenField[] = [...thrResult.applied];
+  const conflicts: ConflictItem[] = [...thrResult.conflicts];
+  const replacedTables: Array<{ sport: Sport; kind: ZoneKind }> = [];
+  for (const [tk, tableIncoming] of tables) {
+    const [sport, kind] = tk.split(".") as [Sport, ZoneKind];
+    const state = classifyZoneTable(profile, sport, kind, snapshot);
+    const snapZones = getSnapshotZones(snapshot, sport, kind);
+    const snapshotByField = snapZones
+      ? snapshotZonesToFieldMap(snapZones, sport, kind)
+      : undefined;
+    const result = reconcileBandTable(
+      next,
+      state,
+      sport,
+      kind,
+      tableIncoming,
+      snapshotByField
+    );
+    next = result.profile;
+    applied.push(...result.applied);
+    conflicts.push(...result.conflicts);
+    if (result.applied.length > 0) replacedTables.push({ sport, kind });
+  }
+  if (replacedTables.length > 0) {
+    next = updateSnapshot(
+      next,
+      source,
+      replacedTables,
+      new Date().toISOString()
+    );
   }
   return { profile: next, applied, conflicts };
 };

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-method-aware.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-method-aware.test.ts
@@ -129,13 +129,11 @@ describe("syncZones method-aware — first-sync (3.4a)", () => {
       "train2go"
     );
     expect(persisted?.sportZones.cycling?.powerZones?.method).toBe("train2go");
-    expect(persisted?.sportZones.cycling?.heartRateZones?.zones[3]).toMatchObject(
-      { minBpm: 161, maxBpm: 174 }
-    );
-    // Snapshot established.
     expect(
-      persisted?.linkedAccounts[0]?.lastSyncedZonesSnapshot
-    ).toBeDefined();
+      persisted?.sportZones.cycling?.heartRateZones?.zones[3]
+    ).toMatchObject({ minBpm: 161, maxBpm: 174 });
+    // Snapshot established.
+    expect(persisted?.linkedAccounts[0]?.lastSyncedZonesSnapshot).toBeDefined();
   });
 });
 

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-method-aware.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-method-aware.test.ts
@@ -1,0 +1,321 @@
+/**
+ * `syncZones` + `commitConflictResolution` — method-aware end-to-end
+ * tests (per tasks §3.4 of zones-method-aware-reconcile). Companion to
+ * `sync-zones-bands.test.ts` (which covered the prior pre-classifier
+ * behavior).
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { createInMemoryProfileRepository } from "../../test-utils/in-memory-profile-repository";
+import type { LastSyncedZonesSnapshot } from "../../types/coaching-account";
+import type {
+  ConflictDecision,
+  FieldKey,
+  ZonesPayload,
+} from "../../types/coaching-zones";
+import type { Profile } from "../../types/profile";
+import { DEFAULT_HEART_RATE_ZONES } from "../../types/profile";
+import { calculatePowerZones } from "../../utils/calculate-power-zones";
+import type { CoachingTransport } from "./coaching-transport-port";
+import { commitConflictResolution } from "./commit-conflict-resolution";
+import { syncZones } from "./sync-zones";
+
+const PROFILE_ID = "00000000-0000-0000-0000-000000000777";
+const NOW = "2026-05-05T10:00:00.000Z";
+
+const T2G_HR = {
+  z1: { lower: 107, upper: 133 },
+  z2: { lower: 134, upper: 147 },
+  z3: { lower: 148, upper: 160 },
+  z4: { lower: 161, upper: 174 },
+  z5: { lower: 175, upper: 187 },
+};
+
+const T2G_POWER = {
+  z1: { lower: 111, upper: 149 },
+  z2: { lower: 150, upper: 203 },
+  z3: { lower: 204, upper: 239 },
+  z4: { lower: 240, upper: 268 },
+  z5: { lower: 269, upper: 386 },
+};
+
+const PAYLOAD: ZonesPayload = {
+  physiological: { weight: 83, bpmMax: 187 },
+  paces: { cycling: { ...T2G_POWER, z4Upper: 268, z5Lower: 269 } },
+  hrZones: { generic: T2G_HR },
+};
+
+const makeProfile = (overrides: Partial<Profile> = {}): Profile =>
+  ({
+    id: PROFILE_ID,
+    name: "Pablo",
+    sportZones: {},
+    linkedAccounts: [
+      {
+        source: "train2go",
+        externalUserId: "99999",
+        externalUserName: "Pablo",
+        linkedAt: NOW,
+        syncZones: true,
+      },
+    ],
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  }) as Profile;
+
+const makeTransport = (): CoachingTransport => ({
+  source: "train2go",
+  ping: vi.fn(async () => ({
+    sessionActive: true,
+    externalUserId: "99999",
+    externalUserName: "Pablo",
+  })),
+  openExternal: vi.fn(async () => undefined),
+  readWeek: vi.fn(async () => []),
+  readDay: vi.fn(async () => []),
+  readZones: vi.fn(async () => PAYLOAD),
+});
+
+describe("syncZones method-aware — first-sync (3.4a)", () => {
+  it("should produce zero conflicts and flip method to 'train2go' on a fresh profile", async () => {
+    // Arrange — fresh profile: cycling has Coggan-7 power; cycling/running/
+    // swimming heartRateZones are seeded with all-zero HR.
+    const repo = createInMemoryProfileRepository();
+    await repo.put(
+      makeProfile({
+        sportZones: {
+          cycling: {
+            thresholds: {},
+            heartRateZones: {
+              method: "custom",
+              zones: DEFAULT_HEART_RATE_ZONES.map((z) => ({ ...z })),
+            },
+            powerZones: {
+              method: "coggan-7",
+              zones: calculatePowerZones("coggan-7"),
+            },
+          },
+          running: {
+            thresholds: {},
+            heartRateZones: {
+              method: "custom",
+              zones: DEFAULT_HEART_RATE_ZONES.map((z) => ({ ...z })),
+            },
+          },
+          swimming: {
+            thresholds: {},
+            heartRateZones: {
+              method: "custom",
+              zones: DEFAULT_HEART_RATE_ZONES.map((z) => ({ ...z })),
+            },
+          },
+        },
+      })
+    );
+
+    // Act
+    const result = await syncZones(PROFILE_ID, makeTransport(), repo);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conflicts).toEqual([]);
+    const persisted = await repo.getById(PROFILE_ID);
+    expect(persisted?.sportZones.cycling?.heartRateZones?.method).toBe(
+      "train2go"
+    );
+    expect(persisted?.sportZones.running?.heartRateZones?.method).toBe(
+      "train2go"
+    );
+    expect(persisted?.sportZones.cycling?.powerZones?.method).toBe("train2go");
+    expect(persisted?.sportZones.cycling?.heartRateZones?.zones[3]).toMatchObject(
+      { minBpm: 161, maxBpm: 174 }
+    );
+    // Snapshot established.
+    expect(
+      persisted?.linkedAccounts[0]?.lastSyncedZonesSnapshot
+    ).toBeDefined();
+  });
+});
+
+describe("syncZones method-aware — re-sync stability (3.4b)", () => {
+  it("should produce zero conflicts AND zero applied entries on re-sync of unchanged data", async () => {
+    // Arrange — first sync establishes baseline.
+    const repo = createInMemoryProfileRepository();
+    await repo.put(
+      makeProfile({
+        sportZones: {
+          cycling: {
+            thresholds: {},
+            heartRateZones: {
+              method: "custom",
+              zones: DEFAULT_HEART_RATE_ZONES.map((z) => ({ ...z })),
+            },
+          },
+        },
+      })
+    );
+    await syncZones(PROFILE_ID, makeTransport(), repo);
+
+    // Act — second sync against same data.
+    const result = await syncZones(PROFILE_ID, makeTransport(), repo);
+
+    // Assert
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.conflicts).toEqual([]);
+    expect(result.applied).toEqual([]);
+  });
+});
+
+describe("commitConflictResolution method-aware — accept-all (3.4g)", () => {
+  it("should set method = 'train2go' when ALL band conflicts of a table are accepted", async () => {
+    // Arrange — profile already user-customized; conflicts emitted; user
+    // accepts all 5 cycling-HR band-bound conflicts.
+    const repo = createInMemoryProfileRepository();
+    await repo.put(
+      makeProfile({
+        sportZones: {
+          cycling: {
+            thresholds: {},
+            heartRateZones: {
+              method: "user",
+              zones: [
+                { zone: 1, name: "Recovery", minBpm: 100, maxBpm: 130 },
+                { zone: 2, name: "Aerobic", minBpm: 131, maxBpm: 145 },
+                { zone: 3, name: "Tempo", minBpm: 146, maxBpm: 160 },
+                { zone: 4, name: "Threshold", minBpm: 161, maxBpm: 170 },
+                { zone: 5, name: "VO2 Max", minBpm: 171, maxBpm: 187 },
+              ],
+            },
+          },
+        },
+      })
+    );
+    const decisions = {
+      "cycling.heartRateZones.z1.minBpm": "accept",
+      "cycling.heartRateZones.z1.maxBpm": "accept",
+      "cycling.heartRateZones.z2.maxBpm": "accept",
+      "cycling.heartRateZones.z4.maxBpm": "accept",
+      "cycling.heartRateZones.z5.minBpm": "accept",
+    } as Record<FieldKey, ConflictDecision>;
+
+    // Act
+    await commitConflictResolution(PROFILE_ID, decisions, repo, PAYLOAD);
+
+    // Assert
+    const persisted = await repo.getById(PROFILE_ID);
+    expect(persisted?.sportZones.cycling?.heartRateZones?.method).toBe(
+      "train2go"
+    );
+    expect(
+      persisted?.linkedAccounts[0]?.lastSyncedZonesSnapshot?.cyclingHr
+    ).toBeDefined();
+  });
+});
+
+describe("commitConflictResolution method-aware — mixed accept/reject (3.4f)", () => {
+  it("should set method = 'user' when SOME but NOT ALL band conflicts are accepted", async () => {
+    // Arrange — user accepts Z1 (both bounds) and Z2.maxBpm; rejects Z4.maxBpm and Z5.minBpm.
+    const repo = createInMemoryProfileRepository();
+    await repo.put(
+      makeProfile({
+        sportZones: {
+          cycling: {
+            thresholds: {},
+            heartRateZones: {
+              method: "user",
+              zones: [
+                { zone: 1, name: "Recovery", minBpm: 100, maxBpm: 130 },
+                { zone: 2, name: "Aerobic", minBpm: 131, maxBpm: 145 },
+                { zone: 3, name: "Tempo", minBpm: 146, maxBpm: 160 },
+                { zone: 4, name: "Threshold", minBpm: 161, maxBpm: 170 },
+                { zone: 5, name: "VO2 Max", minBpm: 171, maxBpm: 187 },
+              ],
+            },
+          },
+        },
+      })
+    );
+    const decisions = {
+      "cycling.heartRateZones.z1.minBpm": "accept",
+      "cycling.heartRateZones.z1.maxBpm": "accept",
+      "cycling.heartRateZones.z2.maxBpm": "accept",
+      "cycling.heartRateZones.z4.maxBpm": "reject",
+      "cycling.heartRateZones.z5.minBpm": "reject",
+    } as Record<FieldKey, ConflictDecision>;
+
+    // Act
+    await commitConflictResolution(PROFILE_ID, decisions, repo, PAYLOAD);
+
+    // Assert
+    const persisted = await repo.getById(PROFILE_ID);
+    expect(persisted?.sportZones.cycling?.heartRateZones?.method).toBe("user");
+    // Accepted bands took T2G value; rejected bands kept pre-sync.
+    const zones = persisted?.sportZones.cycling?.heartRateZones?.zones;
+    expect(zones?.[0].minBpm).toBe(107); // accepted
+    expect(zones?.[3].maxBpm).toBe(170); // rejected → pre-sync
+    expect(zones?.[4].minBpm).toBe(171); // rejected → pre-sync
+  });
+});
+
+describe("commitConflictResolution method-aware — all-reject (3.4d)", () => {
+  it("should leave method and snapshot untouched when ALL band decisions are reject", async () => {
+    // Arrange
+    const repo = createInMemoryProfileRepository();
+    const preSnapshot: LastSyncedZonesSnapshot = {
+      syncedAt: "2025-01-01T00:00:00.000Z",
+      cyclingHr: [],
+      runningHr: [],
+      swimmingHr: [],
+      cyclingPower: [],
+      runningPace: [],
+      swimmingPace: [],
+    } as LastSyncedZonesSnapshot;
+    await repo.put(
+      makeProfile({
+        sportZones: {
+          cycling: {
+            thresholds: {},
+            heartRateZones: {
+              method: "user",
+              zones: [
+                { zone: 1, name: "Recovery", minBpm: 100, maxBpm: 130 },
+                { zone: 2, name: "Aerobic", minBpm: 131, maxBpm: 145 },
+                { zone: 3, name: "Tempo", minBpm: 146, maxBpm: 160 },
+                { zone: 4, name: "Threshold", minBpm: 161, maxBpm: 170 },
+                { zone: 5, name: "VO2 Max", minBpm: 171, maxBpm: 187 },
+              ],
+            },
+          },
+        },
+        linkedAccounts: [
+          {
+            source: "train2go",
+            externalUserId: "99999",
+            externalUserName: "Pablo",
+            linkedAt: NOW,
+            syncZones: true,
+            lastSyncedZonesSnapshot: preSnapshot,
+          },
+        ],
+      })
+    );
+    const decisions = {
+      "cycling.heartRateZones.z1.minBpm": "reject",
+      "cycling.heartRateZones.z1.maxBpm": "reject",
+    } as Record<FieldKey, ConflictDecision>;
+
+    // Act
+    await commitConflictResolution(PROFILE_ID, decisions, repo, PAYLOAD);
+
+    // Assert
+    const persisted = await repo.getById(PROFILE_ID);
+    expect(persisted?.sportZones.cycling?.heartRateZones?.method).toBe("user");
+    // Snapshot stays untouched (syncedAt unchanged) per D-MA4 all-reject rule.
+    expect(
+      persisted?.linkedAccounts[0]?.lastSyncedZonesSnapshot?.syncedAt
+    ).toBe("2025-01-01T00:00:00.000Z");
+  });
+});

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-partition.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-partition.ts
@@ -1,0 +1,58 @@
+/**
+ * `partitionIncoming` + `reconcileThresholds` — co-located helpers for
+ * `sync-zones-helpers.ts:reconcile` so the parent file stays under the
+ * 80-line cap.
+ */
+import type {
+  ConflictItem,
+  FieldKey,
+  WrittenField,
+} from "../../types/coaching-zones";
+import type { Profile } from "../../types/profile";
+import type { IncomingMap } from "./sync-zones-payload-mapper";
+import { readField, writeField } from "./sync-zones-profile-fields";
+import { tableKeyOfField } from "./sync-zones-snapshot";
+import type { Sport, ZoneKind } from "./zone-table-classifier-types";
+
+export type TableGroups = Map<`${Sport}.${ZoneKind}`, Map<FieldKey, number>>;
+
+export const partitionIncoming = (
+  incoming: IncomingMap
+): { thresholds: IncomingMap; tables: TableGroups } => {
+  const thresholds: IncomingMap = new Map();
+  const tables: TableGroups = new Map();
+  for (const [field, value] of incoming) {
+    const key = tableKeyOfField(field);
+    if (!key) {
+      thresholds.set(field, value);
+      continue;
+    }
+    const tk = `${key.sport}.${key.kind}` as const;
+    let entry = tables.get(tk);
+    if (!entry) {
+      entry = new Map();
+      tables.set(tk, entry);
+    }
+    entry.set(field, value);
+  }
+  return { thresholds, tables };
+};
+
+export const reconcileThresholds = (
+  profile: Profile,
+  thresholds: IncomingMap
+): { profile: Profile; applied: WrittenField[]; conflicts: ConflictItem[] } => {
+  const applied: WrittenField[] = [];
+  const conflicts: ConflictItem[] = [];
+  let next = profile;
+  for (const [field, value] of thresholds) {
+    const current = readField(next, field);
+    if (current === undefined) {
+      next = writeField(next, field, value);
+      applied.push({ field, value });
+    } else if (current !== value) {
+      conflicts.push({ field, current, incoming: value });
+    }
+  }
+  return { profile: next, applied, conflicts };
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-snapshot-write.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-snapshot-write.ts
@@ -1,0 +1,76 @@
+/**
+ * `updateSnapshot` — given a profile and a sport-kind that just had
+ * its zones silent-replaced from T2G, return a new profile with the
+ * linked-account's `lastSyncedZonesSnapshot` updated to reflect the
+ * post-write zones (atomic with the zone write per D-MA2).
+ */
+import type { LastSyncedZonesSnapshot } from "../../types/coaching-account";
+import type { Profile } from "../../types/profile";
+import type { Sport, ZoneKind } from "./zone-table-classifier-types";
+
+const KIND_TO_SNAPSHOT_KEY: Record<
+  `${Sport}.${ZoneKind}`,
+  keyof LastSyncedZonesSnapshot
+> = {
+  "cycling.heartRateZones": "cyclingHr",
+  "running.heartRateZones": "runningHr",
+  "swimming.heartRateZones": "swimmingHr",
+  "cycling.powerZones": "cyclingPower",
+  "running.paceZones": "runningPace",
+  "swimming.paceZones": "swimmingPace",
+  "cycling.paceZones": "runningPace",
+  "running.powerZones": "cyclingPower",
+  "swimming.powerZones": "cyclingPower",
+};
+
+const emptySnapshot = (now: string): LastSyncedZonesSnapshot =>
+  ({
+    syncedAt: now,
+    cyclingHr: [],
+    runningHr: [],
+    swimmingHr: [],
+    cyclingPower: [],
+    runningPace: [],
+    swimmingPace: [],
+  }) as LastSyncedZonesSnapshot;
+
+const readPersistedZones = (
+  profile: Profile,
+  sport: Sport,
+  kind: ZoneKind
+): unknown[] | undefined => {
+  const cfg = profile.sportZones[sport];
+  if (!cfg) return undefined;
+  const zc = (cfg as Record<string, unknown>)[kind] as
+    | { zones?: unknown[] }
+    | undefined;
+  return zc?.zones;
+};
+
+/**
+ * Update `linkedAccounts[i].lastSyncedZonesSnapshot` with the persisted
+ * zones for the given sport-kinds. `syncedAt` is bumped to `now`.
+ */
+export const updateSnapshot = (
+  profile: Profile,
+  source: string,
+  sportKinds: Array<{ sport: Sport; kind: ZoneKind }>,
+  now: string
+): Profile => {
+  if (sportKinds.length === 0) return profile;
+  const idx = profile.linkedAccounts.findIndex((a) => a.source === source);
+  if (idx === -1) return profile;
+  const account = profile.linkedAccounts[idx];
+  const base = account.lastSyncedZonesSnapshot ?? emptySnapshot(now);
+  const next: LastSyncedZonesSnapshot = { ...base, syncedAt: now };
+  for (const { sport, kind } of sportKinds) {
+    const zones = readPersistedZones(profile, sport, kind);
+    if (!zones) continue;
+    const key = KIND_TO_SNAPSHOT_KEY[`${sport}.${kind}`];
+    (next as Record<string, unknown>)[key] = zones;
+  }
+  const linkedAccounts = profile.linkedAccounts.map((a, i) =>
+    i === idx ? { ...a, lastSyncedZonesSnapshot: next } : a
+  );
+  return { ...profile, linkedAccounts };
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-snapshot.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-snapshot.ts
@@ -1,0 +1,86 @@
+/**
+ * Snapshot helpers — get/set `lastSyncedZonesSnapshot` on a linked
+ * coaching account, and project snapshot zones into per-FieldKey maps
+ * for the classifier's `train2go-synced-edited` per-band detection.
+ */
+import type { LastSyncedZonesSnapshot } from "../../types/coaching-account";
+import type { FieldKey } from "../../types/coaching-zones";
+import type { Sport, ZoneKind } from "./zone-table-classifier-types";
+
+const KIND_TO_SNAPSHOT_KEY: Record<
+  `${Sport}.${ZoneKind}`,
+  keyof LastSyncedZonesSnapshot
+> = {
+  "cycling.heartRateZones": "cyclingHr",
+  "running.heartRateZones": "runningHr",
+  "swimming.heartRateZones": "swimmingHr",
+  "cycling.powerZones": "cyclingPower",
+  "running.paceZones": "runningPace",
+  "swimming.paceZones": "swimmingPace",
+  "cycling.paceZones": "runningPace", // unused (no cycling pace) — sentinel
+  "running.powerZones": "cyclingPower", // unused
+  "swimming.powerZones": "cyclingPower", // unused
+};
+
+export const getSnapshotZones = (
+  snapshot: LastSyncedZonesSnapshot | undefined,
+  sport: Sport,
+  kind: ZoneKind
+): unknown[] | undefined => {
+  if (!snapshot) return undefined;
+  const key = KIND_TO_SNAPSHOT_KEY[`${sport}.${kind}`];
+  return snapshot[key] as unknown[] | undefined;
+};
+
+const BAND_KEY_RE =
+  /^(cycling|running|swimming)\.(heartRateZones|powerZones|paceZones)\.(z[1-5])\.(minBpm|maxBpm|minPercent|maxPercent|minPace|maxPace)$/;
+
+const BAND_INDEX: Record<string, number> = {
+  z1: 0,
+  z2: 1,
+  z3: 2,
+  z4: 3,
+  z5: 4,
+};
+
+/**
+ * Project the snapshot zones for a single sport-kind into a
+ * `Map<FieldKey, number>` keyed by the band-level FieldKeys so the
+ * `train2go-synced-edited` strategy can compare per-band against snapshot.
+ */
+export const snapshotZonesToFieldMap = (
+  snapshotZones: unknown[] | undefined,
+  sport: Sport,
+  kind: ZoneKind
+): Map<FieldKey, number> => {
+  const out = new Map<FieldKey, number>();
+  if (!snapshotZones) return out;
+  for (let i = 0; i < snapshotZones.length; i++) {
+    const z = snapshotZones[i] as Record<string, number>;
+    const band = `z${i + 1}`;
+    if (kind === "heartRateZones") {
+      out.set(`${sport}.${kind}.${band}.minBpm` as FieldKey, z.minBpm);
+      out.set(`${sport}.${kind}.${band}.maxBpm` as FieldKey, z.maxBpm);
+    } else if (kind === "powerZones") {
+      out.set(`${sport}.${kind}.${band}.minPercent` as FieldKey, z.minPercent);
+      out.set(`${sport}.${kind}.${band}.maxPercent` as FieldKey, z.maxPercent);
+    } else {
+      out.set(`${sport}.${kind}.${band}.minPace` as FieldKey, z.minPace);
+      out.set(`${sport}.${kind}.${band}.maxPace` as FieldKey, z.maxPace);
+    }
+  }
+  return out;
+};
+
+export const tableKeyOfField = (
+  field: FieldKey
+): { sport: Sport; kind: ZoneKind } | null => {
+  const m = BAND_KEY_RE.exec(field);
+  if (!m) return null;
+  return { sport: m[1] as Sport, kind: m[2] as ZoneKind };
+};
+
+export const bandIndexOfField = (field: FieldKey): number | undefined => {
+  const m = BAND_KEY_RE.exec(field);
+  return m ? BAND_INDEX[m[3]] : undefined;
+};

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-threshold-fields.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-threshold-fields.ts
@@ -37,7 +37,7 @@ const setSportThreshold = (
   const thresholds = { ...(existing?.thresholds ?? {}), ...patch };
   const sportConfig = existing
     ? { ...existing, thresholds }
-    : { thresholds, heartRateZones: { method: "manual", zones: [] } };
+    : { thresholds, heartRateZones: { method: "custom", zones: [] } };
   return {
     ...profile,
     sportZones: { ...profile.sportZones, [sport]: sportConfig },

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones.ts
@@ -62,8 +62,11 @@ export const syncZones = async (
     return { ok: false, reason: "shape-mismatch" };
   }
   const incoming = mapPayloadToIncoming(payload);
-  const result = reconcile(profile, incoming);
-  if (result.applied.length > 0) {
+  const result = reconcile(profile, incoming, transport.source);
+  // Persist whenever reconcile mutated the profile — covers silent-fills
+  // (applied), method-flips on default-template/method-derived tables,
+  // and snapshot-write on train2go-synced-clean re-syncs (per D-MA4).
+  if (result.profile !== profile) {
     await repo.put({
       ...result.profile,
       updatedAt: new Date().toISOString(),

--- a/packages/workout-spa-editor/src/application/coaching/zone-table-classifier-detectors.ts
+++ b/packages/workout-spa-editor/src/application/coaching/zone-table-classifier-detectors.ts
@@ -15,8 +15,7 @@ import {
 } from "./zone-table-classifier-types";
 
 export const isAllZeroHr = (zones: HeartRateZone[]): boolean =>
-  zones.length === 5 &&
-  zones.every((z) => z.minBpm === 0 && z.maxBpm === 0);
+  zones.length === 5 && zones.every((z) => z.minBpm === 0 && z.maxBpm === 0);
 
 export const isAllZeroPace = (zones: PaceZone[]): boolean =>
   zones.length === 5 && zones.every((z) => z.minPace === 0 && z.maxPace === 0);
@@ -24,14 +23,18 @@ export const isAllZeroPace = (zones: PaceZone[]): boolean =>
 export const isFormulaId = (method: string): boolean =>
   ALL_FORMULA_IDS.has(method);
 
-export const equalsHrZones = (a: HeartRateZone[], b: HeartRateZone[]): boolean =>
+export const equalsHrZones = (
+  a: HeartRateZone[],
+  b: HeartRateZone[]
+): boolean =>
   a.length === b.length &&
   a.every((z, i) => z.minBpm === b[i].minBpm && z.maxBpm === b[i].maxBpm);
 
 export const equalsPowerZones = (a: PowerZone[], b: PowerZone[]): boolean =>
   a.length === b.length &&
   a.every(
-    (z, i) => z.minPercent === b[i].minPercent && z.maxPercent === b[i].maxPercent
+    (z, i) =>
+      z.minPercent === b[i].minPercent && z.maxPercent === b[i].maxPercent
   );
 
 export const equalsPaceZones = (a: PaceZone[], b: PaceZone[]): boolean =>
@@ -64,7 +67,10 @@ export const matchesPaceFormula = (
   unit: "min_per_km" | "min_per_100m" | undefined
 ): boolean => {
   if (!thresholdPace || thresholdPace <= 0 || !unit) return false;
-  return equalsPaceZones(zones, calculatePaceZones(thresholdPace, unit, method));
+  return equalsPaceZones(
+    zones,
+    calculatePaceZones(thresholdPace, unit, method)
+  );
 };
 
 export const getThreshold = (

--- a/packages/workout-spa-editor/src/application/coaching/zone-table-classifier-detectors.ts
+++ b/packages/workout-spa-editor/src/application/coaching/zone-table-classifier-detectors.ts
@@ -1,0 +1,80 @@
+/**
+ * Zone-table classifier detectors — pure predicates for the 6 states
+ * (per design D-MA1 of zones-method-aware-reconcile). Co-located with
+ * `zone-table-classifier.ts` so the parent stays under the 80-line cap.
+ */
+import type { HeartRateZone, PowerZone, Profile } from "../../types/profile";
+import type { PaceZone } from "../../types/sport-zones";
+import { calculateHrZones } from "../../utils/calculate-hr-zones";
+import { calculatePaceZones } from "../../utils/calculate-pace-zones";
+import { calculatePowerZones } from "../../utils/calculate-power-zones";
+import {
+  ALL_FORMULA_IDS,
+  type Sport,
+  type ZoneKind,
+} from "./zone-table-classifier-types";
+
+export const isAllZeroHr = (zones: HeartRateZone[]): boolean =>
+  zones.length === 5 &&
+  zones.every((z) => z.minBpm === 0 && z.maxBpm === 0);
+
+export const isAllZeroPace = (zones: PaceZone[]): boolean =>
+  zones.length === 5 && zones.every((z) => z.minPace === 0 && z.maxPace === 0);
+
+export const isFormulaId = (method: string): boolean =>
+  ALL_FORMULA_IDS.has(method);
+
+export const equalsHrZones = (a: HeartRateZone[], b: HeartRateZone[]): boolean =>
+  a.length === b.length &&
+  a.every((z, i) => z.minBpm === b[i].minBpm && z.maxBpm === b[i].maxBpm);
+
+export const equalsPowerZones = (a: PowerZone[], b: PowerZone[]): boolean =>
+  a.length === b.length &&
+  a.every(
+    (z, i) => z.minPercent === b[i].minPercent && z.maxPercent === b[i].maxPercent
+  );
+
+export const equalsPaceZones = (a: PaceZone[], b: PaceZone[]): boolean =>
+  a.length === b.length &&
+  a.every(
+    (z, i) =>
+      z.minPace === b[i].minPace &&
+      z.maxPace === b[i].maxPace &&
+      z.unit === b[i].unit
+  );
+
+export const matchesHrFormula = (
+  zones: HeartRateZone[],
+  method: string,
+  lthr: number | undefined
+): boolean => {
+  if (!lthr || lthr <= 0) return false;
+  return equalsHrZones(zones, calculateHrZones(lthr, method));
+};
+
+export const matchesPowerFormula = (
+  zones: PowerZone[],
+  method: string
+): boolean => equalsPowerZones(zones, calculatePowerZones(method));
+
+export const matchesPaceFormula = (
+  zones: PaceZone[],
+  method: string,
+  thresholdPace: number | undefined,
+  unit: "min_per_km" | "min_per_100m" | undefined
+): boolean => {
+  if (!thresholdPace || thresholdPace <= 0 || !unit) return false;
+  return equalsPaceZones(zones, calculatePaceZones(thresholdPace, unit, method));
+};
+
+export const getThreshold = (
+  profile: Profile,
+  sport: Sport,
+  kind: ZoneKind
+): number | undefined => {
+  const t = profile.sportZones[sport]?.thresholds;
+  if (!t) return undefined;
+  if (kind === "heartRateZones") return t.lthr;
+  if (kind === "powerZones") return t.ftp;
+  return t.thresholdPace;
+};

--- a/packages/workout-spa-editor/src/application/coaching/zone-table-classifier-state-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/zone-table-classifier-state-helpers.ts
@@ -1,0 +1,69 @@
+/**
+ * Per-state detection helpers for `classifyZoneTable`. Co-located so
+ * the classifier stays under the 80-line file cap.
+ */
+import type {
+  HeartRateZone,
+  PowerZone,
+  Profile,
+} from "../../types/profile";
+import type { PaceZone } from "../../types/sport-zones";
+import {
+  equalsHrZones,
+  equalsPaceZones,
+  equalsPowerZones,
+  getThreshold,
+  isAllZeroHr,
+  isAllZeroPace,
+  matchesHrFormula,
+  matchesPaceFormula,
+  matchesPowerFormula,
+} from "./zone-table-classifier-detectors";
+import type { Sport, ZoneKind } from "./zone-table-classifier-types";
+
+export const isFormulaDerived = (
+  zones: unknown[],
+  method: string,
+  profile: Profile,
+  sport: Sport,
+  kind: ZoneKind
+): boolean => {
+  if (kind === "heartRateZones") {
+    return matchesHrFormula(
+      zones as HeartRateZone[],
+      method,
+      getThreshold(profile, sport, kind)
+    );
+  }
+  if (kind === "powerZones") {
+    return matchesPowerFormula(zones as PowerZone[], method);
+  }
+  return matchesPaceFormula(
+    zones as PaceZone[],
+    method,
+    getThreshold(profile, sport, kind),
+    profile.sportZones[sport]?.thresholds.paceUnit
+  );
+};
+
+export const equalsSnapshot = (
+  zones: unknown[],
+  snapshotZones: unknown[] | undefined,
+  kind: ZoneKind
+): boolean => {
+  if (!snapshotZones) return false;
+  if (kind === "heartRateZones")
+    return equalsHrZones(zones as HeartRateZone[], snapshotZones as HeartRateZone[]);
+  if (kind === "powerZones")
+    return equalsPowerZones(zones as PowerZone[], snapshotZones as PowerZone[]);
+  return equalsPaceZones(zones as PaceZone[], snapshotZones as PaceZone[]);
+};
+
+export const isDefaultTemplate = (
+  zones: unknown[],
+  kind: ZoneKind
+): boolean => {
+  if (kind === "heartRateZones") return isAllZeroHr(zones as HeartRateZone[]);
+  if (kind === "paceZones") return isAllZeroPace(zones as PaceZone[]);
+  return false;
+};

--- a/packages/workout-spa-editor/src/application/coaching/zone-table-classifier-state-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/zone-table-classifier-state-helpers.ts
@@ -2,11 +2,7 @@
  * Per-state detection helpers for `classifyZoneTable`. Co-located so
  * the classifier stays under the 80-line file cap.
  */
-import type {
-  HeartRateZone,
-  PowerZone,
-  Profile,
-} from "../../types/profile";
+import type { HeartRateZone, PowerZone, Profile } from "../../types/profile";
 import type { PaceZone } from "../../types/sport-zones";
 import {
   equalsHrZones,
@@ -53,7 +49,10 @@ export const equalsSnapshot = (
 ): boolean => {
   if (!snapshotZones) return false;
   if (kind === "heartRateZones")
-    return equalsHrZones(zones as HeartRateZone[], snapshotZones as HeartRateZone[]);
+    return equalsHrZones(
+      zones as HeartRateZone[],
+      snapshotZones as HeartRateZone[]
+    );
   if (kind === "powerZones")
     return equalsPowerZones(zones as PowerZone[], snapshotZones as PowerZone[]);
   return equalsPaceZones(zones as PaceZone[], snapshotZones as PaceZone[]);

--- a/packages/workout-spa-editor/src/application/coaching/zone-table-classifier-types.ts
+++ b/packages/workout-spa-editor/src/application/coaching/zone-table-classifier-types.ts
@@ -1,0 +1,28 @@
+/**
+ * Zone-table classifier types and constants.
+ */
+import { HR_METHODS } from "../../lib/hr-methods";
+import { PACE_METHODS } from "../../lib/pace-methods";
+import { POWER_METHODS } from "../../lib/power-methods";
+
+export type ZoneTableState =
+  | "empty"
+  | "default-template"
+  | "method-derived"
+  | "train2go-synced-clean"
+  | "train2go-synced-edited"
+  | "user-customized";
+
+export type Sport = "cycling" | "running" | "swimming";
+export type ZoneKind = "heartRateZones" | "powerZones" | "paceZones";
+
+/**
+ * The set of method ids accepted as `method-derived` (per D-MA1
+ * "Method registry — source of truth"). Computed once from the
+ * lib/zone-methods registry. Tests use this set, never a hardcoded list.
+ */
+export const ALL_FORMULA_IDS = new Set<string>([
+  ...HR_METHODS.map((m) => m.id),
+  ...POWER_METHODS.map((m) => m.id),
+  ...PACE_METHODS.map((m) => m.id),
+]);

--- a/packages/workout-spa-editor/src/application/coaching/zone-table-classifier.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/zone-table-classifier.test.ts
@@ -48,11 +48,41 @@ const t2gHr = () => [
 ];
 
 const allZeroPace = () => [
-  { zone: 1, name: "Recovery", minPace: 0, maxPace: 0, unit: "min_per_km" as const },
-  { zone: 2, name: "Aerobic", minPace: 0, maxPace: 0, unit: "min_per_km" as const },
-  { zone: 3, name: "Tempo", minPace: 0, maxPace: 0, unit: "min_per_km" as const },
-  { zone: 4, name: "Threshold", minPace: 0, maxPace: 0, unit: "min_per_km" as const },
-  { zone: 5, name: "VO2 Max", minPace: 0, maxPace: 0, unit: "min_per_km" as const },
+  {
+    zone: 1,
+    name: "Recovery",
+    minPace: 0,
+    maxPace: 0,
+    unit: "min_per_km" as const,
+  },
+  {
+    zone: 2,
+    name: "Aerobic",
+    minPace: 0,
+    maxPace: 0,
+    unit: "min_per_km" as const,
+  },
+  {
+    zone: 3,
+    name: "Tempo",
+    minPace: 0,
+    maxPace: 0,
+    unit: "min_per_km" as const,
+  },
+  {
+    zone: 4,
+    name: "Threshold",
+    minPace: 0,
+    maxPace: 0,
+    unit: "min_per_km" as const,
+  },
+  {
+    zone: 5,
+    name: "VO2 Max",
+    minPace: 0,
+    maxPace: 0,
+    unit: "min_per_km" as const,
+  },
 ];
 
 const snapshotFor = (cyclingHrZones: unknown): LastSyncedZonesSnapshot =>
@@ -69,7 +99,12 @@ const snapshotFor = (cyclingHrZones: unknown): LastSyncedZonesSnapshot =>
 describe("classifyZoneTable — empty (2.2a)", () => {
   it("should return 'empty' when zones array is missing", () => {
     // Arrange + Act
-    const state = classifyZoneTable(baseProfile(), "cycling", "heartRateZones", undefined);
+    const state = classifyZoneTable(
+      baseProfile(),
+      "cycling",
+      "heartRateZones",
+      undefined
+    );
 
     // Assert
     expect(state).toBe("empty");
@@ -78,11 +113,19 @@ describe("classifyZoneTable — empty (2.2a)", () => {
   it("should return 'empty' when zones array is length 0", () => {
     // Arrange
     const profile = baseProfile({
-      cycling: { thresholds: {}, heartRateZones: { method: "custom", zones: [] } },
+      cycling: {
+        thresholds: {},
+        heartRateZones: { method: "custom", zones: [] },
+      },
     });
 
     // Act
-    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+    const state = classifyZoneTable(
+      profile,
+      "cycling",
+      "heartRateZones",
+      undefined
+    );
 
     // Assert
     expect(state).toBe("empty");
@@ -100,7 +143,12 @@ describe("classifyZoneTable — default-template (2.2b)", () => {
     });
 
     // Act
-    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+    const state = classifyZoneTable(
+      profile,
+      "cycling",
+      "heartRateZones",
+      undefined
+    );
 
     // Assert
     expect(state).toBe("default-template");
@@ -131,12 +179,20 @@ describe("classifyZoneTable — method-derived (2.2c)", () => {
       cycling: {
         thresholds: { ftp: 268 },
         heartRateZones: { method: "custom", zones: [] },
-        powerZones: { method: "coggan-7", zones: calculatePowerZones("coggan-7") },
+        powerZones: {
+          method: "coggan-7",
+          zones: calculatePowerZones("coggan-7"),
+        },
       },
     });
 
     // Act
-    const state = classifyZoneTable(profile, "cycling", "powerZones", undefined);
+    const state = classifyZoneTable(
+      profile,
+      "cycling",
+      "powerZones",
+      undefined
+    );
 
     // Assert
     expect(state).toBe("method-derived");
@@ -156,7 +212,12 @@ describe("classifyZoneTable — method-derived (2.2c)", () => {
     });
 
     // Act
-    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+    const state = classifyZoneTable(
+      profile,
+      "cycling",
+      "heartRateZones",
+      undefined
+    );
 
     // Assert
     expect(state).toBe("method-derived");
@@ -197,7 +258,12 @@ describe("classifyZoneTable — train2go-synced-clean (2.2d)", () => {
     const snapshot = snapshotFor(t2gHr());
 
     // Act
-    const state = classifyZoneTable(profile, "cycling", "heartRateZones", snapshot);
+    const state = classifyZoneTable(
+      profile,
+      "cycling",
+      "heartRateZones",
+      snapshot
+    );
 
     // Assert
     expect(state).toBe("train2go-synced-clean");
@@ -219,7 +285,12 @@ describe("classifyZoneTable — train2go-synced-edited (2.2e)", () => {
     const snapshot = snapshotFor(t2gHr());
 
     // Act
-    const state = classifyZoneTable(profile, "cycling", "heartRateZones", snapshot);
+    const state = classifyZoneTable(
+      profile,
+      "cycling",
+      "heartRateZones",
+      snapshot
+    );
 
     // Assert
     expect(state).toBe("train2go-synced-edited");
@@ -237,7 +308,12 @@ describe("classifyZoneTable — user-customized (2.2f, 2.2g)", () => {
     });
 
     // Act
-    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+    const state = classifyZoneTable(
+      profile,
+      "cycling",
+      "heartRateZones",
+      undefined
+    );
 
     // Assert
     expect(state).toBe("user-customized");
@@ -255,7 +331,12 @@ describe("classifyZoneTable — user-customized (2.2f, 2.2g)", () => {
     });
 
     // Act
-    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+    const state = classifyZoneTable(
+      profile,
+      "cycling",
+      "heartRateZones",
+      undefined
+    );
 
     // Assert
     expect(state).toBe("user-customized");
@@ -273,7 +354,12 @@ describe("classifyZoneTable — user-customized (2.2f, 2.2g)", () => {
     });
 
     // Act
-    const state = classifyZoneTable(profile, "running", "heartRateZones", undefined);
+    const state = classifyZoneTable(
+      profile,
+      "running",
+      "heartRateZones",
+      undefined
+    );
 
     // Assert
     expect(state).toBe("default-template");
@@ -289,7 +375,12 @@ describe("classifyZoneTable — user-customized (2.2f, 2.2g)", () => {
     });
 
     // Act
-    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+    const state = classifyZoneTable(
+      profile,
+      "cycling",
+      "heartRateZones",
+      undefined
+    );
 
     // Assert
     expect(state).toBe("user-customized");

--- a/packages/workout-spa-editor/src/application/coaching/zone-table-classifier.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/zone-table-classifier.test.ts
@@ -1,0 +1,297 @@
+/**
+ * `classifyZoneTable` tests — one per state per sport-kind plus edge
+ * cases (per tasks §2.2 of zones-method-aware-reconcile).
+ */
+import { describe, expect, it } from "vitest";
+
+import type { LastSyncedZonesSnapshot } from "../../types/coaching-account";
+import type { Profile } from "../../types/profile";
+import { calculateHrZones } from "../../utils/calculate-hr-zones";
+import { calculatePaceZones } from "../../utils/calculate-pace-zones";
+import { calculatePowerZones } from "../../utils/calculate-power-zones";
+import { classifyZoneTable } from "./zone-table-classifier";
+
+const NOW = "2026-05-04T10:00:00.000Z";
+
+const baseProfile = (sportZones: unknown = {}): Profile =>
+  ({
+    id: "00000000-0000-0000-0000-000000000001",
+    name: "Pablo",
+    sportZones,
+    linkedAccounts: [],
+    createdAt: NOW,
+    updatedAt: NOW,
+  }) as Profile;
+
+const allZeroHr = () => [
+  { zone: 1, name: "Recovery", minBpm: 0, maxBpm: 0 },
+  { zone: 2, name: "Aerobic", minBpm: 0, maxBpm: 0 },
+  { zone: 3, name: "Tempo", minBpm: 0, maxBpm: 0 },
+  { zone: 4, name: "Threshold", minBpm: 0, maxBpm: 0 },
+  { zone: 5, name: "VO2 Max", minBpm: 0, maxBpm: 0 },
+];
+
+const userEditedHr = () => [
+  { zone: 1, name: "Recovery", minBpm: 100, maxBpm: 130 },
+  { zone: 2, name: "Aerobic", minBpm: 131, maxBpm: 145 },
+  { zone: 3, name: "Tempo", minBpm: 146, maxBpm: 160 },
+  { zone: 4, name: "Threshold", minBpm: 161, maxBpm: 170 },
+  { zone: 5, name: "VO2 Max", minBpm: 171, maxBpm: 187 },
+];
+
+const t2gHr = () => [
+  { zone: 1, name: "Recovery", minBpm: 107, maxBpm: 133 },
+  { zone: 2, name: "Aerobic", minBpm: 134, maxBpm: 147 },
+  { zone: 3, name: "Tempo", minBpm: 148, maxBpm: 160 },
+  { zone: 4, name: "Threshold", minBpm: 161, maxBpm: 174 },
+  { zone: 5, name: "VO2 Max", minBpm: 175, maxBpm: 187 },
+];
+
+const allZeroPace = () => [
+  { zone: 1, name: "Recovery", minPace: 0, maxPace: 0, unit: "min_per_km" as const },
+  { zone: 2, name: "Aerobic", minPace: 0, maxPace: 0, unit: "min_per_km" as const },
+  { zone: 3, name: "Tempo", minPace: 0, maxPace: 0, unit: "min_per_km" as const },
+  { zone: 4, name: "Threshold", minPace: 0, maxPace: 0, unit: "min_per_km" as const },
+  { zone: 5, name: "VO2 Max", minPace: 0, maxPace: 0, unit: "min_per_km" as const },
+];
+
+const snapshotFor = (cyclingHrZones: unknown): LastSyncedZonesSnapshot =>
+  ({
+    syncedAt: NOW,
+    cyclingHr: cyclingHrZones,
+    runningHr: t2gHr(),
+    swimmingHr: t2gHr(),
+    cyclingPower: calculatePowerZones("coggan-7").slice(0, 5),
+    runningPace: allZeroPace(),
+    swimmingPace: allZeroPace(),
+  }) as LastSyncedZonesSnapshot;
+
+describe("classifyZoneTable — empty (2.2a)", () => {
+  it("should return 'empty' when zones array is missing", () => {
+    // Arrange + Act
+    const state = classifyZoneTable(baseProfile(), "cycling", "heartRateZones", undefined);
+
+    // Assert
+    expect(state).toBe("empty");
+  });
+
+  it("should return 'empty' when zones array is length 0", () => {
+    // Arrange
+    const profile = baseProfile({
+      cycling: { thresholds: {}, heartRateZones: { method: "custom", zones: [] } },
+    });
+
+    // Act
+    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+
+    // Assert
+    expect(state).toBe("empty");
+  });
+});
+
+describe("classifyZoneTable — default-template (2.2b)", () => {
+  it("should return 'default-template' for HR all-zero seed", () => {
+    // Arrange
+    const profile = baseProfile({
+      cycling: {
+        thresholds: {},
+        heartRateZones: { method: "custom", zones: allZeroHr() },
+      },
+    });
+
+    // Act
+    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+
+    // Assert
+    expect(state).toBe("default-template");
+  });
+
+  it("should return 'default-template' for pace all-zero seed (5 entries)", () => {
+    // Arrange
+    const profile = baseProfile({
+      running: {
+        thresholds: {},
+        heartRateZones: { method: "custom", zones: [] },
+        paceZones: { method: "custom", zones: allZeroPace() },
+      },
+    });
+
+    // Act
+    const state = classifyZoneTable(profile, "running", "paceZones", undefined);
+
+    // Assert
+    expect(state).toBe("default-template");
+  });
+});
+
+describe("classifyZoneTable — method-derived (2.2c)", () => {
+  it("should return 'method-derived' for cycling.powerZones with Coggan-7 defaults", () => {
+    // Arrange
+    const profile = baseProfile({
+      cycling: {
+        thresholds: { ftp: 268 },
+        heartRateZones: { method: "custom", zones: [] },
+        powerZones: { method: "coggan-7", zones: calculatePowerZones("coggan-7") },
+      },
+    });
+
+    // Act
+    const state = classifyZoneTable(profile, "cycling", "powerZones", undefined);
+
+    // Assert
+    expect(state).toBe("method-derived");
+  });
+
+  it("should return 'method-derived' for HR karvonen-5 + LTHR present + zones match formula", () => {
+    // Arrange
+    const lthr = 174;
+    const profile = baseProfile({
+      cycling: {
+        thresholds: { lthr },
+        heartRateZones: {
+          method: "karvonen-5",
+          zones: calculateHrZones(lthr, "karvonen-5"),
+        },
+      },
+    });
+
+    // Act
+    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+
+    // Assert
+    expect(state).toBe("method-derived");
+  });
+
+  it("should return 'method-derived' for pace daniels-5 + thresholdPace present + zones match", () => {
+    // Arrange
+    const thresholdPace = 250;
+    const profile = baseProfile({
+      running: {
+        thresholds: { thresholdPace, paceUnit: "min_per_km" },
+        heartRateZones: { method: "custom", zones: [] },
+        paceZones: {
+          method: "daniels-5",
+          zones: calculatePaceZones(thresholdPace, "min_per_km", "daniels-5"),
+        },
+      },
+    });
+
+    // Act
+    const state = classifyZoneTable(profile, "running", "paceZones", undefined);
+
+    // Assert
+    expect(state).toBe("method-derived");
+  });
+});
+
+describe("classifyZoneTable — train2go-synced-clean (2.2d)", () => {
+  it("should return 'train2go-synced-clean' when method = 'train2go' and zones === snapshot", () => {
+    // Arrange
+    const zones = t2gHr();
+    const profile = baseProfile({
+      cycling: {
+        thresholds: {},
+        heartRateZones: { method: "train2go", zones },
+      },
+    });
+    const snapshot = snapshotFor(t2gHr());
+
+    // Act
+    const state = classifyZoneTable(profile, "cycling", "heartRateZones", snapshot);
+
+    // Assert
+    expect(state).toBe("train2go-synced-clean");
+  });
+});
+
+describe("classifyZoneTable — train2go-synced-edited (2.2e)", () => {
+  it("should return 'train2go-synced-edited' when method = 'train2go' and zones differ from snapshot", () => {
+    // Arrange — snapshot says Z2.maxBpm=147; persisted has 145 (user edited).
+    const persisted = t2gHr().map((z, i) =>
+      i === 1 ? { ...z, maxBpm: 145 } : z
+    );
+    const profile = baseProfile({
+      cycling: {
+        thresholds: {},
+        heartRateZones: { method: "train2go", zones: persisted },
+      },
+    });
+    const snapshot = snapshotFor(t2gHr());
+
+    // Act
+    const state = classifyZoneTable(profile, "cycling", "heartRateZones", snapshot);
+
+    // Assert
+    expect(state).toBe("train2go-synced-edited");
+  });
+});
+
+describe("classifyZoneTable — user-customized (2.2f, 2.2g)", () => {
+  it("should return 'user-customized' when method = 'user'", () => {
+    // Arrange
+    const profile = baseProfile({
+      cycling: {
+        thresholds: {},
+        heartRateZones: { method: "user", zones: userEditedHr() },
+      },
+    });
+
+    // Act
+    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+
+    // Assert
+    expect(state).toBe("user-customized");
+  });
+
+  it("should return 'user-customized' for method = 'custom' + non-default zones (tail rule)", () => {
+    // Arrange — content-detection tail rule: method = "custom" but
+    // zones don't match seed/formula. Defensive — covers PR 2/PR 3
+    // ship window where method-tracking isn't fully ironclad yet.
+    const profile = baseProfile({
+      cycling: {
+        thresholds: {},
+        heartRateZones: { method: "custom", zones: userEditedHr() },
+      },
+    });
+
+    // Act
+    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+
+    // Assert
+    expect(state).toBe("user-customized");
+  });
+
+  it("should fall through to 'default-template' for HR formula method without threshold + seed zones", () => {
+    // Arrange — D-MA1 threshold-fallback rule: when method is a formula
+    // id but threshold is absent, classifier falls through to content
+    // detection. Seed zones → default-template.
+    const profile = baseProfile({
+      running: {
+        thresholds: {}, // no LTHR
+        heartRateZones: { method: "karvonen-5", zones: allZeroHr() },
+      },
+    });
+
+    // Act
+    const state = classifyZoneTable(profile, "running", "heartRateZones", undefined);
+
+    // Assert
+    expect(state).toBe("default-template");
+  });
+
+  it("should return 'user-customized' when method='train2go' but snapshot is null (D-MA1 explicit branch)", () => {
+    // Arrange
+    const profile = baseProfile({
+      cycling: {
+        thresholds: {},
+        heartRateZones: { method: "train2go", zones: t2gHr() },
+      },
+    });
+
+    // Act
+    const state = classifyZoneTable(profile, "cycling", "heartRateZones", undefined);
+
+    // Assert
+    expect(state).toBe("user-customized");
+  });
+});

--- a/packages/workout-spa-editor/src/application/coaching/zone-table-classifier.ts
+++ b/packages/workout-spa-editor/src/application/coaching/zone-table-classifier.ts
@@ -1,0 +1,66 @@
+/**
+ * `classifyZoneTable(profile, sport, kind, snapshot)` — returns one of
+ * the six canonical states (per design D-MA1 of
+ * zones-method-aware-reconcile). Drives the reconcile strategy in
+ * `sync-zones-helpers.ts:reconcile`.
+ */
+import type { LastSyncedZonesSnapshot } from "../../types/coaching-account";
+import type { Profile } from "../../types/profile";
+import { isFormulaId } from "./zone-table-classifier-detectors";
+import {
+  equalsSnapshot,
+  isDefaultTemplate,
+  isFormulaDerived,
+} from "./zone-table-classifier-state-helpers";
+import type {
+  Sport,
+  ZoneKind,
+  ZoneTableState,
+} from "./zone-table-classifier-types";
+
+const SNAPSHOT_KEY: Record<
+  `${Sport}.${ZoneKind}`,
+  keyof LastSyncedZonesSnapshot
+> = {
+  "cycling.heartRateZones": "cyclingHr",
+  "running.heartRateZones": "runningHr",
+  "swimming.heartRateZones": "swimmingHr",
+  "cycling.powerZones": "cyclingPower",
+  "running.paceZones": "runningPace",
+  "swimming.paceZones": "swimmingPace",
+  "cycling.paceZones": "runningPace",
+  "running.powerZones": "cyclingPower",
+  "swimming.powerZones": "cyclingPower",
+};
+
+export const classifyZoneTable = (
+  profile: Profile,
+  sport: Sport,
+  kind: ZoneKind,
+  snapshot: LastSyncedZonesSnapshot | undefined
+): ZoneTableState => {
+  const cfg = profile.sportZones[sport];
+  const zc = cfg ? (cfg as Record<string, unknown>)[kind] : undefined;
+  const config = zc as { method?: string; zones?: unknown[] } | undefined;
+  const zones = config?.zones;
+  if (!Array.isArray(zones) || zones.length === 0) return "empty";
+  const method = config?.method ?? "custom";
+  if (method === "train2go") {
+    if (!snapshot) return "user-customized";
+    const snapZones = snapshot[SNAPSHOT_KEY[`${sport}.${kind}`]] as
+      | unknown[]
+      | undefined;
+    return equalsSnapshot(zones, snapZones, kind)
+      ? "train2go-synced-clean"
+      : "train2go-synced-edited";
+  }
+  if (method === "user") return "user-customized";
+  if (
+    isFormulaId(method) &&
+    isFormulaDerived(zones, method, profile, sport, kind)
+  ) {
+    return "method-derived";
+  }
+  if (isDefaultTemplate(zones, kind)) return "default-template";
+  return "user-customized";
+};


### PR DESCRIPTION
PR 2 of 6 for **zones-method-aware-reconcile**.

**Behaviour change:** the conflict dialog no longer surfaces 30+ pseudo-conflict rows on a freshly-created profile's first sync. Tables on the seed/template/method-derived path are silent-replaced; only genuinely user-customized tables produce per-band conflicts.

## Changes
- New `classifyZoneTable(profile, sport, kind, snapshot)` returns one of 6 canonical states.
- `reconcile` rewritten to use the classifier; strategies per state per design D-MA4.
- `commitConflictResolution` updates `method` and `lastSyncedZonesSnapshot` per D-MA4.
- Normalized `"manual"` fallback to `"custom"` (existing vocabulary).

## Test plan
- [x] 3257 tests pass (3239 → 3257, +18 new — 13 classifier states + 5 method-aware end-to-end)
- [x] Build + lint green
- [ ] CI green
- [ ] PR 3 (ZoneEditor user flag) follows after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)