### PR TITLE
test(spa-editor): add tests for ProfileManager/hooks/ (§5.2)

### DIFF
--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileActions.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileActions.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * useProfileActions orchestrator hook tests.
+ *
+ * Verifies the hook merges CRUD + switch handlers into a single
+ * surface and that handler invocation drives the underlying
+ * PersistencePort. Per-handler edge cases are covered in the leaf
+ * hook test files.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { makeProfile } from "../../../../application/profile/test-fixtures";
+import { PersistenceProvider } from "../../../../contexts/persistence-context";
+import type { PersistencePort } from "../../../../ports/persistence-port";
+import { createInMemoryPersistence } from "../../../../test-utils/in-memory-persistence";
+import type { Profile } from "../../../../types/profile";
+import { useProfileActions } from "./useProfileActions";
+
+vi.mock("../../../../contexts/ToastContext", () => ({
+  useToastContext: () => ({ error: vi.fn() }),
+}));
+
+const wrap = (persistence: PersistencePort) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <PersistenceProvider persistence={persistence}>
+      {children}
+    </PersistenceProvider>
+  );
+  return Wrapper;
+};
+
+const PROFILE: Profile = makeProfile({
+  id: "00000000-0000-4000-8000-0000000000c1",
+  name: "Switcher",
+});
+
+describe("useProfileActions", () => {
+  it("should expose every CRUD and switch handler in the returned shape", () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const { result } = renderHook(
+      () =>
+        useProfileActions({
+          profiles: [],
+          formData: { name: "" },
+          editingProfile: null,
+          setFormData: vi.fn(),
+          setEditingProfile: vi.fn(),
+          setDeleteConfirmId: vi.fn(),
+          setSwitchNotification: vi.fn(),
+        }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Assert
+    expect(typeof result.current.handleCreate).toBe("function");
+    expect(typeof result.current.handleEdit).toBe("function");
+    expect(typeof result.current.handleSave).toBe("function");
+    expect(typeof result.current.handleCancel).toBe("function");
+    expect(typeof result.current.handleDelete).toBe("function");
+    expect(typeof result.current.confirmDelete).toBe("function");
+    expect(typeof result.current.handleSwitchProfile).toBe("function");
+  });
+
+  it("should set the active profile when handleSwitchProfile finds a match", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    await persistence.profiles.put(PROFILE);
+    const setSwitchNotification = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useProfileActions({
+          profiles: [PROFILE],
+          formData: { name: "" },
+          editingProfile: null,
+          setFormData: vi.fn(),
+          setEditingProfile: vi.fn(),
+          setDeleteConfirmId: vi.fn(),
+          setSwitchNotification,
+        }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleSwitchProfile(PROFILE.id);
+    });
+
+    // Assert
+    await waitFor(async () => {
+      expect(await persistence.profiles.getActiveId()).toBe(PROFILE.id);
+    });
+    expect(setSwitchNotification).toHaveBeenCalledWith(
+      "Switched to profile: Switcher"
+    );
+  });
+
+  it("should propagate handleDelete to setDeleteConfirmId", () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const setDeleteConfirmId = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useProfileActions({
+          profiles: [],
+          formData: { name: "" },
+          editingProfile: null,
+          setFormData: vi.fn(),
+          setEditingProfile: vi.fn(),
+          setDeleteConfirmId,
+          setSwitchNotification: vi.fn(),
+        }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleDelete("p-99");
+    });
+
+    // Assert
+    expect(setDeleteConfirmId).toHaveBeenCalledWith("p-99");
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileCRUD.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileCRUD.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * useProfileCRUD orchestrator hook tests.
+ *
+ * Verifies the hook returns the merged shape of its three composed
+ * leaf hooks (create, edit, delete) and that calling each handler
+ * propagates through to the persistence port. Edge-case coverage of
+ * the leaf hooks lives in their own test files.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { makeProfile } from "../../../../application/profile/test-fixtures";
+import { PersistenceProvider } from "../../../../contexts/persistence-context";
+import type { PersistencePort } from "../../../../ports/persistence-port";
+import { createInMemoryPersistence } from "../../../../test-utils/in-memory-persistence";
+import { useProfileCRUD } from "./useProfileCRUD";
+
+vi.mock("../../../../contexts/ToastContext", () => ({
+  useToastContext: () => ({ error: vi.fn() }),
+}));
+
+const wrap = (persistence: PersistencePort) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <PersistenceProvider persistence={persistence}>
+      {children}
+    </PersistenceProvider>
+  );
+  return Wrapper;
+};
+
+describe("useProfileCRUD", () => {
+  it("should expose handlers from create, edit, and delete leaf hooks", () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const { result } = renderHook(
+      () =>
+        useProfileCRUD({
+          formData: { name: "" },
+          editingProfile: null,
+          setFormData: vi.fn(),
+          setEditingProfile: vi.fn(),
+          setDeleteConfirmId: vi.fn(),
+        }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Assert
+    expect(typeof result.current.handleCreate).toBe("function");
+    expect(typeof result.current.handleEdit).toBe("function");
+    expect(typeof result.current.handleSave).toBe("function");
+    expect(typeof result.current.handleCancel).toBe("function");
+    expect(typeof result.current.handleDelete).toBe("function");
+    expect(typeof result.current.confirmDelete).toBe("function");
+  });
+
+  it("should call setDeleteConfirmId when handleDelete fires", () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const setDeleteConfirmId = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useProfileCRUD({
+          formData: { name: "" },
+          editingProfile: null,
+          setFormData: vi.fn(),
+          setEditingProfile: vi.fn(),
+          setDeleteConfirmId,
+        }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleDelete("p-77");
+    });
+
+    // Assert
+    expect(setDeleteConfirmId).toHaveBeenCalledWith("p-77");
+  });
+
+  it("should populate the form when handleEdit is invoked", () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const setFormData = vi.fn();
+    const setEditingProfile = vi.fn();
+    const profile = makeProfile({ name: "Pablo", bodyWeight: 70 });
+
+    const { result } = renderHook(
+      () =>
+        useProfileCRUD({
+          formData: { name: "" },
+          editingProfile: null,
+          setFormData,
+          setEditingProfile,
+          setDeleteConfirmId: vi.fn(),
+        }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleEdit(profile);
+    });
+
+    // Assert
+    expect(setEditingProfile).toHaveBeenCalledWith(profile);
+    expect(setFormData).toHaveBeenCalledWith({
+      name: "Pablo",
+      bodyWeight: 70,
+    });
+  });
+
+  it("should persist a new profile when handleCreate fires with a non-empty name", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const setFormData = vi.fn();
+
+    const { result } = renderHook(
+      () =>
+        useProfileCRUD({
+          formData: { name: "Sample" },
+          editingProfile: null,
+          setFormData,
+          setEditingProfile: vi.fn(),
+          setDeleteConfirmId: vi.fn(),
+        }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleCreate();
+    });
+
+    // Assert
+    await waitFor(async () => {
+      expect(await persistence.profiles.getAll()).toHaveLength(1);
+    });
+    expect(setFormData).toHaveBeenCalledWith({ name: "" });
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileCreate.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileCreate.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * useProfileCreate hook tests.
+ *
+ * Drives the hook against an in-memory PersistencePort, asserting that
+ * the create handler delegates to the application use case, clears the
+ * form on success, and surfaces persistence rejections through the
+ * toast context.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PersistenceProvider } from "../../../../contexts/persistence-context";
+import type { PersistencePort } from "../../../../ports/persistence-port";
+import { createInMemoryPersistence } from "../../../../test-utils/in-memory-persistence";
+import type { ProfileFormData } from "../types";
+import { useProfileCreate } from "./useProfileCreate";
+
+const errorSpy = vi.fn();
+
+vi.mock("../../../../contexts/ToastContext", () => ({
+  useToastContext: () => ({ error: errorSpy }),
+}));
+
+const wrap = (persistence: PersistencePort) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <PersistenceProvider persistence={persistence}>
+      {children}
+    </PersistenceProvider>
+  );
+  return Wrapper;
+};
+
+describe("useProfileCreate", () => {
+  it("should create a profile when name is non-empty and clear the form", async () => {
+    // Arrange
+    errorSpy.mockReset();
+    const persistence = createInMemoryPersistence();
+    const setFormData = vi.fn();
+    const formData: ProfileFormData = { name: "Pablo", bodyWeight: 72 };
+
+    const { result } = renderHook(
+      () => useProfileCreate({ formData, setFormData }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleCreate();
+    });
+
+    // Assert
+    await waitFor(async () => {
+      const all = await persistence.profiles.getAll();
+      expect(all).toHaveLength(1);
+    });
+    expect(setFormData).toHaveBeenCalledWith({ name: "" });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("should trim whitespace from the profile name before persisting", async () => {
+    // Arrange
+    errorSpy.mockReset();
+    const persistence = createInMemoryPersistence();
+    const setFormData = vi.fn();
+    const formData: ProfileFormData = { name: "   Athlete   " };
+
+    const { result } = renderHook(
+      () => useProfileCreate({ formData, setFormData }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleCreate();
+    });
+
+    // Assert
+    await waitFor(async () => {
+      const all = await persistence.profiles.getAll();
+      expect(all).toHaveLength(1);
+      expect(all[0]?.name).toBe("Athlete");
+    });
+  });
+
+  it("should do nothing when the name is blank or whitespace", async () => {
+    // Arrange
+    errorSpy.mockReset();
+    const persistence = createInMemoryPersistence();
+    const setFormData = vi.fn();
+    const formData: ProfileFormData = { name: "    " };
+
+    const { result } = renderHook(
+      () => useProfileCreate({ formData, setFormData }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleCreate();
+    });
+
+    // Assert
+    expect(setFormData).not.toHaveBeenCalled();
+    expect(await persistence.profiles.getAll()).toEqual([]);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("should surface a toast error and skip form reset when persistence rejects", async () => {
+    // Arrange
+    errorSpy.mockReset();
+    const persistence = createInMemoryPersistence();
+    persistence.profiles.put = vi.fn(() =>
+      Promise.reject(new Error("simulated"))
+    );
+    const setFormData = vi.fn();
+    const formData: ProfileFormData = { name: "Will Fail" };
+
+    const { result } = renderHook(
+      () => useProfileCreate({ formData, setFormData }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleCreate();
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Failed to create profile — please retry."
+      );
+    });
+    expect(setFormData).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileDelete.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileDelete.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * useProfileDelete hook tests.
+ *
+ * Drives the delete + confirm flow against an in-memory PersistencePort.
+ * Asserts the cascade fan-out runs through the injected persistence,
+ * the row is gone after `confirmDelete`, and the confirm dialog stays
+ * open when persistence rejects.
+ */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { makeProfile } from "../../../../application/profile/test-fixtures";
+import { PersistenceProvider } from "../../../../contexts/persistence-context";
+import type { PersistencePort } from "../../../../ports/persistence-port";
+import { createInMemoryPersistence } from "../../../../test-utils/in-memory-persistence";
+import { useProfileDelete } from "./useProfileDelete";
+
+const errorSpy = vi.fn();
+
+vi.mock("../../../../contexts/ToastContext", () => ({
+  useToastContext: () => ({ error: errorSpy }),
+}));
+
+const wrap = (persistence: PersistencePort) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <PersistenceProvider persistence={persistence}>
+      {children}
+    </PersistenceProvider>
+  );
+  return Wrapper;
+};
+
+describe("useProfileDelete", () => {
+  describe("handleDelete", () => {
+    it("should record the candidate id without touching persistence", () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const setDeleteConfirmId = vi.fn();
+      const deleteSpy = vi.spyOn(persistence.profiles, "delete");
+
+      const { result } = renderHook(
+        () => useProfileDelete({ setDeleteConfirmId }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.handleDelete("p-123");
+      });
+
+      // Assert
+      expect(setDeleteConfirmId).toHaveBeenCalledWith("p-123");
+      expect(deleteSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("confirmDelete", () => {
+    it("should remove the profile and clear the confirm id on success", async () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const profile = makeProfile({
+        id: "00000000-0000-4000-8000-0000000000d2",
+        name: "Doomed",
+      });
+      await persistence.profiles.put(profile);
+      await persistence.profiles.setActiveId(profile.id);
+      const setDeleteConfirmId = vi.fn();
+
+      const { result } = renderHook(
+        () => useProfileDelete({ setDeleteConfirmId }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.confirmDelete(profile.id);
+      });
+
+      // Assert
+      await waitFor(async () => {
+        expect(await persistence.profiles.getById(profile.id)).toBeUndefined();
+      });
+      expect(await persistence.profiles.getActiveId()).toBeNull();
+      expect(setDeleteConfirmId).toHaveBeenCalledWith(null);
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing when no confirm id is provided", () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const setDeleteConfirmId = vi.fn();
+      const deleteSpy = vi.spyOn(persistence.profiles, "delete");
+
+      const { result } = renderHook(
+        () => useProfileDelete({ setDeleteConfirmId }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.confirmDelete(null);
+      });
+
+      // Assert
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(setDeleteConfirmId).not.toHaveBeenCalled();
+    });
+
+    it("should keep the confirm dialog open and surface a toast on persistence rejection", async () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const profile = makeProfile({
+        id: "00000000-0000-4000-8000-0000000000d3",
+        name: "Failure",
+      });
+      await persistence.profiles.put(profile);
+      persistence.profiles.delete = vi.fn(() =>
+        Promise.reject(new Error("simulated"))
+      );
+      const setDeleteConfirmId = vi.fn();
+
+      const { result } = renderHook(
+        () => useProfileDelete({ setDeleteConfirmId }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.confirmDelete(profile.id);
+      });
+
+      // Assert
+      await waitFor(() => {
+        expect(errorSpy).toHaveBeenCalledWith(
+          "Failed to delete profile — please retry."
+        );
+      });
+      expect(setDeleteConfirmId).not.toHaveBeenCalledWith(null);
+      // Profile row should still be present because the cascade rolled back.
+      expect(await persistence.profiles.getById(profile.id)).toBeDefined();
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileEdit.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileEdit.test.tsx
@@ -1,0 +1,281 @@
+/**
+ * useProfileEdit hook tests.
+ *
+ * Covers the three handlers exposed by the hook (handleEdit, handleSave,
+ * handleCancel) against an in-memory PersistencePort, including override
+ * data on save, the no-op early-return paths, and toast surfacing on
+ * persistence rejection.
+ */
+/* eslint-disable no-magic-numbers -- test fixtures use literal values for clarity */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { makeProfile } from "../../../../application/profile/test-fixtures";
+import { PersistenceProvider } from "../../../../contexts/persistence-context";
+import type { PersistencePort } from "../../../../ports/persistence-port";
+import { createInMemoryPersistence } from "../../../../test-utils/in-memory-persistence";
+import type { Profile } from "../../../../types/profile";
+import type { ProfileFormData } from "../types";
+import { useProfileEdit } from "./useProfileEdit";
+
+const errorSpy = vi.fn();
+
+vi.mock("../../../../contexts/ToastContext", () => ({
+  useToastContext: () => ({ error: errorSpy }),
+}));
+
+const wrap = (persistence: PersistencePort) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <PersistenceProvider persistence={persistence}>
+      {children}
+    </PersistenceProvider>
+  );
+  return Wrapper;
+};
+
+const seededProfile = (overrides: Partial<Profile> = {}): Profile =>
+  makeProfile({
+    id: "00000000-0000-4000-8000-0000000000a1",
+    name: "Original",
+    bodyWeight: 70,
+    ...overrides,
+  });
+
+describe("useProfileEdit", () => {
+  describe("handleEdit", () => {
+    it("should populate editing state and form data from the selected profile", () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const setEditingProfile = vi.fn();
+      const setFormData = vi.fn();
+      const profile = seededProfile();
+
+      const { result } = renderHook(
+        () =>
+          useProfileEdit({
+            formData: { name: "" },
+            editingProfile: null,
+            setFormData,
+            setEditingProfile,
+          }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.handleEdit(profile);
+      });
+
+      // Assert
+      expect(setEditingProfile).toHaveBeenCalledWith(profile);
+      expect(setFormData).toHaveBeenCalledWith({
+        name: "Original",
+        bodyWeight: 70,
+      });
+    });
+  });
+
+  describe("handleSave", () => {
+    it("should persist updates and clear editing state on success", async () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const profile = seededProfile();
+      await persistence.profiles.put(profile);
+      const setEditingProfile = vi.fn();
+      const setFormData = vi.fn();
+      const formData: ProfileFormData = { name: "Renamed", bodyWeight: 75 };
+
+      const { result } = renderHook(
+        () =>
+          useProfileEdit({
+            formData,
+            editingProfile: profile,
+            setFormData,
+            setEditingProfile,
+          }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.handleSave();
+      });
+
+      // Assert
+      await waitFor(async () => {
+        const fresh = await persistence.profiles.getById(profile.id);
+        expect(fresh?.name).toBe("Renamed");
+        expect(fresh?.bodyWeight).toBe(75);
+      });
+      expect(setEditingProfile).toHaveBeenCalledWith(null);
+      expect(setFormData).toHaveBeenCalledWith({ name: "" });
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("should prefer override data over hook formData when provided", async () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const profile = seededProfile();
+      await persistence.profiles.put(profile);
+      const setEditingProfile = vi.fn();
+      const setFormData = vi.fn();
+      const baseFormData: ProfileFormData = { name: "Stale" };
+
+      const { result } = renderHook(
+        () =>
+          useProfileEdit({
+            formData: baseFormData,
+            editingProfile: profile,
+            setFormData,
+            setEditingProfile,
+          }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.handleSave({ name: "FromOverride", bodyWeight: 80 });
+      });
+
+      // Assert
+      await waitFor(async () => {
+        const fresh = await persistence.profiles.getById(profile.id);
+        expect(fresh?.name).toBe("FromOverride");
+        expect(fresh?.bodyWeight).toBe(80);
+      });
+    });
+
+    it("should do nothing when no profile is currently being edited", () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const setEditingProfile = vi.fn();
+      const setFormData = vi.fn();
+      const putSpy = vi.spyOn(persistence.profiles, "put");
+
+      const { result } = renderHook(
+        () =>
+          useProfileEdit({
+            formData: { name: "Whatever" },
+            editingProfile: null,
+            setFormData,
+            setEditingProfile,
+          }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.handleSave();
+      });
+
+      // Assert
+      expect(putSpy).not.toHaveBeenCalled();
+      expect(setEditingProfile).not.toHaveBeenCalled();
+      expect(setFormData).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing when the trimmed form name is empty", () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const profile = seededProfile();
+      const setEditingProfile = vi.fn();
+      const setFormData = vi.fn();
+      const putSpy = vi.spyOn(persistence.profiles, "put");
+
+      const { result } = renderHook(
+        () =>
+          useProfileEdit({
+            formData: { name: "   " },
+            editingProfile: profile,
+            setFormData,
+            setEditingProfile,
+          }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.handleSave();
+      });
+
+      // Assert
+      expect(putSpy).not.toHaveBeenCalled();
+      expect(setEditingProfile).not.toHaveBeenCalled();
+    });
+
+    it("should surface a toast error when persistence rejects mid-save", async () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const profile = seededProfile();
+      await persistence.profiles.put(profile);
+      persistence.profiles.put = vi.fn(() =>
+        Promise.reject(new Error("simulated"))
+      );
+      const setEditingProfile = vi.fn();
+      const setFormData = vi.fn();
+
+      const { result } = renderHook(
+        () =>
+          useProfileEdit({
+            formData: { name: "Will Fail" },
+            editingProfile: profile,
+            setFormData,
+            setEditingProfile,
+          }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.handleSave();
+      });
+
+      // Assert
+      await waitFor(() => {
+        expect(errorSpy).toHaveBeenCalledWith(
+          "Failed to save profile — please retry."
+        );
+      });
+      expect(setEditingProfile).not.toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe("handleCancel", () => {
+    it("should clear editing state and reset the form", () => {
+      // Arrange
+      errorSpy.mockReset();
+      const persistence = createInMemoryPersistence();
+      const profile = seededProfile();
+      const setEditingProfile = vi.fn();
+      const setFormData = vi.fn();
+
+      const { result } = renderHook(
+        () =>
+          useProfileEdit({
+            formData: { name: "Half-typed" },
+            editingProfile: profile,
+            setFormData,
+            setEditingProfile,
+          }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      act(() => {
+        result.current.handleCancel();
+      });
+
+      // Assert
+      expect(setEditingProfile).toHaveBeenCalledWith(null);
+      expect(setFormData).toHaveBeenCalledWith({ name: "" });
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileImportExport.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileImportExport.test.tsx
@@ -1,0 +1,232 @@
+/**
+ * useProfileImportExport hook tests.
+ *
+ * Drives the export (Blob/anchor flow stubbed via createObjectURL) and
+ * import (file → JSON → schema validate → createProfile) handlers
+ * against an in-memory PersistencePort. Covers happy paths, missing
+ * file (silent return), invalid JSON, and schema-validation errors.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeProfile } from "../../../../application/profile/test-fixtures";
+import { PersistenceProvider } from "../../../../contexts/persistence-context";
+import type { PersistencePort } from "../../../../ports/persistence-port";
+import { createInMemoryPersistence } from "../../../../test-utils/in-memory-persistence";
+import type { Profile } from "../../../../types/profile";
+import { useProfileImportExport } from "./useProfileImportExport";
+
+const wrap = (persistence: PersistencePort) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <PersistenceProvider persistence={persistence}>
+      {children}
+    </PersistenceProvider>
+  );
+  return Wrapper;
+};
+
+type FakeFile = {
+  text: () => Promise<string>;
+};
+
+const fakeChangeEvent = (
+  file: FakeFile | null
+): React.ChangeEvent<HTMLInputElement> => {
+  const input = { value: "file-name.json" } as { value: string };
+  return {
+    target: {
+      ...input,
+      files: file ? [file] : [],
+    },
+  } as unknown as React.ChangeEvent<HTMLInputElement>;
+};
+
+describe("useProfileImportExport", () => {
+  beforeEach(() => {
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:test");
+    vi.spyOn(URL, "revokeObjectURL").mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("handleExport", () => {
+    it("should serialize the profile and trigger a download via createObjectURL", () => {
+      // Arrange
+      const persistence = createInMemoryPersistence();
+      const setImportError = vi.fn();
+      const profile: Profile = makeProfile({
+        id: "00000000-0000-4000-8000-0000000000e1",
+        name: "Pablo Albaladejo",
+      });
+      const clickSpy = vi.fn();
+      const realCreateElement = document.createElement.bind(document);
+      const createElementSpy = vi
+        .spyOn(document, "createElement")
+        .mockImplementation((tag: string) => {
+          const el = realCreateElement(tag);
+          if (tag === "a") {
+            (el as HTMLAnchorElement).click = clickSpy;
+          }
+          return el;
+        });
+
+      const { result } = renderHook(
+        () => useProfileImportExport({ setImportError }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      result.current.handleExport(profile);
+
+      // Assert
+      expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+      expect(clickSpy).toHaveBeenCalledTimes(1);
+      expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:test");
+
+      createElementSpy.mockRestore();
+    });
+
+    it("should produce a kebab-cased filename derived from the profile name", () => {
+      // Arrange
+      const persistence = createInMemoryPersistence();
+      const setImportError = vi.fn();
+      const profile: Profile = makeProfile({
+        id: "00000000-0000-4000-8000-0000000000e2",
+        name: "Mountain Bike Pro",
+      });
+      let observedDownload = "";
+      const realCreateElement = document.createElement.bind(document);
+      const createElementSpy = vi
+        .spyOn(document, "createElement")
+        .mockImplementation((tag: string) => {
+          const el = realCreateElement(tag);
+          if (tag === "a") {
+            (el as HTMLAnchorElement).click = () => {
+              observedDownload = (el as HTMLAnchorElement).download;
+            };
+          }
+          return el;
+        });
+
+      const { result } = renderHook(
+        () => useProfileImportExport({ setImportError }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      result.current.handleExport(profile);
+
+      // Assert
+      expect(observedDownload).toBe("profile-mountain-bike-pro.json");
+
+      createElementSpy.mockRestore();
+    });
+  });
+
+  describe("handleImport", () => {
+    it("should create a profile from a valid JSON file and clear the input", async () => {
+      // Arrange
+      const persistence = createInMemoryPersistence();
+      const setImportError = vi.fn();
+      const validProfile: Profile = makeProfile({
+        id: "00000000-0000-4000-8000-0000000000f1",
+        name: "Imported",
+      });
+      const file: FakeFile = {
+        text: () => Promise.resolve(JSON.stringify(validProfile)),
+      };
+      const event = fakeChangeEvent(file);
+
+      const { result } = renderHook(
+        () => useProfileImportExport({ setImportError }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      await result.current.handleImport(event);
+
+      // Assert
+      const all = await persistence.profiles.getAll();
+      expect(all).toHaveLength(1);
+      expect(all[0]?.name).toBe("Imported");
+      expect(setImportError).toHaveBeenCalledWith(null);
+      expect(event.target.value).toBe("");
+    });
+
+    it("should silently no-op when no file is selected", async () => {
+      // Arrange
+      const persistence = createInMemoryPersistence();
+      const setImportError = vi.fn();
+      const event = fakeChangeEvent(null);
+
+      const { result } = renderHook(
+        () => useProfileImportExport({ setImportError }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      await result.current.handleImport(event);
+
+      // Assert
+      expect(setImportError).not.toHaveBeenCalled();
+      expect(await persistence.profiles.getAll()).toEqual([]);
+    });
+
+    it("should report a parse error when the file is not valid JSON", async () => {
+      // Arrange
+      const persistence = createInMemoryPersistence();
+      const setImportError = vi.fn();
+      const file: FakeFile = {
+        text: () => Promise.resolve("not json"),
+      };
+      const event = fakeChangeEvent(file);
+
+      const { result } = renderHook(
+        () => useProfileImportExport({ setImportError }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      await result.current.handleImport(event);
+
+      // Assert
+      await waitFor(() => {
+        expect(setImportError).toHaveBeenCalledWith(
+          expect.stringMatching(/^Import failed: /)
+        );
+      });
+      expect(await persistence.profiles.getAll()).toEqual([]);
+      expect(event.target.value).toBe("");
+    });
+
+    it("should report a schema-validation error when the JSON is shaped wrong", async () => {
+      // Arrange
+      const persistence = createInMemoryPersistence();
+      const setImportError = vi.fn();
+      const file: FakeFile = {
+        text: () => Promise.resolve(JSON.stringify({ totally: "wrong" })),
+      };
+      const event = fakeChangeEvent(file);
+
+      const { result } = renderHook(
+        () => useProfileImportExport({ setImportError }),
+        { wrapper: wrap(persistence) }
+      );
+
+      // Act
+      await result.current.handleImport(event);
+
+      // Assert
+      await waitFor(() => {
+        expect(setImportError).toHaveBeenCalledWith(
+          expect.stringMatching(/^Import failed: /)
+        );
+      });
+      expect(await persistence.profiles.getAll()).toEqual([]);
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileSwitch.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileSwitch.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * useProfileSwitch hook tests.
+ *
+ * Drives the switch-active-profile flow: matching profile in the
+ * `profiles` array, missing profile (silent no-op), and persistence
+ * rejection (toast surfacing). The 3000ms notification-clear timeout
+ * is exercised under fake timers in a dedicated test.
+ */
+/* eslint-disable no-magic-numbers -- test fixtures use literal values for clarity */
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { makeProfile } from "../../../../application/profile/test-fixtures";
+import { PersistenceProvider } from "../../../../contexts/persistence-context";
+import type { PersistencePort } from "../../../../ports/persistence-port";
+import { createInMemoryPersistence } from "../../../../test-utils/in-memory-persistence";
+import type { Profile } from "../../../../types/profile";
+import { useProfileSwitch } from "./useProfileSwitch";
+
+const errorSpy = vi.fn();
+
+vi.mock("../../../../contexts/ToastContext", () => ({
+  useToastContext: () => ({ error: errorSpy }),
+}));
+
+const wrap = (persistence: PersistencePort) => {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <PersistenceProvider persistence={persistence}>
+      {children}
+    </PersistenceProvider>
+  );
+  return Wrapper;
+};
+
+const PROFILE_A: Profile = makeProfile({
+  id: "00000000-0000-4000-8000-0000000000a1",
+  name: "Alice",
+});
+const PROFILE_B: Profile = makeProfile({
+  id: "00000000-0000-4000-8000-0000000000b2",
+  name: "Bob",
+});
+
+describe("useProfileSwitch", () => {
+  beforeEach(() => {
+    errorSpy.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should set the active profile and post a switch notification on success", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    await persistence.profiles.put(PROFILE_A);
+    await persistence.profiles.put(PROFILE_B);
+    const setSwitchNotification = vi.fn();
+    const profiles: ReadonlyArray<Profile> = [PROFILE_A, PROFILE_B];
+
+    const { result } = renderHook(
+      () => useProfileSwitch({ profiles, setSwitchNotification }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleSwitchProfile(PROFILE_B.id);
+    });
+
+    // Assert
+    await waitFor(async () => {
+      expect(await persistence.profiles.getActiveId()).toBe(PROFILE_B.id);
+    });
+    expect(setSwitchNotification).toHaveBeenCalledWith(
+      "Switched to profile: Bob"
+    );
+  });
+
+  it("should clear the switch notification after the 3000ms timeout", async () => {
+    // Arrange
+    vi.useFakeTimers();
+    const persistence = createInMemoryPersistence();
+    await persistence.profiles.put(PROFILE_A);
+    const setSwitchNotification = vi.fn();
+    const profiles: ReadonlyArray<Profile> = [PROFILE_A];
+
+    const { result } = renderHook(
+      () => useProfileSwitch({ profiles, setSwitchNotification }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    await act(async () => {
+      result.current.handleSwitchProfile(PROFILE_A.id);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+
+    // Assert
+    expect(setSwitchNotification).toHaveBeenNthCalledWith(
+      1,
+      "Switched to profile: Alice"
+    );
+    expect(setSwitchNotification).toHaveBeenNthCalledWith(2, null);
+  });
+
+  it("should do nothing when the profile id is not present in the profiles array", () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const setSwitchNotification = vi.fn();
+    const setActiveSpy = vi.spyOn(persistence.profiles, "setActiveId");
+    const profiles: ReadonlyArray<Profile> = [PROFILE_A];
+
+    const { result } = renderHook(
+      () => useProfileSwitch({ profiles, setSwitchNotification }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleSwitchProfile("missing-id");
+    });
+
+    // Assert
+    expect(setActiveSpy).not.toHaveBeenCalled();
+    expect(setSwitchNotification).not.toHaveBeenCalled();
+  });
+
+  it("should surface a toast error when setActiveId rejects", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    persistence.profiles.setActiveId = vi.fn(() =>
+      Promise.reject(new Error("simulated"))
+    );
+    const setSwitchNotification = vi.fn();
+    const profiles: ReadonlyArray<Profile> = [PROFILE_A];
+
+    const { result } = renderHook(
+      () => useProfileSwitch({ profiles, setSwitchNotification }),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    act(() => {
+      result.current.handleSwitchProfile(PROFILE_A.id);
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(
+        "Failed to switch profile — please retry."
+      );
+    });
+    expect(setSwitchNotification).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Implements §5.2 of the `repo-quality-maintenance-waves` change. Adds co-located test files for the seven hooks under `packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/`:

- `useProfileCreate.test.tsx`
- `useProfileEdit.test.tsx`
- `useProfileDelete.test.tsx`
- `useProfileSwitch.test.tsx`
- `useProfileImportExport.test.tsx`
- `useProfileCRUD.test.tsx` (orchestrator)
- `useProfileActions.test.tsx` (orchestrator)

All 32 new tests follow `R-ItTitleShould` (`should …` prefix) and `R-ItBodyAAA` (`// Arrange / // Act / // Assert` markers separated by blank lines). Tests drive each hook against an in-memory `PersistencePort` (no Dexie/jsdom IndexedDB) and exercise the full handler surface — happy paths, early-return guards, and toast surfacing on persistence rejection.

## Coverage

Aggregate coverage of `ProfileManager/hooks/` (above the 70 % frontend threshold):

| Metric     | %      |
| ---------- | ------ |
| Statements | 100 %  |
| Branches   | 93.75% |
| Functions  | 100 %  |
| Lines      | 100 %  |

## Constraints satisfied

- Every hook file in the directory has a co-located `.test.tsx`.
- No deep `~/types/...` imports — `grep -RnE "from ['\"]~/types/" packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks` returns no matches.
- `node scripts/check-test-aaa.mjs --changed-files <new files>` passes for the new files.
- `node scripts/check-test-title-should.mjs` passes full-tree.
- Hook source files are unchanged.

## Test plan

- [x] `pnpm exec vitest --run src/components/organisms/ProfileManager/hooks/` — 7 files / 32 tests pass
- [x] `pnpm exec vitest --run --coverage --coverage.include='src/components/organisms/ProfileManager/hooks/**' …` — coverage above 70 % on every metric
- [x] `pnpm exec eslint 'src/components/organisms/ProfileManager/hooks/*.test.*'` — clean
- [x] `pnpm exec prettier --check 'src/components/organisms/ProfileManager/hooks/*.test.*'` — clean
- [x] `pnpm test:scripts` — 411 / 411 pass
- [x] `pnpm exec tsc --noEmit -p .` (in `workout-spa-editor`) — clean
- [x] Pre-commit + pre-push husky hooks — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)