### PR TITLE
feat(spa-editor): conflict dialog grouped by sport-kind + FTP coupling (PR 4/6)

### DIFF
--- a/.changeset/zones-method-aware-dialog-grouping.md
+++ b/.changeset/zones-method-aware-dialog-grouping.md
@@ -1,0 +1,24 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+Conflict dialog grouped by sport-kind table + FTP/power-bands coupling (PR 4 of 6 of `zones-method-aware-reconcile`).
+
+**UX behavior change:** the conflict dialog no longer renders a 30-row scroll-fest of per-band-bound rows. Band-level conflicts are grouped into a single decision unit per `<sport>.<kind>` table (e.g., "Cycling HR Zones — 5 bands differ") with one [Accept Train2Go] / [Keep current] radio plus an expandable [Detail] view showing per-band rows.
+
+When the FTP scalar is in conflicts AND any cycling.powerZones bands are also in conflicts, the dialog couples them into a single "Cycling threshold + zones" decision unit (per D-MA6) — accepting either implies accepting both, since power bands are stored as %FTP and accepting one without the other creates display inconsistency.
+
+**New components:**
+
+- `group-conflicts.ts` — partitions conflicts into scalars / band groups / coupled FTP+power.
+- `ConflictGroup.tsx` — single group row with header, accept/reject radio, expandable detail.
+- `ConflictGroupHeader.tsx`, `ConflictGroupRadios.tsx`, `ConflictGroupDetail.tsx`, `ConflictGroupList.tsx`, `DialogShell.tsx` — extracted from the dialog to fit React 60-line component cap.
+- `use-conflict-decisions.ts` — owns per-row + per-group decision + expand state.
+
+**Test changes:**
+
+- 3 PR-3-era band tests rewritten to use group testids (5.2a/b/c).
+- 1 new test for FTP+power-bands coupling (5.2d / D-MA6).
+- Total 3262 tests pass (3261 → 3262).
+
+Existing per-band testids (`zones-conflict-row-<field>`) are preserved INSIDE the expandable Detail view (DOM persists, hidden via `aria-hidden`).

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ConflictGroup.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ConflictGroup.tsx
@@ -1,0 +1,50 @@
+/**
+ * ConflictGroup — single group row inside `ZonesConflictDialog`.
+ * Represents one `<sport>.<kind>` table or the coupled FTP+power-bands
+ * decision (per D-MA5/D-MA6 of zones-method-aware-reconcile).
+ */
+import type {
+  ConflictDecision,
+  ConflictItem,
+} from "../../../types/coaching-zones";
+import { ConflictGroupDetail } from "./ConflictGroupDetail";
+import { ConflictGroupHeader } from "./ConflictGroupHeader";
+import { ConflictGroupRadios } from "./ConflictGroupRadios";
+
+export type ConflictGroupProps = {
+  groupKey: string;
+  label: string;
+  conflicts: readonly ConflictItem[];
+  decision: ConflictDecision;
+  expanded: boolean;
+  onChange: (next: ConflictDecision) => void;
+  onToggleExpand: () => void;
+};
+
+export const ConflictGroup = ({
+  groupKey,
+  label,
+  conflicts,
+  decision,
+  expanded,
+  onChange,
+  onToggleExpand,
+}: ConflictGroupProps) => (
+  <li
+    data-testid={`zones-conflict-group-${groupKey}`}
+    className="rounded border p-2"
+  >
+    <ConflictGroupHeader
+      label={label}
+      bandCount={conflicts.length}
+      expanded={expanded}
+      onToggleExpand={onToggleExpand}
+    />
+    <ConflictGroupRadios
+      groupKey={groupKey}
+      decision={decision}
+      onChange={onChange}
+    />
+    <ConflictGroupDetail conflicts={conflicts} expanded={expanded} />
+  </li>
+);

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ConflictGroupDetail.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ConflictGroupDetail.tsx
@@ -1,0 +1,37 @@
+/**
+ * `ConflictGroupDetail` — expandable per-band display rows inside a
+ * group. Visibility-only (rows stay in DOM via aria-hidden).
+ */
+import type { ConflictItem } from "../../../types/coaching-zones";
+import { formatFieldValue } from "./field-labels";
+
+export type ConflictGroupDetailProps = {
+  conflicts: readonly ConflictItem[];
+  expanded: boolean;
+};
+
+export const ConflictGroupDetail = ({
+  conflicts,
+  expanded,
+}: ConflictGroupDetailProps) => (
+  <ul
+    className={
+      expanded ? "mt-2 space-y-1 text-xs" : "mt-2 space-y-1 text-xs hidden"
+    }
+    aria-hidden={!expanded}
+  >
+    {conflicts.map((c) => (
+      <li
+        key={c.field}
+        data-testid={`zones-conflict-row-${c.field}`}
+        className="text-muted-foreground"
+      >
+        {c.field}: {formatFieldValue(c.field, c.current)}
+        <span aria-hidden="true"> → </span>
+        <span className="font-medium">
+          {formatFieldValue(c.field, c.incoming)}
+        </span>
+      </li>
+    ))}
+  </ul>
+);

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ConflictGroupHeader.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ConflictGroupHeader.tsx
@@ -1,0 +1,37 @@
+/**
+ * `ConflictGroupHeader` — title + band-count summary + Detail toggle
+ * button. Extracted from `ConflictGroup` to keep that component under
+ * the React 60-line cap.
+ */
+
+export type ConflictGroupHeaderProps = {
+  label: string;
+  bandCount: number;
+  expanded: boolean;
+  onToggleExpand: () => void;
+};
+
+const summary = (count: number): string =>
+  count === 1 ? "1 band differs" : `${count} bands differ`;
+
+export const ConflictGroupHeader = ({
+  label,
+  bandCount,
+  expanded,
+  onToggleExpand,
+}: ConflictGroupHeaderProps) => (
+  <div className="flex items-center justify-between">
+    <div>
+      <div className="text-sm font-medium">{label}</div>
+      <div className="text-xs text-muted-foreground">{summary(bandCount)}</div>
+    </div>
+    <button
+      type="button"
+      onClick={onToggleExpand}
+      aria-expanded={expanded}
+      className="text-xs text-muted-foreground hover:underline"
+    >
+      {expanded ? "Hide" : "Detail"}
+    </button>
+  </div>
+);

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ConflictGroupList.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ConflictGroupList.tsx
@@ -1,0 +1,60 @@
+/**
+ * `ConflictGroupList` — renders the band groups + coupled FTP group
+ * inside the conflict dialog. Extracted so `ZonesConflictDialog` stays
+ * under the 60-line React component cap.
+ */
+import type {
+  ConflictDecision,
+  ConflictItem,
+} from "../../../types/coaching-zones";
+import { ConflictGroup } from "./ConflictGroup";
+import type { BandGroup, CoupledFtpGroup } from "./group-conflicts";
+
+export type ConflictGroupListProps = {
+  bandGroups: BandGroup[];
+  ftpCoupled: CoupledFtpGroup | undefined;
+  groupDecisions: Record<string, ConflictDecision>;
+  expanded: Set<string>;
+  onSetGroup: (groupKey: string, d: ConflictDecision) => void;
+  onToggleExpand: (groupKey: string) => void;
+};
+
+const flattenCoupledConflicts = (coupled: CoupledFtpGroup): ConflictItem[] => [
+  coupled.ftpConflict,
+  ...coupled.powerBandConflicts,
+];
+
+export const ConflictGroupList = ({
+  bandGroups,
+  ftpCoupled,
+  groupDecisions,
+  expanded,
+  onSetGroup,
+  onToggleExpand,
+}: ConflictGroupListProps) => (
+  <>
+    {ftpCoupled && (
+      <ConflictGroup
+        groupKey={ftpCoupled.groupKey}
+        label={ftpCoupled.label}
+        conflicts={flattenCoupledConflicts(ftpCoupled)}
+        decision={groupDecisions[ftpCoupled.groupKey] ?? "reject"}
+        expanded={expanded.has(ftpCoupled.groupKey)}
+        onChange={(d) => onSetGroup(ftpCoupled.groupKey, d)}
+        onToggleExpand={() => onToggleExpand(ftpCoupled.groupKey)}
+      />
+    )}
+    {bandGroups.map((g) => (
+      <ConflictGroup
+        key={g.groupKey}
+        groupKey={g.groupKey}
+        label={g.label}
+        conflicts={g.conflicts}
+        decision={groupDecisions[g.groupKey] ?? "reject"}
+        expanded={expanded.has(g.groupKey)}
+        onChange={(d) => onSetGroup(g.groupKey, d)}
+        onToggleExpand={() => onToggleExpand(g.groupKey)}
+      />
+    ))}
+  </>
+);

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ConflictGroupRadios.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ConflictGroupRadios.tsx
@@ -1,0 +1,40 @@
+/**
+ * `ConflictGroupRadios` — accept/reject radio pair for a single group.
+ * Extracted from `ConflictGroup` to keep that component under the cap.
+ */
+import type { ConflictDecision } from "../../../types/coaching-zones";
+
+export type ConflictGroupRadiosProps = {
+  groupKey: string;
+  decision: ConflictDecision;
+  onChange: (next: ConflictDecision) => void;
+};
+
+export const ConflictGroupRadios = ({
+  groupKey,
+  decision,
+  onChange,
+}: ConflictGroupRadiosProps) => (
+  <div className="mt-2 flex gap-3 text-xs">
+    <label className="flex items-center gap-1">
+      <input
+        type="radio"
+        name={`zones-conflict-${groupKey}`}
+        value="accept"
+        checked={decision === "accept"}
+        onChange={() => onChange("accept")}
+      />
+      Accept Train2Go
+    </label>
+    <label className="flex items-center gap-1">
+      <input
+        type="radio"
+        name={`zones-conflict-${groupKey}`}
+        value="reject"
+        checked={decision === "reject"}
+        onChange={() => onChange("reject")}
+      />
+      Keep current
+    </label>
+  </div>
+);

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/DialogShell.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/DialogShell.tsx
@@ -1,0 +1,53 @@
+/**
+ * `DialogShell` — modal backdrop, title, intro text, and Cancel/Apply
+ * buttons. Extracted from `ZonesConflictDialog` to keep the parent
+ * component under the React 60-line cap.
+ */
+import type { ReactNode } from "react";
+
+export type DialogShellProps = {
+  children: ReactNode;
+  onCancel: () => void;
+  onApply: () => void;
+};
+
+export const DialogShell = ({
+  children,
+  onCancel,
+  onApply,
+}: DialogShellProps) => (
+  <div
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="zones-conflict-title"
+    data-testid="zones-conflict-dialog"
+    className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+  >
+    <div className="w-full max-w-md rounded-lg bg-white p-4 shadow-lg dark:bg-gray-900">
+      <h2 id="zones-conflict-title" className="text-base font-semibold">
+        Resolve zones-sync conflicts
+      </h2>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Train2Go has different values for these fields. Pick which to keep —
+        Kaiord (current) or Train2Go (incoming).
+      </p>
+      <ul className="mt-3 space-y-2">{children}</ul>
+      <div className="mt-4 flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border px-3 py-1 text-sm hover:bg-gray-50 dark:hover:bg-gray-800"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onApply}
+          className="rounded-md bg-rose-600 px-3 py-1 text-sm text-white hover:bg-rose-700"
+        >
+          Apply
+        </button>
+      </div>
+    </div>
+  </div>
+);

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ZonesConflictDialog.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ZonesConflictDialog.test.tsx
@@ -140,7 +140,7 @@ describe("ZonesConflictDialog", () => {
     });
   });
 
