### PR TITLE
chore(ci): parallelize pnpm lint umbrella (§2.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
   "scripts": {
     "build": "pnpm -r build",
     "test": "pnpm -r test && pnpm test:scripts",
-    "lint": "pnpm -r lint && pnpm lint:archive && pnpm lint:archive-index && pnpm lint:archive-followups && pnpm lint:specs && pnpm lint:tsup-watchdog && pnpm lint:mapper-no-tests && pnpm lint:converter-has-tests && pnpm lint:husky-no-bypass && pnpm lint:package-deps && pnpm lint:architecture && pnpm lint:no-unconditional-skip && pnpm lint:no-library-dual-mount && pnpm lint:allowlists-empty && pnpm lint:icons-distinct && pnpm lint:build-portable && pnpm lint:ci-fanout && pnpm lint:scripts-orphans && pnpm lint:workflow-timeouts && pnpm lint:overrides-stale",
+    "lint": "pnpm lint:parallel && pnpm lint:post",
+    "lint:parallel": "npm-run-all2 -p --max-parallel=4 --aggregate-output lint:packages lint:archive lint:specs lint:tsup-watchdog lint:mapper-no-tests lint:converter-has-tests lint:husky-no-bypass lint:package-deps lint:architecture lint:no-unconditional-skip lint:no-library-dual-mount lint:allowlists-empty lint:icons-distinct lint:build-portable lint:ci-fanout lint:scripts-orphans lint:workflow-timeouts lint:overrides-stale",
+    "lint:post": "npm-run-all2 -s lint:archive-index lint:archive-followups",
     "lint:fix": "pnpm -r lint:fix && prettier --write .",
     "lint:packages": "pnpm -r lint",
     "lint:archive": "node scripts/check-archive-dates.mjs",
@@ -118,6 +120,7 @@
     "jscpd": "^4.0.9",
     "knip": "^6.7.0",
     "lint-staged": "^16.4.0",
+    "npm-run-all2": "^8.0.4",
     "prettier": "^3.8.3",
     "sharp": "^0.34.5",
     "size-limit": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
+      npm-run-all2:
+        specifier: ^8.0.4
+        version: 8.0.4
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -5452,6 +5455,10 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-parse-even-better-errors@4.0.0:
+    resolution: {integrity: sha512-lR4MXjGNgkJc7tkQ97kb2nuEMnNCyU//XYVH0MKTGcXEiSudQ5MKGKen3C5QubYy0vmq+JGitUg92uuywGEwIA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -5740,6 +5747,10 @@ packages:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
 
+  memorystream@0.3.1:
+    resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
+    engines: {node: '>= 0.10.0'}
+
   meow@13.2.0:
     resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
     engines: {node: '>=18'}
@@ -5938,6 +5949,15 @@ packages:
   npm-normalize-package-bin@1.0.1:
     resolution: {integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==}
 
+  npm-normalize-package-bin@4.0.0:
+    resolution: {integrity: sha512-TZKxPvItzai9kN9H/TkmCtx/ZN/hvr3vUycjlfmH0ootY9yFBzNOpiXAdIn1Iteqsvk4lQn6B5PTrt+n6h8k/w==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  npm-run-all2@8.0.4:
+    resolution: {integrity: sha512-wdbB5My48XKp2ZfJUlhnLVihzeuA1hgBnqB2J9ahV77wLS+/YAJAlN8I+X3DIFIPZ3m5L7nplmlbhNiFDmXRDA==}
+    engines: {node: ^20.5.0 || >=22.0.0, npm: '>= 10'}
+    hasBin: true
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -6135,6 +6155,11 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  pidtree@0.6.0:
+    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
+    engines: {node: '>=0.10'}
+    hasBin: true
 
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
@@ -6359,6 +6384,10 @@ packages:
     resolution: {integrity: sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==}
     deprecated: This package is no longer supported.
 
+  read-package-json-fast@4.0.0:
+    resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   read-package-json@2.1.2:
     resolution: {integrity: sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==}
     deprecated: This package is no longer supported. Please use @npmcli/package-json instead.
@@ -6549,6 +6578,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
 
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
@@ -12019,6 +12052,8 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-parse-even-better-errors@4.0.0: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -12398,6 +12433,8 @@ snapshots:
 
   media-typer@1.1.0: {}
 
+  memorystream@0.3.1: {}
+
   meow@13.2.0: {}
 
   merge-descriptors@2.0.0: {}
@@ -12644,6 +12681,19 @@ snapshots:
       validate-npm-package-license: 3.0.4
 
   npm-normalize-package-bin@1.0.1: {}
+
+  npm-normalize-package-bin@4.0.0: {}
+
+  npm-run-all2@8.0.4:
+    dependencies:
+      ansi-styles: 6.2.3
+      cross-spawn: 7.0.6
+      memorystream: 0.3.1
+      picomatch: 4.0.4
+      pidtree: 0.6.0
+      read-package-json-fast: 4.0.0
+      shell-quote: 1.8.3
+      which: 5.0.0
 
   npm-run-path@4.0.1:
     dependencies:
@@ -12898,6 +12948,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pidtree@0.6.0: {}
+
   pify@4.0.1: {}
 
   pirates@4.0.7: {}
@@ -13137,6 +13189,11 @@ snapshots:
       util-extend: 1.0.3
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  read-package-json-fast@4.0.0:
+    dependencies:
+      json-parse-even-better-errors: 4.0.0
+      npm-normalize-package-bin: 4.0.0
 
   read-package-json@2.1.2:
     dependencies:
@@ -13423,6 +13480,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.3: {}
 
   shiki@3.23.0:
     dependencies:


### PR DESCRIPTION
## Summary

Splits the 19-link \`&&\` chain that runs every \`lint:*\` check sequentially into a parallel group + a post group, per design D10 of \`repo-quality-maintenance-waves\`. Implements §2.2.

## What changed

- **lint:parallel** — \`npm-run-all2 -p --max-parallel=4 --aggregate-output\` over the 18 independent checks (lint:packages, lint:archive, lint:specs, lint:tsup-watchdog, lint:mapper-no-tests, lint:converter-has-tests, lint:husky-no-bypass, lint:package-deps, lint:architecture, lint:no-unconditional-skip, lint:no-library-dual-mount, lint:allowlists-empty, lint:icons-distinct, lint:build-portable, lint:ci-fanout, lint:scripts-orphans, lint:workflow-timeouts, lint:overrides-stale).
- **lint:post** — \`npm-run-all2 -s\` over the two checks that read archive state and must run after \`lint:archive\` validates the folder shape: lint:archive-index, lint:archive-followups.
- **lint** — orchestrator: \`lint:parallel && lint:post\`.

## Why \`--max-parallel=4\`

Calibrates the cap for \`ubuntu-latest\` (2 vCPUs, 7 GB RAM) and avoids RAM pressure during \`lint:specs\` which loads every spec into memory. \`--aggregate-output\` keeps per-process output contiguous so a CI failure log is grep-able.

## Why \`npm-run-all2\` over alternatives

Chosen over \`concurrently\` (less ANSI interleaving on aggregate output) and \`turbo run\` (avoids a new build orchestrator surface in a maintenance change).

## Test plan

- [ ] CI green
- [ ] \`pnpm lint\` runs ≥ 2× faster than the pre-PR baseline on a warm cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)