### PR TITLE
refactor(spa-editor): split CalendarPage into hook + view (§4.3)

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/CalendarPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPage.tsx
@@ -1,156 +1,19 @@
 /**
- * Calendar week view, the editor's home page.
- *
- * Builds three per-day buckets (matched / solo plan / solo actual) by
- * joining the coaching activities, workouts, and matches live queries
- * once at the page level — DayColumn / CalendarWeekGrid then render
- * the buckets in the order spec'd by spa-calendar.
- *
- * Auto-match suggestions surface above the grid via `AutoMatchBanner`
- * when `useAutoMatchSuggestions` returns at least one undismissed pair
- * for the visible week. Accept persists a `SessionMatch` (source
- * `auto-suggestion`); Reject persists a per-pair dismissal.
- *
- * Coaching data flows through the generic CoachingSource registry —
- * this file has zero platform-specific imports.
+ * Calendar week view, the editor's home page. All orchestration lives
+ * in `useCalendarPage` (data plumbing) and `CalendarPageView` (render).
+ * This file is a thin adapter from the hook's discriminated `state` to
+ * either a `Redirect`, a skeleton, or the populated view.
  */
 
-import { useMemo, useState } from "react";
 import { Redirect } from "wouter";
 
-import type { MatchSuggestion } from "../../application/match-suggestion";
-import { useActiveProfileLive } from "../../hooks/use-active-profile-live";
-import { useAutoMatchBannerActions } from "../../hooks/use-auto-match-banner-actions";
-import { useAutoMatchSuggestions } from "../../hooks/use-auto-match-suggestions";
-import { useCoachingActivities } from "../../hooks/use-coaching-activities";
-import { useCoachingAutoSync } from "../../hooks/use-coaching-auto-sync";
-import { useMatchedSessions } from "../../hooks/use-matched-sessions";
-import { useSetCalendarDensity } from "../../hooks/use-set-calendar-density";
-import { useUserPreferences } from "../../hooks/use-user-preferences";
-import { ROUTE_HEADING_ATTR } from "../../routing/constants";
-import type { CoachingActivity } from "../../types/coaching-activity";
 import { CalendarSkeleton } from "../molecules/WorkoutCard/CalendarSkeleton";
