### PR TITLE
refactor(spa-editor): extract shared repetition-block helpers (§4.1)

### DIFF
--- a/packages/workout-spa-editor/src/store/actions/_helpers/build-krd-with-workout.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/_helpers/build-krd-with-workout.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import type { KRD, Workout } from "../../../types/krd";
+import { buildKrdWithWorkout } from "./build-krd-with-workout";
+
+describe("buildKrdWithWorkout", () => {
+  it("should set structured_workout while preserving the rest of the KRD", () => {
+    // Arrange
+    const original: KRD = {
+      version: "1.0",
+      type: "structured_workout",
+      metadata: { created: "2025-01-01T00:00:00Z", sport: "running" },
+      extensions: {
+        structured_workout: { name: "old", sport: "running", steps: [] },
+      },
+    };
+    const updatedWorkout: Workout = {
+      name: "new",
+      sport: "cycling",
+      steps: [],
+    };
+
+    // Act
+    const result = buildKrdWithWorkout(original, updatedWorkout);
+
+    // Assert
+    expect(result.extensions?.structured_workout).toEqual(updatedWorkout);
+    expect(result.metadata).toEqual(original.metadata);
+  });
+
+  it("should preserve sibling extensions other than structured_workout", () => {
+    // Arrange
+    const original: KRD = {
+      version: "1.0",
+      type: "structured_workout",
+      metadata: { created: "2025-01-01T00:00:00Z", sport: "running" },
+      extensions: {
+        structured_workout: { name: "old", sport: "running", steps: [] },
+        custom: { foo: "bar" },
+      } as KRD["extensions"],
+    };
+    const updatedWorkout: Workout = {
+      name: "new",
+      sport: "running",
+      steps: [],
+    };
+
+    // Act
+    const result = buildKrdWithWorkout(original, updatedWorkout);
+
+    // Assert
+    expect(
+      (result.extensions as { custom?: { foo: string } } | undefined)?.custom
+    ).toEqual({ foo: "bar" });
+  });
+
+  it("should return a fresh KRD object distinct from the input", () => {
+    // Arrange
+    const original: KRD = {
+      version: "1.0",
+      type: "structured_workout",
+      metadata: { created: "2025-01-01T00:00:00Z", sport: "running" },
+    };
+    const workout: Workout = { name: "x", sport: "running", steps: [] };
+
+    // Act
+    const result = buildKrdWithWorkout(original, workout);
+
+    // Assert
+    expect(result).not.toBe(original);
+  });
+});

--- a/packages/workout-spa-editor/src/store/actions/_helpers/build-krd-with-workout.ts
+++ b/packages/workout-spa-editor/src/store/actions/_helpers/build-krd-with-workout.ts
@@ -1,0 +1,16 @@
+/**
+ * Re-wraps a mutated structured Workout back into its parent KRD,
+ * preserving every other extension. Centralizes the spread-into-
+ * extensions pattern shared by all repetition-block / step mutation
+ * actions.
+ */
+
+import type { KRD, Workout } from "../../../types/krd";
+
+export const buildKrdWithWorkout = (krd: KRD, workout: Workout): KRD => ({
+  ...krd,
+  extensions: {
+    ...krd.extensions,
+    structured_workout: workout,
+  },
+});