-  it("should render a band-level conflict row with a generated label (5.2a)", () => {
+  it("should render a band-level conflict as a single group row with band-count summary (5.2a)", () => {
     // Arrange
     const bandConflicts: ConflictItem[] = [
       {
@@ -160,17 +160,24 @@ describe("ZonesConflictDialog", () => {
       />
     );
 
-    // Assert
+    // Assert — group row uses the new testid; per-band row exists in
+    // the DOM (inside collapsed Detail) but is hidden via aria-hidden.
+    expect(
+      screen.getByTestId("zones-conflict-group-cycling.heartRateZones")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Cycling HR Zones")).toBeInTheDocument();
+    expect(screen.getByText("1 band differs")).toBeInTheDocument();
     expect(
       screen.getByTestId("zones-conflict-row-cycling.heartRateZones.z2.maxBpm")
     ).toBeInTheDocument();
-    expect(screen.getByText("Cycling HR Z2 max")).toBeInTheDocument();
   });
 
-  it("should preserve insertion order grouping scalars and band-level conflicts (5.2b)", () => {
-    // Arrange — mixed scalar + band conflicts, scalar first
+  it("should preserve insertion order grouping scalars first then band groups (5.2b)", () => {
+    // Arrange — mixed scalar + band conflicts; scalar (LTHR) first.
+    // FTP would couple with cycling.powerZones — use cycling.thresholds.lthr to
+    // avoid the FTP+power coupling and test pure ordering.
     const mixed: ConflictItem[] = [
-      { field: "cycling.thresholds.ftp", current: 200, incoming: 270 },
+      { field: "cycling.thresholds.lthr", current: 160, incoming: 174 },
       {
         field: "cycling.heartRateZones.z2.minBpm",
         current: 131,
@@ -193,20 +200,19 @@ describe("ZonesConflictDialog", () => {
       />
     );
 
-    // Assert — all three rows render with distinct testids
+    // Assert — scalar keeps its per-row testid; bands collapse into one group.
     expect(
-      screen.getByTestId("zones-conflict-row-cycling.thresholds.ftp")
+      screen.getByTestId("zones-conflict-row-cycling.thresholds.lthr")
     ).toBeInTheDocument();
     expect(
-      screen.getByTestId("zones-conflict-row-cycling.heartRateZones.z2.minBpm")
+      screen.getByTestId("zones-conflict-group-cycling.heartRateZones")
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId("zones-conflict-row-cycling.heartRateZones.z2.maxBpm")
-    ).toBeInTheDocument();
+    expect(screen.getByText("2 bands differ")).toBeInTheDocument();
   });
 
-  it("should emit accept decisions for all rows of a sport-kind table when each is toggled (5.2c)", async () => {
-    // Arrange
+  it("should emit accept decisions for all bands when the group's accept radio is selected (5.2c)", async () => {
+    // Arrange — 4 conflicts in cycling.heartRateZones; user clicks ONCE
+    // on the group's accept radio (NOT 4 individual radios).
     const tableConflicts: ConflictItem[] = [
       {
         field: "cycling.heartRateZones.z1.minBpm",
@@ -238,23 +244,81 @@ describe("ZonesConflictDialog", () => {
         onCancel={vi.fn()}
       />
     );
-    for (const c of tableConflicts) {
-      const row = screen.getByTestId(`zones-conflict-row-${c.field}`);
-      const acceptInput = row.querySelector(
-        'input[value="accept"]'
-      ) as HTMLInputElement;
-      await userEvent.click(acceptInput);
-    }
+    const group = screen.getByTestId(
+      "zones-conflict-group-cycling.heartRateZones"
+    );
+    const acceptInput = group.querySelector(
+      'input[value="accept"]'
+    ) as HTMLInputElement;
+    await userEvent.click(acceptInput);
 
     // Act
     await userEvent.click(screen.getByRole("button", { name: "Apply" }));
 
-    // Assert
+    // Assert — single group click emits accept for all 4 band-bound keys.
     expect(onConfirm).toHaveBeenCalledWith({
       "cycling.heartRateZones.z1.minBpm": "accept",
       "cycling.heartRateZones.z1.maxBpm": "accept",
       "cycling.heartRateZones.z2.minBpm": "accept",
       "cycling.heartRateZones.z2.maxBpm": "accept",
+    });
+  });
+
+  it("should couple FTP scalar + cycling.powerZones into a single group (5.2d / D-MA6)", async () => {
+    // Arrange — FTP scalar conflict alongside cycling-power band conflicts
+    // SHALL render as one coupled group, not separate.
+    const coupled: ConflictItem[] = [
+      { field: "cycling.thresholds.ftp", current: 200, incoming: 268 },
+      {
+        field: "cycling.powerZones.z4.minPercent",
+        current: 91,
+        incoming: 90,
+      },
+      {
+        field: "cycling.powerZones.z4.maxPercent",
+        current: 105,
+        incoming: 100,
+      },
+    ];
+    const onConfirm = vi.fn();
+    render(
+      <ZonesConflictDialog
+        open
+        conflicts={coupled}
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+
+    // Assert — coupled group exists; the FTP row testid lives INSIDE
+    // the coupled group's Detail view (per the spec — Detail keeps all
+    // rows in DOM via aria-hidden), NOT as a standalone scalar row.
+    const coupledGroup = screen.getByTestId(
+      "zones-conflict-group-cycling.threshold-and-zones"
+    );
+    expect(coupledGroup).toBeInTheDocument();
+    expect(screen.getByText("Cycling threshold + zones")).toBeInTheDocument();
+    // FTP testid is INSIDE the coupled group, not at top level.
+    const ftpRow = screen.getByTestId(
+      "zones-conflict-row-cycling.thresholds.ftp"
+    );
+    expect(coupledGroup.contains(ftpRow)).toBe(true);
+
+    // Act — accept the coupled group; both FTP and bands should be in the decisions.
+    const group = screen.getByTestId(
+      "zones-conflict-group-cycling.threshold-and-zones"
+    );
+    const acceptInput = group.querySelector(
+      'input[value="accept"]'
+    ) as HTMLInputElement;
+    await userEvent.click(acceptInput);
+    await userEvent.click(screen.getByRole("button", { name: "Apply" }));
+
+    // Assert
+    expect(onConfirm).toHaveBeenCalledWith({
+      "cycling.thresholds.ftp": "accept",
+      "cycling.powerZones.z4.minPercent": "accept",
+      "cycling.powerZones.z4.maxPercent": "accept",
     });
   });
 });

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ZonesConflictDialog.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/ZonesConflictDialog.tsx
@@ -1,26 +1,25 @@
 /**
- * ZonesConflictDialog — phase-2 of the zones-sync flow.
- *
- * The use case `syncZones` returns an array of `ConflictItem`s with
- * the user's current value and the incoming Train2Go value. The user
- * picks accept or reject per row; on confirm the parent invokes
- * `commitConflictResolution` with the per-row decisions.
- *
- * Hard contract (verified by tests + ESLint react/no-danger):
- *   - NEVER use `dangerouslySetInnerHTML`.
- *   - Field labels come from the static `FIELD_LABELS` map keyed by
- *     `FieldKey`, NEVER from a T2G-supplied string.
- *   - Numeric values render as React children so React's default
- *     escaping handles any future shape drift.
+ * ZonesConflictDialog — phase-2 of the zones-sync flow. Conflicts are
+ * grouped by `<sport>.<kind>` table for usability (per D-MA5/D-MA6 of
+ * zones-method-aware-reconcile). Layout shell extracted to
+ * `DialogShell.tsx`; group rendering extracted to `ConflictGroupList`;
+ * decision state extracted to `useConflictDecisions`.
  */
-import { useState } from "react";
+import { useMemo } from "react";
 
 import type {
   ConflictDecision,
   ConflictItem,
   FieldKey,
 } from "../../../types/coaching-zones";
+import { ConflictGroupList } from "./ConflictGroupList";
 import { ConflictRow } from "./ConflictRow";
+import { DialogShell } from "./DialogShell";
+import { groupConflicts } from "./group-conflicts";
+import {
+  buildConfirmDecisions,
+  useConflictDecisions,
+} from "./use-conflict-decisions";
 
 export type ZonesConflictDialogProps = {
   open: boolean;
@@ -29,71 +28,40 @@ export type ZonesConflictDialogProps = {
   onCancel: () => void;
 };
 
-const initialDecisions = (
-  conflicts: readonly ConflictItem[]
-): Record<FieldKey, ConflictDecision> => {
-  const out = {} as Record<FieldKey, ConflictDecision>;
-  for (const c of conflicts) out[c.field] = "reject";
-  return out;
-};
-
 export const ZonesConflictDialog = ({
   open,
   conflicts,
   onConfirm,
   onCancel,
 }: ZonesConflictDialogProps) => {
-  const [decisions, setDecisions] = useState<
-    Record<FieldKey, ConflictDecision>
-  >(() => initialDecisions(conflicts));
-
+  const grouped = useMemo(() => groupConflicts(conflicts), [conflicts]);
+  const ds = useConflictDecisions(grouped);
   if (!open) return null;
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="zones-conflict-title"
-      data-testid="zones-conflict-dialog"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+    <DialogShell
+      onCancel={onCancel}
+      onApply={() =>
+        onConfirm(
+          buildConfirmDecisions(grouped, ds.scalarDecisions, ds.groupDecisions)
+        )
+      }
     >
-      <div className="w-full max-w-md rounded-lg bg-white p-4 shadow-lg dark:bg-gray-900">
-        <h2 id="zones-conflict-title" className="text-base font-semibold">
-          Resolve zones-sync conflicts
-        </h2>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Train2Go has different values for these fields. Pick which to keep —
-          Kaiord (current) or Train2Go (incoming).
-        </p>
-        <ul className="mt-3 space-y-2">
-          {conflicts.map((c) => (
-            <ConflictRow
-              key={c.field}
-              conflict={c}
-              decision={decisions[c.field] ?? "reject"}
-              onChange={(d) =>
-                setDecisions((prev) => ({ ...prev, [c.field]: d }))
-              }
-            />
-          ))}
-        </ul>
-        <div className="mt-4 flex justify-end gap-2">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="rounded-md border px-3 py-1 text-sm hover:bg-gray-50 dark:hover:bg-gray-800"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={() => onConfirm(decisions)}
-            className="rounded-md bg-rose-600 px-3 py-1 text-sm text-white hover:bg-rose-700"
-          >
-            Apply
-          </button>
-        </div>
-      </div>
-    </div>
+      {grouped.scalars.map((c) => (
+        <ConflictRow
+          key={c.field}
+          conflict={c}
+          decision={ds.scalarDecisions[c.field] ?? "reject"}
+          onChange={(d) => ds.setScalar(c.field, d)}
+        />
+      ))}
+      <ConflictGroupList
+        bandGroups={grouped.bandGroups}
+        ftpCoupled={grouped.ftpCoupled}
+        groupDecisions={ds.groupDecisions}
+        expanded={ds.expanded}
+        onSetGroup={ds.setGroup}
+        onToggleExpand={ds.toggleExpand}
+      />
+    </DialogShell>
   );
 };

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/group-conflicts-labels.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/group-conflicts-labels.ts
@@ -1,0 +1,28 @@
+/**
+ * Static label tables + group factory for `group-conflicts.ts`.
+ * Co-located so the parent stays under the 80-line cap.
+ */
+import type { BandGroup } from "./group-conflicts";
+
+const SPORT_LABELS = {
+  cycling: "Cycling",
+  running: "Running",
+  swimming: "Swimming",
+} as const;
+
+const KIND_LABELS = {
+  heartRateZones: "HR Zones",
+  powerZones: "Power Zones",
+  paceZones: "Pace Zones",
+} as const;
+
+export const buildGroup = (
+  sport: BandGroup["sport"],
+  kind: BandGroup["kind"]
+): BandGroup => ({
+  groupKey: `${sport}.${kind}`,
+  sport,
+  kind,
+  label: `${SPORT_LABELS[sport]} ${KIND_LABELS[kind]}`,
+  conflicts: [],
+});

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/group-conflicts.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/group-conflicts.ts
@@ -1,0 +1,76 @@
+/**
+ * `groupConflicts` — partitions a flat ConflictItem array into:
+ *   1. Threshold scalars (the legacy 7 keys; rendered per-row).
+ *   2. Band-level groups by `<sport>.<kind>` table.
+ *   3. Coupled FTP+cycling-power group (when both FTP scalar AND
+ *      cycling.powerZones bands have conflicts — D-MA6).
+ */
+import { tableKeyOfField } from "../../../application/coaching/sync-zones-snapshot";
+import type { ConflictItem } from "../../../types/coaching-zones";
+
+export type BandGroup = {
+  groupKey: string;
+  sport: "cycling" | "running" | "swimming";
+  kind: "heartRateZones" | "powerZones" | "paceZones";
+  label: string;
+  conflicts: ConflictItem[];
+};
+
+export type CoupledFtpGroup = {
+  groupKey: "cycling.threshold-and-zones";
+  label: "Cycling threshold + zones";
+  ftpConflict: ConflictItem;
+  powerBandConflicts: ConflictItem[];
+};
+
+export type GroupedConflicts = {
+  scalars: ConflictItem[];
+  bandGroups: BandGroup[];
+  ftpCoupled?: CoupledFtpGroup;
+};
+
+import { buildGroup } from "./group-conflicts-labels";
+
+export const groupConflicts = (
+  conflicts: readonly ConflictItem[]
+): GroupedConflicts => {
+  const scalars: ConflictItem[] = [];
+  const bandTables = new Map<string, BandGroup>();
+  let ftpScalar: ConflictItem | undefined;
+  for (const c of conflicts) {
+    if (c.field === "cycling.thresholds.ftp") {
+      ftpScalar = c;
+      continue;
+    }
+    const tk = tableKeyOfField(c.field);
+    if (!tk) {
+      scalars.push(c);
+      continue;
+    }
+    const sport = tk.sport as BandGroup["sport"];
+    const kind = tk.kind as BandGroup["kind"];
+    const groupKey = `${sport}.${kind}`;
+    let group = bandTables.get(groupKey);
+    if (!group) {
+      group = buildGroup(sport, kind);
+      bandTables.set(groupKey, group);
+    }
+    group.conflicts.push(c);
+  }
+  const cyclingPower = bandTables.get("cycling.powerZones");
+  if (ftpScalar && cyclingPower) {
+    bandTables.delete("cycling.powerZones");
+    return {
+      scalars,
+      bandGroups: Array.from(bandTables.values()),
+      ftpCoupled: {
+        groupKey: "cycling.threshold-and-zones",
+        label: "Cycling threshold + zones",
+        ftpConflict: ftpScalar,
+        powerBandConflicts: cyclingPower.conflicts,
+      },
+    };
+  }
+  if (ftpScalar) scalars.push(ftpScalar);
+  return { scalars, bandGroups: Array.from(bandTables.values()) };
+};

--- a/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/use-conflict-decisions.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ZonesConflictDialog/use-conflict-decisions.ts
@@ -1,0 +1,79 @@
+/**
+ * `useConflictDecisions` — owns the per-row + per-group decision state
+ * + expand state for the conflict dialog. Co-located with
+ * `ZonesConflictDialog.tsx` so the parent component stays under the
+ * 60-line React component cap.
+ */
+import { useState } from "react";
+
+import type { ConflictDecision, FieldKey } from "../../../types/coaching-zones";
+import type { GroupedConflicts } from "./group-conflicts";
+
+type GroupDecisions = Record<string, ConflictDecision>;
+type ScalarDecisions = Record<FieldKey, ConflictDecision>;
+
+const initialScalars = (grouped: GroupedConflicts): ScalarDecisions => {
+  const out = {} as ScalarDecisions;
+  for (const c of grouped.scalars) out[c.field] = "reject";
+  return out;
+};
+
+const initialGroups = (grouped: GroupedConflicts): GroupDecisions => {
+  const out: GroupDecisions = {};
+  for (const g of grouped.bandGroups) out[g.groupKey] = "reject";
+  if (grouped.ftpCoupled) out[grouped.ftpCoupled.groupKey] = "reject";
+  return out;
+};
+
+export const useConflictDecisions = (grouped: GroupedConflicts) => {
+  const [scalarDecisions, setScalarDecisions] = useState<ScalarDecisions>(() =>
+    initialScalars(grouped)
+  );
+  const [groupDecisions, setGroupDecisions] = useState<GroupDecisions>(() =>
+    initialGroups(grouped)
+  );
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const setScalar = (field: FieldKey, d: ConflictDecision) =>
+    setScalarDecisions((prev) => ({ ...prev, [field]: d }));
+
+  const setGroup = (groupKey: string, d: ConflictDecision) =>
+    setGroupDecisions((prev) => ({ ...prev, [groupKey]: d }));
+
+  const toggleExpand = (groupKey: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(groupKey)) next.delete(groupKey);
+      else next.add(groupKey);
+      return next;
+    });
+
+  return {
+    scalarDecisions,
+    groupDecisions,
+    expanded,
+    setScalar,
+    setGroup,
+    toggleExpand,
+  };
+};
+
+export const buildConfirmDecisions = (
+  grouped: GroupedConflicts,
+  scalarDecisions: ScalarDecisions,
+  groupDecisions: GroupDecisions
+): Record<FieldKey, ConflictDecision> => {
+  const out = { ...scalarDecisions } as Record<FieldKey, ConflictDecision>;
+  for (const g of grouped.bandGroups) {
+    const d = groupDecisions[g.groupKey] ?? "reject";
+    for (const c of g.conflicts) out[c.field] = d;
+  }
+  if (grouped.ftpCoupled) {
+    const d = groupDecisions[grouped.ftpCoupled.groupKey] ?? "reject";
+    out[grouped.ftpCoupled.ftpConflict.field] = d;
+    for (const c of grouped.ftpCoupled.powerBandConflicts) {
+      out[c.field] = d;
+    }
+  }
+  return out;
+};


### PR DESCRIPTION
PR 4 of 6 for **zones-method-aware-reconcile** (D-MA5 + D-MA6 + D-MA9).

## UX behavior change
- Band-level conflicts collapse into a single decision unit per `<sport>.<kind>` table.
- FTP scalar + cycling.powerZones → coupled "Cycling threshold + zones" group (D-MA6).
- Per-band testids preserved inside expandable Detail view.

## Components
- `group-conflicts.ts` partition helper + `group-conflicts-labels.ts` factory.
- `ConflictGroup.tsx` + `ConflictGroupHeader` / `ConflictGroupRadios` / `ConflictGroupDetail` / `ConflictGroupList` (split for 60-line React component cap).
- `DialogShell.tsx` modal shell extracted.
- `use-conflict-decisions.ts` decision-state hook.

## Test plan
- [x] 3262 tests pass (3261 → 3262, +1 net — 4 new dialog tests minus rewrites).
- [x] Build + lint green.
- [ ] CI green.
- [ ] PR 5 (e2e flows) follows after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)