-import { AutoMatchBanner } from "../organisms/AutoMatchBanner/AutoMatchBanner";
-import { buildCalendarBuckets, type CalendarBuckets } from "./calendar-buckets";
-import { CalendarDialogs } from "./CalendarDialogs";
-import { CalendarHeader } from "./CalendarHeader";
-import { CalendarWeekGrid } from "./CalendarWeekGrid";
-import { useCalendarState } from "./use-calendar-state";
-
-const viewportDefaultDensity = (): "compact" | "comfortable" =>
-  typeof window !== "undefined" && window.innerWidth >= 768
-    ? "compact"
-    : "comfortable";
+import { CalendarPageView } from "./CalendarPageView";
+import { useCalendarPage } from "./use-calendar-page";
 
 export default function CalendarPage() {
-  const s = useCalendarState();
-  const coaching = useCoachingActivities(s.data.days);
-  useCoachingAutoSync(coaching.syncSources, s.data.days[0]);
-  const [selectedActivity, setSelectedActivity] =
-    useState<CoachingActivity | null>(null);
-  const profileId = useActiveProfileLive()?.id ?? null;
-  const weekStart = s.data.days[0] ?? "";
-  const rawMatched = useMatchedSessions(profileId, s.data.days);
-  const suggestions = useAutoMatchSuggestions(profileId, weekStart);
-  const bannerActions = useAutoMatchBannerActions(profileId, weekStart);
-  const prefs = useUserPreferences({
-    profileId,
-    defaultDensity: viewportDefaultDensity(),
-  });
-  const buckets = useMemo(
-    () =>
-      buildCalendarBuckets({
-        days: s.data.days,
-        workoutsByDay: s.data.workoutsByDay,
-        coachingByDay: coaching.byDay,
-        matched: rawMatched ?? [],
-      }),
-    [s.data.days, s.data.workoutsByDay, coaching.byDay, rawMatched]
-  );
-  const handleDensityChange = useSetCalendarDensity(profileId);
-
-  if (!s.data.isValidWeek) return <Redirect to="/calendar" />;
-  if (s.data.hydration === "pending") return <CalendarSkeleton />;
-
-  return (
-    <CalendarPageView
-      s={s}
-      coaching={coaching}
-      buckets={buckets}
-      density={prefs?.calendarDensity}
-      onDensityChange={handleDensityChange}
-      selectedActivity={selectedActivity}
-      setSelectedActivity={setSelectedActivity}
-      suggestions={suggestions ?? []}
-      bannerActions={bannerActions}
-    />
-  );
-}
-
-type CalendarPageViewProps = {
-  s: ReturnType<typeof useCalendarState>;
-  coaching: ReturnType<typeof useCoachingActivities>;
-  buckets: CalendarBuckets;
-  density: "compact" | "comfortable" | undefined;
-  onDensityChange: (d: "compact" | "comfortable") => void;
-  selectedActivity: CoachingActivity | null;
-  setSelectedActivity: (a: CoachingActivity | null) => void;
-  suggestions: MatchSuggestion[];
-  bannerActions: {
-    onAccept: (s: MatchSuggestion) => Promise<void>;
-    onReject: (s: MatchSuggestion) => Promise<void>;
-  };
-};
-
-function CalendarPageView({
-  s,
-  coaching,
-  buckets,
-  density,
-  onDensityChange,
-  selectedActivity,
-  setSelectedActivity,
-  suggestions,
-  bannerActions,
-}: CalendarPageViewProps) {
-  return (
-    <div className="space-y-4" data-testid="calendar-page">
-      <h1 tabIndex={-1} {...{ [ROUTE_HEADING_ATTR]: "" }} className="sr-only">
-        Calendar
-      </h1>
-      <CalendarHeader
-        state={s}
-        coaching={coaching}
-        density={density}
-        onDensityChange={onDensityChange}
-      />
-      {suggestions.length > 0 && (
-        <AutoMatchBanner
-          suggestions={suggestions}
-          onAccept={bannerActions.onAccept}
-          onReject={bannerActions.onReject}
-        />
-      )}
-      <CalendarWeekGrid
-        days={s.data.days}
-        matchedByDay={buckets.matchedByDay}
-        soloPlansByDay={buckets.soloPlansByDay}
-        soloActualsByDay={buckets.soloActualsByDay}
-        todayDate={new Date().toISOString().slice(0, 10)}
-        density={density}
-        onWorkoutClick={s.handleWorkoutClick}
-        onEmptyDayClick={s.setEmptyDayDate}
-        onActivityClick={setSelectedActivity}
-      />
-      <CalendarDialogs
-        selectedWorkout={s.selectedWorkout}
-        emptyDayDate={s.emptyDayDate}
-        selectedCoachingActivity={selectedActivity}
-        onCloseWorkout={() => s.setSelectedWorkout(null)}
-        onCloseDay={() => s.setEmptyDayDate(null)}
-        onCloseCoaching={() => setSelectedActivity(null)}
-        expandActivity={coaching.expandActivity}
-      />
-    </div>
-  );
+  const result = useCalendarPage();
+  if (result.state === "redirect") return <Redirect to="/calendar" />;
+  if (result.state === "skeleton") return <CalendarSkeleton />;
+  return <CalendarPageView {...result} />;
 }

