### PR TITLE
refactor(spa-editor): inject analytics token at runtime, not build (§1.6)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -57,8 +57,34 @@ jobs:
       - name: Build SPA Editor
         env:
           VITE_BASE_PATH: /editor/
-          VITE_CF_ANALYTICS_TOKEN: ${{ secrets.CF_ANALYTICS_TOKEN }}
         run: pnpm --filter @kaiord/workout-spa-editor... build
+
+      # Inject the Cloudflare Web Analytics token at deploy time (runtime
+      # config). The bundle itself is environment-agnostic per 12-factor
+      # III + V — see packages/workout-spa-editor/docs/analytics.md. When the
+      # secret is absent the placeholder remains and the SPA's noop analytics
+      # adapter wins.
+      - name: Substitute analytics token in SPA index.html
+        env:
+          CF_ANALYTICS_TOKEN: ${{ secrets.CF_ANALYTICS_TOKEN }}
+        run: |
+          set -e
+          if [ -z "${CF_ANALYTICS_TOKEN:-}" ]; then
+            echo "CF_ANALYTICS_TOKEN unset; leaving placeholder in index.html (analytics disabled)"
+            exit 0
+          fi
+          INDEX="packages/workout-spa-editor/dist/index.html"
+          test -f "$INDEX" || { echo "::error::SPA build artifact missing: $INDEX"; exit 1; }
+          # Use | as the delimiter to avoid escaping issues if the token
+          # contains slashes.
+          sed -i "s|__CF_ANALYTICS_TOKEN__|${CF_ANALYTICS_TOKEN}|g" "$INDEX"
+          # Verify substitution actually replaced the placeholder so a
+          # silent failure does not ship a no-analytics build.
+          if grep -q "__CF_ANALYTICS_TOKEN__" "$INDEX"; then
+            echo "::error::Placeholder __CF_ANALYTICS_TOKEN__ still present after sed"
+            exit 1
+          fi
+          echo "Analytics token injected at runtime"
 
       - name: Build Docs
         run: pnpm --filter @kaiord/docs... build

--- a/packages/workout-spa-editor/.env.example
+++ b/packages/workout-spa-editor/.env.example
@@ -1,12 +1,12 @@
 # Workout SPA Editor Environment Variables
 
-# Cloudflare Web Analytics beacon token (public, not a secret).
-# Leave empty in local dev — analytics will be disabled (noop adapter).
-# Set in CI/CD to enable Cloudflare Web Analytics in production builds.
-VITE_CF_ANALYTICS_TOKEN=
-
 # Base path for deployment (e.g., GitHub Pages)
 # VITE_BASE_PATH=/workout-spa-editor
+
+# NOTE: The Cloudflare Web Analytics token is NOT a build-time env var any
+# more. It is injected at deploy time as a runtime config substitution into
+# `index.html` (see docs/analytics.md → "Runtime config injection").
+# Local dev intentionally has no analytics; the noop adapter wins.
 
 # Bridge extensions (Garmin, Train2Go) are discovered at runtime via
 # content script announcements. No extension IDs are required at build

