### PR TITLE
feat(spa-editor): ZoneEditor manual edit flips method to 'user' (PR 3/6)

### DIFF
--- a/.changeset/zones-method-aware-zoneeditor-user-flag.md
+++ b/.changeset/zones-method-aware-zoneeditor-user-flag.md
@@ -1,0 +1,13 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+ZoneEditor manual band edits now flip `method = "user"` (PR 3 of 6 of `zones-method-aware-reconcile`).
+
+When the user edits any zone band via the Profile Manager `ZoneEditor`, the corresponding `<sport>.<kind>.method` is updated to `"user"` as part of the persistence write. Subsequent T2G syncs treat that table as `user-customized` (per the classifier in PR 2) and emit per-band conflicts rather than silent-replacing.
+
+The dropdown's formula-recompute pathway (`setZoneMethod`) is unchanged — it preserves the chosen method id (`"karvonen-5"`, `"coggan-7"`, etc.) so formula-derived zones stay classifiable as `method-derived`.
+
+`updateSportZones` use case is the manual-band-edit signal; `setZoneMethod` is the dropdown signal. The two pathways are now semantically distinct per design D-MA3 of zones-method-aware-reconcile.
+
+Test coverage: 4 new cases (4.3a-d) in `zones.test.ts` covering: train2go → user, custom → user, setZoneMethod stays formula, formula → user on band edit. Total 3261 tests pass (3257 → 3261).

--- a/packages/workout-spa-editor/src/application/profile/zones/update-sport-zones.ts
+++ b/packages/workout-spa-editor/src/application/profile/zones/update-sport-zones.ts
@@ -1,10 +1,17 @@
 /**
  * updateSportZones — application use case.
  *
- * Replaces the zones array for a (sport, zoneType) pair, leaving the
- * method untouched. No-op if the sport config has no entry for that
- * zoneType (matches legacy semantics). Throws `ProfileNotFoundError`
- * when the id is unknown.
+ * Replaces the zones array for a (sport, zoneType) pair AND flips
+ * `method` to `"user"` (per D-MA3 of zones-method-aware-reconcile).
+ * This is the band-edit pathway from the Profile Manager `ZoneEditor`
+ * — manually editing a band signals the table is now user-customized
+ * and subsequent T2G syncs MUST emit per-band conflicts rather than
+ * silent-replace. The dropdown's formula-recompute pathway uses
+ * `setZoneMethod` instead, which preserves the chosen method id.
+ *
+ * No-op if the sport config has no entry for that zoneType (matches
+ * legacy semantics). Throws `ProfileNotFoundError` when the id is
+ * unknown.
  */
 
 import type { PersistencePort } from "../../../ports/persistence-port";
@@ -27,7 +34,7 @@ export const updateSportZones = async (
     const updated = updateSportConfig(existing, sport, (cfg) => {
       const zc = cfg[zoneType];
       if (!zc) return cfg;
-      return { ...cfg, [zoneType]: { ...zc, zones } };
+      return { ...cfg, [zoneType]: { ...zc, method: "user", zones } };
     });
     await persistence.profiles.put(updated);
     return updated;

--- a/packages/workout-spa-editor/src/application/profile/zones/zones.test.ts
+++ b/packages/workout-spa-editor/src/application/profile/zones/zones.test.ts
@@ -139,6 +139,118 @@ describe("updateSportZones", () => {
       updateSportZones(persistence, "missing", "cycling", "heartRateZones", [])
     ).rejects.toBeInstanceOf(ProfileNotFoundError);
   });