--- a/packages/workout-spa-editor/src/components/pages/CalendarPageView.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPageView.tsx
@@ -1,0 +1,65 @@
+/**
+ * Pure render component for `CalendarPage`. Receives the resolved
+ * `ready` state from `useCalendarPage` and emits the JSX tree —
+ * no data fetching, no side effects, no early-return branching.
+ */
+
+import { ROUTE_HEADING_ATTR } from "../../routing/constants";
+import { AutoMatchBanner } from "../organisms/AutoMatchBanner/AutoMatchBanner";
+import { CalendarDialogs } from "./CalendarDialogs";
+import { CalendarHeader } from "./CalendarHeader";
+import { CalendarWeekGrid } from "./CalendarWeekGrid";
+import type { CalendarPageReadyState } from "./use-calendar-page";
+
+export function CalendarPageView({
+  s,
+  coaching,
+  buckets,
+  density,
+  onDensityChange,
+  selectedActivity,
+  setSelectedActivity,
+  suggestions,
+  bannerActions,
+}: CalendarPageReadyState) {
+  return (
+    <div className="space-y-4" data-testid="calendar-page">
+      <h1 tabIndex={-1} {...{ [ROUTE_HEADING_ATTR]: "" }} className="sr-only">
+        Calendar
+      </h1>
+      <CalendarHeader
+        state={s}
+        coaching={coaching}
+        density={density}
+        onDensityChange={onDensityChange}
+      />
+      {suggestions.length > 0 && (
+        <AutoMatchBanner
+          suggestions={suggestions}
+          onAccept={bannerActions.onAccept}
+          onReject={bannerActions.onReject}
+        />
+      )}
+      <CalendarWeekGrid
+        days={s.data.days}
+        matchedByDay={buckets.matchedByDay}
+        soloPlansByDay={buckets.soloPlansByDay}
+        soloActualsByDay={buckets.soloActualsByDay}
+        todayDate={new Date().toISOString().slice(0, 10)}
+        density={density}
+        onWorkoutClick={s.handleWorkoutClick}
+        onEmptyDayClick={s.setEmptyDayDate}
+        onActivityClick={setSelectedActivity}
+      />
+      <CalendarDialogs
+        selectedWorkout={s.selectedWorkout}
+        emptyDayDate={s.emptyDayDate}
+        selectedCoachingActivity={selectedActivity}
+        onCloseWorkout={() => s.setSelectedWorkout(null)}
+        onCloseDay={() => s.setEmptyDayDate(null)}
+        onCloseCoaching={() => setSelectedActivity(null)}
+        expandActivity={coaching.expandActivity}
+      />
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-page.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-page.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Co-located tests for `useCalendarPage`.
+ *
+ * Exercises the three branches the page UI relies on:
+ *  - positive flow → `state: "ready"` with hydrated buckets and density
+ *  - auto-match suggestion → `suggestions[0]` surfaces the seeded pair
+ *  - no active profile → `state: "ready"` with empty suggestions and
+ *    no crash from the downstream live-query joins
+ *
+ * The week id is fixed (`2026-W15`, Mon 2026-04-06 → Sun 2026-04-12)
+ * so seeded rows always fall inside the visible week regardless of the
+ * test machine's clock.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Route, Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+
+import { db } from "../../adapters/dexie/dexie-database";
+import { GarminBridgeProvider } from "../../contexts";
+import { CoachingRegistryProvider } from "../../contexts/coaching-registry-context";
+import { PersistenceProvider } from "../../contexts/persistence-context";
+import { createInMemoryPersistence } from "../../test-utils/in-memory-persistence";
+import type { WorkoutRecord } from "../../types/calendar-record";
+import type { CoachingActivityRecord } from "../../types/coaching-activity-record";
+import type { Profile } from "../../types/profile";
+import { useCalendarPage } from "./use-calendar-page";
+
+const PROFILE_ID = "00000000-0000-4000-8000-0000000000a1";
+const WEEK_ID = "2026-W15";
+const MONDAY = "2026-04-06";
+const ONE_HOUR_SECONDS = 3600;
+
+const makeProfile = (id: string = PROFILE_ID): Profile => ({
+  id,
+  name: "Tester",
+  sportZones: {},
+  linkedAccounts: [],
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-01T00:00:00.000Z",
+});
+
+const seedActivity = (date: string): CoachingActivityRecord => ({
+  id: `${PROFILE_ID}:train2go:1`,
+  profileId: PROFILE_ID,
+  source: "train2go",
+  sourceId: "1",
+  date,
+  sport: "cycling",
+  title: "FTP test",
+  duration: "60 min",
+  status: "pending",
+  fetchedAt: "2026-04-05T10:00:00.000Z",
+});
+
+const seedWorkout = (
+  date: string,
+  durationSeconds: number = ONE_HOUR_SECONDS,
+  id = "w-1"
+): WorkoutRecord =>
+  ({
+    id,
+    date,
+    sport: "cycling",
+    source: "manual",
+    state: "ready",
+    raw: {
+      title: "FTP",
+      description: "",
+      comments: [],
+      distance: null,
+      duration: { value: durationSeconds, unit: "s" },
+      prescribedRpe: null,
+      rawHash: "h1",
+    },
+    createdAt: `${date}T08:00:00.000Z`,
+    updatedAt: `${date}T08:00:00.000Z`,
+  }) as unknown as WorkoutRecord;
+
+const setActiveProfile = async (profile: Profile | null) => {
+  if (profile) {
+    await db.table("profiles").put(profile);
+    await db.table("meta").put({ key: "activeProfileId", value: profile.id });
+  } else {
+    await db.table("meta").delete("activeProfileId");
+  }
+};
+
+const clearAll = () =>
+  Promise.all([
+    db.table("workouts").clear(),
+    db.table("coachingActivities").clear(),
+    db.table("sessionMatches").clear(),
+    db.table("autoMatchDismissals").clear(),
+    db.table("profiles").clear(),
+    db.table("meta").clear(),
+    db.table("userPreferences").clear(),
+  ]);
+
+const wrap = (children: ReactNode) => {
+  const { hook } = memoryLocation({ path: `/calendar/${WEEK_ID}` });
+  return (
+    <PersistenceProvider persistence={createInMemoryPersistence()}>
+      <GarminBridgeProvider>
+        <CoachingRegistryProvider factories={[]}>
+          <Router hook={hook}>
+            <Route path="/calendar/:weekId?">{children}</Route>
+          </Router>
+        </CoachingRegistryProvider>
+      </GarminBridgeProvider>
+    </PersistenceProvider>
+  );
+};
+
+describe("useCalendarPage", () => {
+  beforeEach(clearAll);
+  afterEach(clearAll);
+
+  it("should resolve to a ready state with hydrated buckets for the visible week", async () => {
+    // Arrange
+    await setActiveProfile(makeProfile());
+    await db
+      .table("workouts")
+      .put(seedWorkout(MONDAY, ONE_HOUR_SECONDS, "w-mon"));
+
+    // Act
+    const { result } = renderHook(() => useCalendarPage(), {
+      wrapper: ({ children }) => wrap(children),
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.state).toBe("ready");
+    });
+    if (result.current.state !== "ready") throw new Error("not ready");
+    expect(result.current.s.data.days[0]).toBe(MONDAY);
+    expect(result.current.buckets.soloActualsByDay[MONDAY]).toHaveLength(1);
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it("should surface an auto-match suggestion when an unmatched activity+workout pair exists", async () => {
+    // Arrange
+    await setActiveProfile(makeProfile());
+    await db.table("coachingActivities").put(seedActivity(MONDAY));
+    await db
+      .table("workouts")
+      .put(seedWorkout(MONDAY, ONE_HOUR_SECONDS, "w-1"));
+
+    // Act
+    const { result } = renderHook(() => useCalendarPage(), {
+      wrapper: ({ children }) => wrap(children),
+    });
+
+    // Assert
+    await waitFor(() => {
+      if (result.current.state !== "ready") throw new Error("not ready yet");
+      expect(result.current.suggestions).toHaveLength(1);
+    });
+    if (result.current.state !== "ready") throw new Error("not ready");
+    expect(result.current.suggestions[0]!.activityId).toBe(
+      `${PROFILE_ID}:train2go:1`
+    );
+    expect(result.current.suggestions[0]!.workoutId).toBe("w-1");
+  });
+
+  it("should fall back to a ready state with no suggestions when no profile is active", async () => {
+    // Arrange
+    await setActiveProfile(null);
+    await db
+      .table("workouts")
+      .put(seedWorkout(MONDAY, ONE_HOUR_SECONDS, "w-mon"));
+
+    // Act
+    const { result } = renderHook(() => useCalendarPage(), {
+      wrapper: ({ children }) => wrap(children),
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.state).toBe("ready");
+    });
+    if (result.current.state !== "ready") throw new Error("not ready");
+    expect(result.current.suggestions).toEqual([]);
+    expect(result.current.density).toBeUndefined();
+    expect(result.current.buckets.soloActualsByDay[MONDAY]).toHaveLength(1);
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-page.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-page.ts
@@ -1,0 +1,97 @@
+/**
+ * useCalendarPage — orchestrates the data plumbing for `CalendarPage`.
+ *
+ * Joins the calendar state (week + handlers), coaching activity registry,
+ * matched / suggested sessions, and per-profile UI preferences into a
+ * single discriminated `state` so the view component is a pure render.
+ *
+ * The early-return states (`"redirect"` / `"skeleton"`) are surfaced as
+ * variants of the same union — the page does not branch on hooks, only
+ * on the resulting `state`. When `profileId` is null, suggestions and
+ * banner actions still resolve (the underlying hooks gate on the same
+ * id), so the view falls back to a profile-less calendar without crashing.
+ */
+
+import { useMemo, useState } from "react";
+
+import type { MatchSuggestion } from "../../application/match-suggestion";
+import { useActiveProfileLive } from "../../hooks/use-active-profile-live";
+import {
+  type AutoMatchBannerActions,
+  useAutoMatchBannerActions,
+} from "../../hooks/use-auto-match-banner-actions";
+import { useAutoMatchSuggestions } from "../../hooks/use-auto-match-suggestions";
+import { useCoachingActivities } from "../../hooks/use-coaching-activities";
+import { useCoachingAutoSync } from "../../hooks/use-coaching-auto-sync";
+import { useMatchedSessions } from "../../hooks/use-matched-sessions";
+import { useSetCalendarDensity } from "../../hooks/use-set-calendar-density";
+import { useUserPreferences } from "../../hooks/use-user-preferences";
+import type { CoachingActivity } from "../../types/coaching-activity";
+import { buildCalendarBuckets, type CalendarBuckets } from "./calendar-buckets";
+import { useCalendarState } from "./use-calendar-state";
+
+const viewportDefaultDensity = (): "compact" | "comfortable" =>
+  typeof window !== "undefined" && window.innerWidth >= 768
+    ? "compact"
+    : "comfortable";
+
+export type CalendarPageReadyState = {
+  state: "ready";
+  s: ReturnType<typeof useCalendarState>;
+  coaching: ReturnType<typeof useCoachingActivities>;
+  buckets: CalendarBuckets;
+  density: "compact" | "comfortable" | undefined;
+  onDensityChange: (d: "compact" | "comfortable") => void;
+  selectedActivity: CoachingActivity | null;
+  setSelectedActivity: (a: CoachingActivity | null) => void;
+  suggestions: MatchSuggestion[];
+  bannerActions: AutoMatchBannerActions;
+};
+
+export type CalendarPageState =
+  | { state: "redirect" }
+  | { state: "skeleton" }
+  | CalendarPageReadyState;
+
+export function useCalendarPage(): CalendarPageState {
+  const s = useCalendarState();
+  const coaching = useCoachingActivities(s.data.days);
+  useCoachingAutoSync(coaching.syncSources, s.data.days[0]);
+  const [selectedActivity, setSelectedActivity] =
+    useState<CoachingActivity | null>(null);
+  const profileId = useActiveProfileLive()?.id ?? null;
+  const weekStart = s.data.days[0] ?? "";
+  const rawMatched = useMatchedSessions(profileId, s.data.days);
+  const suggestions = useAutoMatchSuggestions(profileId, weekStart);
+  const bannerActions = useAutoMatchBannerActions(profileId, weekStart);
+  const prefs = useUserPreferences({
+    profileId,
+    defaultDensity: viewportDefaultDensity(),
+  });
+  const buckets = useMemo(
+    () =>
+      buildCalendarBuckets({
+        days: s.data.days,
+        workoutsByDay: s.data.workoutsByDay,
+        coachingByDay: coaching.byDay,
+        matched: rawMatched ?? [],
+      }),
+    [s.data.days, s.data.workoutsByDay, coaching.byDay, rawMatched]
+  );
+  const onDensityChange = useSetCalendarDensity(profileId);
+
+  if (!s.data.isValidWeek) return { state: "redirect" };
+  if (s.data.hydration === "pending") return { state: "skeleton" };
+  return {
+    state: "ready",
+    s,
+    coaching,
+    buckets,
+    density: prefs?.calendarDensity,
+    onDensityChange,
+    selectedActivity,
+    setSelectedActivity,
+    suggestions: suggestions ?? [],
+    bannerActions,
+  };
+}


### PR DESCRIPTION
## Summary

Implements §4.3 of `repo-quality-maintenance-waves`: splits the
156-LOC `CalendarPage.tsx` (which orchestrates 10+ data hooks) into
three focused files so the page itself reads as a thin adapter.

- `CalendarPage.tsx` (19 LOC): adapter mapping the hook's
  discriminated `state` to either `<Redirect>`, the skeleton, or
  `<CalendarPageView>`.
- `use-calendar-page.ts` (97 LOC): the new coordinating hook.
  Joins calendar state, coaching activities, matched / suggested
  sessions, user preferences, and the auto-match banner actions
  into a single `CalendarPageState` discriminator
  (`"redirect" | "skeleton" | "ready"`).
- `CalendarPageView.tsx` (65 LOC): pure render component that
  consumes `CalendarPageReadyState`. No data fetching, no side
  effects, no early-return branching.

Behavior is preserved: identical hook ordering, identical
`buildCalendarBuckets` inputs, identical `AutoMatchBanner` gating
(`suggestions.length > 0`), and identical fallback to a profile-less
calendar when no `Profile` is active.

## Test plan

- [x] New `use-calendar-page.test.tsx` covers the three required
      scenarios: positive flow → `ready`, auto-match suggestion
      surfaces in `result.current.suggestions`, no-active-profile
      fallback (`ready` with empty suggestions and undefined density).
- [x] Existing `CalendarPage.test.tsx` (6 tests) passes unmodified —
      behavior equivalence checked.
- [x] Full SPA editor unit suite green: `pnpm --filter @kaiord/workout-spa-editor test` →
      370 files / 3326 tests passed.
- [x] SPA editor build green: `pnpm --filter @kaiord/workout-spa-editor build`.
- [x] Calendar-related e2e specs green (chromium, serial workers):
      `calendar-empty-states`, `calendar-navigation`, `calendar-workouts`,
      `calendar-batch`, `calendar-performance`, `library-calendar`,
      `coaching-dialog-train2go`.
- [x] `pnpm test:scripts` (411 tests) passes — AAA + title-should
      guards green for the new test file.
- [x] Lint + Prettier clean for changed files.
- [x] File size constraints satisfied:
      `CalendarPage.tsx` 19 LOC ≤ 60,
      `use-calendar-page.ts` 97 LOC ≤ 100.

## Refs

- OpenSpec change: `openspec/changes/repo-quality-maintenance-waves`
- Task: `tasks.md` → `## §4.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)