--- a/packages/workout-spa-editor/docs/analytics.md
+++ b/packages/workout-spa-editor/docs/analytics.md
@@ -6,19 +6,63 @@ The SPA editor uses the `AnalyticsPort` interface (defined in `@kaiord/core/port
 
 ```
 src/main.tsx
-  ├── createCloudflareAnalytics(import.meta.env.VITE_CF_ANALYTICS_TOKEN)
+  ├── getCfAnalyticsToken()                    // reads window.__KAIORD_CONFIG__
+  ├── createCloudflareAnalytics(token)         // noop if token is undefined
   └── <AnalyticsProvider analytics={analytics}>
 ```
 
-The adapter (`src/adapters/analytics/cloudflare-analytics.ts`) forwards each `event(name, props)` call to `window.cfBeacon.pushEvent(name, props)` — the global beacon CloudFlare injects into the page when the analytics token is configured.
+The adapter (`src/adapters/analytics/cloudflare-analytics.ts`) forwards each `event(name, props)` call to `window.cfBeacon.pushEvent(name, props)` — the global beacon CloudFlare injects into the page when the analytics token is present.
 
-When `VITE_CF_ANALYTICS_TOKEN` is absent or empty, the adapter falls back to `createNoopAnalytics()` from `@kaiord/core` and no events are sent.
+When the runtime token is absent, empty, or still equals the placeholder `__CF_ANALYTICS_TOKEN__`, the adapter falls back to `createNoopAnalytics()` from `@kaiord/core` and no events are sent.
+
+## Runtime config injection (12-factor III + V)
+
+The token is **NOT** baked into the build. The compiled bundle is environment-agnostic — the same artifact ships to every deploy. The token is injected at deploy time via a runtime config object on `window`:
+
+1. `index.html` contains an inline `<script>` block that initializes `window.__KAIORD_CONFIG__` with a placeholder value, e.g.:
+
+   ```html
+   <script>
+     window.__KAIORD_CONFIG__ = window.__KAIORD_CONFIG__ || {
+       cfAnalyticsToken: "__CF_ANALYTICS_TOKEN__",
+     };
+   </script>
+   ```
+
+2. A second inline `<script>` reads `window.__KAIORD_CONFIG__.cfAnalyticsToken`. If it is non-empty AND not equal to the placeholder, the script appends the Cloudflare beacon `<script>` to `<head>` with the token in `data-cf-beacon`. Otherwise it returns silently — no beacon is loaded.
+
+3. `src/main.tsx` calls `getCfAnalyticsToken()` (`src/lib/runtime-config.ts`) which returns `undefined` for the same "no token" cases, so the analytics adapter selects the no-op path.
+
+4. The `||` fallback in step 1 lets earlier scripts (e.g., Playwright `addInitScript` in e2e tests) pre-seed `window.__KAIORD_CONFIG__` and have those values win.
 
 ## Activating analytics in a deploy
 
-Set the `VITE_CF_ANALYTICS_TOKEN` build-time env var to the CloudFlare Web Analytics site token. The token is **public** (it identifies the site to CloudFlare's beacon endpoint) — there are no secrets to handle here. The build embeds it; no additional runtime config is required.
+The deploy step substitutes the placeholder string inside the deployed `index.html`. The current pipeline (`.github/workflows/deploy-site.yml`, "Substitute analytics token" step) does this with `sed`:
 
-To disable analytics for a deploy, leave the var unset (or set it to the empty string).
+```bash
+if [ -n "$CF_ANALYTICS_TOKEN" ]; then
+  sed -i "s|__CF_ANALYTICS_TOKEN__|${CF_ANALYTICS_TOKEN}|g" \
+    packages/workout-spa-editor/dist/index.html
+fi
+```
+
+The token is **public** (it identifies the site to CloudFlare's beacon endpoint) — there are no secrets to handle here. To disable analytics for a deploy, simply skip the substitution step (or leave the secret unset); the placeholder remains and the noop adapter wins.
+
+## Testing analytics locally
+
+For local manual verification:
+
+1. Build the SPA: `pnpm --filter @kaiord/workout-spa-editor build`.
+2. Replace the placeholder in the served `index.html`:
+
+   ```bash
+   sed -i '' "s|__CF_ANALYTICS_TOKEN__|<your-cf-token>|g" \
+     packages/workout-spa-editor/dist/index.html
+   ```
+
+3. Serve `dist/` (e.g. `npx serve packages/workout-spa-editor/dist`) and verify the Cloudflare beacon `<script>` is in the document head and `pageView` events appear in the CloudFlare dashboard.
+
+In the e2e suite (`e2e/spa-route-refresh.spec.ts`), Playwright's `addInitScript` injects `window.__KAIORD_CONFIG__` and a fake `window.cfBeacon` before the SPA loads — the build itself runs without a token.
 
 ## Events emitted
 
@@ -38,10 +82,11 @@ The `route-error` payload is the most sensitive surface: an unscrubbed React err
 
 ## Verifying in staging
 
-1. Deploy the SPA with `VITE_CF_ANALYTICS_TOKEN` set to the staging-site token.
-2. Trigger a render error on a routed page (e.g., temporarily throw from a dev-mode route component).
-3. Confirm the CloudFlare Web Analytics dashboard shows the `route-error` custom event.
-4. Inspect the event payload in CloudFlare's "Custom Events" view: confirm `route` does not contain UUIDs / bearer tokens / emails; confirm `message` and `componentStack` are truncated to ≤ 500 / ≤ 1000 chars.
+1. Deploy the SPA. Confirm the deploy step runs the placeholder substitution.
+2. Open the deployed editor in a browser and inspect `<head>`: the Cloudflare beacon `<script>` element with `data-cf-beacon` should be present.
+3. Trigger a render error on a routed page (e.g., temporarily throw from a dev-mode route component).
+4. Confirm the CloudFlare Web Analytics dashboard shows the `route-error` custom event.
+5. Inspect the event payload in CloudFlare's "Custom Events" view: confirm `route` does not contain UUIDs / bearer tokens / emails; confirm `message` and `componentStack` are truncated to ≤ 500 / ≤ 1000 chars.
 
 ## Replacing the provider
 
@@ -49,8 +94,9 @@ If a future product decision swaps providers (e.g., to PostHog or Sentry), the c
 
 1. Add a new adapter at `src/adapters/analytics/<provider>-analytics.ts` implementing the `Analytics` type from `@kaiord/core`.
 2. Swap the `createCloudflareAnalytics(...)` call in `src/main.tsx` for the new factory.
-3. Remove `cloudflare-analytics.{ts,test.ts}` if the CloudFlare adapter is no longer needed.
-4. Update this document.
+3. Extend `src/lib/runtime-config.ts` with the new provider's runtime fields if needed; mirror the placeholder pattern in `index.html` and the deploy step.
+4. Remove `cloudflare-analytics.{ts,test.ts}` if the CloudFlare adapter is no longer needed.
+5. Update this document.
 
 The `AnalyticsPort` interface is the contract — every adapter implementation only has to satisfy `pageView` and `event`. Consumers (`useAnalytics` hook, `RouteErrorBoundary` analytics prop, the coaching flow's emitter) need no changes.
 
@@ -62,4 +108,5 @@ The `AnalyticsPort` interface is the contract — every adapter implementation o
 - `packages/workout-spa-editor/src/contexts/analytics-context.tsx` — React context wrapper.
 - `packages/workout-spa-editor/src/components/molecules/RouteErrorBoundary.tsx` — the route-error emitter.
 - `packages/workout-spa-editor/src/lib/scrub-analytics-string.ts` — the PII regex allow-list.
+- `packages/workout-spa-editor/src/lib/runtime-config.ts` — the runtime-config accessor.
 - `scripts/check-no-pii-leakage.mjs` — mechanical PII-leak guard run by `pnpm test:scripts`.

--- a/packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts
+++ b/packages/workout-spa-editor/e2e/spa-route-refresh.spec.ts
@@ -23,15 +23,16 @@ test.describe("@spa-route-refresh SPA route refresh", () => {
   let mergedDist: string;
 
   test.beforeAll(async () => {
+    // The build is now token-agnostic: the Cloudflare analytics token is no
+    // longer a Vite build-time env var. Test 4 exercises the real adapter
+    // path by injecting `window.__KAIORD_CONFIG__` (and a fake `cfBeacon`)
+    // via `page.addInitScript` before navigation — matching the deploy-time
+    // runtime-config injection model.
     execSync("pnpm --filter @kaiord/workout-spa-editor build", {
       cwd: repoRoot,
       env: {
         ...process.env,
         VITE_BASE_PATH: "/editor/",
-        // The Cloudflare adapter no-ops without a token. Setting a placeholder
-        // exercises the real adapter path so Test 4 can verify analytics.pageView
-        // fires with the base-stripped wouter path.
-        VITE_CF_ANALYTICS_TOKEN: "e2e-test-token",
       },
       stdio: "inherit",
     });
@@ -122,6 +123,14 @@ test.describe("@spa-route-refresh SPA route refresh", () => {
       captured.push(path);
     });
     await page.addInitScript(() => {
+      // Inject a runtime-config token so the Cloudflare analytics adapter
+      // selects its real path (instead of the noop fallback). The token value
+      // is irrelevant — the adapter only checks for non-empty.
+      Object.defineProperty(window, "__KAIORD_CONFIG__", {
+        value: { cfAnalyticsToken: "e2e-test-token" },
+        writable: true,
+        configurable: true,
+      });
       // Plant a fake cfBeacon so the production Cloudflare analytics adapter
       // routes pushEvent calls into our capture instead of the network.
       Object.defineProperty(window, "cfBeacon", {

--- a/packages/workout-spa-editor/index.html
+++ b/packages/workout-spa-editor/index.html
@@ -52,13 +52,34 @@
     />
     <meta name="twitter:image" content="https://kaiord.com/og-image.png" />
 
-    <!-- CF_BEACON_START -->
-    <script
-      defer
-      src="https://static.cloudflareinsights.com/beacon.min.js"
-      data-cf-beacon='{"token": "%VITE_CF_ANALYTICS_TOKEN%"}'
-    ></script>
-    <!-- CF_BEACON_END -->
+    <!--
+      Runtime configuration. The placeholder __CF_ANALYTICS_TOKEN__ is
+      substituted by the deploy step (NOT by Vite). When the placeholder is
+      still in place — local dev, preview builds, or deploys without a
+      token — the conditional loader below treats it as "no token" and the
+      Cloudflare beacon is never injected. 12-factor III + V: the build
+      artifact is environment-agnostic.
+    -->
+    <script>
+      // Defaults; the deploy step substitutes the placeholder. Earlier scripts
+      // (e.g., test fixtures using Playwright's addInitScript) may pre-seed
+      // window.__KAIORD_CONFIG__ — preserve their values.
+      window.__KAIORD_CONFIG__ = window.__KAIORD_CONFIG__ || {
+        cfAnalyticsToken: "__CF_ANALYTICS_TOKEN__",
+      };
+    </script>
+    <script>
+      (function () {
+        var cfg = window.__KAIORD_CONFIG__ || {};
+        var token = cfg.cfAnalyticsToken;
+        if (!token || token === "__CF_ANALYTICS_TOKEN__") return;
+        var s = document.createElement("script");
+        s.defer = true;
+        s.src = "https://static.cloudflareinsights.com/beacon.min.js";
+        s.setAttribute("data-cf-beacon", JSON.stringify({ token: token }));
+        document.head.appendChild(s);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/workout-spa-editor/src/lib/runtime-config.test.ts
+++ b/packages/workout-spa-editor/src/lib/runtime-config.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  CF_ANALYTICS_TOKEN_PLACEHOLDER,
+  getCfAnalyticsToken,
+} from "./runtime-config";
+
+type WindowWithConfig = Window &
+  typeof globalThis & {
+    __KAIORD_CONFIG__?: { cfAnalyticsToken?: string };
+  };
+
+describe("getCfAnalyticsToken", () => {
+  afterEach(() => {
+    delete (window as WindowWithConfig).__KAIORD_CONFIG__;
+  });
+
+  it("should return undefined when window.__KAIORD_CONFIG__ is unset", () => {
+    // Arrange
+    delete (window as WindowWithConfig).__KAIORD_CONFIG__;
+
+    // Act
+    const token = getCfAnalyticsToken();
+
+    // Assert
+    expect(token).toBeUndefined();
+  });
+
+  it("should return undefined when cfAnalyticsToken is empty string", () => {
+    // Arrange
+    (window as WindowWithConfig).__KAIORD_CONFIG__ = { cfAnalyticsToken: "" };
+
+    // Act
+    const token = getCfAnalyticsToken();
+
+    // Assert
+    expect(token).toBeUndefined();
+  });
+
+  it("should return undefined when the un-substituted placeholder is present", () => {
+    // Arrange
+    (window as WindowWithConfig).__KAIORD_CONFIG__ = {
+      cfAnalyticsToken: CF_ANALYTICS_TOKEN_PLACEHOLDER,
+    };
+
+    // Act
+    const token = getCfAnalyticsToken();
+
+    // Assert
+    expect(token).toBeUndefined();
+  });
+
+  it("should return the real token when deploy-time substitution has run", () => {
+    // Arrange
+    (window as WindowWithConfig).__KAIORD_CONFIG__ = {
+      cfAnalyticsToken: "abc123-real-token",
+    };
+
+    // Act
+    const token = getCfAnalyticsToken();
+
+    // Assert
+    expect(token).toBe("abc123-real-token");
+  });
+});

--- a/packages/workout-spa-editor/src/lib/runtime-config.ts
+++ b/packages/workout-spa-editor/src/lib/runtime-config.ts
@@ -1,0 +1,38 @@
+/**
+ * Runtime configuration accessor.
+ *
+ * Reads environment-specific values from `window.__KAIORD_CONFIG__`, which is
+ * populated by an inline `<script>` block in `index.html` whose values are
+ * substituted at deploy time (NOT at build time). This keeps the compiled
+ * bundle environment-agnostic per 12-factor III (config in env) and V
+ * (build / release / run separation).
+ *
+ * Until the deploy step substitutes the placeholder, the literal placeholder
+ * string remains in the field. Treat that as "no value" so dev / preview /
+ * unconfigured deploys silently fall back to the no-op analytics adapter.
+ */
+
+export const CF_ANALYTICS_TOKEN_PLACEHOLDER = "__CF_ANALYTICS_TOKEN__";
+
+export type RuntimeConfig = {
+  cfAnalyticsToken?: string;
+};
+
+type WindowWithConfig = Window &
+  typeof globalThis & {
+    __KAIORD_CONFIG__?: RuntimeConfig;
+  };
+
+/**
+ * Returns the Cloudflare Web Analytics token if a real value has been injected
+ * at deploy time. Returns `undefined` when the placeholder is still in place,
+ * the field is empty, or `window` is unavailable (SSR / tests without DOM).
+ */
+export const getCfAnalyticsToken = (): string | undefined => {
+  if (typeof window === "undefined") return undefined;
+  const cfg = (window as WindowWithConfig).__KAIORD_CONFIG__;
+  const token = cfg?.cfAnalyticsToken;
+  if (!token) return undefined;
+  if (token === CF_ANALYTICS_TOKEN_PLACEHOLDER) return undefined;
+  return token;
+};

--- a/packages/workout-spa-editor/src/main.tsx
+++ b/packages/workout-spa-editor/src/main.tsx
@@ -15,11 +15,13 @@ import {
 } from "./contexts";
 import { CoachingRegistryBootstrap } from "./contexts/coaching-registry-bootstrap";
 import { PersistenceProvider } from "./contexts/persistence-context";
+import { getCfAnalyticsToken } from "./lib/runtime-config";
 import { computeRouterBase } from "./router-base";
 
-const analytics = createCloudflareAnalytics(
-  import.meta.env.VITE_CF_ANALYTICS_TOKEN as string | undefined
-);
+// Analytics token is read from runtime config (window.__KAIORD_CONFIG__),
+// populated by an inline <script> in index.html whose value is substituted at
+// deploy time. The bundle stays environment-agnostic (12-factor III + V).
+const analytics = createCloudflareAnalytics(getCfAnalyticsToken());
 
 const persistence = createDexiePersistence();
 

--- a/packages/workout-spa-editor/vite.config.ts
+++ b/packages/workout-spa-editor/vite.config.ts
@@ -1,83 +1,64 @@
 import { codecovVitePlugin } from "@codecov/vite-plugin";
 import react from "@vitejs/plugin-react";
 import path from "path";
-import { defineConfig, loadEnv } from "vite";
-import type { Plugin } from "vite";
+import { defineConfig } from "vite";
 
-function conditionalBeacon(token: string | undefined): Plugin {
-  return {
-    name: "conditional-beacon",
-    transformIndexHtml(html) {
-      if (!token) {
-        return html.replace(
-          /<!--\s*CF_BEACON_START\s*-->[\s\S]*?<!--\s*CF_BEACON_END\s*-->/g,
-          ""
-        );
-      }
-      return html
-        .replace(/<!--\s*CF_BEACON_START\s*-->/g, "")
-        .replace(/<!--\s*CF_BEACON_END\s*-->/g, "")
-        .replace(/%VITE_CF_ANALYTICS_TOKEN%/g, token);
-    },
-  };
-}
-
+// The Cloudflare Web Analytics token is no longer baked at build time. It is
+// injected at deploy time into the placeholder in index.html and read at
+// runtime via window.__KAIORD_CONFIG__. See packages/workout-spa-editor/docs/
+// analytics.md and src/lib/runtime-config.ts.
 // https://vite.dev/config/
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), "");
-  return {
-    plugins: [
-      react(),
-      conditionalBeacon(env.VITE_CF_ANALYTICS_TOKEN),
-      codecovVitePlugin({
-        enableBundleAnalysis: !!process.env.CODECOV_TOKEN,
-        bundleName: "workout-spa-editor",
-        uploadToken: process.env.CODECOV_TOKEN ?? "",
-      }),
-    ],
-    resolve: {
-      alias: {
-        "@": path.resolve(__dirname, "./src"),
-      },
+export default defineConfig({
+  plugins: [
+    react(),
+    codecovVitePlugin({
+      enableBundleAnalysis: !!process.env.CODECOV_TOKEN,
+      bundleName: "workout-spa-editor",
+      uploadToken: process.env.CODECOV_TOKEN ?? "",
+    }),
+  ],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
     },
-    // GitHub Pages deployment configuration
-    base: process.env.VITE_BASE_PATH || "/",
-    build: {
-      outDir: "dist",
-      sourcemap: true,
-      // Optimize for production (Vite 8 default: oxc, 30-90x faster than terser)
-      minify: "oxc",
-      target: "es2020",
-      rolldownOptions: {
-        output: {
-          codeSplitting: {
-            groups: [
-              {
-                name: "vendor-ui",
-                test: /[\\/]node_modules[\\/]@radix-ui[\\/]/,
-              },
-              {
-                name: "vendor-state",
-                test: /[\\/]node_modules[\\/]zustand[\\/]/,
-              },
-              { name: "vendor-zod", test: /[\\/]node_modules[\\/]zod[\\/]/ },
-              {
-                name: "vendor-dnd",
-                test: /[\\/]node_modules[\\/]@dnd-kit[\\/]/,
-              },
-              {
-                name: "vendor-icons",
-                test: /[\\/]node_modules[\\/]lucide-react[\\/]/,
-              },
-              { name: "kaiord-core", test: /[\\/]packages[\\/]core[\\/]/ },
-              { name: "kaiord-fit", test: /[\\/]packages[\\/]fit[\\/]/ },
-              { name: "kaiord-tcx", test: /[\\/]packages[\\/]tcx[\\/]/ },
-              { name: "kaiord-zwo", test: /[\\/]packages[\\/]zwo[\\/]/ },
-              { name: "kaiord-garmin", test: /[\\/]packages[\\/]garmin[\\/]/ },
-            ],
-          },
+  },
+  // GitHub Pages deployment configuration
+  base: process.env.VITE_BASE_PATH || "/",
+  build: {
+    outDir: "dist",
+    sourcemap: true,
+    // Optimize for production (Vite 8 default: oxc, 30-90x faster than terser)
+    minify: "oxc",
+    target: "es2020",
+    rolldownOptions: {
+      output: {
+        codeSplitting: {
+          groups: [
+            {
+              name: "vendor-ui",
+              test: /[\\/]node_modules[\\/]@radix-ui[\\/]/,
+            },
+            {
+              name: "vendor-state",
+              test: /[\\/]node_modules[\\/]zustand[\\/]/,
+            },
+            { name: "vendor-zod", test: /[\\/]node_modules[\\/]zod[\\/]/ },
+            {
+              name: "vendor-dnd",
+              test: /[\\/]node_modules[\\/]@dnd-kit[\\/]/,
+            },
+            {
+              name: "vendor-icons",
+              test: /[\\/]node_modules[\\/]lucide-react[\\/]/,
+            },
+            { name: "kaiord-core", test: /[\\/]packages[\\/]core[\\/]/ },
+            { name: "kaiord-fit", test: /[\\/]packages[\\/]fit[\\/]/ },
+            { name: "kaiord-tcx", test: /[\\/]packages[\\/]tcx[\\/]/ },
+            { name: "kaiord-zwo", test: /[\\/]packages[\\/]zwo[\\/]/ },
+            { name: "kaiord-garmin", test: /[\\/]packages[\\/]garmin[\\/]/ },
+          ],
         },
       },
     },
-  };
+  },
 });


### PR DESCRIPTION
## Summary

Decouples the SPA editor bundle from the Cloudflare Web Analytics token (12-factor III + V). The token was baked into the build via `VITE_CF_ANALYTICS_TOKEN`, meaning every deploy environment required its own build artifact. This PR moves the token to a runtime config injected at deploy time. The same `dist/` ships everywhere.

Implements §1.6 of OpenSpec change `repo-quality-maintenance-waves`.

## Mechanism (design D9 Option B)

`window.__KAIORD_CONFIG__` initialized by an inline `<script>` in `index.html` whose value is a placeholder (`__CF_ANALYTICS_TOKEN__`). The deploy step substitutes the placeholder via `sed`. A second inline `<script>` reads the runtime config and conditionally appends the Cloudflare beacon `<script>` only when a real token has been substituted. `main.tsx` reads the same runtime config via a new `getCfAnalyticsToken()` helper.

Why Option B over A and C:
- A (`/config.json` fetched on startup): adds an HTTP round-trip and a fetch + parse + error-handling surface.
- B (this PR): zero extra HTTP requests, zero JS-bundle changes for new env vars (just edit `index.html`), works with the existing `deploy-site.yml` machinery.
- C (Cloudflare-side script): externalizes the snippet outside source control entirely — feels like a tracability regression.

The `||` fallback in step 1 (`window.__KAIORD_CONFIG__ = window.__KAIORD_CONFIG__ || { ... }`) lets earlier scripts (e.g. Playwright `addInitScript` in e2e tests) pre-seed the global, so the test fixture can inject a token without re-baking the build.

## Surfaces touched (the five from design D9)

| # | Surface | Before | After |
|---|---------|--------|-------|
| 1 | `src/main.tsx:21` | `import.meta.env.VITE_CF_ANALYTICS_TOKEN` | `getCfAnalyticsToken()` from new `src/lib/runtime-config.ts` |
| 2 | `index.html:59` | `data-cf-beacon='{"token": "%VITE_CF_ANALYTICS_TOKEN%"}'` | inline runtime-config bootstrap + conditional beacon loader |
| 3 | `vite.config.ts` | `conditionalBeacon` plugin + `loadEnv` | plugin removed; build is token-agnostic |
| 4 | `e2e/spa-route-refresh.spec.ts:34` | build env var sets the token | `addInitScript` stubs `window.__KAIORD_CONFIG__` |
| 5 | `docs/analytics.md` | "build embeds it; no runtime config required" | rewritten to describe runtime-injection model |

Plus:
- `.github/workflows/deploy-site.yml`: adds a "Substitute analytics token in SPA index.html" step after the SPA build. Runs `sed`, verifies the placeholder is gone, fails the deploy if it isn't (no silent no-analytics ships).
- `packages/workout-spa-editor/.env.example`: removes `VITE_CF_ANALYTICS_TOKEN` (it is no longer a Vite env var); points readers at `docs/analytics.md`.
- `packages/workout-spa-editor/src/lib/runtime-config.{ts,test.ts}`: new helper + 4 unit tests covering missing global / empty string / un-substituted placeholder / real token. R-ItTitleShould + R-ItBodyAAA compliant.

## Before/after grep

```
$ grep -RnE "VITE_CF_ANALYTICS_TOKEN" packages/workout-spa-editor/src packages/workout-spa-editor/index.html packages/workout-spa-editor/vite.config.ts
(no matches)
```

```
$ grep -RoE '__CF_ANALYTICS_TOKEN__' packages/workout-spa-editor/dist | sort | uniq -c
   1 packages/workout-spa-editor/dist/assets/index-*.js
   1 packages/workout-spa-editor/dist/assets/index-*.js.map
   3 packages/workout-spa-editor/dist/index.html
```

The single occurrence in the JS bundle is the sentinel constant the helper compares against at runtime — not a token value. The bundle is environment-agnostic.

## Validation

- [x] `grep -RnE "VITE_CF_ANALYTICS_TOKEN" packages/workout-spa-editor/src packages/workout-spa-editor/index.html packages/workout-spa-editor/vite.config.ts` returns no matches.
- [x] `pnpm --filter @kaiord/workout-spa-editor build` green; dist contains only the placeholder, no token value.
- [x] `pnpm --filter @kaiord/workout-spa-editor test` — runtime-config unit tests (4/4) pass; full SPA test suite passes (the only failures observed across runs were known pre-existing flakes in `routes.test.tsx` / `App.test.tsx` / `LayoutHeader.test.tsx` — they pass when run in isolation, fail under suite parallelism — unrelated to analytics).
- [x] `pnpm --filter @kaiord/workout-spa-editor lint` — 0 errors. Pre-existing `no-magic-numbers` warnings in test files untouched.
- [x] `pnpm test:scripts` — all 396 mechanical guard tests pass.
- [x] e2e `spa-route-refresh.spec.ts` Test 4 (analytics path) **passes on chromium, firefox, webkit, Mobile Safari** (4/5 browsers verified locally). Mobile Chrome failure was a pre-existing flake on the `inject-spa-fallback.mjs` step in `beforeAll` (parallel tmp-dir race), unrelated to analytics.
- [x] `import.meta.env.{MODE,DEV,BASE_URL}` references in `main.tsx` left untouched (legitimate Vite intrinsics per design D9).

## Test plan

- [ ] Verify CI green (lint, build, e2e).
- [ ] Manual smoke in dev: `pnpm --filter @kaiord/workout-spa-editor dev` → confirm app boots, no console errors, no Cloudflare beacon `<script>` injected (placeholder remains, conditional loader returns).
- [ ] Manual smoke with token: build, then `sed -i '' "s|__CF_ANALYTICS_TOKEN__|<test-token>|g" packages/workout-spa-editor/dist/index.html` → serve `dist/` → confirm the Cloudflare beacon `<script>` element appears in `<head>` with the substituted token.
- [ ] After merge, monitor the next `deploy-site.yml` run: confirm the new "Substitute analytics token in SPA index.html" step runs, and the deployed `/editor/` ships the real token in the beacon `<script>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)