### PR TITLE
chore(openspec): scaffold repo-quality-maintenance-waves change

### DIFF
--- a/openspec/changes/repo-quality-maintenance-waves/.openspec.yaml
+++ b/openspec/changes/repo-quality-maintenance-waves/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-05

--- a/openspec/changes/repo-quality-maintenance-waves/design.md
+++ b/openspec/changes/repo-quality-maintenance-waves/design.md
@@ -1,0 +1,269 @@
+## Context
+
+The audit conducted in the explore phase mapped current quality and DX hot spots across the kaiord monorepo. The structural baseline is healthy — strict TypeScript, hex arch enforced, zero skipped tests, no dead code, no legacy markers — but five categories of debt have accumulated:
+
+1. **Mechanical guards configured but not enforced** (`size-limit`, `jscpd`).
+2. **Sequential lint and pre-commit pipelines** that punish iteration speed.
+3. **CI without per-job timeouts**, masking runaway jobs.
+4. **Coverage gaps localized to specific layers**: organism-scoped hooks in `workout-spa-editor`, plus `core` and `garmin` packages below a 30 % test ratio.
+5. **Oversized files and duplication clusters** in both the SPA editor (store-action mutations) and the format adapters (`zone↔watts`, `bpm↔%max`, pace-unit conversion replicated across `fit`, `tcx`, `zwo`).
+
+This change is structured for autonomous execution under `/opsx-ship`: each work unit is a single PR, ownership is delegated to a specific subagent type, and the dependency graph is explicit so the orchestrator can dispatch ready PRs in parallel.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Drain the maintenance backlog in six sequenced waves with clear parallelization rules.
+- Add or activate **detection** mechanisms (size-limit, jscpd, overrides-stale, CI timeouts) before doing any **refactor** so regressions surface immediately.
+- Lift `core` and `garmin` test coverage to the project-mandated **80 %** line / branch / function (CLAUDE.md backend threshold). If the W3.0 baseline already shows the package at threshold, §3.1 / §3.2 are downgraded to no-op deferrals — the goal is "meet the bar," not "manufacture tests".
+- Drop the SPA editor `hooks/`, `lib/`, and `store/` test ratios above the **70 %** frontend threshold (per CLAUDE.md), with priority on currently-untested organism hooks. **The 70 % vs 80 % asymmetry is intentional policy** — frontend hooks are accepted at a lower bar than backend domain logic; tightening to 80 % is a future tightening, not part of this change.
+- Reduce SPA editor file-budget violations to zero (target: every file ≤ 100 LOC, every component ≤ 60 LOC, every other function ≤ 40 LOC).
+- Extract cross-adapter conversion duplication into shared `core` domain helpers without breaking round-trip tolerances.
+- Make every wave consumable by an autonomous subagent: each task names its agent, scope, acceptance check, and dependencies.
+
+**Non-Goals:**
+
+- No new product capability or user-facing feature.
+- No accessibility, privacy, or GDPR work (those flow through their own streams).
+- No bundle-size *reduction* — we only **measure** via size-limit. If the ratchet fires, the response is a follow-up change.
+- No release-cadence work. The 47 unconsumed changesets are out of scope; they are flagged in the audit but will not be touched here.
+- No changes to the public API of any published package.
+- No domain-spec changes other than the W1.5 extension of `scripts-folder-hygiene`.
+
+## Decisions
+
+### D1. Wave structure with explicit parallelization
+
+Six waves. Within a wave, tasks are typed as **parallel** (no inter-task dependency) or **independent-PRs** (separate PRs but conceptually grouped). Between waves, hard sequencing applies:
+
+```mermaid
+flowchart TD
+    W1[Wave 1: Defensive walls<br/>6 parallel PRs] --> W2[Wave 2: DX speedup<br/>3 parallel PRs]
+    W1 --> W3[Wave 3: Backend test floor<br/>3 parallel PRs incl. W3.0 precondition]
+    W2 --> W4[Wave 4: SPA editor refactors<br/>5 PRs, 4.4 sequenced after 4.1]
+    W2 --> W5[Wave 5: SPA editor coverage<br/>4 parallel PRs]
+    W3 --> W4
+    W3 --> W5
+    W4 --> W6a[W6.1 Extract zone tables to core/domain/zones<br/>+ exhaustive enum + property-based tests]
+    W6a --> W6b[W6.2 zwo migrates to use core helpers]
+    W6b --> W6e[W6.3 Round-trip + property-based verify]
+```
+
+W6 is **substantially narrower** than the original draft. See D2 ("W6 audit and rescope") for the code-inspection findings.
+
+**Rationale.** Putting defensive walls (W1) first means W3–W6 cannot regress invariants without CI catching it. W2 follows W1 because the new pre-commit/lint shape will lean on the new CI jobs as the source of truth. W3 (backend tests) is parallel to W2 because they touch disjoint trees. W4 (SPA refactors) requires both W2 (fast inner loop while editing) and W3 (a stable backend baseline). **W5 runs in parallel with W4**, not after it: organism-hooks under `ZoneEditor`, `ProfileManager`, `WorkoutLibrary`, `WorkoutList` are NOT in W4's refactor scope (which touches `store/actions/`, `types/index.ts`, `CalendarPage`, store selectors, and 4 right-size files). Sequencing W5 after W4 would waste agent parallelism. W6 is last because — even after the W6 audit shrunk it — it still touches `core`'s public domain surface and a converter in `zwo`.
+
+**Alternatives considered:**
+
+- *One mega-PR per wave.* Rejected: too coarse-grained for `/opsx-ship` to dispatch in parallel; one stuck task blocks the entire wave.
+- *Strictly serial waves.* Rejected: leaves >50 % of agent time idle; W3 has no real dependency on W2.
+- *Flat task list, no waves.* Rejected: humans need the wave headlines to track progress; the orchestrator needs sequencing constraints expressed somewhere.
+
+### D2. W6 audit and rescope (code-inspection findings)
+
+The original draft claimed cross-adapter duplication of "zone↔watts, bpm↔%max, pace-unit conversion replicated across `fit`, `tcx`, `zwo`" with an estimated 10–15 % LOC reduction. **A code-inspection audit (recorded here for downstream agents) does not support that claim.** The actual landscape:
+
+- **`packages/fit/src/adapters/target/power-helpers.ts`** uses `value − 1000` to extract absolute watts and `value − 100` to extract a percent — both Garmin SDK contract encodings, unique to the FIT format. Not duplicated logic.
+- **`packages/zwo/src/adapters/target/power.converter.ts`** uses `* 100` to convert ZWO's `0.0–3.0` FTP fraction into KRD's `percent_ftp` integer. ZWO-specific arithmetic. Not duplicated logic.
+- **`packages/tcx/src/adapters/target/...`** uses `Low/High` BPM bands directly with no offset transformation. Not duplicated logic.
+- **`packages/zwo/src/adapters/target/power.converter.ts:56` — `convertPowerZoneToPercentFtp`** — is the lone exception. The 7-band mapping `zone → percent FTP` is fitness-domain truth (it expresses how cycling coaches define training intensity), not Zwift-specific encoding. It currently lives only in `zwo` and is duplicated in spirit (not in code) wherever a UI surfaces "zone 4 = 105 % FTP".
+
+**Decision.** W6 is reduced from 5 PRs to 3:
+
+- **W6.1** — extract the zone table into `packages/core/src/domain/zones/power-zones.ts` (and any HR equivalent the agent's audit confirms). Implementation includes exhaustive zone enumeration tests AND property-based tests via `fast-check` for round-trip idempotency across all valid zones. Coverage requirement: ≥ 95 % per file (helpers are pure — there is no excuse).
+- **W6.2** — `zwo` adapter migrates its `power.converter.ts:56` import to the new core helper. Other zwo logic stays put.
+- **W6.3** — round-trip + property-based verification across the migrated state. Acceptance is `pnpm -r test:roundtrip` PLUS a new `pnpm test --filter @kaiord/core -- conversions` showing the property-based suite green.
+
+**FIT and TCX adapters are NOT touched by W6** because they hold no equivalent domain artifact. The W6.1 PR description includes a grep audit (`grep -RnE "<zone-table-fingerprint>" packages/`) confirming no other site needs migrating; if the audit surfaces an unexpected cross-adapter site, that finding is folded into W6.2 rather than spawning new tasks.
+
+**Sub-agent contract.** The architect agent dispatched for W6.1 MUST treat the zone-table claim as a hypothesis — verify it via grep before extracting. If the hypothesis fails (e.g. additional or different cross-adapter math is found), the agent surfaces the discrepancy in the PR description and halts; it does NOT silently broaden scope.
+
+### D3. Subagent assignment per task type
+
+Each task names exactly one agent type so `/opsx-ship` does not have to decide:
+
+| Task family | Agent | Why |
+|---|---|---|
+| CI workflow / size-limit / jscpd / timeouts | `cicd-guardian` | Owns `.github/workflows/**`, knows pipeline shape. |
+| Hook config (pre-commit, pre-push) | `cicd-guardian` | Same scope (DX wiring). |
+| Missing READMEs / docs drift | `docs-expert` | Owns documentation tone and structure. |
+| Test coverage lifts | `test-improver` | Existing autonomous test-coverage improver. |
+| Oversized file splits / function extraction | `complexity-reducer` | Existing autonomous complexity reducer. |
+| `lint:overrides-stale` script + delta spec edit | `general-purpose` | Cross-cutting (script + spec + root `package.json`). |
+| Cross-adapter helper extraction (W6) | `architecture-guardian` | Touches domain layer + three adapters; needs hex-arch awareness. |
+| Round-trip verification (W6.5) | `validate-roundtrip` | Existing roundtrip validator. |
+| SPA bundle env-agnosticism (W1.6) | `spa-expert` | React/Vite expert; owns `workout-spa-editor` runtime patterns. |
+
+### D4. Acceptance check shape
+
+Every task has a single command (or two-command sequence) that an agent or human can run to prove the task is complete. No subjective acceptance. Examples:
+
+- W1.1 (size-limit in CI): `gh workflow view ci.yml | grep -q size-limit` **and** the next CI run shows a "size-limit" check.
+- W3.1 (core test ratio): `node scripts/compute-test-ratio.mjs packages/core` reports ≥ 30 % (this script is one of W1's optional deliverables — see Open Questions).
+- W6.5 (round-trip): `pnpm -r test:roundtrip` passes within current tolerances.
+
+When an acceptance check requires a script that does not yet exist (e.g. `compute-test-ratio.mjs`), the task lists creating that script as a pre-step. Agents handle this without re-asking.
+
+### D5. Capability deltas: one Modified, one New
+
+**Modified — `scripts-folder-hygiene`.** W1.5 extends it with a new mechanical-guard requirement: every entry in root `package.json#pnpm.overrides` SHALL be checked against the upstream version range and flagged when the upstream now satisfies the patched range without the override. The new check is `scripts/check-overrides-stale.mjs` (rule ID `R-OverridesStale`) wired into `pnpm test:scripts`. The delta spec specifies the algorithm precisely (deterministic, network-fail-closed) and includes scenarios for required, stale, allowlisted, malformed, empty/absent, and offline-CI conditions.
+
+**New — `domain-conversions`.** W6.1 introduces `packages/core/src/domain/zones/` as a stable home for fitness-domain zone tables (initially the 7-band power-zone table). Adding new public exports under a brand-new directory inside `core/src/domain/` is a spec-level event: the helpers' contract (signatures, valid input ranges, error semantics, purity guarantee) becomes part of `@kaiord/core`'s API surface. The capability spec encodes that contract and the constraint that any future side-effectful behavior MUST migrate to `application/`, never live under `domain/`.
+
+**Rationale.** Every other wave is internal refactor, test addition, or CI plumbing — none of which alter system behavior in a spec-relevant way. Lint parallelization (W2.2) is observable behavior in some workflows but not enough to justify a capability spec; we accept a small parity risk and trust the W2.2 PR to document any ordering it preserves.
+
+### D6. Hexagonal layer impact
+
+- **Domain (`core/src/domain/`)**: Wave 6 adds `core/src/domain/zones/` — pure constants and conversion helpers for fitness zone tables (initially power; HR if the W6.1 audit confirms a duplicated table). No external imports beyond `zod`, no I/O. Architecture remains `domain depends on nothing`.
+- **Application (`core/src/application/`)**: untouched. **Rule for future work:** if any helper in `domain/zones/` later needs side-effects (e.g. fetching an athlete-specific zone profile from storage), the work migrates to `application/` with an injected port — it does NOT acquire I/O while remaining under `domain/`. The `domain-conversions` spec encodes this constraint.
+- **Ports**: no new ports.
+- **Adapters**: `zwo`'s `power.converter.ts` imports the new domain helper. This is a strict inward dependency, so hex arch is preserved. **`fit` and `tcx` are NOT touched by Wave 6** because their format-specific encodings (FIT's `value+1000`, TCX's BPM bands) are not domain truths and stay in their respective adapters.
+- **Infrastructure**: no changes.
+
+### D7. Dependency additions
+
+- `lint-staged` (devDependency, root only): required by W2.1.
+- `npm-run-all2` (devDependency, root only): required by W2.2. **Chosen over `concurrently`** (less ANSI interleaving noise on aggregate-output) **and over `turbo run`** (avoids introducing a new build orchestrator surface in a maintenance change). Invoked with `--max-parallel=4 --aggregate-output`. The literal `4` is calibrated for GitHub-hosted `ubuntu-latest` runners (2 vCPUs, 7 GB RAM): with 17 lint sub-scripts, allowing more than 4 concurrent processes risks RAM pressure on the runner during the heaviest checks (`lint:specs` runs `openspec validate` which loads every spec into memory). Developer laptops have more cores; if developers prefer to override locally, the cap can be made env-driven in a follow-up. `--aggregate-output` keeps per-process output contiguous so a CI failure log is grep-able.
+- `fast-check` (devDependency, root only): required by W6.1 for property-based tests on the zone helpers.
+- `size-limit` and `@size-limit/file` are already devDependencies. W1.1 only wires them into CI.
+
+No runtime dependencies added to any published package.
+
+### D8. Failure modes and rollback
+
+Each PR is independently revertible. Because every wave's PRs are scoped to disjoint files (verified by the pairwise file-overlap audit recorded in tasks.md), a `git revert` on any single PR does not break the others. The only ordering constraint at revert time is: if W6.1 (helpers added in core) is reverted, W6.2 (zwo migration) must also be reverted because it imports the helpers.
+
+**Kill-switches.** Mirroring the precedent from `2026-05-03-repo-hygiene-tooling`, both new CI gates (W1.1 size-limit, W1.2 jscpd) ship with a repository-variable kill-switch (`SIZE_LIMIT_BOT_ENABLED`, `JSCPD_BOT_ENABLED`). The job-level `if:` checks evaluate `vars.<NAME> != 'false'` so a single GitHub UI toggle disables either gate without code changes — guarding against the case where a regression on `main` blocks every PR.
+
+### D9. SPA editor: runtime config injection (12-factor III + V)
+
+Audit of the SPA against the twelve-factor methodology surfaced one violation that touches **five surfaces**, not one. A grep audit (`grep -RnE "VITE_CF_ANALYTICS_TOKEN" packages/workout-spa-editor/`) shows:
+
+1. `packages/workout-spa-editor/src/main.tsx:21` — `import.meta.env.VITE_CF_ANALYTICS_TOKEN` (the call site).
+2. `packages/workout-spa-editor/index.html:59` — `data-cf-beacon='{"token": "%VITE_CF_ANALYTICS_TOKEN%"}'` (a Vite template-token replaced at build time).
+3. `packages/workout-spa-editor/vite.config.ts:20,31` — `conditionalBeacon(env.VITE_CF_ANALYTICS_TOKEN)` and the `replace(/%VITE_CF_ANALYTICS_TOKEN%/g, ...)` call that performs the build-time substitution.
+4. `packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts:34` — sets the env var when launching the e2e dev server.
+5. `packages/workout-spa-editor/docs/analytics.md` — documents the build-time embed approach.
+
+All five must change for the bundle to be truly environment-agnostic. Two consequences of the current state:
+
+- **Factor III (config in env, not code)**: an environment-specific value lives inside the compiled artifact.
+- **Factor V (build/release/run separation)**: the bundle is no longer environment-agnostic — a different deploy environment requires a different build.
+
+W1.6 decouples this by moving the analytics token to a runtime source. The agent picks the lightest viable mechanism among:
+
+1. **`/config.json` fetched on startup** — written to the static origin at deploy time, read by `main.tsx` before initializing analytics. Closest to the canonical 12-factor SPA pattern.
+2. **`window.__KAIORD_CONFIG__` injected via index.html** — a `<script>` tag in `index.html` is templated at deploy time. Lightweight; no extra HTTP round trip.
+3. **Cloudflare-side script tag** — Cloudflare Web Analytics natively supports including its `<script>` from the CF dashboard rather than from app code; the cleanest answer if the team is willing to manage the snippet outside the app.
+
+The agent chooses based on the existing deploy machinery (whichever option requires the fewest moving parts). The acceptance check is shape-only: `main.tsx` MUST NOT import or reference the value via `import.meta.env`, and the minified bundle MUST NOT contain the literal token of any specific environment.
+
+**Out of scope for W1.6**: the other `import.meta.env` references (`MODE`, `DEV`, `BASE_URL`) are Vite intrinsics that legitimately encode "this is a dev vs production build" — a build-time question, not a deploy-time question. They are 12-factor-compliant and stay.
+
+**Other 12-factor surfaces audited and found clean** (no work required):
+
+- `core`, `fit`, `tcx`, `zwo`, `garmin`, `ai`, `mcp` — zero `process.env` reads in source. Pure libraries.
+- `cli` — reads only `CI`, `NODE_ENV`, `FORCE_COLOR`. Standard 12-factor-correct usage.
+- `garmin-connect` — one hardcoded URL (`https://connect.garmin.com/...`) is a contract endpoint, not config (factor IV is N/A for service contracts).
+- 50+ `console.*` calls in `cli`/`mcp`/`garmin-connect` — factor XI (logs as event streams) already satisfied.
+
+### D10. Lint umbrella ordering matrix (W2.2 input)
+
+`pnpm lint` chains 17 sub-scripts with `&&` (root `package.json:55`). W2.2 parallelizes them via `npm-run-all2 -p --max-parallel=4 --aggregate-output`. Pre-computing the ordering matrix here means the W2.2 PR ships from a known shape, not from agent-side investigation.
+
+**Sequential-required (post group; must run after the rest):**
+
+- `lint:archive-index` ← depends on `lint:archive` having validated the archive folder shape; the index reflects folder state.
+- `lint:archive-followups` ← same dependency on `lint:archive` (both read archive-folder structure).
+
+**Independent (parallel group):**
+
+- `lint:archive`, `lint:specs`, `lint:tsup-watchdog`, `lint:mapper-no-tests`, `lint:converter-has-tests`, `lint:husky-no-bypass`, `lint:package-deps`, `lint:architecture`, `lint:no-unconditional-skip`, `lint:no-library-dual-mount`, `lint:allowlists-empty`, `lint:icons-distinct`, `lint:build-portable`, `lint:ci-fanout`, `lint:scripts-orphans` (15 checks).
+- Plus the new `lint:overrides-stale` (W1.5) and `lint:workflow-timeouts` (W1.3) — both independent.
+
+**Per-package `pnpm -r lint` step:** stays as-is in its current position (eslint + prettier + tsc per package). It is implicitly parallel via pnpm's recursive workspace runner.
+
+**Composition:** `run-s ( run-p [parallel-group] ) ( run-p lint:archive-index lint:archive-followups )`. The outer `run-s` enforces the post-group ordering. The W2.2 PR description echoes this matrix so reviewers can verify it matches design.md.
+
+### D11. Pairwise file-overlap audit (input for /opsx-ship)
+
+For each wave with multiple parallel PRs, the dispatching agent runs a pairwise `git diff --name-only` audit before dispatching. Two PRs in the same wave with overlapping file scopes must be serialized via a `Depends on:` marker in tasks.md. Pre-computed findings:
+
+- **W1**: all 6 PRs touch disjoint trees (CI workflows, READMEs, root package.json + scripts/, SPA editor src+config). No serialization needed.
+- **W2**: 3 PRs all touch root files. W2.1 edits `.husky/pre-commit` and root `package.json`. W2.2 edits root `package.json` (`scripts.lint` only). W2.3 edits `.husky/pre-push` only. W2.1 and W2.2 both touch `package.json` — serialize: **W2.2 Depends on W2.1** (W2.1's lint-staged config block is added first; W2.2 then rewrites `scripts.lint`).
+- **W3**: 3 PRs touch disjoint packages (`packages/core`, `packages/garmin`, plus the W3.3 file-split set in `fit`/`tcx`/`zwo`/`cli`). W3.0 (compute-test-ratio script, see D12) is a precondition for W3.1 and W3.2.
+- **W4**: 5 PRs in `workout-spa-editor`. **W4.1 (`store/actions/`) and W4.4 (selector registry)** both touch `store/`. W4.4 Depends on W4.1 (already encoded). W4.2 (types/index.ts split) touches every import site that pulls from `~/types` — including files the other W4 PRs touch. **W4.2 should land FIRST** in W4 to minimize merge conflicts; encode by making W4.3, W4.4, W4.5 all `Depends on: W4.2`.
+- **W5**: 4 PRs in disjoint `organisms/<X>/hooks` subtrees. No serialization needed.
+- **W6**: 3 PRs already strictly sequenced.
+
+### D12. W3.0 precondition: `compute-test-ratio.mjs` (resolved Open Question OQ1)
+
+W3.1 and W3.2 acceptance use a coverage threshold (see tasks.md), not a file-count ratio. The earlier file-count proxy was abandoned because (a) it counts fixtures and `.types.ts` files in the denominator, inflating it, and (b) it does not correlate with real coverage. **OQ1 is therefore resolved as: do not add `compute-test-ratio.mjs`. Use vitest coverage instead.** The W3.1 and W3.2 acceptance commands invoke `pnpm --filter @kaiord/<pkg> test:coverage` directly.
+
+### D13. `/opsx-ship` orchestration contract
+
+**Pre-dispatch parser smoke (NOT a numbered task; runs once inside the orchestrator before the first PR opens).**
+
+Before dispatching ANY PR for this change, `/opsx-ship` MUST execute the following parser-shape assertion against `openspec/changes/repo-quality-maintenance-waves/tasks.md`:
+
+```js
+import { readFileSync } from 'node:fs';
+const md = readFileSync('openspec/changes/repo-quality-maintenance-waves/tasks.md', 'utf8');
+const tasks = [...md.matchAll(/^## §(\d+\.\d+)\s+(.*)$/gm)].map(m => ({ id: m[1], title: m[2] }));
+const ids = new Set(tasks.map(t => t.id));
+const errors = [];
+for (const t of tasks) {
+  const block = md.split(`## §${t.id}`)[1].split(/^## §/m)[0];
+  const dep = (block.match(/\*\*Depends on:\*\*\s*(.*)/) || [, ''])[1].trim();
+  const agent = (block.match(/\*\*Agent:\*\*\s*(.*)/) || [, ''])[1].trim();
+  const scope = (block.match(/\*\*Scope:\*\*/) || [])[0];
+  const accept = (block.match(/\*\*Accept:\*\*/) || [])[0];
+  if (!agent) errors.push(`§${t.id}: missing **Agent:**`);
+  if (!scope) errors.push(`§${t.id}: missing **Scope:**`);
+  if (!accept) errors.push(`§${t.id}: missing **Accept:**`);
+  if (!dep) errors.push(`§${t.id}: missing **Depends on:**`);
+  if (dep && dep !== 'none') {
+    for (const id of dep.split(/,\s*/).map(s => s.replace(/^§/, ''))) {
+      if (!ids.has(id)) errors.push(`§${t.id}: unknown dependency §${id}`);
+    }
+  }
+}
+if (errors.length) { console.error(errors.join('\n')); process.exit(1); }
+console.log(`OK: ${tasks.length} tasks, all dependencies resolve`);
+```
+
+If the script exits non-zero, the orchestrator MUST halt and surface the error list to the user. **No PR opens until tasks.md parses cleanly.** This replaces the previous §0.0-as-a-PR design (rejected: a 23-PR plan cannot have a single PR as a precondition for the other 22 — too brittle, and §0.0 had no source-code deliverable to review).
+
+**Dispatch order.** The orchestrator MUST:
+
+1. Parse `tasks.md` and discover the dependency markers `Depends on: <task-id>` (one per task).
+2. Treat tasks with no unmet dependency as **ready**.
+3. Dispatch all ready tasks in parallel, each in its own worktree, each as its own PR.
+4. When a PR merges into `main`, mark the task complete and re-evaluate readiness.
+5. Stop only when all tasks are merged.
+
+Tasks within the same wave that have no `Depends on:` line are parallel-safe. Tasks in different waves with cross-wave dependencies use explicit `Depends on: §X.Y` lines.
+
+## Risks / Trade-offs
+
+- **[Risk]** Wave 1.5 (overrides audit) may discover overrides that *cannot* be safely removed (transitively required by old upstreams). → **Mitigation:** the new `R-OverridesStale` rule includes an allowlist mechanism (analogous to the existing scripts-folder allowlist) so a justified override stays, with a one-line "Why kept" note.
+- **[Risk]** Wave 2.2 (parallelizing `pnpm lint`) may surface implicit ordering between checks (e.g. archive-index expects archive-dates to have run first). → **Mitigation:** introduce two parallel groups: an *independent* group and a *post* group, sequenced by `npm-run-all2`. The agent identifies the post group by reading each check's `--help` or source.
+- **[Risk]** Wave 4 refactors land before Wave 5 tests are added, leaving an undertest window. → **Mitigation:** the existing organism-hooks coverage is already 0 %, so refactoring without new tests does not strictly worsen the situation, and the W4 PRs MUST include round-trip-style smoke tests. The deeper coverage lift is W5.
+- **[Risk]** Wave 6 changes the call signature of conversion helpers and introduces tolerance drift. → **Mitigation:** W6.5 is a closing PR that runs `pnpm -r test:roundtrip` and gates on existing tolerances (`time ±1s, power ±1W or ±1%FTP, HR ±1bpm, cadence ±1rpm`). If any tolerance fails, W6.5 cannot merge.
+- **[Trade-off]** Six waves means the change ships across many PRs (~27). A one-shot bundle would be smaller in calendar time but unreviewable. We accept the multi-PR overhead because each PR stays scoped, reviewable, and revertible.
+- **[Trade-off]** Adding `lint-staged` and `npm-run-all2` increases dev dependency surface. Both are well-maintained, MIT-licensed, and add zero runtime cost.
+
+## Migration Plan
+
+No public-API migration required. Internal callers of `fit`, `tcx`, `zwo` target converters are untouched: the converter signatures remain stable; only their internals change in W6.
+
+For consumers of the SPA editor (browser), Wave 4 is internal-only and ships behind no flag. The Wave 4 PRs MUST be smoke-tested against the canonical workout fixture before merge (existing test infrastructure handles this).
+
+## Open Questions
+
+- **OQ1.** Should Wave 1 include a one-off `scripts/compute-test-ratio.mjs`? **Resolved (D12)**: no. W3.1 and W3.2 use vitest coverage thresholds, not a file-count ratio.
+- **OQ2.** When parallelizing `pnpm lint` (W2.2), does any existing check have hidden ordering with another? **Resolved (D10)**: yes. `lint:archive-index` and `lint:archive-followups` post-depend on `lint:archive`. The other 15 are independent.
+- **OQ3.** Does `garmin` need an HR-zone domain helper extracted alongside the power-zone one? **Open**: the W6.1 audit determines this. If no HR-zone duplication is found, W6.1 ships only the power-zone helper and the `domain-conversions` spec is correspondingly minimal.
+
+These are tactical choices the agents may resolve in-PR; they do not block dispatch.

--- a/openspec/changes/repo-quality-maintenance-waves/proposal.md
+++ b/openspec/changes/repo-quality-maintenance-waves/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The kaiord codebase is structurally healthy (clean hex arch, strict TS, zero skipped tests, no dead code) but has accumulated discrete pockets of maintenance debt that hurt daily DX, mask regressions, and concentrate risk in a few oversized files. We have a dedicated maintenance window now and want to drain the queue in a controlled, parallel-friendly way before evolutionary work resumes — without introducing any new product capability.
+
+## What Changes
+
+This change is **non-evolutionary**. It bundles defensive walls, DX speedups, test-floor lifts, and structural refactors into six sequenced waves designed for autonomous agent execution under `/opsx-ship`.
+
+- **Wave 1 — Defensive walls**: wire `.size-limit.json` and `.jscpd.json` into CI (including updates to the `lint-summary` aggregator and branch-protection so they are real required checks, not nominal jobs); add `timeout-minutes` to every CI job; add 4 missing READMEs (`docs`, `garmin-bridge`, `landing`, `train2go-bridge`); audit `pnpm.overrides` and add a `lint:overrides-stale` mechanical guard; decouple `workout-spa-editor` runtime config from the Vite bundle so the artifact is environment-agnostic across **all five `VITE_CF_ANALYTICS_TOKEN` surfaces** — `main.tsx`, `index.html` template token, `vite.config.ts` injection logic, `e2e/spa-route-refresh.spec.ts` test fixture, and the `docs/analytics.md` documentation (12-factor III + V).
+- **Wave 2 — DX speedup**: convert pre-commit to `lint-staged` + tsc-incremental + `test:scripts` (target <30s); parallelize the 17 sequential `lint:*` checks; replace `pre-push lint:fix` with verify-only `pre-push lint`.
+- **Wave 3 — Backend test floor**: lift `core` (14% → ≥30%) and `garmin` (15% → ≥30%) test ratios; split oversized backend files (>100 LOC budget) in `fit`, `tcx`, `zwo`, `cli`.
+- **Wave 4 — Spa-editor structural refactors**: extract shared repetition-block / step mutation helpers; split `src/types/index.ts` (172 LOC); split `CalendarPage.tsx` (156 LOC) into hook + view; build a selector registry for the workout store; right-size the remaining files over budget.
+- **Wave 5 — Spa-editor coverage**: add tests for currently-untested organism hooks (`ZoneEditor/hooks/*`, `ProfileManager/hooks/*`, `WorkoutLibrary/components/*`, `WorkoutList/hooks/*`).
+- **Wave 6 — Domain zones extraction**: a code-inspection audit (recorded in design.md D2 below) found that the alleged "cross-adapter duplication" is largely format-specific encoding (FIT's `value+1000` watts offset, ZWO's `*100` FTP-fraction arithmetic, TCX's `Low/High` BPM bands) — not duplicated logic. The single genuine cross-domain artifact is the 7-band power-zone table currently isolated in `packages/zwo/src/adapters/target/power.converter.ts:56`. Wave 6 extracts that (and any HR-zone equivalent the W6.1 audit confirms) into `packages/core/src/domain/zones/`, migrates the only adapter that holds a copy (`zwo`), and verifies round-trip tolerances and an exhaustive zone enumeration. Estimated 3 PRs, not 5.
+
+No public API changes. No breaking changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `domain-conversions`: introduces `packages/core/src/domain/zones/` as a stable home for fitness-domain zone tables (initially the 7-band power-zone-to-percent-FTP mapping, plus any HR-zone equivalent the W6.1 audit confirms). The capability documents the public contract (helper signatures, valid input ranges, error semantics, purity) and SHALL constrain any future side-effectful behavior to migrate to `application/` with an injected port.
+
+### Modified Capabilities
+
+- `scripts-folder-hygiene`: extended with a new mechanical-guard requirement for stale `pnpm.overrides` (rule ID `R-OverridesStale`). The check belongs to the same family as the existing `R-ScriptsNoOrphans` rule and ships via Wave 1.5 in this change. Delta spec authored alongside this proposal — the algorithm is fully specified (deterministic, network-fail-closed) so an autonomous agent can implement it without re-asking for clarification.
+
+## Impact
+
+- **Affected packages**: every package (`core`, `fit`, `tcx`, `zwo`, `garmin`, `garmin-connect`, `cli`, `mcp`, `ai`, `workout-spa-editor`) plus repo-wide tooling (`.github/workflows/*`, `.husky/*`, root `package.json`, `scripts/*`).
+- **Hexagonal layers touched**: Wave 6 adds new domain helpers in `packages/core/src/domain/zones/` (pure constants and conversion helpers — initially the 7-band power-zone table, plus an HR-zone table only if the W6.1 audit confirms a duplicated one; zero deps beyond `zod`). The `zwo` adapter updates one converter to import them; **`fit` and `tcx` are NOT touched by W6** because their format-specific encodings are not domain truths. No new ports. No infrastructure additions.
+- **CI/CD**: new jobs for size-limit and jscpd; per-job timeouts on all existing jobs; no changes to release workflow.
+- **Hooks**: pre-commit and pre-push contracts change shape (faster, narrower scope) but enforce the same invariants overall.
+- **Public API**: no changes. Adapter `index.ts` re-exports remain identical.
+- **Dependencies**: may add `lint-staged`, `npm-run-all2` (or equivalent), `size-limit` CLI runner in CI. No new runtime deps in any published package.
+- **Round-trip tolerances**: Wave 6 must preserve current tolerances (time ±1s, power ±1W or ±1%FTP, HR ±1bpm, cadence ±1rpm). Acceptance check is the existing round-trip test suite.
+- **Risk**: low–medium. Highest blast-radius unit is Wave 6 (touches three adapters and core); it is sequenced last specifically so earlier waves stabilize the safety net (size-limit, jscpd, test floor) before it runs.
+- **12-factor compliance review**: `core`, `fit`, `tcx`, `zwo`, `garmin`, `ai` are pure libraries with zero `process.env` reads — factor III is already satisfied. `cli` reads only standard env signals (`CI`, `NODE_ENV`, `FORCE_COLOR`) — also compliant. `garmin-connect` has one hardcoded URL (`https://connect.garmin.com/...`) which is a contract endpoint, not config — factor IV does not apply. The only finding is in `workout-spa-editor`: `VITE_CF_ANALYTICS_TOKEN` is consumed via `import.meta.env` and gets baked into the Vite bundle at build time, breaking the env-agnostic-artifact rule (factor V) and storing config in code (factor III). Wave 1.6 fixes this. The other `import.meta.env` references (`MODE`, `DEV`, `BASE_URL`) are Vite intrinsics that legitimately belong at build time — left untouched.

--- a/openspec/changes/repo-quality-maintenance-waves/specs/domain-conversions/spec.md
+++ b/openspec/changes/repo-quality-maintenance-waves/specs/domain-conversions/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Power-zone table lives in domain layer
+
+The 7-band power-zone-to-percent-FTP mapping (zone `1`–`7`) is a fitness-domain truth, not a format encoding. It SHALL live as a pure constant in `packages/core/src/domain/zones/power-zones.ts` and SHALL be the single source of truth for any adapter that needs to translate between a discrete zone number and a percent-FTP value.
+
+The published API of `@kaiord/core` SHALL re-export the helper(s) in an additive-only way (no removals, no signature changes to existing exports). The helpers SHALL be pure functions with zero external imports beyond `zod` schemas already present in `core/src/domain/`.
+
+The audit accompanying the implementation PR SHALL list every adapter file currently containing equivalent zone-table logic and confirm that, post-migration, no such file remains outside `packages/core/src/domain/zones/`.
+
+#### Scenario: Mapping every valid zone returns a finite percent-FTP
+
+- **GIVEN** the helper `zoneToPercentFtp(zone: 1 | 2 | 3 | 4 | 5 | 6 | 7)` exists in `@kaiord/core`
+- **WHEN** the helper is invoked for each integer zone in the closed interval `[1, 7]`
+- **THEN** the result is a positive number, finite, and monotonically non-decreasing as the zone number grows
+
+#### Scenario: Out-of-range zone is rejected
+
+- **GIVEN** the helper `zoneToPercentFtp` exists
+- **WHEN** the helper is invoked with `0`, `8`, `-1`, `NaN`, or any non-integer value
+- **THEN** the helper SHALL throw a `RangeError` (or its zod-validated equivalent) — it MUST NOT return `undefined`, `null`, or a silently clamped value
+
+#### Scenario: Round trip across the full input domain
+
+- **GIVEN** the helpers `zoneToPercentFtp(z)` and any inverse used by an adapter (e.g. `percentFtpToZone(p)`)
+- **WHEN** the helper's input domain is exercised — exhaustively enumerated if finite and small (e.g. the 7 integer zones for power), or via a property-based generator (`fast-check` or equivalent) producing ≥ 100 cases if the domain is large or continuous (e.g. an HR helper accepting a continuous BPM range)
+- **THEN** for every input `z` exercised, `inverse(forward(z))` returns `z` (round-trip identity)
+
+#### Scenario: ZWO adapter migrates without changing existing round-trip tolerances
+
+- **GIVEN** the existing `zwo` adapter previously held its own copy of the zone table at `packages/zwo/src/adapters/target/power.converter.ts:56`
+- **WHEN** the adapter is migrated to import from `@kaiord/core` and the round-trip suite runs
+- **THEN** every existing FIT ↔ KRD ↔ ZWO round-trip fixture passes within the project's standing tolerances (`time ±1s, power ±1W or ±1%FTP, HR ±1bpm, cadence ±1rpm`); no fixture is modified to make the migration pass
+
+### Requirement: Domain pure-helper directories SHALL NOT acquire side effects
+
+Modules under any of the following directories SHALL remain pure: no I/O, no clock reads, no random number generation, no module-level network or filesystem access. The hexagonal architecture lint (the `lint:architecture` script in root `package.json`, equivalent to `pnpm arch:check`) SHALL continue to report zero errors after the helpers are introduced.
+
+The covered directories are:
+
+- `packages/core/src/domain/zones/` — **active** (created by the `repo-quality-maintenance-waves` change in §6.1).
+- `packages/core/src/domain/conversions/` — **reserved**; not created by this change. The forward enumeration makes the purity invariant load-bearing for any future helper added under that path, so a later change that introduces `domain/conversions/` cannot retroactively weaken the contract.
+
+If a future change requires side-effectful behavior (e.g. fetching an athlete-specific zone profile from storage), the work SHALL move to `packages/core/src/application/` with an injected port — never directly into `domain/`.
+
+#### Scenario: Architecture lint stays clean
+
+- **GIVEN** the helpers are added under `packages/core/src/domain/zones/`
+- **WHEN** `pnpm lint:architecture` runs (equivalent to `pnpm arch:check`)
+- **THEN** it reports `0 errors` and the helpers' import graph contains only other `domain/` modules and `zod`
+
+#### Scenario: New helper with side effects is rejected
+
+- **GIVEN** a developer attempts to add `getCurrentAthleteZones()` (which reads from a database) under `packages/core/src/domain/zones/`
+- **WHEN** the architecture lint runs
+- **THEN** it fails because the new file imports from outside `domain/`, and the error message points at the helper file

--- a/openspec/changes/repo-quality-maintenance-waves/specs/scripts-folder-hygiene/spec.md
+++ b/openspec/changes/repo-quality-maintenance-waves/specs/scripts-folder-hygiene/spec.md
@@ -1,0 +1,61 @@
+## ADDED Requirements
+
+### Requirement: No stale pnpm overrides
+
+Every entry in the root `package.json#pnpm.overrides` field SHALL be either (a) still required because at least one transitive dependency in `pnpm-lock.yaml` resolves to a version inside the patched range without the override, or (b) explicitly preserved via an allowlist entry in `scripts/README.md` between the markers `<!-- overrides-allowlist:start -->` and `<!-- overrides-allowlist:end -->`. Each allowlist entry MUST name the override key (e.g. `qs@>=6.7.0 <=6.14.1`) and a one-line "Why kept" note.
+
+The rule SHALL be enforced by `scripts/check-overrides-stale.mjs` (rule ID `R-OverridesStale`), wired into `pnpm test:scripts` and surfaced via `pnpm lint` (or its parallelized successor introduced by Wave 2.2 of the `repo-quality-maintenance-waves` change).
+
+The check SHALL operate using the following deterministic algorithm:
+
+1. **Parse**. Read root `package.json#pnpm.overrides`. For every entry, parse the **key** as `<package-name>(@<vulnerable-range>)?` (e.g. `qs@>=6.7.0 <=6.14.1` ⇒ name `qs`, vulnerable range `>=6.7.0 <=6.14.1`; bare `lodash` ⇒ name `lodash`, vulnerable range `*`). Parse the **value** as the patched-range (e.g. `>=6.14.2`).
+2. **Resolve current install**. Read `pnpm-lock.yaml`. For every entry whose package name matches an override's name, collect the resolved version (the `version:` field).
+3. **Re-resolve without the override**. Either (a) shell out to `pnpm why <pkg> --json` for each override and read the `wantedDependency` of each leaf — i.e. the version the lock would have picked without the override — or (b) call `pnpm install --no-frozen-lockfile --lockfile-only --config.overrides='{}'` into a temp directory and read the resulting `pnpm-lock.yaml`. Implementations MAY pick the cheaper of the two; both are acceptable.
+4. **Decide**. An override is **required** if at least one re-resolved version satisfies the override's `vulnerable-range`. An override is **stale** if every re-resolved version is OUTSIDE the vulnerable range AND inside the patched-range — meaning the upstream tree no longer pulls a vulnerable version, so the pin is dead weight.
+5. **Allowlist**. An override that is stale by step 4 SHALL still pass the check if `scripts/README.md` contains a row inside the markers `<!-- overrides-allowlist:start -->` / `<!-- overrides-allowlist:end -->` naming the override key and a one-line "Why kept" justification.
+6. **Empty / absent**. If `pnpm.overrides` is absent or `{}`, the check SHALL exit `0` silently — there is nothing to validate.
+
+The check MUST be deterministic on any given `pnpm-lock.yaml`: two consecutive runs against the same inputs SHALL produce identical output. Network access is forbidden during the check; if step 3 requires it, the check SHALL fail closed with a "no network" diagnostic rather than rely on online registry access.
+
+Stale overrides SHALL fail the check unless allowlisted with a justification per step 5.
+
+#### Scenario: Required override passes
+
+- **GIVEN** root `package.json#pnpm.overrides` contains `"qs@>=6.7.0 <=6.14.1": ">=6.14.2"`
+- **AND** `pnpm-lock.yaml` records at least one transitive dependency on `qs` whose un-overridden resolution would be inside `>=6.7.0 <=6.14.1`
+- **WHEN** `pnpm test:scripts` runs
+- **THEN** `check-overrides-stale.mjs` records `qs@...` as required and exits 0 for that entry
+
+#### Scenario: Stale override without allowlist fails
+
+- **GIVEN** root `package.json#pnpm.overrides` contains `"some-pkg@<1.0.0": ">=1.0.1"`
+- **AND** every transitive dependency on `some-pkg` in `pnpm-lock.yaml` already resolves to `>=1.0.1` without the override applied
+- **AND** `scripts/README.md` does NOT list `some-pkg@<1.0.0` inside the `<!-- overrides-allowlist:start -->` / `<!-- overrides-allowlist:end -->` block
+- **WHEN** `pnpm test:scripts` runs
+- **THEN** `check-overrides-stale.mjs` reports `some-pkg@<1.0.0` as stale and exits non-zero with rule ID `R-OverridesStale`
+
+#### Scenario: Allowlisted override passes despite being stale
+
+- **GIVEN** root `package.json#pnpm.overrides` contains `"legacy-pkg@<2.0.0": ">=2.0.1"`
+- **AND** the override is currently stale by the analysis above
+- **AND** `scripts/README.md` contains a row inside the `<!-- overrides-allowlist:start -->` / `<!-- overrides-allowlist:end -->` block naming `legacy-pkg@<2.0.0` with a "Why kept" sentence (e.g. `defensive pin for CVE-XXXX-YYYY pending audit`)
+- **WHEN** `pnpm test:scripts` runs
+- **THEN** `check-overrides-stale.mjs` records `legacy-pkg@<2.0.0` as allowlisted and exits 0 for that entry
+
+#### Scenario: Malformed allowlist entry fails
+
+- **GIVEN** the `<!-- overrides-allowlist:start -->` / `<!-- overrides-allowlist:end -->` block contains a line that does not include both an override key and a "Why kept" justification
+- **WHEN** `pnpm test:scripts` runs
+- **THEN** `check-overrides-stale.mjs` exits non-zero with rule ID `R-OverridesStale` and identifies the malformed line
+
+#### Scenario: Empty or absent overrides field exits silently
+
+- **GIVEN** root `package.json` has either no `pnpm.overrides` field at all OR an empty object `pnpm.overrides: {}`
+- **WHEN** `pnpm test:scripts` runs
+- **THEN** `check-overrides-stale.mjs` exits 0 silently — no diagnostic, no warning — because there is nothing to validate
+
+#### Scenario: Network-required execution fails closed
+
+- **GIVEN** the implementation chose strategy (b) — running `pnpm install --no-frozen-lockfile --lockfile-only --config.overrides='{}'` into a temp directory — and no network access is available (e.g. CI sandbox blocks the pnpm registry)
+- **WHEN** `pnpm test:scripts` runs
+- **THEN** `check-overrides-stale.mjs` exits non-zero with a `no-network` diagnostic message — the check MUST NOT silently pass when it cannot perform its analysis

--- a/openspec/changes/repo-quality-maintenance-waves/tasks.md
+++ b/openspec/changes/repo-quality-maintenance-waves/tasks.md
@@ -1,0 +1,248 @@
+<!-- opsx-ship: chunking
+This change ships as 26 PRs total: 25 wave PRs (W1=6, W2=3, W3=4, W4=5, W5=4, W6=3) + §7.1 closing. The orchestrator MUST treat each numbered task §N.M as one PR. The parser-smoke gate is a pre-dispatch check inside /opsx-ship itself (see design.md D13) — NOT a numbered task.
+
+Wave boundaries and inter-wave dependencies:
+  W1 (§1.1–§1.6)  Defensive walls.       6 PRs, all parallel.                                                            Depends on: nothing.
+  W2 (§2.1–§2.3)  DX speedup.             3 PRs; §2.2 depends on §2.1 (both touch root package.json). §2.3 parallel.    Depends on: W1 complete.
+  W3 (§3.0–§3.3)  Backend test floor.    4 PRs; §3.0 precondition for §3.1/§3.2. §3.3 parallel.                          Depends on: W1 complete.
+  W4 (§4.1–§4.5)  SPA editor refactors.  5 PRs; §4.2 lands first; §4.3/§4.4/§4.5 depend on §4.2; §4.4 also depends on §4.1. Depends on: W2 + W3 complete.
+  W5 (§5.1–§5.4)  SPA editor coverage.   4 PRs, all parallel.                                                            Depends on: W2 + W3 complete (NOT W4 — disjoint trees).
+  W6 (§6.1–§6.3)  Domain zones extract.  3 PRs; strictly sequenced.                                                      Depends on: W4 complete.
+  Closing (§7.1) Final tally + verify.   1 PR.                                                                            Depends on: §6.3.
+
+Parser contract for /opsx-ship:
+  - Section header is `## §N.M  <title>` (single source of task IDs).
+  - The single checkbox under each section is the task; sub-bullets carry metadata.
+  - `**Depends on:**` line lists comma-separated task IDs (or `none`).
+  - `**Agent:**` names exactly one subagent type.
+  - `**Scope:**` lists paths the PR is allowed to touch.
+  - `**Accept:**` is the literal command(s) that prove the task is done.
+
+Pairwise file-overlap audit (per design D11): all serializations encoded as Depends-on lines below.
+
+Deferral protocol: if a task is deferred mid-execution, follow openspec/SPEC_TEMPLATE.md rule 6 (blank line + 2-space indent before `> Deferred to: #N`). Update the count line below at the same time.
+
+Tasks: 0 completed, 0 deferred.
+-->
+
+## §1.1 Wire `.size-limit.json` into CI as a required check
+
+- [ ] §1.1
+  - **Agent:** cicd-guardian
+  - **Scope:** `.github/workflows/ci.yml` — adds a NEW top-level peer job named `size-limit` (peer of the existing `lint:` job at `ci.yml:205`, NOT a step inside `lint:`); updates the `lint-summary` aggregator at `ci.yml:795` so its `needs:` array includes the new `size-limit` job. `.github/settings.yml` if branch-protection is managed-as-code (otherwise the PR description includes the manual GitHub UI step to add `size-limit` to required status checks).
+  - **Accept:** the new `size-limit` job is a sibling of `lint:` / `test:` / `build:`, NOT a step inside any existing job; runs WITHOUT a `strategy.matrix` (single run on `node-version: 22.18.0`) — measuring a build artifact is node-version-invariant — verified by `gh run view <id> --json jobs --jq '.jobs[] | select(.name == "size-limit") | .name'` returning exactly one entry per CI run; ships with a `vars.SIZE_LIMIT_BOT_ENABLED != 'false'` kill-switch (per design D8); the `lint-summary` job's `needs:` array (line 795+) includes it; the job fails when any package exceeds its `.size-limit.json` budget; one introductory PR in this branch with a deliberately oversized fixture proves the gate fires
+  - **Depends on:** none
+
+## §1.2 Wire `.jscpd.json` into CI as a required check
+
+- [ ] §1.2
+  - **Agent:** cicd-guardian
+  - **Scope:** `.github/workflows/ci.yml` — adds a NEW top-level peer job named `jscpd` (peer of `lint:` at `ci.yml:205`, NOT a step inside `lint:`); updates `lint-summary` `needs:` array at `ci.yml:795`. `.github/settings.yml` if applicable.
+  - **Accept:** the new `jscpd` job is a sibling of `lint:` / `test:` / `build:`; runs WITHOUT a `strategy.matrix` (single run on `node-version: 22.18.0`) — duplication detection is node-version-invariant; ships with a `vars.JSCPD_BOT_ENABLED != 'false'` kill-switch; included in the `lint-summary` aggregator (`needs:` at `ci.yml:795+`); fails when duplication exceeds the configured 5 % threshold; `pnpm duplication` runs cleanly on the PR branch
+  - **Depends on:** none
+
+## §1.3 Add `timeout-minutes` to every job in every workflow
+
+- [ ] §1.3
+  - **Agent:** cicd-guardian
+  - **Scope:** `.github/workflows/*.yml` (13 files), new `scripts/check-workflow-timeouts.mjs` + co-located `*.test.mjs`, root `package.json` (`lint:workflow-timeouts` script entry + inclusion in the parallelized lint umbrella post-W2.2)
+  - **Accept:** every job in every workflow file has a `timeout-minutes` value; the new check `scripts/check-workflow-timeouts.mjs` is invocable as `node scripts/check-workflow-timeouts.mjs` and exits non-zero if any job is missing a timeout (verified by removing one timeout and observing the failure); `scripts/check-workflow-timeouts.test.mjs` covers: (a) all-timeouts-present passes, (b) missing-timeout fails, (c) malformed YAML fails, (d) workflow with no jobs (matrix-only) is tolerated; `pnpm test:scripts` passes; the timeout value per job is `min(P95 × 1.5, ceiling)` where P95 is computed from the last 20 successful runs of that job (recipe: `gh run list --workflow=<name>.yml --status=success --limit=20 --json jobs --jq '[.[].jobs[] | select(.name == "<job>") | (.completedAt | fromdate) - (.startedAt | fromdate)] | sort | .[18]'` returns the 19th of 20 sorted, i.e. the P95 in seconds — divide by 60 for minutes) AND ceiling is `{lint: 10, build: 20, test: 30, e2e: 45}` minutes by job-family — both numbers (P95×1.5 and the ceiling that applied) recorded in the PR description per workflow
+  - **Depends on:** none
+
+## §1.4 Add the four missing package READMEs
+
+- [ ] §1.4
+  - **Agent:** docs-expert
+  - **Scope:** `packages/docs/README.md`, `packages/garmin-bridge/README.md`, `packages/landing/README.md`, `packages/train2go-bridge/README.md`
+  - **Accept:** each of the four files exists; each includes purpose, public API or build entrypoint, and "how to test" sections; `pnpm lint:links` passes
+  - **Depends on:** none
+
+## §1.5 Audit `pnpm.overrides`; add `lint:overrides-stale` mechanical guard
+
+- [ ] §1.5
+  - **Agent:** general-purpose
+  - **Scope:** root `package.json` (`overrides` audit + new `lint:overrides-stale` script entry), `scripts/check-overrides-stale.mjs` (new), `scripts/check-overrides-stale.test.mjs` (new), `scripts/README.md` (new `<!-- overrides-allowlist:start -->` / `<!-- overrides-allowlist:end -->` block), `openspec/specs/scripts-folder-hygiene/spec.md` (apply the delta from `specs/scripts-folder-hygiene/spec.md` of this change)
+  - **Accept:** `pnpm test:scripts` passes; new tests cover all six scenarios in the delta spec (required, stale, allowlisted, malformed, empty/absent, network-fail-closed); `pnpm lint:overrides-stale` runs as part of `pnpm lint`; running the check on the existing 24 pinned overrides surfaces 0 stale OR each survivor has an allowlist row with a "Why kept" note; algorithm matches D5 spec (deterministic; either `pnpm why --json` walk or temp-dir lockfile-only re-resolve; network-required strategies fail closed); the canonical `openspec/specs/scripts-folder-hygiene/spec.md` first line is updated to `> Synced: <date-of-this-PR-merge> (repo-quality-maintenance-waves)` (the Synced bump belongs to this PR — NOT to §7.1 — because §1.5 is the change that actually re-verifies the spec against shipped code); `pnpm exec openspec validate --specs` passes after applying the delta
+  - **Depends on:** none
+
+## §1.6 Make `workout-spa-editor` bundle environment-agnostic across all five surfaces (12-factor III + V)
+
+- [ ] §1.6
+  - **Agent:** spa-expert
+  - **Scope:** all five `VITE_CF_ANALYTICS_TOKEN` surfaces — `packages/workout-spa-editor/src/main.tsx`, `packages/workout-spa-editor/index.html`, `packages/workout-spa-editor/vite.config.ts`, `packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts`, `packages/workout-spa-editor/docs/analytics.md` — plus whichever runtime-config mechanism the agent selects per design D9 (a new `packages/workout-spa-editor/public/config.json` + matching loader, or an `index.html`-templated `window.__KAIORD_CONFIG__` injected at deploy time, or removal in favor of a Cloudflare-side analytics snippet). Vite `define`/`env` is forbidden as the answer.
+  - **Accept:** `grep -RnE "VITE_CF_ANALYTICS_TOKEN" packages/workout-spa-editor/src packages/workout-spa-editor/index.html packages/workout-spa-editor/vite.config.ts` returns no matches (allowed only in tests/fixtures and the rewritten docs); the production-built bundle (`packages/workout-spa-editor/dist/**/*.js`, `**/*.html`) contains no literal token value — verified by `pnpm --filter @kaiord/workout-spa-editor build && grep -RE "<any-known-prod-token-fragment>" packages/workout-spa-editor/dist`; the analytics path still works in dev (`pnpm --filter @kaiord/workout-spa-editor dev` boots and analytics initializes when a token is provided through the new runtime mechanism); SPA editor build / unit tests / e2e suite all pass; `import.meta.env.{MODE,DEV,BASE_URL}` references are left untouched (legitimate Vite intrinsics, not config); docs/analytics.md is rewritten to describe the runtime-injection pattern, not build-time embed
+  - **Depends on:** none
+
+## §2.1 Convert pre-commit hook to lint-staged on changed files; move `pnpm build` out of pre-commit entirely
+
+- [ ] §2.1
+  - **Agent:** cicd-guardian
+  - **Scope:** `.husky/pre-commit`, root `package.json` (devDependency `lint-staged` + `lint-staged` config block); explicitly REMOVES the `pnpm build` step from pre-commit (build moves to CI only — it already runs there)
+  - **Accept:** new pre-commit shape is exactly: `lint-staged` (file-scoped checks: eslint --fix --max-warnings=0 on `*.{ts,tsx}`; prettier --check on `*.{md,json,yml}`; the test-AAA / test-title-should `--changed-files` modes for staged `*.test.{ts,tsx}`) → `pnpm test:scripts` (full-tree mechanical guards: R-LibraryNoDualMount, R-ScriptsNoOrphans, R-AppDexieImport, etc. — `test:scripts` already runs in <5s) → `pnpm -r exec tsc --noEmit --incremental`; **`pnpm build` is no longer in pre-commit** (it stays in CI); the PR description records BOTH `time git commit` measurements: BEFORE the change (current `.husky/pre-commit` runs `pnpm build` + `pnpm -r exec tsc --noEmit` + `pnpm test:scripts` + `pnpm test`, expected ~2–3 min on a warm cache) and AFTER (target <30s) — the win is the delta, not the absolute number; deliberately introducing an existing whole-tree-only violation (R-LibraryNoDualMount: import `WorkoutLibrary` from a third file outside `LibraryPage.tsx` / `TemplatePickerDialog.tsx`) still blocks the commit (verifies `pnpm test:scripts` retention); deliberately breaking a file-scoped guard (e.g. PII interpolation in a toast) still blocks the commit; tsc incremental cache warmth verified by checking each `tsconfig.json` either inherits or sets `compilerOptions.tsBuildInfoFile`, and the resulting `.tsbuildinfo` files are gitignored
+  - **Depends on:** §1.1, §1.2, §1.3
+
+## §2.2 Parallelize `pnpm lint` per the ordering matrix in design D10
+
+- [ ] §2.2
+  - **Agent:** cicd-guardian
+  - **Scope:** root `package.json` (`scripts.lint`), devDependency `npm-run-all2`
+  - **Accept:** `pnpm lint` completes ≥ 2× faster than the pre-PR baseline on a warm cache (PR description includes timing before/after); the parallel group and post-group exactly match design D10 (parallel: 15 + 2 new from W1.3/W1.5 = 17 checks plus per-package `pnpm -r lint`; post: `lint:archive-index`, `lint:archive-followups`); invoked with `npm-run-all2 -p --max-parallel=4 --aggregate-output` per design D7 to cap workers and keep per-process output contiguous; the PR description includes the output of `for i in $(seq 1 20); do time pnpm lint || echo FAIL >&2; done` showing 20 successes in a row and stable timing (max − min < 30 % of mean) — proves no race-flakes from the parallelization
+  - **Depends on:** §2.1, §1.1, §1.2, §1.3
+
+## §2.3 Replace `pre-push lint:fix` with `pre-push lint` (verify-only, no writes)
+
+- [ ] §2.3
+  - **Agent:** cicd-guardian
+  - **Scope:** `.husky/pre-push` only
+  - **Accept:** `.husky/pre-push` runs `pnpm lint` (read-only), never `pnpm lint:fix`; on a clean tree, push leaves the working tree clean (`git status --porcelain` empty after a successful push); on a tree with lint errors, push aborts with an explicit "run `pnpm lint:fix` yourself" message — the hook does not write to the working tree
+  - **Depends on:** §1.1, §1.2, §1.3
+
+## §3.0 Precondition: confirm vitest coverage tooling is wired in `core` and `garmin`
+
+- [ ] §3.0
+  - **Agent:** test-improver
+  - **Scope:** `packages/core/package.json`, `packages/garmin/package.json` (`scripts.test:coverage`), `packages/core/vitest.config.ts`, `packages/garmin/vitest.config.ts` (coverage `thresholds` block per CLAUDE.md: 80 % line + branch + function for both — backend packages)
+  - **Accept:** discovery + setup performed in this order: (a) read `packages/core/vitest.config.ts` and `packages/garmin/vitest.config.ts`; (b) record whether each has a `coverage.thresholds` block today; (c) if absent, ADD one set to `{ lines: 80, branches: 80, functions: 80, statements: 80 }` as part of THIS PR; (d) if present but lower than 80, raise to 80; (e) if present at 80+, leave intact and note the baseline in the PR description; (f) confirm `scripts.test:coverage` script exists in each package's `package.json` and add it if missing (the canonical command is `vitest --run --coverage`). After discovery: `pnpm --filter @kaiord/core test:coverage` produces a coverage report with thresholds enforced; same for `@kaiord/garmin`; current coverage values recorded in PR description as the baseline; **if the baseline already passes 80 % across all four metrics, §3.1 is downgraded to a no-op** — its tasks.md entry MUST be marked `> Deferred to: <already at threshold>` per the deferral protocol AND the closing §7.1 reflects this in the `Tasks: <C> completed, <D> deferred` line; same rule for §3.2 vs `@kaiord/garmin`. The baseline run is the determinant — if at threshold, do not manufacture synthetic tests just to "do something"
+  - **Depends on:** §1.1, §1.2, §1.3
+
+## §3.1 Lift `core` coverage to ≥ 80 % line + branch + function
+
+- [ ] §3.1
+  - **Agent:** test-improver
+  - **Scope:** `packages/core/**` (source files MUST NOT change; only new `*.test.ts` files added under `packages/core/src/`)
+  - **Accept:** `pnpm --filter @kaiord/core test:coverage` reports ≥ 80 % line, ≥ 80 % branch, ≥ 80 % function per CLAUDE.md; new tests follow R-ItTitleShould and R-ItBodyAAA — verified by running `node scripts/check-test-aaa.mjs` and `node scripts/check-test-title-should.mjs` in full-tree mode at the end of the PR (NOT the `--changed-files` mode); `pnpm test:scripts` passes
+  - **Depends on:** §3.0
+
+## §3.2 Lift `garmin` coverage to ≥ 80 % line + branch + function
+
+- [ ] §3.2
+  - **Agent:** test-improver
+  - **Scope:** `packages/garmin/**` (source unchanged; only new `*.test.ts`)
+  - **Accept:** `pnpm --filter @kaiord/garmin test:coverage` ≥ 80 % line / branch / function; tests follow R-ItTitleShould and R-ItBodyAAA (full-tree mode verified via `node scripts/check-test-aaa.mjs && node scripts/check-test-title-should.mjs`); `pnpm test:scripts` passes
+  - **Depends on:** §3.0
+
+## §3.3 Split oversized backend files (>100 LOC)
+
+- [ ] §3.3
+  - **Agent:** complexity-reducer
+  - **Scope:** `packages/fit/src/adapters/krd-to-fit/krd-to-fit-metadata.converter.ts` (120 LOC), `packages/tcx/src/adapters/target/tcx-to-krd.converter.ts` (111 LOC), `packages/zwo/src/adapters/interval/steady-state.mapper.ts` (106 LOC), `packages/cli/src/commands/garmin/yargs-config.ts` (107 LOC), `packages/cli/src/commands/convert/single-file.ts` (107 LOC)
+  - **Accept:** every file in scope ≤ 100 LOC; every function ≤ 40 LOC; existing tests still pass for each touched package (`pnpm --filter @kaiord/fit test`, `pnpm --filter @kaiord/tcx test`, `pnpm --filter @kaiord/zwo test`, `pnpm --filter @kaiord/cli test`); round-trip tests still pass (`pnpm --filter @kaiord/fit test:roundtrip`, etc., where they exist); public exports of each adapter `index.ts` are byte-identical to pre-PR (`git diff packages/{fit,tcx,zwo}/src/index.ts` shows no change)
+  - **Depends on:** §1.1, §1.2, §1.3
+
+## §4.1 Extract shared repetition-block / step mutation helpers
+
+- [ ] §4.1
+  - **Agent:** complexity-reducer
+  - **Scope:** `packages/workout-spa-editor/src/store/actions/{add-step-to-repetition-block,delete-repetition-block,ungroup-repetition-block,edit-repetition-block,create-empty-repetition-block,duplicate-step}-action.ts`; new helpers under `packages/workout-spa-editor/src/store/actions/_helpers/`; corresponding tests
+  - **Accept:** `pnpm duplication` (jscpd) reports < 50 LOC of duplication across these six files (down from ~100); each action file ≤ 100 LOC; existing action tests still pass; `pnpm test:scripts` still passes (R-DexieImport, R-PersistStateImport unaffected)
+  - **Depends on:** §2.1, §2.2, §2.3, §3.1, §3.2, §3.3
+
+## §4.2 Split `src/types/index.ts` (172 LOC) into domain-scoped barrels — lands FIRST in W4 to minimize merge conflicts
+
+- [ ] §4.2
+  - **Agent:** complexity-reducer
+  - **Scope:** `packages/workout-spa-editor/src/types/index.ts`, new files under `packages/workout-spa-editor/src/types/{workout,profile,sync,ui}.ts`, all import sites that pull from `~/types` or `src/types`
+  - **Accept:** `src/types/index.ts` ≤ 60 LOC and is a pure re-export barrel; per-domain files each ≤ 100 LOC; SPA editor build green (`pnpm --filter @kaiord/workout-spa-editor build`); SPA editor tests green; no TS error from import-path drift
+  - **Depends on:** §2.1, §2.2, §2.3, §3.1, §3.2, §3.3
+
+## §4.3 Split `CalendarPage.tsx` (156 LOC, 10+ hooks) into a coordinating hook + view
+
+- [ ] §4.3
+  - **Agent:** complexity-reducer
+  - **Scope:** `packages/workout-spa-editor/src/components/pages/CalendarPage.tsx`, new co-located `use-calendar-page.ts` (or `useCalendarPage.ts`), new co-located test for the hook
+  - **Accept:** `CalendarPage.tsx` ≤ 60 LOC; the new coordinating hook ≤ 100 LOC; the hook is unit-tested with at least one positive-flow scenario, one auto-match-suggestion scenario, and one no-active-profile fallback scenario (organism-hooks pattern); SPA editor build green; SPA editor e2e suite green
+  - **Depends on:** §2.1, §2.2, §2.3, §3.1, §3.2, §3.3, §4.2
+
+## §4.4 Build a workout-store selector registry
+
+- [ ] §4.4
+  - **Agent:** complexity-reducer
+  - **Scope:** `packages/workout-spa-editor/src/store/workout-store-selectors.ts` (split), `use-keyboard-store-selectors.ts`, `use-context-menu-store.ts`, all 60+ selector callsites
+  - **Accept:** each selector file ≤ 100 LOC; selectors exported through a single entry barrel `src/store/selectors/index.ts`; selector callsite imports flow through the barrel; SPA editor build green; SPA editor tests green
+  - **Depends on:** §2.1, §2.2, §2.3, §3.1, §3.2, §3.3, §4.1, §4.2
+
+## §4.5 Right-size remaining files over budget
+
+- [ ] §4.5
+  - **Agent:** complexity-reducer
+  - **Scope:** `packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts` (140 LOC), `src/utils/save-workout.ts` (123 LOC), `src/utils/profile-storage.ts` (114 LOC), `src/components/pages/WorkoutSection/use-repetition-block-handlers.tsx` (118 LOC)
+  - **Accept:** every file in scope ≤ 100 LOC; every function ≤ 40 LOC (60 for components); existing tests still pass; `R-DexieImport`, `R-PersistStateImport`, `R-AppDexieImport` still satisfied
+  - **Depends on:** §2.1, §2.2, §2.3, §3.1, §3.2, §3.3, §4.2
+
+## §5.1 Tests for `components/organisms/ZoneEditor/hooks/*`
+
+- [ ] §5.1
+  - **Agent:** test-improver
+  - **Scope:** `packages/workout-spa-editor/src/components/organisms/ZoneEditor/hooks/**` (only new `*.test.ts`/`.test.tsx` files)
+  - **Accept:** every hook file under `ZoneEditor/hooks/` has a co-located `.test.tsx` or `.test.ts`; every test file passes R-ItTitleShould and R-ItBodyAAA in full-tree mode (`node scripts/check-test-aaa.mjs && node scripts/check-test-title-should.mjs`); aggregate coverage of `ZoneEditor/hooks/` ≥ 70 % line / branch / function (CLAUDE.md frontend threshold — the gap to backend's 80 % is intentional policy, tracked as a future tightening); test files import types via the `~/types` barrel only (never deep imports into `~/types/<sub>`) — verified by `grep -RnE "from ['\"]~/types/" packages/workout-spa-editor/src/components/organisms/ZoneEditor/hooks` returning no matches
+  - **Depends on:** §2.1, §2.2, §2.3, §3.1, §3.2, §3.3
+
+## §5.2 Tests for `components/organisms/ProfileManager/hooks/*`
+
+- [ ] §5.2
+  - **Agent:** test-improver
+  - **Scope:** `packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/**`
+  - **Accept:** every hook file has a co-located test; full-tree AAA + title compliance verified; coverage of `ProfileManager/hooks/` ≥ 70 % line / branch / function; test files use `~/types` barrel only (`grep -RnE "from ['\"]~/types/" packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks` returns no matches)
+  - **Depends on:** §2.1, §2.2, §2.3, §3.1, §3.2, §3.3
+
+## §5.3 Tests for `components/organisms/WorkoutLibrary/components/*`
+
+- [ ] §5.3
+  - **Agent:** test-improver
+  - **Scope:** `packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/**`
+  - **Accept:** every component file has a co-located test; full-tree AAA + title compliance verified; coverage of `WorkoutLibrary/components/` ≥ 70 %; `R-LibraryNoDualMount` still satisfied; test files use `~/types` barrel only (`grep -RnE "from ['\"]~/types/" packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components` returns no matches)
+  - **Depends on:** §2.1, §2.2, §2.3, §3.1, §3.2, §3.3
+
+## §5.4 Tests for `components/organisms/WorkoutList/hooks/*` (incl. `use-workout-list-dnd.ts`)
+
+- [ ] §5.4
+  - **Agent:** test-improver
+  - **Scope:** `packages/workout-spa-editor/src/components/organisms/WorkoutList/hooks/**`
+  - **Accept:** every hook file has a co-located test; tests cover drag, drop, cancel, and reorder paths; full-tree AAA + title compliance verified; coverage of `WorkoutList/hooks/` ≥ 70 %; test files use `~/types` barrel only (`grep -RnE "from ['\"]~/types/" packages/workout-spa-editor/src/components/organisms/WorkoutList/hooks` returns no matches)
+  - **Depends on:** §2.1, §2.2, §2.3, §3.1, §3.2, §3.3
+
+## §6.1 Extract zone tables to `core/src/domain/zones/` with exhaustive + property-based tests
+
+- [ ] §6.1
+  - **Agent:** architecture-guardian
+  - **Scope:** new `packages/core/src/domain/zones/power-zones.ts`, optional `packages/core/src/domain/zones/hr-zones.ts` (only if the W6.1 grep audit confirms a duplicated HR table — see design D2 sub-agent contract; the helper's zone count is whatever the audit dictates, NOT a presupposed 5-band model — the spec scenarios must match the helper's actual domain), co-located `*.test.ts` siblings (must include exhaustive enumeration; property-based tests via `fast-check` are optional for the 7-element power-zone domain — see Accept), `packages/core/src/index.ts` re-exports, root `package.json` (devDependency `fast-check` ONLY if the property-based path is taken); apply the delta from `specs/domain-conversions/spec.md`; create the canonical post-archive spec at `openspec/specs/domain-conversions/spec.md` with the following exact preamble (then merge in the delta's Requirements):
+
+    ```
+    > Synced: <date-of-this-PR-merge> (repo-quality-maintenance-waves)
+
+    # Domain conversions
+
+    ## Purpose
+
+    Provides pure, side-effect-free fitness-domain conversion helpers (initially the 7-band power-zone-to-percent-FTP table) used by adapter packages to translate between discrete zone numbers and the continuous quantities they represent. Helpers SHALL stay under `domain/` and SHALL NOT acquire I/O; if a future change requires side effects, the work moves to `application/` with an injected port.
+
+    ## Requirements
+
+    <merge in the two ADDED Requirements from the change-folder delta verbatim>
+    ```
+  - **Accept:** pure domain modules with zero external imports beyond `zod` (and `fast-check` only if the property-based path is taken; test-only); each helper has unit tests covering: **exhaustive enumeration** over every integer zone in the valid range as defined by the helper itself (7 for power per Coggan — exhaustive enumeration is mathematically complete for a 7-element domain; HR-zone count determined by the audit if shipped); boundary inputs (`0`, `max+1`, `-1`, `NaN`, `Infinity`, non-integers like `1.5`); a `fast-check` property-based suite (≥ 100 generated cases) is OPTIONAL for the power domain (no theoretical added value over exhaustive enumeration) but RECOMMENDED for the HR domain if it ships with a wider valid range — the PR description names which path was taken and why; per-file coverage on `domain/zones/**` ≥ 95 % line / branch / function — verified by running `pnpm --filter @kaiord/core test -- --coverage --coverage.include='src/domain/zones/**' --coverage.thresholds.lines=95 --coverage.thresholds.branches=95 --coverage.thresholds.functions=95` (CLI overrides the package-level 80 % threshold for this scope only); alternatively, a `node scripts/check-zones-coverage.mjs` parses `coverage/coverage-final.json` and asserts the per-file numbers (either is acceptable; the PR description names which); `pnpm lint:architecture` (alias `pnpm arch:check` if desired) reports 0 errors; `pnpm exec openspec validate --specs` passes after applying the delta AND creating the canonical post-archive spec with the verbatim `## Purpose` block above; published API of `@kaiord/core` adds new exports only (no removals, no signature changes to existing exports — verified by `git diff packages/core/src/index.ts | grep -E "^-export"` empty) — this qualifies as a `minor` bump per SemVer §7; the PR description includes a grep audit (`grep -RnE "<zone-table-fingerprint>" packages/`) listing every site that holds equivalent logic, confirming `zwo` is the only adapter to migrate (or, if FIT/TCX surface unexpected sites, halting the wave for re-scoping per design D2 sub-agent contract); a changeset entry for `core` (`minor`) is added under `.changeset/`; the canonical `openspec/specs/domain-conversions/spec.md` Synced marker bears the merge date of THIS PR (not §7.1)
+  - **Depends on:** §4.1, §4.2, §4.3, §4.4, §4.5
+
+## §6.2 Migrate `zwo` to use the new core helpers
+
+- [ ] §6.2
+  - **Agent:** architecture-guardian
+  - **Scope:** `packages/zwo/src/adapters/target/power.converter.ts` (replace local `convertPowerZoneToPercentFtp` with the import from `@kaiord/core`); other zwo files unchanged
+  - **Accept:** `packages/zwo/src/adapters/target/power.converter.ts` no longer holds an inline zone table; the corresponding logic comes from `@kaiord/core` via `import`; `pnpm --filter @kaiord/zwo test` passes; `pnpm arch:check` 0 errors; cross-adapter imports remain forbidden (`pnpm exec depcruise packages/zwo/src --config .dependency-cruiser.cjs` shows no `@kaiord/fit` or `@kaiord/tcx` imports); `git diff packages/zwo/src/index.ts` shows no changes (public API stable)
+  - **Depends on:** §6.1
+
+## §6.3 Round-trip + property-based verification across the migrated state
+
+- [ ] §6.3
+  - **Agent:** validate-roundtrip
+  - **Scope:** read-only — runs the existing round-trip suites and the new property-based suite; only PR scope is the changeset entry and (if any tolerance has actually improved) the threshold value
+  - **Accept:** `pnpm -r test:roundtrip` passes within current tolerances (time ±1s, power ±1W or ±1%FTP, HR ±1bpm, cadence ±1rpm); since W6 only touched `zwo` (per design D2), the only test family that could reflect a W6 regression is the ZWO round-trip matrix — if any FIT-only or TCX-only round-trip fails, that failure is **pre-existing** and §6.3 is NOT the right PR to fix it (open a separate issue and do not block §6.3 on it); `pnpm --filter @kaiord/core test -- zones` shows the exhaustive-enumeration suite green for every helper that ships, plus the property-based suite if W6.1 took that path; if any tolerance has tightened in practice, the PR description proposes the new value (do not auto-tighten)
+  - **Depends on:** §6.2
+
+## §7.1 Closing — confirm `/opsx-archive` readiness
+
+- [ ] §7.1
+  - **Agent:** general-purpose
+  - **Scope:** `openspec/changes/repo-quality-maintenance-waves/tasks.md` (mark all checkboxes complete; final tally update); read-only audit elsewhere (no spec or code edits — Synced markers were bumped by the PRs that re-verified each spec: §1.5 for `scripts-folder-hygiene`, §6.1 for `domain-conversions`)
+  - **Accept:** every checkbox above is checked; the chunking-block `Tasks: <C> completed, <D> deferred` line is updated with the final tally; the SPEC_TEMPLATE rule 7 top-level `> Tasks: <C> completed, <D> deferred` blockquote (if used per the deferral protocol; both placements are kept in sync if both are used) reflects the same numbers; the canonical `openspec/specs/scripts-folder-hygiene/spec.md` Synced marker is dated within the §1.5 PR's merge window (not later); the canonical `openspec/specs/domain-conversions/spec.md` Synced marker is dated within the §6.1 PR's merge window (not later); `pnpm exec openspec validate repo-quality-maintenance-waves --strict` passes; `pnpm lint` passes; `pnpm -r test` passes; `pnpm -r build` passes; ready to invoke `/opsx-archive repo-quality-maintenance-waves` (the DRI runs `/opsx-archive` after this §7.1 PR merges — the archive is NOT auto-triggered by §7.1 completion)
+  - **Depends on:** §6.3


### PR DESCRIPTION
## Summary

Lands the OpenSpec change folder on `main` so the 26-PR maintenance campaign can dispatch its wave PRs from a main that includes the spec. Pure scaffolding — no source-code changes, no behavior change.

## What

Adds `openspec/changes/repo-quality-maintenance-waves/`:
- `proposal.md` — non-evolutionary change bundling defensive walls, DX speedups, test-coverage lifts, structural refactors, and a 12-factor SPA bundle fix into 6 sequenced waves.
- `design.md` — 13 decisions (D1-D13) including the W6 audit conclusion (cross-adapter "duplication" was largely false; only the 7-band power-zone table is genuinely domain), the `/opsx-ship` orchestration contract, the lint-umbrella ordering matrix, and the pairwise file-overlap audit.
- `specs/domain-conversions/spec.md` — **NEW capability** declaring the public contract of `core/src/domain/zones/` (purity, error semantics, forward-looking constraint that side-effects must move to `application/`).
- `specs/scripts-folder-hygiene/spec.md` — **MODIFIED capability** delta extending it with the `R-OverridesStale` rule (deterministic algorithm, six scenarios including network-fail-closed and empty-overrides).
- `tasks.md` — 26 PRs across 6 waves + closing, each with Agent / Scope / Accept / Depends-on metadata. Pre-dispatch parser smoke verified (D13).

## Why

Without this PR, every wave PR worktree would have to either (a) import the spec from a sibling branch (fragile), or (b) carry its own copy of the spec (drift risk). Landing the spec on main first preserves the parallel-readiness of W1.1-W1.6.

## Validation

- `pnpm exec openspec validate repo-quality-maintenance-waves --strict` ✓
- Pre-dispatch parser smoke (design D13): 26 tasks parse cleanly; all dependencies resolve; 6 tasks ready (W1.1-W1.6, all `Depends on: none`).
- 4 expert-panel review iterations: 5.8 → 8.6 → 9.18 → **9.60** (target ≥ 9.5 reached).

## Test plan

- [x] `pnpm exec openspec validate repo-quality-maintenance-waves --strict` passes
- [ ] CI lint / spec-format checks pass
- [ ] Spec folder is reachable from `main` after merge so wave PRs can branch off it

## Next

After this lands, opsx-ship dispatches Wave 1 (6 parallel-eligible PRs: §1.1 size-limit, §1.2 jscpd, §1.3 timeouts, §1.4 READMEs, §1.5 overrides-stale, §1.6 SPA bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)