+
+  it("should flip method to 'user' on manual band edit (4.3a)", async () => {
+    // Arrange — profile starts with method = "train2go" (post-T2G-sync).
+    const persistence = createInMemoryPersistence();
+    const profile = makeProfile();
+    profile.sportZones.cycling = {
+      thresholds: {},
+      heartRateZones: {
+        method: "train2go",
+        zones: [
+          { zone: 1, name: "Recovery", minBpm: 107, maxBpm: 133 },
+          { zone: 2, name: "Aerobic", minBpm: 134, maxBpm: 147 },
+        ],
+      },
+    };
+    await seedProfile(persistence, profile);
+
+    // Act — user manually edits Z2.maxBpm via Profile Manager.
+    const updated = await updateSportZones(
+      persistence,
+      profile.id,
+      "cycling",
+      "heartRateZones",
+      [
+        { zone: 1, name: "Recovery", minBpm: 107, maxBpm: 133 },
+        { zone: 2, name: "Aerobic", minBpm: 134, maxBpm: 145 },
+      ]
+    );
+
+    // Assert
+    expect(updated.sportZones.cycling?.heartRateZones?.method).toBe("user");
+    expect(
+      updated.sportZones.cycling?.heartRateZones?.zones[1]?.maxBpm
+    ).toBe(145);
+  });
+
+  it("should flip method from 'custom' to 'user' on manual band edit (4.3b)", async () => {
+    // Arrange — fresh profile starting at "custom".
+    const persistence = createInMemoryPersistence();
+    const profile = makeProfile();
+    profile.sportZones.cycling = {
+      thresholds: {},
+      heartRateZones: { method: "custom", zones: [] },
+    };
+    await seedProfile(persistence, profile);
+
+    // Act
+    const updated = await updateSportZones(
+      persistence,
+      profile.id,
+      "cycling",
+      "heartRateZones",
+      [{ zone: 1, name: "Recovery", minBpm: 107, maxBpm: 133 }]
+    );
+
+    // Assert
+    expect(updated.sportZones.cycling?.heartRateZones?.method).toBe("user");
+  });
+
+  it("should not affect setZoneMethod (formula path stays as-is) (4.3c)", async () => {
+    // Arrange — calling setZoneMethod (the formula-recompute path)
+    // should keep the chosen method id, NOT flip to "user".
+    const persistence = createInMemoryPersistence();
+    const profile = makeProfile();
+    profile.sportZones.cycling = {
+      thresholds: { lthr: 174 },
+      heartRateZones: { method: "user", zones: [] },
+    };
+    await seedProfile(persistence, profile);
+
+    // Act
+    const { setZoneMethod } = await import("./set-zone-method");
+    const updated = await setZoneMethod(
+      persistence,
+      profile.id,
+      "cycling",
+      "heartRateZones",
+      "karvonen-5",
+      [{ zone: 1, name: "Recovery", minBpm: 0, maxBpm: 142 }]
+    );
+
+    // Assert
+    expect(updated.sportZones.cycling?.heartRateZones?.method).toBe(
+      "karvonen-5"
+    );
+  });
+
+  it("should flip from formula method to 'user' when user manually edits a band (4.3d)", async () => {
+    // Arrange — profile in `karvonen-5` formula state.
+    const persistence = createInMemoryPersistence();
+    const profile = makeProfile();
+    profile.sportZones.cycling = {
+      thresholds: { lthr: 174 },
+      heartRateZones: {
+        method: "karvonen-5",
+        zones: [{ zone: 1, name: "Recovery", minBpm: 0, maxBpm: 142 }],
+      },
+    };
+    await seedProfile(persistence, profile);
+
+    // Act — user touches a band via Profile Manager.
+    const updated = await updateSportZones(
+      persistence,
+      profile.id,
+      "cycling",
+      "heartRateZones",
+      [{ zone: 1, name: "Recovery", minBpm: 0, maxBpm: 140 }]
+    );
+
+    // Assert
+    expect(updated.sportZones.cycling?.heartRateZones?.method).toBe("user");
+  });
 });
 
 describe("setZoneMethod", () => {

--- a/packages/workout-spa-editor/src/application/profile/zones/zones.test.ts
+++ b/packages/workout-spa-editor/src/application/profile/zones/zones.test.ts
@@ -170,9 +170,9 @@ describe("updateSportZones", () => {
 
     // Assert
     expect(updated.sportZones.cycling?.heartRateZones?.method).toBe("user");
-    expect(
-      updated.sportZones.cycling?.heartRateZones?.zones[1]?.maxBpm
-    ).toBe(145);
+    expect(updated.sportZones.cycling?.heartRateZones?.zones[1]?.maxBpm).toBe(
+      145
+    );
   });
 
   it("should flip method from 'custom' to 'user' on manual band edit (4.3b)", async () => {


### PR DESCRIPTION
PR 3 of 6 for **zones-method-aware-reconcile** (D-MA3 + D-MA8).

## Behaviour

When the user edits any zone band via Profile Manager, `updateSportZones` flips `method = "user"` so subsequent T2G syncs treat the table as `user-customized` (per the classifier in PR 2) and emit per-band conflicts rather than silent-replacing.

The dropdown's formula-recompute pathway (`setZoneMethod`) preserves the chosen method id (`karvonen-5`, `coggan-7`, etc.) — formula-derived zones stay classifiable as `method-derived`.

## Test plan
- [x] 3261 tests pass (3257 → 3261, +4 new — 4.3a-d)
- [x] Build + lint green
- [ ] CI green
- [ ] PR 4 (dialog grouping + FTP coupling) follows after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Manual zone band edits in the Profile Manager are now marked as user-customized, ensuring your adjustments are preserved during synchronization instead of being silently replaced.
  * Formula-based methods remain preserved when selected via the dropdown menu.

* **Tests**
  * Added test coverage for manual zone editing behavior and formula method preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->