### PR TITLE
test(spa-editor): add tests for WorkoutLibrary/components/ (§5.3)

### DIFF
--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardBadges.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardBadges.test.tsx
@@ -22,7 +22,9 @@ describe("CardBadges", () => {
 
     // Assert
     expect(screen.getByText("cycling")).toBeInTheDocument();
-    expect(screen.queryByText(/^easy$|^medium$|^hard$/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/^easy$|^medium$|^hard$/)
+    ).not.toBeInTheDocument();
     expect(screen.queryByText(/m$/)).not.toBeInTheDocument();
   });
 
@@ -72,9 +74,7 @@ describe("CardBadges", () => {
     // Arrange
 
     // Act
-    render(
-      <CardBadges sport="swimming" difficulty="hard" duration={2700} />
-    );
+    render(<CardBadges sport="swimming" difficulty="hard" duration={2700} />);
 
     // Assert
     expect(screen.getByText("swimming")).toBeInTheDocument();

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardBadges.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardBadges.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * CardBadges tests.
+ *
+ * Renders 1–3 badges describing a workout card: sport (always),
+ * difficulty (optional), duration (optional, formatted via
+ * formatDuration). The component is purely presentational; the
+ * branches under test are the conditional renders for difficulty +
+ * duration and the difficulty-color helper coupling.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { render, screen } from "../../../../test-utils";
+import { CardBadges } from "./CardBadges";
+
+describe("CardBadges", () => {
+  it("should render only the sport badge when difficulty and duration are absent", () => {
+    // Arrange
+
+    // Act
+    render(<CardBadges sport="cycling" />);
+
+    // Assert
+    expect(screen.getByText("cycling")).toBeInTheDocument();
+    expect(screen.queryByText(/^easy$|^medium$|^hard$/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/m$/)).not.toBeInTheDocument();
+  });
+
+  it("should render the difficulty badge with the matching color class", () => {
+    // Arrange
+
+    // Act
+    render(<CardBadges sport="running" difficulty="medium" />);
+
+    // Assert
+    const badge = screen.getByText("medium");
+    expect(badge).toBeInTheDocument();
+    expect(badge.className).toContain("bg-yellow-100");
+  });
+
+  it("should render the duration badge formatted in minutes only when under one hour", () => {
+    // Arrange
+
+    // Act
+    render(<CardBadges sport="cycling" duration={1800} />);
+
+    // Assert
+    expect(screen.getByText("30m")).toBeInTheDocument();
+  });
+
+  it("should render the duration badge formatted with hours and minutes when over one hour", () => {
+    // Arrange
+
+    // Act
+    render(<CardBadges sport="cycling" duration={5400} />);
+
+    // Assert
+    expect(screen.getByText("1h 30m")).toBeInTheDocument();
+  });
+
+  it("should not render the duration badge when duration is zero", () => {
+    // Arrange
+
+    // Act
+    render(<CardBadges sport="cycling" duration={0} />);
+
+    // Assert
+    expect(screen.queryByText(/m$/)).not.toBeInTheDocument();
+  });
+
+  it("should render all three badges when sport, difficulty, and duration are provided", () => {
+    // Arrange
+
+    // Act
+    render(
+      <CardBadges sport="swimming" difficulty="hard" duration={2700} />
+    );
+
+    // Assert
+    expect(screen.getByText("swimming")).toBeInTheDocument();
+    expect(screen.getByText("hard")).toBeInTheDocument();
+    expect(screen.getByText("45m")).toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardHeader.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardHeader.test.tsx
@@ -44,9 +44,7 @@ describe("CardHeader", () => {
     render(<CardHeader workoutName="Tempo Ride" onDelete={onDelete} />);
 
     // Act
-    await user.click(
-      screen.getByRole("button", { name: "Delete Tempo Ride" })
-    );
+    await user.click(screen.getByRole("button", { name: "Delete Tempo Ride" }));
 
     // Assert
     expect(onDelete).toHaveBeenCalledTimes(1);

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardHeader.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardHeader.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * CardHeader tests.
+ *
+ * Displays the workout name plus an aria-labelled delete button. The
+ * delete button is hover-revealed in the design system but the test
+ * surface only cares about (a) name rendering, (b) accessible label,
+ * (c) onDelete callback firing on click.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../test-utils";
+import { CardHeader } from "./CardHeader";
+
+describe("CardHeader", () => {
+  it("should render the workout name as a heading", () => {
+    // Arrange
+
+    // Act
+    render(<CardHeader workoutName="Tempo Ride" onDelete={vi.fn()} />);
+
+    // Assert
+    expect(
+      screen.getByRole("heading", { name: "Tempo Ride", level: 3 })
+    ).toBeInTheDocument();
+  });
+
+  it("should expose an accessible delete button labelled with the workout name", () => {
+    // Arrange
+
+    // Act
+    render(<CardHeader workoutName="Tempo Ride" onDelete={vi.fn()} />);
+
+    // Assert
+    expect(
+      screen.getByRole("button", { name: "Delete Tempo Ride" })
+    ).toBeInTheDocument();
+  });
+
+  it("should call onDelete once when the delete button is activated", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    render(<CardHeader workoutName="Tempo Ride" onDelete={onDelete} />);
+
+    // Act
+    await user.click(
+      screen.getByRole("button", { name: "Delete Tempo Ride" })
+    );
+
+    // Assert
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardScheduleAction.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardScheduleAction.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * CardScheduleAction tests.
+ *
+ * Single-button surface that fires onSchedule when activated. Renders
+ * a calendar icon plus the literal "Schedule" label.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../test-utils";
+import { CardScheduleAction } from "./CardScheduleAction";
+
+describe("CardScheduleAction", () => {
+  it("should render a Schedule button", () => {
+    // Arrange
+
+    // Act
+    render(<CardScheduleAction onSchedule={vi.fn()} />);
+
+    // Assert
+    expect(
+      screen.getByRole("button", { name: /schedule/i })
+    ).toBeInTheDocument();
+  });
+
+  it("should call onSchedule once when the button is clicked", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onSchedule = vi.fn();
+    render(<CardScheduleAction onSchedule={onSchedule} />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /schedule/i }));
+
+    // Assert
+    expect(onSchedule).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardTags.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardTags.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * CardTags tests.
+ *
+ * Renders up to three tag badges plus a "+N" overflow badge when more
+ * than three tags are supplied. The empty-array branch returns null
+ * (renders nothing).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { render, screen } from "../../../../test-utils";
+import { CardTags } from "./CardTags";
+
+describe("CardTags", () => {
+  it("should render nothing when the tag list is empty", () => {
+    // Arrange
+
+    // Act
+    const { container } = render(<CardTags tags={[]} />);
+
+    // Assert
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should render every tag when there are three or fewer", () => {
+    // Arrange
+
+    // Act
+    render(<CardTags tags={["fast", "easy", "hills"]} />);
+
+    // Assert
+    expect(screen.getByText("fast")).toBeInTheDocument();
+    expect(screen.getByText("easy")).toBeInTheDocument();
+    expect(screen.getByText("hills")).toBeInTheDocument();
+    expect(screen.queryByText(/^\+\d+$/)).not.toBeInTheDocument();
+  });
+
+  it("should render only the first three tags plus an overflow badge when there are more", () => {
+    // Arrange
+
+    // Act
+    render(<CardTags tags={["a", "b", "c", "d", "e"]} />);
+
+    // Assert
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.getByText("b")).toBeInTheDocument();
+    expect(screen.getByText("c")).toBeInTheDocument();
+    expect(screen.queryByText("d")).not.toBeInTheDocument();
+    expect(screen.queryByText("e")).not.toBeInTheDocument();
+    expect(screen.getByText("+2")).toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardThumbnail.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardThumbnail.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * CardThumbnail tests.
+ *
+ * Renders the workout's thumbnail image when one is provided; renders
+ * nothing when thumbnailData is absent. Alt text is derived from the
+ * workout name.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { render, screen } from "../../../../test-utils";
+import { CardThumbnail } from "./CardThumbnail";
+
+describe("CardThumbnail", () => {
+  it("should render nothing when thumbnailData is undefined", () => {
+    // Arrange
+
+    // Act
+    const { container } = render(<CardThumbnail workoutName="Ride" />);
+
+    // Assert
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should render an img with the provided thumbnail data and a derived alt", () => {
+    // Arrange
+    const dataUri = "data:image/png;base64,AAAA";
+
+    // Act
+    render(<CardThumbnail workoutName="Tempo Ride" thumbnailData={dataUri} />);
+
+    // Assert
+    const img = screen.getByRole("img", { name: "Tempo Ride preview" });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", dataUri);
+  });
+
+  it("should render nothing when thumbnailData is an empty string", () => {
+    // Arrange
+
+    // Act
+    const { container } = render(
+      <CardThumbnail workoutName="Ride" thumbnailData="" />
+    );
+
+    // Assert
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/DeleteWorkoutDialog.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/DeleteWorkoutDialog.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * DeleteWorkoutDialog tests.
+ *
+ * Radix-based confirmation dialog. Closed when `open=false`, mounted
+ * when `open=true`. The Cancel button and the dialog's onOpenChange
+ * (Escape / overlay click) both go through onCancel; the Delete
+ * button fires onConfirm.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../test-utils";
+import { DeleteWorkoutDialog } from "./DeleteWorkoutDialog";
+
+describe("DeleteWorkoutDialog", () => {
+  it("should render nothing when open is false", () => {
+    // Arrange
+
+    // Act
+    render(
+      <DeleteWorkoutDialog
+        open={false}
+        workoutName="Tempo Ride"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    // Assert
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("should render the dialog with the workout name in the description when open", () => {
+    // Arrange
+
+    // Act
+    render(
+      <DeleteWorkoutDialog
+        open
+        workoutName="Tempo Ride"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    // Assert
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Delete Workout")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Are you sure you want to delete "Tempo Ride"\?/)
+    ).toBeInTheDocument();
+  });
+
+  it("should call onConfirm when the Delete button is clicked", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(
+      <DeleteWorkoutDialog
+        open
+        workoutName="Tempo Ride"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    );
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    // Assert
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onCancel when the Cancel button is clicked", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(
+      <DeleteWorkoutDialog
+        open
+        workoutName="Tempo Ride"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    // Assert
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onCancel when the dialog is dismissed via Escape", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(
+      <DeleteWorkoutDialog
+        open
+        workoutName="Tempo Ride"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+
+    // Act
+    await user.keyboard("{Escape}");
+
+    // Assert
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/EmptyLibrary.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/EmptyLibrary.test.tsx
@@ -21,9 +21,7 @@ describe("EmptyLibrary", () => {
 
     // Assert
     expect(screen.getByText("Your library is empty")).toBeInTheDocument();
-    expect(
-      screen.getByText(/Create your first workout/)
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Create your first workout/)).toBeInTheDocument();
   });
 
   it("should not render the Clear Filters button when not filtered even if onClearFilters is provided", () => {

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/EmptyLibrary.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/EmptyLibrary.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * EmptyLibrary tests.
+ *
+ * Two empty-state branches: (a) `isFiltered=true` shows a "no
+ * results" message with an optional Clear Filters button, (b)
+ * `isFiltered=false` shows a "library is empty" onboarding message
+ * and never renders the Clear Filters button.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../test-utils";
+import { EmptyLibrary } from "./EmptyLibrary";
+
+describe("EmptyLibrary", () => {
+  it("should render the empty-library onboarding message when not filtered", () => {
+    // Arrange
+
+    // Act
+    render(<EmptyLibrary isFiltered={false} />);
+
+    // Assert
+    expect(screen.getByText("Your library is empty")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Create your first workout/)
+    ).toBeInTheDocument();
+  });
+
+  it("should not render the Clear Filters button when not filtered even if onClearFilters is provided", () => {
+    // Arrange
+
+    // Act
+    render(<EmptyLibrary isFiltered={false} onClearFilters={vi.fn()} />);
+
+    // Assert
+    expect(
+      screen.queryByRole("button", { name: /clear filters/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render the no-results message when filtered", () => {
+    // Arrange
+
+    // Act
+    render(<EmptyLibrary isFiltered onClearFilters={vi.fn()} />);
+
+    // Assert
+    expect(screen.getByText("No workouts found")).toBeInTheDocument();
+    expect(
+      screen.getByText(/No workouts match your current filters/)
+    ).toBeInTheDocument();
+  });
+
+  it("should render the Clear Filters button when filtered and onClearFilters is provided", () => {
+    // Arrange
+
+    // Act
+    render(<EmptyLibrary isFiltered onClearFilters={vi.fn()} />);
+
+    // Assert
+    expect(
+      screen.getByRole("button", { name: /clear filters/i })
+    ).toBeInTheDocument();
+  });
+
+  it("should not render the Clear Filters button when filtered and onClearFilters is omitted", () => {
+    // Arrange
+
+    // Act
+    render(<EmptyLibrary isFiltered />);
+
+    // Assert
+    expect(
+      screen.queryByRole("button", { name: /clear filters/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("should call onClearFilters when the Clear Filters button is clicked", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onClearFilters = vi.fn();
+    render(<EmptyLibrary isFiltered onClearFilters={onClearFilters} />);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /clear filters/i }));
+
+    // Assert
+    expect(onClearFilters).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/LibraryFilters.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/LibraryFilters.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * LibraryFilters tests.
+ *
+ * Container component composing the search input, sport / difficulty
+ * dropdowns, sort-by / sort-order dropdowns, and a Clear Filters
+ * button. The test surface verifies (a) every controlled value is
+ * forwarded to the matching subcomponent, (b) every change handler
+ * fires with the expected next value, (c) the Clear Filters button
+ * fires its handler.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../test-utils";
+import { LibraryFilters } from "./LibraryFilters";
+
+type Difficulty = "easy" | "medium" | "hard";
+type Sport = "cycling" | "running" | "swimming" | "generic";
+
+type Handlers = {
+  onSearchChange: ReturnType<typeof vi.fn>;
+  onSportFilterChange: ReturnType<typeof vi.fn>;
+  onDifficultyFilterChange: ReturnType<typeof vi.fn>;
+  onSortByChange: ReturnType<typeof vi.fn>;
+  onSortOrderChange: ReturnType<typeof vi.fn>;
+  onClearFilters: ReturnType<typeof vi.fn>;
+};
+
+function makeHandlers(): Handlers {
+  return {
+    onSearchChange: vi.fn(),
+    onSportFilterChange: vi.fn(),
+    onDifficultyFilterChange: vi.fn(),
+    onSortByChange: vi.fn(),
+    onSortOrderChange: vi.fn(),
+    onClearFilters: vi.fn(),
+  };
+}
+
+function renderFilters(
+  overrides: Partial<{
+    searchTerm: string;
+    sportFilter: Sport | "all";
+    difficultyFilter: Difficulty | "all";
+    sortBy: "name" | "date" | "difficulty";
+    sortOrder: "asc" | "desc";
+  }> = {},
+  handlers: Handlers = makeHandlers()
+) {
+  const props = {
+    searchTerm: overrides.searchTerm ?? "",
+    sportFilter: overrides.sportFilter ?? ("all" as const),
+    difficultyFilter: overrides.difficultyFilter ?? ("all" as const),
+    sortBy: overrides.sortBy ?? ("name" as const),
+    sortOrder: overrides.sortOrder ?? ("asc" as const),
+    ...handlers,
+  };
+  render(<LibraryFilters {...props} />);
+  return handlers;
+}
+
+describe("LibraryFilters", () => {
+  it("should render every filter sub-control and the Clear Filters button", () => {
+    // Arrange
+
+    // Act
+    renderFilters();
+
+    // Assert
+    expect(
+      screen.getByPlaceholderText("Search workouts...")
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText("Sport")).toBeInTheDocument();
+    expect(screen.getByLabelText("Difficulty")).toBeInTheDocument();
+    expect(screen.getByLabelText("Sort By")).toBeInTheDocument();
+    expect(screen.getByLabelText("Order")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /clear filters/i })
+    ).toBeInTheDocument();
+  });
+
+  it("should reflect the controlled searchTerm in the search input", () => {
+    // Arrange
+
+    // Act
+    renderFilters({ searchTerm: "intervals" });
+
+    // Assert
+    expect(screen.getByPlaceholderText("Search workouts...")).toHaveValue(
+      "intervals"
+    );
+  });
+
+  it("should fire onSearchChange with the next value when the search input changes", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const handlers = renderFilters();
+
+    // Act
+    await user.type(screen.getByPlaceholderText("Search workouts..."), "x");
+
+    // Assert
+    expect(handlers.onSearchChange).toHaveBeenCalledWith("x");
+  });
+
+  it("should fire onSportFilterChange with the picked sport", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const handlers = renderFilters();
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Sport"), "cycling");
+
+    // Assert
+    expect(handlers.onSportFilterChange).toHaveBeenCalledWith("cycling");
+  });
+
+  it("should fire onDifficultyFilterChange with the picked difficulty", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const handlers = renderFilters();
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Difficulty"), "hard");
+
+    // Assert
+    expect(handlers.onDifficultyFilterChange).toHaveBeenCalledWith("hard");
+  });
+
+  it("should fire onSortByChange with the picked sort key", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const handlers = renderFilters();
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Sort By"), "date");
+
+    // Assert
+    expect(handlers.onSortByChange).toHaveBeenCalledWith("date");
+  });
+
+  it("should fire onSortOrderChange with the picked order", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const handlers = renderFilters();
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Order"), "desc");
+
+    // Assert
+    expect(handlers.onSortOrderChange).toHaveBeenCalledWith("desc");
+  });
+
+  it("should fire onClearFilters when the Clear Filters button is clicked", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const handlers = renderFilters();
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /clear filters/i }));
+
+    // Assert
+    expect(handlers.onClearFilters).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/TagFilterButtons.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/TagFilterButtons.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * TagFilterButtons tests.
+ *
+ * Renders one toggle button per tag with `aria-pressed` reflecting
+ * membership in `selectedTags`. Empty `allTags` short-circuits to
+ * null. Click events fire `onTagToggle(tag)` for the clicked tag.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../test-utils";
+import { TagFilterButtons } from "./TagFilterButtons";
+
+describe("TagFilterButtons", () => {
+  it("should render nothing when allTags is empty", () => {
+    // Arrange
+
+    // Act
+    const { container } = render(
+      <TagFilterButtons
+        allTags={[]}
+        selectedTags={[]}
+        onTagToggle={vi.fn()}
+      />
+    );
+
+    // Assert
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("should render the Tags label and one button per tag when allTags is non-empty", () => {
+    // Arrange
+
+    // Act
+    render(
+      <TagFilterButtons
+        allTags={["fast", "easy"]}
+        selectedTags={[]}
+        onTagToggle={vi.fn()}
+      />
+    );
+
+    // Assert
+    expect(screen.getByText("Tags:")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "fast" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "easy" })).toBeInTheDocument();
+  });
+
+  it("should mark only the selected tags with aria-pressed=true", () => {
+    // Arrange
+
+    // Act
+    render(
+      <TagFilterButtons
+        allTags={["fast", "easy", "hills"]}
+        selectedTags={["easy"]}
+        onTagToggle={vi.fn()}
+      />
+    );
+
+    // Assert
+    expect(screen.getByRole("button", { name: "fast" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+    expect(screen.getByRole("button", { name: "easy" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(screen.getByRole("button", { name: "hills" })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+  });
+
+  it("should call onTagToggle with the clicked tag", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onTagToggle = vi.fn();
+    render(
+      <TagFilterButtons
+        allTags={["fast", "easy"]}
+        selectedTags={[]}
+        onTagToggle={onTagToggle}
+      />
+    );
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "fast" }));
+
+    // Assert
+    expect(onTagToggle).toHaveBeenCalledWith("fast");
+    expect(onTagToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/TagFilterButtons.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/TagFilterButtons.test.tsx
@@ -17,11 +17,7 @@ describe("TagFilterButtons", () => {
 
     // Act
     const { container } = render(
-      <TagFilterButtons
-        allTags={[]}
-        selectedTags={[]}
-        onTagToggle={vi.fn()}
-      />
+      <TagFilterButtons allTags={[]} selectedTags={[]} onTagToggle={vi.fn()} />
     );
 
     // Assert

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/DifficultyFilter.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/DifficultyFilter.test.tsx
@@ -1,0 +1,64 @@
+/* eslint-disable no-magic-numbers -- option counts are literal for clarity */
+
+/**
+ * DifficultyFilter tests.
+ *
+ * Controlled <select> exposing four difficulty options (all / easy /
+ * medium / hard). Verifies controlled-value rendering and onChange
+ * forwarding for each option.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../../test-utils";
+import { DifficultyFilter } from "./DifficultyFilter";
+
+describe("DifficultyFilter", () => {
+  it("should render the Difficulty label and a select with four options", () => {
+    // Arrange
+
+    // Act
+    render(<DifficultyFilter value="all" onChange={vi.fn()} />);
+
+    // Assert
+    const select = screen.getByLabelText("Difficulty") as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.options).toHaveLength(4);
+  });
+
+  it("should reflect the controlled value in the select", () => {
+    // Arrange
+
+    // Act
+    render(<DifficultyFilter value="medium" onChange={vi.fn()} />);
+
+    // Assert
+    expect(screen.getByLabelText("Difficulty")).toHaveValue("medium");
+  });
+
+  it("should call onChange with the picked difficulty when the user selects easy", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DifficultyFilter value="all" onChange={onChange} />);
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Difficulty"), "easy");
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith("easy");
+  });
+
+  it("should call onChange with all when the user resets to All Levels", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<DifficultyFilter value="hard" onChange={onChange} />);
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Difficulty"), "all");
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith("all");
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/DifficultyFilter.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/DifficultyFilter.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-magic-numbers -- option counts are literal for clarity */
-
 /**
  * DifficultyFilter tests.
  *
@@ -13,6 +11,8 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen, userEvent } from "../../../../../test-utils";
 import { DifficultyFilter } from "./DifficultyFilter";
 
+const EXPECTED_OPTION_COUNT = 4;
+
 describe("DifficultyFilter", () => {
   it("should render the Difficulty label and a select with four options", () => {
     // Arrange
@@ -23,7 +23,7 @@ describe("DifficultyFilter", () => {
     // Assert
     const select = screen.getByLabelText("Difficulty") as HTMLSelectElement;
     expect(select).toBeInTheDocument();
-    expect(select.options).toHaveLength(4);
+    expect(select.options).toHaveLength(EXPECTED_OPTION_COUNT);
   });
 
   it("should reflect the controlled value in the select", () => {

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SearchInput.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SearchInput.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * SearchInput tests.
+ *
+ * Thin wrapper around the Input atom: forwards `value` and emits the
+ * raw next string via `onChange` (event.target.value is unwrapped).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../../test-utils";
+import { SearchInput } from "./SearchInput";
+
+describe("SearchInput", () => {
+  it("should render with the search placeholder", () => {
+    // Arrange
+
+    // Act
+    render(<SearchInput value="" onChange={vi.fn()} />);
+
+    // Assert
+    expect(
+      screen.getByPlaceholderText("Search workouts...")
+    ).toBeInTheDocument();
+  });
+
+  it("should reflect the controlled value", () => {
+    // Arrange
+
+    // Act
+    render(<SearchInput value="climb" onChange={vi.fn()} />);
+
+    // Assert
+    expect(screen.getByPlaceholderText("Search workouts...")).toHaveValue(
+      "climb"
+    );
+  });
+
+  it("should call onChange with the unwrapped next string per keystroke", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SearchInput value="" onChange={onChange} />);
+
+    // Act
+    await user.type(screen.getByPlaceholderText("Search workouts..."), "ab");
+
+    // Assert
+    expect(onChange).toHaveBeenNthCalledWith(1, "a");
+    expect(onChange).toHaveBeenNthCalledWith(2, "b");
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SortBySelect.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SortBySelect.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-magic-numbers -- option counts are literal for clarity */
-
 /**
  * SortBySelect tests.
  *
@@ -12,6 +10,8 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen, userEvent } from "../../../../../test-utils";
 import { SortBySelect } from "./SortBySelect";
 
+const EXPECTED_OPTION_COUNT = 3;
+
 describe("SortBySelect", () => {
   it("should render the Sort By label and three options", () => {
     // Arrange
@@ -22,7 +22,7 @@ describe("SortBySelect", () => {
     // Assert
     const select = screen.getByLabelText("Sort By") as HTMLSelectElement;
     expect(select).toBeInTheDocument();
-    expect(select.options).toHaveLength(3);
+    expect(select.options).toHaveLength(EXPECTED_OPTION_COUNT);
   });
 
   it("should reflect the controlled value", () => {

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SortBySelect.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SortBySelect.test.tsx
@@ -1,0 +1,63 @@
+/* eslint-disable no-magic-numbers -- option counts are literal for clarity */
+
+/**
+ * SortBySelect tests.
+ *
+ * Controlled <select> for sort criteria (name / date / difficulty).
+ * Verifies value reflection plus onChange forwarding for each option.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../../test-utils";
+import { SortBySelect } from "./SortBySelect";
+
+describe("SortBySelect", () => {
+  it("should render the Sort By label and three options", () => {
+    // Arrange
+
+    // Act
+    render(<SortBySelect value="name" onChange={vi.fn()} />);
+
+    // Assert
+    const select = screen.getByLabelText("Sort By") as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.options).toHaveLength(3);
+  });
+
+  it("should reflect the controlled value", () => {
+    // Arrange
+
+    // Act
+    render(<SortBySelect value="date" onChange={vi.fn()} />);
+
+    // Assert
+    expect(screen.getByLabelText("Sort By")).toHaveValue("date");
+  });
+
+  it("should call onChange with date when the user selects Date Created", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SortBySelect value="name" onChange={onChange} />);
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Sort By"), "date");
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith("date");
+  });
+
+  it("should call onChange with difficulty when the user selects Difficulty", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SortBySelect value="name" onChange={onChange} />);
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Sort By"), "difficulty");
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith("difficulty");
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SortOrderSelect.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SortOrderSelect.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * SortOrderSelect tests.
+ *
+ * Two-option controlled <select> (asc / desc). Verifies value
+ * reflection and onChange forwarding for both directions.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../../test-utils";
+import { SortOrderSelect } from "./SortOrderSelect";
+
+describe("SortOrderSelect", () => {
+  it("should render the Order label and two options", () => {
+    // Arrange
+
+    // Act
+    render(<SortOrderSelect value="asc" onChange={vi.fn()} />);
+
+    // Assert
+    const select = screen.getByLabelText("Order") as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.options).toHaveLength(2);
+  });
+
+  it("should reflect the controlled value when descending", () => {
+    // Arrange
+
+    // Act
+    render(<SortOrderSelect value="desc" onChange={vi.fn()} />);
+
+    // Assert
+    expect(screen.getByLabelText("Order")).toHaveValue("desc");
+  });
+
+  it("should call onChange with desc when the user selects Descending", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SortOrderSelect value="asc" onChange={onChange} />);
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Order"), "desc");
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith("desc");
+  });
+
+  it("should call onChange with asc when the user selects Ascending", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SortOrderSelect value="desc" onChange={onChange} />);
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Order"), "asc");
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith("asc");
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SportFilter.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SportFilter.test.tsx
@@ -1,0 +1,68 @@
+/* eslint-disable no-magic-numbers -- option counts and call ordinals are literal for clarity */
+
+/**
+ * SportFilter tests.
+ *
+ * Controlled <select> exposing five sport options (all / cycling /
+ * running / swimming / generic). Verifies value reflection and
+ * onChange forwarding.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { render, screen, userEvent } from "../../../../../test-utils";
+import { SportFilter } from "./SportFilter";
+
+describe("SportFilter", () => {
+  it("should render the Sport label and five options", () => {
+    // Arrange
+
+    // Act
+    render(<SportFilter value="all" onChange={vi.fn()} />);
+
+    // Assert
+    const select = screen.getByLabelText("Sport") as HTMLSelectElement;
+    expect(select).toBeInTheDocument();
+    expect(select.options).toHaveLength(5);
+  });
+
+  it("should reflect the controlled value", () => {
+    // Arrange
+
+    // Act
+    render(<SportFilter value="cycling" onChange={vi.fn()} />);
+
+    // Assert
+    expect(screen.getByLabelText("Sport")).toHaveValue("cycling");
+  });
+
+  it("should call onChange with the picked sport for each option", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SportFilter value="all" onChange={onChange} />);
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Sport"), "running");
+    await user.selectOptions(screen.getByLabelText("Sport"), "swimming");
+    await user.selectOptions(screen.getByLabelText("Sport"), "generic");
+
+    // Assert
+    expect(onChange).toHaveBeenNthCalledWith(1, "running");
+    expect(onChange).toHaveBeenNthCalledWith(2, "swimming");
+    expect(onChange).toHaveBeenNthCalledWith(3, "generic");
+  });
+
+  it("should call onChange with all when the user resets to All Sports", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<SportFilter value="cycling" onChange={onChange} />);
+
+    // Act
+    await user.selectOptions(screen.getByLabelText("Sport"), "all");
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith("all");
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SportFilter.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SportFilter.test.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-magic-numbers -- option counts and call ordinals are literal for clarity */
-
 /**
  * SportFilter tests.
  *
@@ -13,6 +11,11 @@ import { describe, expect, it, vi } from "vitest";
 import { render, screen, userEvent } from "../../../../../test-utils";
 import { SportFilter } from "./SportFilter";
 
+const EXPECTED_OPTION_COUNT = 5;
+const FIRST_CALL = 1;
+const SECOND_CALL = 2;
+const THIRD_CALL = 3;
+
 describe("SportFilter", () => {
   it("should render the Sport label and five options", () => {
     // Arrange
@@ -23,7 +26,7 @@ describe("SportFilter", () => {
     // Assert
     const select = screen.getByLabelText("Sport") as HTMLSelectElement;
     expect(select).toBeInTheDocument();
-    expect(select.options).toHaveLength(5);
+    expect(select.options).toHaveLength(EXPECTED_OPTION_COUNT);
   });
 
   it("should reflect the controlled value", () => {
@@ -48,9 +51,9 @@ describe("SportFilter", () => {
     await user.selectOptions(screen.getByLabelText("Sport"), "generic");
 
     // Assert
-    expect(onChange).toHaveBeenNthCalledWith(1, "running");
-    expect(onChange).toHaveBeenNthCalledWith(2, "swimming");
-    expect(onChange).toHaveBeenNthCalledWith(3, "generic");
+    expect(onChange).toHaveBeenNthCalledWith(FIRST_CALL, "running");
+    expect(onChange).toHaveBeenNthCalledWith(SECOND_CALL, "swimming");
+    expect(onChange).toHaveBeenNthCalledWith(THIRD_CALL, "generic");
   });
 
   it("should call onChange with all when the user resets to All Sports", async () => {


### PR DESCRIPTION
## Summary

Adds 59 tests across 14 new files for `packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/`. Implements §5.3 of `repo-quality-maintenance-waves`.

## Coverage

- Before: 0% (no tests existed)
- After: **100%** lines / branches / functions / statements

## Compliance

- R-ItTitleShould ✓ (every `it()` starts with `should `)
- R-ItBodyAAA ✓ (Arrange/Act/Assert markers separated by blank lines)
- R-LibraryNoDualMount ✓ (tests import each component directly via relative paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the workout library UI: badges (sport/difficulty/duration formatting and visibility), headers and delete action, schedule action, tags display and overflow, thumbnail rendering, delete confirmation dialog, empty-state messaging and clear-filters behavior, and all filter controls (search, sport, difficulty, sort, order) including button/tag interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->