### PR TITLE
chore(ci): make pre-push verify-only (§2.3)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,17 +1,18 @@
-# Run lint:fix before pushing
-echo "🔍 Running lint:fix before push..."
-pnpm lint:fix
+# Verify lint before pushing (read-only — does NOT write to the working tree).
+echo "🔍 Running lint check before push..."
+pnpm lint
 
-# Check if lint:fix made any changes
-if [ -n "$(git status --porcelain)" ]; then
-  echo "❌ Lint fixes were applied. Please review and commit them:"
-  git status --short
+# Check exit code — fail the push if lint reports any errors.
+if [ $? -ne 0 ]; then
   echo ""
-  echo "Run: git add . && git commit -m 'chore: apply lint fixes'"
+  echo "❌ Lint check failed! Push blocked."
+  echo ""
+  echo "Run 'pnpm lint:fix' yourself to apply auto-fixes, review the changes,"
+  echo "then commit them and retry the push."
   exit 1
-else
-  echo "✅ Lint check passed!"
 fi
+
+echo "✅ Lint check passed!"
 echo ""
 echo "🔍 Running TypeScript type check..."
 


### PR DESCRIPTION
## Summary

- Replace `pnpm lint:fix` with `pnpm lint` in `.husky/pre-push` so the hook is verify-only and never writes to the working tree.
- Update the abort message to instruct the user to run `pnpm lint:fix` themselves, review the diff, and commit before retrying.
- Preserve the TypeScript type-check step (`pnpm -r --workspace-concurrency=1 exec tsc --noEmit`) added in #519.

## Why

The previous hook ran `lint:fix` mid-push, which mutates the user's working tree as a side effect of pushing, then aborted if anything changed. That's a destructive write-during-push pattern: the user's clean-on-push assumption was violated, and a follow-up commit was required just to clean up after the hook itself.

The new hook runs `pnpm lint` in verify-only mode:
- On a clean tree, the push leaves the working tree clean (`git status --porcelain` empty after a successful push) — confirmed locally on this PR's own push.
- On a tree with lint errors, the push aborts with an explicit message telling the user to run `pnpm lint:fix` themselves. The hook never writes.

Refs: `openspec/changes/repo-quality-maintenance-waves/tasks.md` §2.3.

## Test plan

- [x] `.husky/pre-push` runs `pnpm lint` (read-only), never `pnpm lint:fix` — verified by diff.
- [x] On a clean tree, push leaves the working tree clean — verified locally: `git status --porcelain` returned empty after this PR's own push.
- [x] On a tree with lint errors, push aborts with a "run `pnpm lint:fix` yourself" message — verified by inspecting the new hook's failure branch (no `git status --porcelain` write check; explicit instruction string).
- [x] `pnpm lint` and `pnpm -r --workspace-concurrency=1 exec tsc --noEmit` both ran cleanly during this PR's own pre-push — proving the hook executes correctly end-to-end.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)