### PR TITLE
fix(train2go-bridge): parse Generic HR block from full HTML

### DIFF
--- a/.changeset/train2go-bridge-generic-outside-hrzones.md
+++ b/.changeset/train2go-bridge-generic-outside-hrzones.md
@@ -1,0 +1,7 @@
+---
+"@kaiord/train2go-bridge": patch
+---
+
+Fix Generic HR block extraction in production T2G HTML. The `heart-rate-zone-generic` wrapper is rendered as a sibling under `<section class="pupil-details">` — outside the per-user `<div id="hrzones-{id}">` container that holds the sport-specific blocks. The parser used to slice `id="hrzones-{id}"` → first `</section>` and scan for all four zone wrappers in that slice, so on real T2G HTML it never reached generic and emitted only the cycling Specific block. The SPA mapper's Specific → Generic → skip fallback (D-FB1) consequently never fired for running and swimming, leaving those HR tables at 0-0 after sync.
+
+Now the parser parses Generic from the full HTML (with comments stripped first so prose mentions of `heart-rate-zone-generic` in fixture headers can't anchor the wrapper regex). The lazy match in `extractHrFullBands` stays self-anchored on the literal class name and stops at the next `heart-rate-zone-X` or `</section>`, so the wider scope cannot bleed into sport-specific blocks. Sport-specific extraction continues to operate on the narrower slice for safety.

--- a/packages/train2go-bridge/parser.js
+++ b/packages/train2go-bridge/parser.js
@@ -283,19 +283,32 @@ const parsePacesBlock = (html) => {
 };
 
 const parseHrZonesBlock = (html) => {
-  // Per-sport HR zones plus the Generic Karvonen-derived block.
-  // sport_id is implicit on the heart-rate-zone wrapper
-  // (heart-rate-zone-{generic,cycling,running,swimming}). Each block
-  // is emitted ONLY when present in the upstream HTML — the SPA
-  // mapper applies a Specific → Generic → skip fallback per D-FB1.
-  const block = sliceBetween(html, /id="hrzones-\d+"/, /<\/main>|<\/section>/);
-  if (!block) return null;
+  // Sport-specific blocks (cycling/running/swimming) live INSIDE the
+  // per-user `<div id="hrzones-{id}">` container; the Generic block
+  // is rendered as a SIBLING under <section class="pupil-details">
+  // and ends up OUTSIDE that container. We therefore parse Generic
+  // from the full HTML and the sport-specific blocks from the
+  // narrower slice. extractHrFullBands' lazy regex is self-anchored
+  // on `heart-rate-zone-generic` and stops at the next
+  // `heart-rate-zone-X` or `</section>`, so it can't bleed into the
+  // sport-specific blocks. The SPA mapper applies a Specific →
+  // Generic → skip fallback per D-FB1. HTML comments are stripped
+  // first so prose mentions of zone class names (e.g. fixture
+  // headers) cannot anchor the wrapper regex.
+  const stripped = html.replace(/<!--[\s\S]*?-->/g, "");
+  const block = sliceBetween(
+    stripped,
+    /id="hrzones-\d+"/,
+    /<\/main>|<\/section>/
+  );
   const out = {};
-  const generic = extractHrFullBands(block, "generic");
+  const generic = extractHrFullBands(stripped, "generic");
   if (generic) out.generic = generic;
-  for (const sport of ["cycling", "running", "swimming"]) {
-    const bands = extractHrFullBands(block, sport);
-    if (bands) out[sport] = bands;
+  if (block) {
+    for (const sport of ["cycling", "running", "swimming"]) {
+      const bands = extractHrFullBands(block, sport);
+      if (bands) out[sport] = bands;
+    }
   }
   return Object.keys(out).length > 0 ? out : null;
 };

--- a/packages/train2go-bridge/test/parser.test.js
+++ b/packages/train2go-bridge/test/parser.test.js
@@ -559,5 +559,60 @@ describe("parser", () => {
       expect(result.hrZones.swimming.z5).toEqual({ lower: 173, upper: 185 });
       expect(result.hrZones.swimming.z4Upper).toBe(172);
     });
+
+    it("should still emit hrZones.generic when the generic block is a sibling of hrzones-{id} (outside the per-user container, as in production T2G)", () => {
+      // Arrange
+      // Mirrors real T2G: cycling Specific lives INSIDE
+      // `<div id="hrzones-{id}">`, while the Generic Karvonen block
+      // is rendered as a sibling under <section class="pupil-details">
+      // — outside the slice the legacy parseHrZonesBlock used to
+      // anchor on. The fix parses Generic from the full HTML.
+      const html = `<main><section class="pupil-details">
+        <div id="hrzones-28035" class="details-hrzones">
+          <div class="heart-rate-zone heart-rate-zone-cycling">
+            <form action="/api/v2/hrzones/cyc" class="remote">
+              <input name="z0_lower" type="number" value="107" />
+              <input name="z0_upper" type="number" value="133" />
+              <input name="z1_lower" type="number" value="134" />
+              <input name="z1_upper" type="number" value="147" />
+              <input name="z2_lower" type="number" value="148" />
+              <input name="z2_upper" type="number" value="160" />
+              <input name="z3_lower" type="number" value="161" />
+              <input name="z3_upper" type="number" value="174" />
+              <input name="z4_lower" type="number" value="175" />
+              <input name="z4_upper" type="number" value="187" />
+            </form>
+          </div>
+        </div>
+        <div class="heart-rate-zone heart-rate-zone-generic">
+          <form action="/api/v2/hrzones/gen" class="remote">
+            <input name="z0_lower" type="number" value="107" />
+            <input name="z0_upper" type="number" value="133" />
+            <input name="z1_lower" type="number" value="134" />
+            <input name="z1_upper" type="number" value="147" />
+            <input name="z2_lower" type="number" value="148" />
+            <input name="z2_upper" type="number" value="160" />
+            <input name="z3_lower" type="number" value="161" />
+            <input name="z3_upper" type="number" value="174" />
+            <input name="z4_lower" type="number" value="175" />
+            <input name="z4_upper" type="number" value="187" />
+          </form>
+        </div>
+      </section></main>`;
+
+      // Act
+      const result = parseDetailsHtml(html);
+
+      // Assert
+      expect(result.hrZones.generic).toEqual({
+        z1: { lower: 107, upper: 133 },
+        z2: { lower: 134, upper: 147 },
+        z3: { lower: 148, upper: 160 },
+        z4: { lower: 161, upper: 174 },
+        z5: { lower: 175, upper: 187 },
+        z4Upper: 174,
+      });
+      expect(result.hrZones.cycling.z4).toEqual({ lower: 161, upper: 174 });
+    });
   });
 });