--- a/packages/workout-spa-editor/src/store/actions/_helpers/extract-workout.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/_helpers/extract-workout.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import type { KRD, Workout } from "../../../types/krd";
+import { extractStructuredWorkout } from "./extract-workout";
+
+const baseKrd = (overrides: Partial<KRD> = {}): KRD => ({
+  version: "1.0",
+  type: "structured_workout",
+  metadata: { created: "2025-01-01T00:00:00Z", sport: "running" },
+  ...overrides,
+});
+
+describe("extractStructuredWorkout", () => {
+  it("should return null when extensions is missing", () => {
+    // Arrange
+    const krd = baseKrd();
+
+    // Act
+    const result = extractStructuredWorkout(krd);
+
+    // Assert
+    expect(result).toBeNull();
+  });
+
+  it("should return null when structured_workout is missing", () => {
+    // Arrange
+    const krd = baseKrd({ extensions: {} });
+
+    // Act
+    const result = extractStructuredWorkout(krd);
+
+    // Assert
+    expect(result).toBeNull();
+  });
+
+  it("should return the workout payload when present", () => {
+    // Arrange
+    const workout: Workout = {
+      name: "Test",
+      sport: "running",
+      steps: [],
+    };
+    const krd = baseKrd({
+      extensions: { structured_workout: workout },
+    });
+
+    // Act
+    const result = extractStructuredWorkout(krd);
+
+    // Assert
+    expect(result).toEqual(workout);
+  });
+});

--- a/packages/workout-spa-editor/src/store/actions/_helpers/extract-workout.ts
+++ b/packages/workout-spa-editor/src/store/actions/_helpers/extract-workout.ts
@@ -1,0 +1,16 @@
+/**
+ * Extracts the structured-workout payload from a KRD document, or
+ * returns `null` when the document is not structured (no
+ * `extensions.structured_workout`). Centralizes the early-return guard
+ * shared by every repetition-block / step mutation action — they all
+ * must no-op on non-structured input.
+ */
+
+import type { KRD, Workout } from "../../../types/krd";
+
+export const extractStructuredWorkout = (krd: KRD): Workout | null => {
+  if (!krd.extensions?.structured_workout) {
+    return null;
+  }
+  return krd.extensions.structured_workout as Workout;
+};

--- a/packages/workout-spa-editor/src/store/actions/_helpers/index.ts
+++ b/packages/workout-spa-editor/src/store/actions/_helpers/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared helpers for repetition-block / step mutation actions.
+ *
+ * These helpers extract the recurring KRD-extraction / KRD-rebuild /
+ * single-block-replacement patterns that previously appeared
+ * verbatim across every repetition-block action file. They are
+ * intentionally thin pure-functional wrappers — no side effects, no
+ * focus or selection logic — so each action can compose them in its
+ * own focus / undo flow.
+ */
+
+export { buildKrdWithWorkout } from "./build-krd-with-workout";
+export { extractStructuredWorkout } from "./extract-workout";
+export { replaceBlockAtPosition } from "./replace-block-at-position";

--- a/packages/workout-spa-editor/src/store/actions/_helpers/replace-block-at-position.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/_helpers/replace-block-at-position.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { RepetitionBlock, Workout, WorkoutStep } from "../../../types/krd";
+import { replaceBlockAtPosition } from "./replace-block-at-position";
+
+const REPEAT_DEFAULT = 2;
+const REPEAT_NEW = 5;
+
+const makeStep = (stepIndex: number): WorkoutStep => ({
+  stepIndex,
+  durationType: "open",
+  duration: { type: "open" },
+  targetType: "open",
+  target: { type: "open" },
+});
+
+const makeBlock = (id: string, repeat = REPEAT_DEFAULT): RepetitionBlock => ({
+  id,
+  repeatCount: repeat,
+  steps: [],
+});
+
+describe("replaceBlockAtPosition", () => {
+  it("should replace the block at the given position", () => {
+    // Arrange
+    const workout: Workout = {
+      name: "w",
+      sport: "running",
+      steps: [makeStep(0), makeBlock("a"), makeStep(1)],
+    };
+    const newBlock = makeBlock("b", REPEAT_NEW);
+
+    // Act
+    const result = replaceBlockAtPosition(workout, 1, newBlock);
+
+    // Assert
+    expect(result.steps[1]).toEqual(newBlock);
+  });
+
+  it("should leave other steps untouched", () => {
+    // Arrange
+    const left = makeStep(0);
+    const right = makeStep(1);
+    const workout: Workout = {
+      name: "w",
+      sport: "running",
+      steps: [left, makeBlock("a"), right],
+    };
+
+    // Act
+    const result = replaceBlockAtPosition(workout, 1, makeBlock("b"));
+
+    // Assert
+    expect(result.steps[0]).toBe(left);
+    expect(result.steps[2]).toBe(right);
+  });
+
+  it("should return a fresh workout object", () => {
+    // Arrange
+    const workout: Workout = {
+      name: "w",
+      sport: "running",
+      steps: [makeBlock("a")],
+    };
+
+    // Act
+    const result = replaceBlockAtPosition(workout, 0, makeBlock("b"));
+
+    // Assert
+    expect(result).not.toBe(workout);
+    expect(result.steps).not.toBe(workout.steps);
+  });
+});

