### PR TITLE
chore(ci): wire jscpd as required check (§1.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,35 @@ jobs:
               sys.exit(1)
           PY
 
+  # Code-duplication gate (jscpd). Top-level peer of `lint:` / `test:` /
+  # `build:`, NOT a step inside `lint:`. Single run (no strategy.matrix)
+  # because duplication detection scans source text and is therefore
+  # node-version-invariant. Reads source under `packages/*/src` per the
+  # root `pnpm duplication` script and the `.jscpd.json` config; does not
+  # depend on `build` artifacts. Fails when duplication exceeds the 5%
+  # threshold configured in `.jscpd.json`.
+  #
+  # Kill-switch: `vars.JSCPD_BOT_ENABLED != 'false'` lets a maintainer
+  # disable the gate from the GitHub UI without a code change, mirroring
+  # the `SIZE_LIMIT_BOT_ENABLED` precedent (design D8).
+  jscpd:
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.should-test == 'true' &&
+      vars.JSCPD_BOT_ENABLED != 'false'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm with caching
+        uses: ./.github/actions/setup-pnpm
+        with:
+          node-version: "22.18.0"
+
+      - name: Run code-duplication check (jscpd)
+        run: pnpm duplication
+
   # Always runs (no `if:` gate) and lychee is pinned to a MAJOR.MINOR —
   # both are spec-locked under `doc-drift-prevention`. See
   # `openspec/specs/doc-drift-prevention/spec.md`.
@@ -795,13 +824,14 @@ jobs:
   lint-summary:
     name: lint
     runs-on: ubuntu-latest
-    needs: [build, lint]
+    needs: [build, lint, jscpd]
     if: always()
     steps:
       - name: Check lint status (with build awareness)
         run: |
           build_result="${{ needs.build.result }}"
           lint_result="${{ needs.lint.result }}"
+          jscpd_result="${{ needs.jscpd.result }}"
           if [ "$build_result" = "skipped" ]; then
             echo "Build skipped (docs-only); lint correctly not run."
             exit 0
@@ -812,6 +842,13 @@ jobs:
           fi
           if [ "$lint_result" != "success" ]; then
             echo "::error::Build succeeded but lint did not. Lint result: $lint_result"
+            exit 1
+          fi
+          # jscpd is allowed to be skipped only via the kill-switch
+          # (vars.JSCPD_BOT_ENABLED == 'false'); any other non-success
+          # state is a real failure.
+          if [ "$jscpd_result" != "success" ] && [ "$jscpd_result" != "skipped" ]; then
+            echo "::error::Code-duplication gate (jscpd) did not pass. Result: $jscpd_result"
             exit 1
           fi
           echo "Lint passed."
@@ -895,6 +932,7 @@ jobs:
       [
         detect-changes,
         lint,
+        jscpd,
         check-links,
         typecheck,
         test,
@@ -910,6 +948,7 @@ jobs:
       github.ref == 'refs/heads/main' &&
       vars.CI_ISSUE_BOT_ENABLED != 'false' &&
       (needs.lint.result == 'failure' ||
+       needs.jscpd.result == 'failure' ||
        needs.check-links.result == 'failure' ||
        needs.typecheck.result == 'failure' ||
        needs.test.result == 'failure' ||


### PR DESCRIPTION
## Summary

Wires the existing `pnpm duplication` (jscpd) into CI as a required gate for §1.2 of the `repo-quality-maintenance-waves` change.

- Adds a NEW top-level peer job `jscpd` in `.github/workflows/ci.yml` — sibling of `lint:` / `test:` / `build:`, NOT a step inside `lint:`.
- Single run on `node-version: 22.18.0` (no `strategy.matrix`) — duplication detection scans source text and is therefore node-version-invariant.
- Reads source under `packages/*/src` per the root `pnpm duplication` script + `.jscpd.json` config; does not depend on `build` artifacts.
- Fails when duplication exceeds the 5 % threshold configured in `.jscpd.json`.
- Kill-switch `vars.JSCPD_BOT_ENABLED != 'false'` lets a maintainer disable the gate from the GitHub UI without a code change, mirroring the `SIZE_LIMIT_BOT_ENABLED` precedent (design D8).
- `lint-summary` aggregator (`needs:` array) now includes `jscpd`, so branch protection on the `lint` summary status check picks up jscpd failures. The summary tolerates the kill-switch `skipped` state but treats any other non-success state as a real failure.
- `notify-failure` (main-branch issue bot) also routes jscpd failures.

Refs §1.2 of `repo-quality-maintenance-waves`.

## Baseline `pnpm duplication` on the PR branch

```
clones:           71
duplicatedLines:  900
duplicatedTokens: 8578
percentage:       1.34 %   (threshold 5 %)
percentageTokens: 1.66 %
exit code:        0
```

`pnpm duplication` runs cleanly on the PR branch — no real duplication is failing the threshold; the gate is wired against the existing healthy baseline.

## Branch-protection follow-up (manual GitHub UI step)

`.github/settings.yml` is not present in this repo (branch protection is not managed-as-code). After this PR merges, add `jscpd` to the required status checks for `main` in **Settings → Branches → main → Edit** so the new gate is independently required (the `lint` summary check, which already aggregates `jscpd`, is still required as well).

## Test plan

- [ ] CI green on this PR (the new `jscpd` job runs and passes against the 5 % threshold).
- [ ] `gh run view <id> --json jobs --jq '.jobs[] | select(.name == "jscpd") | .name'` returns exactly one entry per CI run (single run, no matrix expansion).
- [ ] `lint` summary status check on this PR transitions to success only after `jscpd` succeeds.
- [ ] Toggle `vars.JSCPD_BOT_ENABLED=false` on a sandbox and confirm the `jscpd` job is skipped while `lint` summary still passes — confirms the kill-switch path.
- [ ] Once merged, add `jscpd` to required status checks for `main` (manual UI step above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated code duplication detection into the CI/CD pipeline to run alongside existing quality checks. Updated workflow orchestration to ensure duplication analysis completes before generating summaries. Failures from duplication checks are now tracked and included in automated notifications so the development team remains informed of any code quality issues discovered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->