--- a/packages/train2go-bridge/test/parser.test.js
+++ b/packages/train2go-bridge/test/parser.test.js
@@ -567,20 +567,23 @@ describe("parser", () => {
       // is rendered as a sibling under <section class="pupil-details">
       // — outside the slice the legacy parseHrZonesBlock used to
       // anchor on. The fix parses Generic from the full HTML.
+      // Cycling and Generic use DISTINCT band values so the test
+      // would fail if extraction bled across siblings (e.g. cycling
+      // accidentally read the generic block or vice versa).
       const html = `<main><section class="pupil-details">
         <div id="hrzones-28035" class="details-hrzones">
           <div class="heart-rate-zone heart-rate-zone-cycling">
             <form action="/api/v2/hrzones/cyc" class="remote">
-              <input name="z0_lower" type="number" value="107" />
-              <input name="z0_upper" type="number" value="133" />
-              <input name="z1_lower" type="number" value="134" />
-              <input name="z1_upper" type="number" value="147" />
-              <input name="z2_lower" type="number" value="148" />
-              <input name="z2_upper" type="number" value="160" />
-              <input name="z3_lower" type="number" value="161" />
-              <input name="z3_upper" type="number" value="174" />
-              <input name="z4_lower" type="number" value="175" />
-              <input name="z4_upper" type="number" value="187" />
+              <input name="z0_lower" type="number" value="110" />
+              <input name="z0_upper" type="number" value="136" />
+              <input name="z1_lower" type="number" value="137" />
+              <input name="z1_upper" type="number" value="150" />
+              <input name="z2_lower" type="number" value="151" />
+              <input name="z2_upper" type="number" value="163" />
+              <input name="z3_lower" type="number" value="164" />
+              <input name="z3_upper" type="number" value="177" />
+              <input name="z4_lower" type="number" value="178" />
+              <input name="z4_upper" type="number" value="190" />
             </form>
           </div>
         </div>
@@ -612,7 +615,8 @@ describe("parser", () => {
         z5: { lower: 175, upper: 187 },
         z4Upper: 174,
       });
-      expect(result.hrZones.cycling.z4).toEqual({ lower: 161, upper: 174 });
+      expect(result.hrZones.cycling.z4).toEqual({ lower: 164, upper: 177 });
+      expect(result.hrZones.cycling.z4Upper).toBe(177);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the post-ship bug Pablo hit on his real T2G account: running and swimming HR zone tables stayed at 0-0 after sync, even though Generic HR is configured upstream (107-187 bpm). Cycling worked because his account has a Specific cycling block; running and swimming have no Specific blocks and were supposed to fall back to Generic per design D-FB1.

## Root cause

The `heart-rate-zone-generic` wrapper is rendered **outside** the `<div id="hrzones-{id}">` container in production T2G HTML — as a sibling under `<section class="pupil-details">`. The parser used to slice `id="hrzones-{id}"` → first `</section>` and scan inside that slice for all four zone wrappers. On real accounts the slice ended before reaching the generic block, so `payload.hrZones.generic` was always `undefined`, and the SPA mapper's Specific → Generic → skip fallback never had a fallback to apply.

Confirmed against Pablo's live DOM (DevTools query):
```
heart-rate-zone-generic   | nearest: SECTION pupil-details   ← outside the slice
heart-rate-zone-cycling   | nearest: DIV     hrzones-28035   ← inside the slice
```

The test fixture nests them all together, which masked the bug in unit tests.

## Fix

Parse Generic from the full HTML (with HTML comments stripped first so fixture/prose mentions of `heart-rate-zone-generic` can't anchor the wrapper regex). Sport-specific extraction stays on the narrower `hrzones-{id}` slice for safety. `extractHrFullBands`' lazy regex remains self-anchored on the literal class name and stops at the next `heart-rate-zone-X` or `</section>`, so the wider scope cannot bleed into sport-specific blocks.

## Regression test

Added a test that mirrors real T2G structure: cycling Specific inside `<div id="hrzones-{id}">` and generic as a sibling `<div class="heart-rate-zone heart-rate-zone-generic">`. Asserts both blocks are extracted correctly. Shipped fixture-based tests continue to pass.

## Deploy note (for Pablo)

Bridge is loaded as an unpacked extension. After merge:
1. `git pull`
2. Reload kaiord-train2go-bridge in `chrome://extensions`
3. Re-trigger sync from the Kaiord SPA
4. Hard-reload kaiord.com if needed

Running and swimming HR should populate Z1=107-133 / Z2=134-147 / Z3=148-160 / Z4=161-174 / Z5=175-187.

## Test plan

- [x] 124 train2go-bridge tests pass
- [x] New regression test reproduces production HTML structure
- [x] Pre-push typecheck green
- [ ] CI green
- [ ] Manual verification post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where Generic heart rate zones were missed when positioned in certain areas of the page layout. Heart rate zone data now correctly extracts and displays across all supported sport categories—Generic, Cycling, Running, and Swimming—ensuring consistent functionality regardless of HTML structure positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->