--- a/packages/workout-spa-editor/src/store/actions/_helpers/replace-block-at-position.ts
+++ b/packages/workout-spa-editor/src/store/actions/_helpers/replace-block-at-position.ts
@@ -1,0 +1,18 @@
+/**
+ * Replaces a single block at a given top-level position in the
+ * workout's steps array, returning a new Workout. Used by actions that
+ * mutate one repetition block in place (add-step, edit-repeat-count)
+ * without changing surrounding step order or top-level indices.
+ */
+
+import type { RepetitionBlock, Workout } from "../../../types/krd";
+
+export const replaceBlockAtPosition = (
+  workout: Workout,
+  position: number,
+  block: RepetitionBlock
+): Workout => {
+  const updatedSteps = [...workout.steps];
+  updatedSteps[position] = block;
+  return { ...workout, steps: updatedSteps };
+};

--- a/packages/workout-spa-editor/src/store/actions/add-step-to-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/add-step-to-repetition-block-action.ts
@@ -8,12 +8,17 @@
  * - Requirement 2.4: Use block ID for operations
  */
 
-import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
+import type { KRD, RepetitionBlock } from "../../types/krd";
 import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
+import {
+  buildKrdWithWorkout,
+  extractStructuredWorkout,
+  replaceBlockAtPosition,
+} from "./_helpers";
 
 /**
  * Adds a new step to a repetition block by its ID
@@ -28,18 +33,11 @@ export const addStepToRepetitionBlockAction = (
   blockId: string,
   state: WorkoutState
 ): Partial<WorkoutState> => {
-  if (!krd.extensions?.structured_workout) {
-    return {};
-  }
+  const workout = extractStructuredWorkout(krd);
+  if (!workout) return {};
 
-  const workout = krd.extensions.structured_workout as Workout;
-
-  // Find block by ID
   const blockInfo = findBlockById(workout, blockId);
-
-  if (!blockInfo) {
-    return {};
-  }
+  if (!blockInfo) return {};
 
   const { block, position } = blockInfo;
 
@@ -64,21 +62,12 @@ export const addStepToRepetitionBlockAction = (
     steps: [...block.steps, newStep],
   };
 
-  const updatedSteps = [...workout.steps];
-  updatedSteps[position] = updatedBlock;
-
-  const updatedWorkout: Workout = {
-    ...workout,
-    steps: updatedSteps,
-  };
-
-  const updatedKrd: KRD = {
-    ...krd,
-    extensions: {
-      ...krd.extensions,
-      structured_workout: updatedWorkout,
-    },
-  };
+  const updatedWorkout = replaceBlockAtPosition(
+    workout,
+    position,
+    updatedBlock
+  );
+  const updatedKrd: KRD = buildKrdWithWorkout(krd, updatedWorkout);
 
   return {
     ...createUpdateWorkoutAction(updatedKrd, state),

--- a/packages/workout-spa-editor/src/store/actions/create-empty-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/create-empty-repetition-block-action.ts
@@ -8,18 +8,14 @@
  * - Automatically add a default step (5 minutes, open target, active intensity)
  */
 
-import type {
-  KRD,
-  RepetitionBlock,
-  Workout,
-  WorkoutStep,
-} from "../../types/krd";
-import { isWorkoutStep } from "../../types/krd";
+import type { KRD, RepetitionBlock, WorkoutStep } from "../../types/krd";
 import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
 import type { ItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
+import { buildKrdWithWorkout, extractStructuredWorkout } from "./_helpers";
+import { recalculateStepIndices } from "./recalculate-step-indices";
 
 /**
  * Default step template for new empty repetition blocks
@@ -29,14 +25,9 @@ import { createUpdateWorkoutAction } from "../workout-actions";
  */
 const DEFAULT_STEP: Omit<WorkoutStep, "stepIndex"> = {
   durationType: "time",
-  duration: {
-    type: "time",
-    seconds: 300, // 5 minutes
-  },
+  duration: { type: "time", seconds: 300 },
   targetType: "open",
-  target: {
-    type: "open",
-  },
+  target: { type: "open" },
   intensity: "active",
 };
 
@@ -53,60 +44,34 @@ export const createEmptyRepetitionBlockAction = (
   repeatCount: number,
   state: WorkoutState
 ): Partial<WorkoutState> => {
-  if (!krd.extensions?.structured_workout) {
-    return {};
-  }
-
-  // Validate inputs
+  const workout = extractStructuredWorkout(krd);
+  if (!workout) return {};
   if (repeatCount < 1) return {};
 
-  const workout = krd.extensions.structured_workout as Workout;
-
-  // Create default step with stepIndex 0 (within the block context) and a
-  // stable ItemId so focus / selection can reference it.
+  // Default step gets stepIndex 0 in-block plus a stable ItemId so
+  // focus / selection can reference it. Block and step ids both come
+  // from `defaultIdProvider()` so the in-memory ItemId contract is
+  // uniform across steps and blocks.
   const defaultStep: WorkoutStep & { id: string } = {
     ...DEFAULT_STEP,
     stepIndex: 0,
     id: defaultIdProvider(),
   };
-
-  // Block and nested step ids all come from `defaultIdProvider()` so the
-  // in-memory ItemId contract is uniform across steps and blocks.
   const repetitionBlock: RepetitionBlock = {
     id: defaultIdProvider(),
     repeatCount,
     steps: [defaultStep],
   };
 
-  // Add the repetition block at the end
+  // Append the new block, then recompute stepIndex across the whole
+  // workout so top-level WorkoutSteps stay contiguous.
   const newSteps = [...workout.steps, repetitionBlock];
+  const reindexedSteps = recalculateStepIndices(newSteps);
 
-  // Recalculate stepIndex for all WorkoutSteps
-  let currentIndex = 0;
-  const reindexedSteps = newSteps.map((step) => {
-    if (isWorkoutStep(step)) {
-      const reindexedStep = {
-        ...step,
-        stepIndex: currentIndex,
-      };
-      currentIndex++;
-      return reindexedStep;
-    }
-    return step;
-  });
-
-  const updatedWorkout = {
+  const updatedKrd: KRD = buildKrdWithWorkout(krd, {
     ...workout,
     steps: reindexedSteps,
-  };
-
-  const updatedKrd: KRD = {
-    ...krd,
-    extensions: {
-      ...krd.extensions,
-      structured_workout: updatedWorkout,
-    },
-  };
+  });
 
   return {
     ...createUpdateWorkoutAction(updatedKrd, state),

--- a/packages/workout-spa-editor/src/store/actions/delete-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-repetition-block-action.ts
@@ -11,82 +11,39 @@
  * - Update workout statistics after deletion
  */
 
-import type { KRD, Workout } from "../../types/krd";
+import type { KRD } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
 import type { UIWorkoutItem } from "../../types/krd-ui";
 import { nextAfterDelete } from "../focus-rules";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
+import { buildKrdWithWorkout, extractStructuredWorkout } from "./_helpers";
 
 /**
  * Deletes a repetition block and all its contained steps.
  *
- * This action uses the block's unique ID to locate and remove it, ensuring the
- * correct block is deleted even if blocks have been reordered via drag-and-drop.
- *
- * ## Process
- *
- * 1. **Locate block**: Uses `findBlockById()` to find the block by its unique ID
- * 2. **Remove block**: Filters out the block from the workout steps
- * 3. **Reindex steps**: Recalculates stepIndex for all remaining WorkoutSteps
- * 4. **Clear selections**: Removes any selections referencing deleted steps
- * 5. **Update history**: Adds the deletion to undo history for restoration
- *
- * ## Why ID-Based Deletion?
- *
- * Previously, blocks were deleted by array index, which caused bugs when:
- * - Blocks were reordered via drag-and-drop (visual order ≠ data order)
- * - Multiple rapid operations occurred (race conditions)
- * - Undo/redo operations changed block positions
- *
- * Using unique IDs ensures the correct block is always deleted.
- *
- * ## Undo Support
- *
- * The deleted block is stored in the undo history with:
- * - The complete block data (including all steps)
- * - Its original position in the workout
- * - A timestamp for the deletion
- *
- * This allows perfect restoration via Ctrl+Z / Cmd+Z.
+ * Locates the block by its unique ID (so drag-reorders, undo/redo and
+ * concurrent operations cannot misalign the index), removes it,
+ * reindexes the surviving top-level steps, records the deletion in
+ * undo history, and clears any selections that referenced the deleted
+ * subtree.
  *
  * @param krd - The current KRD workout data
  * @param blockId - The unique ID of the block to delete
  * @param state - The current workout state
  * @returns Partial state update with modified workout and cleared selections
- *
- * @example
- * ```typescript
- * // Delete a block by its ID
- * const newState = deleteRepetitionBlockAction(
- *   currentKrd,
- *   "block-1704123456789-x7k2m9p4q",
- *   currentState
- * );
- *
- * // The correct block is deleted, regardless of its position
- * // All remaining steps are reindexed sequentially
- * // Selections are cleared if they referenced deleted steps
- * ```
  */
 export const deleteRepetitionBlockAction = (
   krd: KRD,
   blockId: string,
   state: WorkoutState
 ): Partial<WorkoutState> => {
-  if (!krd.extensions?.structured_workout) {
-    return {};
-  }
+  const workout = extractStructuredWorkout(krd);
+  if (!workout) return {};
 
-  const workout = krd.extensions.structured_workout as Workout;
-
-  // Find block by ID
   const blockInfo = findBlockById(workout, blockId);
-
-  if (!blockInfo) {
-    return {};
-  }
+  if (!blockInfo) return {};
 
   const { block, position } = blockInfo;
 
@@ -100,13 +57,10 @@ export const deleteRepetitionBlockAction = (
     return step;
   });
 
-  const updatedKrd: KRD = {
-    ...krd,
-    extensions: {
-      ...krd.extensions,
-      structured_workout: { ...workout, steps: reindexedSteps },
-    },
-  };
+  const updatedKrd: KRD = buildKrdWithWorkout(krd, {
+    ...workout,
+    steps: reindexedSteps,
+  });
 
   // Track deleted block for undo. The block came from the in-memory
   // UIWorkout, so it carries a stable ItemId at runtime; re-assert the

--- a/packages/workout-spa-editor/src/store/actions/duplicate-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/duplicate-step-action.ts
@@ -4,29 +4,22 @@
  * Action for duplicating a workout step and inserting it after the original.
  */
 
-import type {
-  KRD,
-  RepetitionBlock,
-  Workout,
-  WorkoutStep,
-} from "../../types/krd";
+import type { KRD, RepetitionBlock, WorkoutStep } from "../../types/krd";
 import { isWorkoutStep } from "../../types/krd";
 import { createdItemTarget } from "../focus-rules";
 import { defaultIdProvider } from "../providers/id-provider";
 import type { ItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
+import { buildKrdWithWorkout, extractStructuredWorkout } from "./_helpers";
 
 export const duplicateStepAction = (
   krd: KRD,
   stepIndex: number,
   state: WorkoutState
 ): Partial<WorkoutState> => {
-  if (!krd.extensions?.structured_workout) {
-    return {};
-  }
-
-  const workout = krd.extensions.structured_workout as Workout;
+  const workout = extractStructuredWorkout(krd);
+  if (!workout) return {};
 
   // Find the step to duplicate
   const stepToDuplicate = workout.steps.find(
@@ -38,9 +31,7 @@ export const duplicateStepAction = (
     }
   ) as WorkoutStep | undefined;
 
-  if (!stepToDuplicate) {
-    return {};
-  }
+  if (!stepToDuplicate) return {};
 
   // Create a deep clone of the step and assign a fresh ItemId so focus /
   // selection can reference the duplicate distinctly from the original.
@@ -62,18 +53,10 @@ export const duplicateStepAction = (
     stepIndex: index,
   }));
 
-  const updatedWorkout = {
+  const updatedKrd: KRD = buildKrdWithWorkout(krd, {
     ...workout,
     steps: reindexedSteps,
-  };
-
-  const updatedKrd: KRD = {
-    ...krd,
-    extensions: {
-      ...krd.extensions,
-      structured_workout: updatedWorkout,
-    },
-  };
+  });
 
   return {
     ...createUpdateWorkoutAction(updatedKrd, state),

--- a/packages/workout-spa-editor/src/store/actions/edit-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/edit-repetition-block-action.ts
@@ -8,10 +8,15 @@
  * - Requirement 2.4: Use block ID for operations
  */
 
-import type { KRD, RepetitionBlock, Workout } from "../../types/krd";
+import type { KRD, RepetitionBlock } from "../../types/krd";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
+import {
+  buildKrdWithWorkout,
+  extractStructuredWorkout,
+  replaceBlockAtPosition,
+} from "./_helpers";
 
 /**
  * Updates the repeat count of a repetition block by its ID
@@ -28,22 +33,12 @@ export const editRepetitionBlockAction = (
   repeatCount: number,
   state: WorkoutState
 ): Partial<WorkoutState> => {
-  if (!krd.extensions?.structured_workout) {
-    return {};
-  }
+  const workout = extractStructuredWorkout(krd);
+  if (!workout) return {};
+  if (repeatCount < 1) return {};
 
-  if (repeatCount < 1) {
-    return {};
-  }
-
-  const workout = krd.extensions.structured_workout as Workout;
-
-  // Find block by ID
   const blockInfo = findBlockById(workout, blockId);
-
-  if (!blockInfo) {
-    return {};
-  }
+  if (!blockInfo) return {};
 
   const { position } = blockInfo;
 
@@ -52,21 +47,12 @@ export const editRepetitionBlockAction = (
     repeatCount,
   };
 
-  const updatedSteps = [...workout.steps];
-  updatedSteps[position] = updatedBlock;
-
-  const updatedWorkout: Workout = {
-    ...workout,
-    steps: updatedSteps,
-  };
-
-  const updatedKrd: KRD = {
-    ...krd,
-    extensions: {
-      ...krd.extensions,
-      structured_workout: updatedWorkout,
-    },
-  };
+  const updatedWorkout = replaceBlockAtPosition(
+    workout,
+    position,
+    updatedBlock
+  );
+  const updatedKrd: KRD = buildKrdWithWorkout(krd, updatedWorkout);
 
   return createUpdateWorkoutAction(updatedKrd, state);
 };

--- a/packages/workout-spa-editor/src/store/actions/ungroup-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/ungroup-repetition-block-action.ts
@@ -8,12 +8,13 @@
  * - Requirement 2.4: Use block ID for operations
  */
 
-import type { KRD, Workout } from "../../types/krd";
+import type { KRD } from "../../types/krd";
 import { createdItemTarget } from "../focus-rules";
 import type { ItemId } from "../providers/item-id";
 import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
+import { buildKrdWithWorkout, extractStructuredWorkout } from "./_helpers";
 import { recalculateStepIndices } from "./recalculate-step-indices";
 
 /**
@@ -29,46 +30,28 @@ export const ungroupRepetitionBlockAction = (
   blockId: string,
   state: WorkoutState
 ): Partial<WorkoutState> => {
-  if (!krd.extensions?.structured_workout) {
-    return {};
-  }
+  const workout = extractStructuredWorkout(krd);
+  if (!workout) return {};
 
-  const workout = krd.extensions.structured_workout as Workout;
-
-  // Find block by ID
   const blockInfo = findBlockById(workout, blockId);
-
-  if (!blockInfo) {
-    return {};
-  }
+  if (!blockInfo) return {};
 
   const { block, position } = blockInfo;
 
-  // Extract steps from the block
+  // Extract steps from the block, splice them in at the block's slot,
+  // then rebuild contiguous top-level stepIndex values.
   const extractedSteps = block.steps;
-
-  // Remove the block and insert the extracted steps at its position
   const newSteps = [
     ...workout.steps.slice(0, position),
     ...extractedSteps,
     ...workout.steps.slice(position + 1),
   ];
-
-  // Recalculate step indices for all steps
   const reindexedSteps = recalculateStepIndices(newSteps);
 
-  const updatedWorkout: Workout = {
+  const updatedKrd: KRD = buildKrdWithWorkout(krd, {
     ...workout,
     steps: reindexedSteps,
-  };
-
-  const updatedKrd: KRD = {
-    ...krd,
-    extensions: {
-      ...krd.extensions,
-      structured_workout: updatedWorkout,
-    },
-  };
+  });
 
   // Focus lands on the first formerly-child step at its new top-level
   // position (the same `position` the block occupied). Falls back to


### PR DESCRIPTION
## Summary

- Extract the three patterns that previously appeared verbatim across six repetition-block store actions into shared helpers under `packages/workout-spa-editor/src/store/actions/_helpers/`:
  - `extractStructuredWorkout(krd)` — the `structured_workout` null-guard early-return.
  - `buildKrdWithWorkout(krd, workout)` — the KRD-rebuild spread.
  - `replaceBlockAtPosition(workout, position, block)` — the single-position step-array swap used by `add-step` / `edit`.
- Public action API surface is unchanged; the six action files are now thinner and compose the helpers. Existing action tests pass without modification.
- New helpers ship with co-located unit tests following R-ItTitleShould + R-ItBodyAAA.

## LOC + duplication

| Action file                                       | Before | After |
| ------------------------------------------------- | -----: | ----: |
| `add-step-to-repetition-block-action.ts`          |     87 |    76 |
| `delete-repetition-block-action.ts`               |    139 |    93 |
| `ungroup-repetition-block-action.ts`              |     86 |    69 |
| `edit-repetition-block-action.ts`                 |     72 |    58 |
| `create-empty-repetition-block-action.ts`         |    117 |    82 |
| `duplicate-step-action.ts`                        |     82 |    65 |
| **total (in-scope)**                              |  **583** | **443** |

`pnpm duplication` (jscpd) duplication across the six in-scope files: **~94 LOC → ~33 LOC** (well under the §4.1 target of <50 LOC). Every action file stays ≤100 LOC.

## Test plan

- [x] `pnpm --filter @kaiord/workout-spa-editor test` (366 files / 3273 tests pass, no test changes)
- [x] `pnpm --filter @kaiord/workout-spa-editor build` (clean)
- [x] `pnpm --filter @kaiord/workout-spa-editor lint` (0 errors)
- [x] `pnpm test:scripts` (411 tests pass — R-DexieImport, R-PersistStateImport, R-AppDexieImport unaffected)
- [x] `pnpm -r build` (whole monorepo green)
- [x] `pnpm duplication` (in-scope dup down from ~94 LOC to ~33 LOC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)