### PR TITLE
refactor(spa-editor): right-size dexie/save-workout/profile-storage/handlers (§4.5)

### DIFF
--- a/openspec/changes/repo-quality-maintenance-waves/tasks.md
+++ b/openspec/changes/repo-quality-maintenance-waves/tasks.md
@@ -163,7 +163,7 @@ Tasks: 0 completed, 0 deferred.
 
 ## §4.5 Right-size remaining files over budget
 
-- [ ] §4.5
+- [x] §4.5
   - **Agent:** complexity-reducer
   - **Scope:** `packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts` (140 LOC), `src/utils/save-workout.ts` (123 LOC), `src/utils/profile-storage.ts` (114 LOC), `src/components/pages/WorkoutSection/use-repetition-block-handlers.tsx` (118 LOC)
   - **Accept:** every file in scope ≤ 100 LOC; every function ≤ 40 LOC (60 for components); existing tests still pass; `R-DexieImport`, `R-PersistStateImport`, `R-AppDexieImport` still satisfied

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
@@ -7,12 +7,7 @@
 
 import Dexie from "dexie";
 
-import {
-  applyV8Upgrade,
-  applyV9Upgrade,
-  backfillBridgeSnapshotState,
-  backfillUsageRow,
-} from "./dexie-migrations";
+import { registerKaiordVersions } from "./register-kaiord-versions";
 
 export {
   backfillBridgeSnapshotState,
@@ -20,115 +15,10 @@ export {
   makeBackfillAiProviderCreatedAt,
 } from "./dexie-migrations";
 
-const CORE_V1 = {
-  workouts: "id, date, [date+state], [source+sourceId], sport, *tags",
-  templates: "id, sport, *tags",
-  profiles: "id",
-  aiProviders: "id",
-  syncState: "source",
-  usage: "yearMonth",
-  meta: "key",
-};
-const CORE_V2 = { ...CORE_V1, bridges: "extensionId, status, lastSeen" };
-const CORE_V4 = {
-  ...CORE_V2,
-  coachingActivities:
-    "id, [profileId+date], [profileId+source+sourceId], [profileId+source]",
-  coachingSyncState: "[source+profileId], source, profileId",
-};
-const CORE_V5 = {
-  ...CORE_V4,
-  // PK is `id` (nanoid). Indexes support all spec-mandated queries:
-  //   - [profileId+coachingActivityId] / [profileId+workoutId]: uniqueness checks
-  //   - [profileId+date]: weekly listByProfileAndWeek
-  //   - coachingActivityId / workoutId: cascade hooks
-  //   - profileId: profile-delete cascade
-  sessionMatches:
-    "id, [profileId+coachingActivityId], [profileId+workoutId], [profileId+date], coachingActivityId, workoutId, profileId",
-  // PK is `profileId` (one row per profile, lazy creation).
-  userPreferences: "profileId",
-  // PK is composite `[profileId+weekStart]`; index on profileId for cascade.
-  autoMatchDismissals: "[profileId+weekStart], profileId",
-};
-// v8 — AI provider insertion-order index. `createdAt` becomes a Dexie
-// index so the repository's getAll can `orderBy("createdAt")` cheaply.
-// PK stays on `id`; the index is additive.
-const CORE_V8 = { ...CORE_V5, aiProviders: "id, createdAt" };
-
-const backfillLinkedAccounts = (row: Record<string, unknown>): void => {
-  if (!Array.isArray(row.linkedAccounts)) row.linkedAccounts = [];
-};
-
 export class KaiordDatabase extends Dexie {
   constructor(name = "kaiord-spa") {
     super(name);
-    this.version(1).stores(CORE_V1);
-    this.version(2).stores(CORE_V2);
-    this.version(3)
-      .stores(CORE_V2)
-      .upgrade(async (tx) => {
-        await tx.table("usage").toCollection().modify(backfillUsageRow);
-      });
-    // v4 — coaching integration. Bridge-discovery syncState is byte-
-    // identically unchanged; coachingActivities + coachingSyncState are
-    // new; existing profiles are backfilled with linkedAccounts: [].
-    this.version(4)
-      .stores(CORE_V4)
-      .upgrade(async (tx) => {
-        await tx
-          .table("profiles")
-          .toCollection()
-          .modify(backfillLinkedAccounts);
-      });
-    // v5 — session-match + user-preferences + auto-match-dismissals.
-    // All new tables are empty on first load; no existing rows are mutated.
-    // Forward-only: opening an older bundle against a v5 DB raises VersionError.
-    this.version(5).stores(CORE_V5);
-    // v6 — bridge profile-snapshot push: backfills `pendingClear: false`
-    // and `lastSuccessfulFingerprint: null` on existing bridge rows so
-    // the snapshot pusher's de-dup and right-to-be-forgotten paths can
-    // assume well-defined state. Stores config is unchanged (the new
-    // fields are non-indexed); the upgrade only touches data.
-    this.version(6)
-      .stores(CORE_V5)
-      .upgrade(async (tx) => {
-        await tx
-          .table("bridges")
-          .toCollection()
-          .modify(backfillBridgeSnapshotState);
-      });
-    // v7 — autoMatchDismissals row shape switched from a single
-    // `dismissedAt` timestamp to a per-pair `dismissedPairs: Array<{
-    // activityId, workoutId, dismissedAt }>` (per design D15 of
-    // calendar-coaching-redesign-completion). The table is UX-state
-    // cache, not user data, so the migration clears it forward-only —
-    // simpler than a row-by-row reshape and avoids carrying any
-    // legacy code path in the adapter. Users see the banner re-surface
-    // once after upgrade for any week where they had previously
-    // dismissed it; subsequent dismissals are recorded in the new
-    // shape.
-    this.version(7)
-      .stores(CORE_V5)
-      .upgrade(async (tx) => {
-        await tx.table("autoMatchDismissals").clear();
-      });
-    // v8 — AI provider insertion-order. Adds a `createdAt` index on
-    // aiProviders and backfills the field on legacy rows so getAll()'s
-    // orderBy is stable. Without this, providers were ordered by their
-    // randomly-assigned UUIDs — a deterministic but probabilistic flake
-    // visible to users (selector reorders) and to E2E tests.
-    this.version(8).stores(CORE_V8).upgrade(applyV8Upgrade);
-    // v9 — zone-method-aware reconcile prep
-    // (zones-method-aware-reconcile change). Stores config is unchanged;
-    // the upgrade only mutates row data:
-    //   - Normalizes `method = "manual"` (introduced by the prior
-    //     train2go-zones-sync-full-bands change) to `"custom"`.
-    //   - Conservatively reclassifies `method = "custom"` + clearly-
-    //     edited zones to `method = "user"` so the new classifier
-    //     correctly emits per-band conflicts on user-customized tables.
-    // `lastSyncedZonesSnapshot` stays absent for migrated profiles —
-    // next sync establishes the baseline.
-    this.version(9).stores(CORE_V8).upgrade(applyV9Upgrade);
+    registerKaiordVersions(this);
   }
 }
 

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-schemas.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-schemas.ts
@@ -1,0 +1,54 @@
+/**
+ * Dexie Schema Definitions
+ *
+ * Per-version `stores()` configs for the Kaiord IndexedDB schema.
+ * Co-located with `dexie-database.ts` but split out so the database
+ * class stays under the per-file line cap.
+ */
+
+const CORE_V1 = {
+  workouts: "id, date, [date+state], [source+sourceId], sport, *tags",
+  templates: "id, sport, *tags",
+  profiles: "id",
+  aiProviders: "id",
+  syncState: "source",
+  usage: "yearMonth",
+  meta: "key",
+};
+const CORE_V2 = { ...CORE_V1, bridges: "extensionId, status, lastSeen" };
+const CORE_V4 = {
+  ...CORE_V2,
+  coachingActivities:
+    "id, [profileId+date], [profileId+source+sourceId], [profileId+source]",
+  coachingSyncState: "[source+profileId], source, profileId",
+};
+const CORE_V5 = {
+  ...CORE_V4,
+  // PK is `id` (nanoid). Indexes support all spec-mandated queries:
+  //   - [profileId+coachingActivityId] / [profileId+workoutId]: uniqueness
+  //   - [profileId+date]: weekly listByProfileAndWeek
+  //   - coachingActivityId / workoutId: cascade hooks
+  //   - profileId: profile-delete cascade
+  sessionMatches:
+    "id, [profileId+coachingActivityId], [profileId+workoutId], [profileId+date], coachingActivityId, workoutId, profileId",
+  // PK is `profileId` (one row per profile, lazy creation).
+  userPreferences: "profileId",
+  // PK is composite `[profileId+weekStart]`; index on profileId for cascade.
+  autoMatchDismissals: "[profileId+weekStart], profileId",
+};
+// v8 — AI provider insertion-order index. `createdAt` becomes a Dexie
+// index so the repository's getAll can `orderBy("createdAt")` cheaply.
+const CORE_V8 = { ...CORE_V5, aiProviders: "id, createdAt" };
+
+export const SCHEMAS = {
+  v1: CORE_V1,
+  v2: CORE_V2,
+  v4: CORE_V4,
+  v5: CORE_V5,
+  v8: CORE_V8,
+} as const;
+
+/** Backfills `linkedAccounts: []` on profile rows missing the field. */
+export const backfillLinkedAccounts = (row: Record<string, unknown>): void => {
+  if (!Array.isArray(row.linkedAccounts)) row.linkedAccounts = [];
+};

--- a/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions.ts
@@ -1,0 +1,79 @@
+/**
+ * Kaiord Dexie Version Registration
+ *
+ * Wires every schema version + upgrade onto a Dexie instance. Extracted
+ * from `KaiordDatabase` so the constructor stays under the per-function
+ * line cap. See per-version comments inline for migration intent and
+ * forward-only invariants.
+ */
+
+import type Dexie from "dexie";
+
+import {
+  applyV8Upgrade,
+  applyV9Upgrade,
+  backfillBridgeSnapshotState,
+  backfillUsageRow,
+} from "./dexie-migrations";
+import { backfillLinkedAccounts, SCHEMAS } from "./dexie-schemas";
+
+// Narrowed handle: only `version()` is needed and Dexie's full surface
+// causes "Type instantiation is excessively deep" when passed as a
+// param across module boundaries. The runtime value is always a
+// `KaiordDatabase`/`Dexie` instance.
+type DexieVersionHost = Pick<Dexie, "version">;
+
+const registerV1ToV3 = (db: DexieVersionHost): void => {
+  db.version(1).stores(SCHEMAS.v1);
+  db.version(2).stores(SCHEMAS.v2);
+  db.version(3)
+    .stores(SCHEMAS.v2)
+    .upgrade(async (tx) => {
+      await tx.table("usage").toCollection().modify(backfillUsageRow);
+    });
+};
+
+const registerV4ToV6 = (db: DexieVersionHost): void => {
+  // v4 — coaching integration. New tables; existing profiles backfilled
+  // with linkedAccounts: [].
+  db.version(4)
+    .stores(SCHEMAS.v4)
+    .upgrade(async (tx) => {
+      await tx.table("profiles").toCollection().modify(backfillLinkedAccounts);
+    });
+  // v5 — session-match + user-preferences + auto-match-dismissals.
+  // Forward-only; new tables empty on first load.
+  db.version(5).stores(SCHEMAS.v5);
+  // v6 — bridge profile-snapshot push: backfills snapshot-pusher state
+  // so de-dup and right-to-be-forgotten paths have well-defined data.
+  db.version(6)
+    .stores(SCHEMAS.v5)
+    .upgrade(async (tx) => {
+      await tx
+        .table("bridges")
+        .toCollection()
+        .modify(backfillBridgeSnapshotState);
+    });
+};
+
+const registerV7ToV9 = (db: DexieVersionHost): void => {
+  // v7 — autoMatchDismissals reshape (D15 of calendar-coaching-redesign).
+  // UX-state cache, not user data: cleared forward-only rather than
+  // row-by-row reshaped.
+  db.version(7)
+    .stores(SCHEMAS.v5)
+    .upgrade(async (tx) => {
+      await tx.table("autoMatchDismissals").clear();
+    });
+  // v8 — AI provider insertion-order. Adds `createdAt` index +
+  // backfills legacy rows so getAll() orderBy is stable.
+  db.version(8).stores(SCHEMAS.v8).upgrade(applyV8Upgrade);
+  // v9 — zone-method-aware reconcile prep (data-only upgrade).
+  db.version(9).stores(SCHEMAS.v8).upgrade(applyV9Upgrade);
+};
+
+export const registerKaiordVersions = (db: DexieVersionHost): void => {
+  registerV1ToV3(db);
+  registerV4ToV6(db);
+  registerV7ToV9(db);
+};

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-repetition-block-handlers.helpers.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-repetition-block-handlers.helpers.tsx
@@ -1,0 +1,90 @@
+import { useCallback } from "react";
+
+import { useToastContext } from "../../../contexts/ToastContext";
+import { findById } from "../../../store/find-by-id";
+import {
+  useDeleteRepetitionBlock,
+  useShowConfirmationModal,
+  useUndoDelete,
+} from "../../../store/workout-store-selectors";
+import type { Workout } from "../../../types/krd";
+import { executeDeleteWithToast } from "./delete-block-with-toast";
+
+/**
+ * Resolve the selected ids — now stable ItemIds — to their main-list
+ * array positions. Only top-level steps are candidates for wrapping into
+ * a repetition block (nested-step / block selections are ignored).
+ */
+export function extractStepIndices(
+  ids: readonly string[],
+  workout: Workout | undefined
+): Array<number> {
+  if (!workout) return [];
+  return ids
+    .map((id) => {
+      const found = findById(workout, id);
+      return found?.kind === "step" ? found.index : null;
+    })
+    .filter((i): i is number => i !== null);
+}
+
+export function useDeleteWithConfirmation() {
+  const deleteAction = useDeleteRepetitionBlock();
+  const undoDelete = useUndoDelete();
+  const showModal = useShowConfirmationModal();
+  const { toast } = useToastContext();
+
+  return useCallback(
+    (blockId: string) => {
+      showModal({
+        title: "Delete Repetition Block",
+        message:
+          "Are you sure you want to delete this repetition block? This action can be undone.",
+        confirmLabel: "Delete",
+        cancelLabel: "Cancel",
+        variant: "destructive",
+        onConfirm: () => {
+          executeDeleteWithToast(blockId, deleteAction, toast, undoDelete);
+        },
+      });
+    },
+    [deleteAction, toast, undoDelete, showModal]
+  );
+}
+
+const MIN_STEPS_FOR_BLOCK = 2;
+
+export type ConfirmCreateBlockDeps = {
+  selectedStepIds: ReadonlyArray<string>;
+  workout: Workout | undefined;
+  createRepetitionBlock: (indices: Array<number>, repeatCount: number) => void;
+  createEmptyBlock: (repeatCount: number) => void;
+  clearSelection: () => void;
+  closeDialog: () => void;
+};
+
+/**
+ * Build the create-repetition-block confirm handler. Pure factory: the
+ * caller wires deps from the hook scope; the returned function is what
+ * the dialog's `onConfirm` invokes. Splitting this out keeps
+ * `useRepetitionBlockHandlers` under the per-function line cap.
+ */
+export const buildHandleConfirmCreateBlock =
+  (deps: ConfirmCreateBlockDeps) =>
+  (repeatCount: number): void => {
+    const { selectedStepIds, workout, closeDialog } = deps;
+    // No workout but a selection exists — invariant broken; close the
+    // dialog rather than silently swallowing the user's selection.
+    if (!workout && selectedStepIds.length > 0) {
+      closeDialog();
+      return;
+    }
+    const indices = extractStepIndices(selectedStepIds, workout);
+    if (indices.length >= MIN_STEPS_FOR_BLOCK) {
+      deps.createRepetitionBlock(indices, repeatCount);
+      deps.clearSelection();
+    } else {
+      deps.createEmptyBlock(repeatCount);
+    }
+    closeDialog();
+  };

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-repetition-block-handlers.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-repetition-block-handlers.tsx
@@ -1,7 +1,3 @@
-import { useCallback } from "react";
-
-import { useToastContext } from "../../../contexts/ToastContext";
-import { findById } from "../../../store/find-by-id";
 import {
   useAddStepToRepetitionBlock,
   useClearStepSelection,
@@ -10,59 +6,17 @@ import {
   useCreateEmptyRepetitionBlock,
   useCreateRepetitionBlock,
   useCurrentWorkout,
-  useDeleteRepetitionBlock,
   useDuplicateStepInRepetitionBlock,
   useEditRepetitionBlock,
   useOpenCreateBlockDialog,
   useSelectedStepIds,
-  useShowConfirmationModal,
-  useUndoDelete,
   useUngroupRepetitionBlock,
 } from "../../../store/workout-store-selectors";
 import type { Workout } from "../../../types/krd";
-import { executeDeleteWithToast } from "./delete-block-with-toast";
-
-/**
- * Resolve the selected ids — now stable ItemIds — to their main-list
- * array positions. Only top-level steps are candidates for wrapping into
- * a repetition block (nested-step / block selections are ignored).
- */
-function extractStepIndices(
-  ids: readonly string[],
-  workout: Workout | undefined
-): Array<number> {
-  if (!workout) return [];
-  return ids
-    .map((id) => {
-      const found = findById(workout, id);
-      return found?.kind === "step" ? found.index : null;
-    })
-    .filter((i): i is number => i !== null);
-}
-
-function useDeleteWithConfirmation() {
-  const deleteAction = useDeleteRepetitionBlock();
-  const undoDelete = useUndoDelete();
-  const showModal = useShowConfirmationModal();
-  const { toast } = useToastContext();
-
-  return useCallback(
-    (blockId: string) => {
-      showModal({
-        title: "Delete Repetition Block",
-        message:
-          "Are you sure you want to delete this repetition block? This action can be undone.",
-        confirmLabel: "Delete",
-        cancelLabel: "Cancel",
-        variant: "destructive",
-        onConfirm: () => {
-          executeDeleteWithToast(blockId, deleteAction, toast, undoDelete);
-        },
-      });
-    },
-    [deleteAction, toast, undoDelete, showModal]
-  );
-}
+import {
+  buildHandleConfirmCreateBlock,
+  useDeleteWithConfirmation,
+} from "./use-repetition-block-handlers.helpers";
 
 export function useRepetitionBlockHandlers() {
   const selectedStepIds = useSelectedStepIds();
@@ -79,28 +33,17 @@ export function useRepetitionBlockHandlers() {
   const closeDialog = useCloseCreateBlockDialog();
   const handleDelete = useDeleteWithConfirmation();
 
-  const handleConfirmCreateBlock = (repeatCount: number) => {
-    const workout = currentWorkout?.extensions?.structured_workout as
-      | Workout
-      | undefined;
-    // No workout → no selection can be resolved. Fall through to the
-    // empty-block path only when the user explicitly has no selection
-    // (consistent with the legacy behavior). If a selection exists but
-    // no workout, the invariant is broken — no-op and close the dialog
-    // rather than silently swallowing the user's selection.
-    if (!workout && selectedStepIds.length > 0) {
-      closeDialog();
-      return;
-    }
-    const indices = extractStepIndices(selectedStepIds, workout);
-    if (indices.length >= 2) {
-      createRepetitionBlock(indices, repeatCount);
-      clearSelection();
-    } else {
-      createEmptyBlock(repeatCount);
-    }
-    closeDialog();
-  };
+  const workout = currentWorkout?.extensions?.structured_workout as
+    | Workout
+    | undefined;
+  const handleConfirmCreateBlock = buildHandleConfirmCreateBlock({
+    selectedStepIds,
+    workout,
+    createRepetitionBlock,
+    createEmptyBlock,
+    clearSelection,
+    closeDialog,
+  });
 
   return {
     selectedStepIds,

--- a/packages/workout-spa-editor/src/utils/profile-storage.ts
+++ b/packages/workout-spa-editor/src/utils/profile-storage.ts
@@ -4,36 +4,32 @@
  * Handles persistence of user profiles to localStorage with error handling.
  */
 
-import { z } from "zod";
-
 import type { Profile } from "../types/profile";
-import { profileSchema } from "../types/profile";
+import {
+  ACTIVE_PROFILE_KEY,
+  STORAGE_KEY,
+  type StorageError,
+  type StorageState,
+  storageStateSchema,
+} from "./profile-storage.types";
 
-const STORAGE_KEY = "workout-spa-profiles";
-const ACTIVE_PROFILE_KEY = "workout-spa-active-profile";
+export type { StorageError, StorageState } from "./profile-storage.types";
 
-/**
- * Storage State Schema
- *
- * Validates the complete storage state structure.
- */
-const storageStateSchema = z.object({
-  profiles: z.array(profileSchema),
-  activeProfileId: z.uuid().nullable(),
-});
-
-export type StorageState = z.infer<typeof storageStateSchema>;
-
-/**
- * Storage Error Types
- */
-export type StorageError =
-  | { type: "quota_exceeded"; message: string }
-  | { type: "parse_error"; message: string }
-  | { type: "unknown_error"; message: string };
+const toSaveError = (error: unknown): StorageError => {
+  if (error instanceof Error && error.name === "QuotaExceededError") {
+    return {
+      type: "quota_exceeded",
+      message: "Storage quota exceeded. Unable to save profiles.",
+    };
+  }
+  return {
+    type: "unknown_error",
+    message: error instanceof Error ? error.message : "Unknown error",
+  };
+};
 
 /**
- * Save profiles to localStorage
+ * Save profiles to localStorage.
  *
  * @param profiles - Array of profiles to save
  * @param activeProfileId - ID of the active profile
@@ -45,25 +41,34 @@ export const saveProfiles = (
 ): StorageError | null => {
   try {
     const state: StorageState = { profiles, activeProfileId };
-    const serialized = JSON.stringify(state);
-    localStorage.setItem(STORAGE_KEY, serialized);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
     return null;
   } catch (error) {
-    if (error instanceof Error && error.name === "QuotaExceededError") {
-      return {
-        type: "quota_exceeded",
-        message: "Storage quota exceeded. Unable to save profiles.",
-      };
-    }
-    return {
-      type: "unknown_error",
-      message: error instanceof Error ? error.message : "Unknown error",
-    };
+    return toSaveError(error);
   }
 };
 
+const parseLoadedState = (
+  serialized: string
+):
+  | { success: true; data: StorageState }
+  | { success: false; error: StorageError } => {
+  const parsed = JSON.parse(serialized);
+  const result = storageStateSchema.safeParse(parsed);
+  if (!result.success) {
+    return {
+      success: false,
+      error: {
+        type: "parse_error",
+        message: "Invalid profile data in storage",
+      },
+    };
+  }
+  return { success: true, data: result.data };
+};
+
 /**
- * Load profiles from localStorage
+ * Load profiles from localStorage.
  *
  * @returns Loaded state or error
  */
@@ -72,28 +77,10 @@ export const loadProfiles = ():
   | { success: false; error: StorageError } => {
   try {
     const serialized = localStorage.getItem(STORAGE_KEY);
-
     if (!serialized) {
-      return {
-        success: true,
-        data: { profiles: [], activeProfileId: null },
-      };
+      return { success: true, data: { profiles: [], activeProfileId: null } };
     }
-
-    const parsed = JSON.parse(serialized);
-    const result = storageStateSchema.safeParse(parsed);
-
-    if (!result.success) {
-      return {
-        success: false,
-        error: {
-          type: "parse_error",
-          message: "Invalid profile data in storage",
-        },
-      };
-    }
-
-    return { success: true, data: result.data };
+    return parseLoadedState(serialized);
   } catch (error) {
     return {
       success: false,
@@ -105,9 +92,7 @@ export const loadProfiles = ():
   }
 };
 
-/**
- * Clear all profiles from localStorage
- */
+/** Clear all profiles from localStorage. */
 export const clearProfiles = (): void => {
   localStorage.removeItem(STORAGE_KEY);
   localStorage.removeItem(ACTIVE_PROFILE_KEY);

--- a/packages/workout-spa-editor/src/utils/profile-storage.types.ts
+++ b/packages/workout-spa-editor/src/utils/profile-storage.types.ts
@@ -1,0 +1,28 @@
+/**
+ * Profile Storage Types & Schema
+ *
+ * Storage state schema and error union for the localStorage profile
+ * adapter. Co-located with `profile-storage.ts` but split out so the
+ * adapter stays under the per-file line cap.
+ */
+
+import { z } from "zod";
+
+import { profileSchema } from "../types/profile";
+
+export const STORAGE_KEY = "workout-spa-profiles";
+export const ACTIVE_PROFILE_KEY = "workout-spa-active-profile";
+
+/** Validates the complete storage state structure. */
+export const storageStateSchema = z.object({
+  profiles: z.array(profileSchema),
+  activeProfileId: z.uuid().nullable(),
+});
+
+export type StorageState = z.infer<typeof storageStateSchema>;
+
+/** Storage error union returned by save/load operations. */
+export type StorageError =
+  | { type: "quota_exceeded"; message: string }
+  | { type: "parse_error"; message: string }
+  | { type: "unknown_error"; message: string };

--- a/packages/workout-spa-editor/src/utils/save-workout.helpers.ts
+++ b/packages/workout-spa-editor/src/utils/save-workout.helpers.ts
@@ -1,0 +1,32 @@
+/**
+ * Save Workout Helpers
+ *
+ * Pure helpers for the KRD save pipeline (filename sanitization, browser
+ * download trigger). Co-located with `save-workout.ts` but split out so
+ * the orchestrator stays under the per-file line cap.
+ */
+
+/** Trigger browser download of file. */
+export const triggerDownload = (content: string, filename: string): void => {
+  const blob = new Blob([content], { type: "application/vnd.kaiord+json" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};
+
+/** Sanitize filename for safe file system usage. */
+export const sanitizeFilename = (name: string): string => {
+  return (
+    name
+      .replace(/[^a-z0-9_-]/gi, "_")
+      .replace(/_+/g, "_")
+      .replace(/^_|_$/g, "")
+      .toLowerCase()
+      .slice(0, 50) || "workout"
+  );
+};

--- a/packages/workout-spa-editor/src/utils/save-workout.ts
+++ b/packages/workout-spa-editor/src/utils/save-workout.ts
@@ -12,102 +12,59 @@ import { stripIds } from "../store/strip-ids";
 import type { KRD, ValidationError } from "../types/krd";
 import { krdSchema } from "../types/schemas";
 import { formatZodError } from "../types/validation";
-
-// ============================================
-// Types
-// ============================================
+import { sanitizeFilename, triggerDownload } from "./save-workout.helpers";
 
 export type SaveResult =
   | { success: true; filename: string }
   | { success: false; errors: Array<ValidationError> };
 
-// ============================================
-// Save Functions
-// ============================================
+const resolveFilename = (krd: KRD, override?: string): string => {
+  if (override) return override;
+  const workoutName =
+    (krd.extensions?.structured_workout as { name?: string })?.name ||
+    "workout";
+  return `${sanitizeFilename(workoutName)}.krd`;
+};
+
+const saveErrorFromException = (error: unknown): ValidationError => ({
+  path: ["save"],
+  message:
+    error instanceof Error
+      ? `Failed to save file: ${error.message}`
+      : "Failed to save file: Unknown error",
+});
 
 /**
- * Validate and save workout as KRD file
+ * Validate and save workout as KRD file.
  *
  * @param krd - KRD workout data to save
  * @param filename - Optional custom filename (defaults to workout name)
  * @returns SaveResult with success status and errors if validation fails
  */
-/**
- * Trigger browser download of file
- */
-const triggerDownload = (content: string, filename: string): void => {
-  const blob = new Blob([content], { type: "application/vnd.kaiord+json" });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  URL.revokeObjectURL(url);
-};
-
 export const saveWorkout = (krd: KRD, filename?: string): SaveResult => {
   // stripIds chokepoint: UIWorkout ids never leak into exported .krd files.
   const portable = stripIds(krd);
 
   // Validate workout against KRD schema (Requirement 6.1)
   const validationResult = krdSchema.safeParse(portable);
-
   if (!validationResult.success) {
-    return {
-      success: false,
-      errors: formatZodError(validationResult.error),
-    };
+    return { success: false, errors: formatZodError(validationResult.error) };
   }
 
   // Generate filename (Requirement 6.5)
-  const workoutName =
-    (krd.extensions?.structured_workout as { name?: string })?.name ||
-    "workout";
-  const finalFilename = filename || `${sanitizeFilename(workoutName)}.krd`;
-
+  const finalFilename = resolveFilename(krd, filename);
   try {
     // Generate and download KRD JSON file (Requirement 6.2, 6.4)
     const jsonContent = JSON.stringify(validationResult.data, null, 2);
     triggerDownload(jsonContent, finalFilename);
-
-    return {
-      success: true,
-      filename: finalFilename,
-    };
+    return { success: true, filename: finalFilename };
   } catch (error) {
-    return {
-      success: false,
-      errors: [
-        {
-          path: ["save"],
-          message:
-            error instanceof Error
-              ? `Failed to save file: ${error.message}`
-              : "Failed to save file: Unknown error",
-        },
-      ],
-    };
+    return { success: false, errors: [saveErrorFromException(error)] };
   }
 };
 
 /**
- * Sanitize filename for safe file system usage
- */
-const sanitizeFilename = (name: string): string => {
-  return (
-    name
-      .replace(/[^a-z0-9_-]/gi, "_")
-      .replace(/_+/g, "_")
-      .replace(/^_|_$/g, "")
-      .toLowerCase()
-      .slice(0, 50) || "workout"
-  );
-};
-
-/**
- * Format validation errors for user display
+ * Format validation errors for user display.
  *
  * @param errors - Array of validation errors
  * @returns User-friendly error messages


### PR DESCRIPTION
## Summary

Implements §4.5 of `repo-quality-maintenance-waves`: right-sizes four SPA-editor files that exceeded the 100-LOC budget.

- `adapters/dexie/dexie-database.ts` 140 → 30 LOC. Version-registration logic moved to `register-kaiord-versions.ts` (further split into v1-v3 / v4-v6 / v7-v9 sub-helpers, each ≤ 40 LOC). Per-version schema configs + `backfillLinkedAccounts` moved to `dexie-schemas.ts`.
- `utils/save-workout.ts` 123 → 80 LOC. `triggerDownload` and `sanitizeFilename` moved to `save-workout.helpers.ts`; `saveWorkout` further trimmed via local `resolveFilename` and `saveErrorFromException` helpers.
- `utils/profile-storage.ts` 114 → 99 LOC. Schema, storage keys, and the error union moved to `profile-storage.types.ts`. Save/load split with a `parseLoadedState` helper and a `toSaveError` helper.
- `components/pages/WorkoutSection/use-repetition-block-handlers.tsx` 118 → 61 LOC. `extractStepIndices` and `useDeleteWithConfirmation` moved to a sibling `*.helpers.tsx`; the inline confirm-block handler extracted to a `buildHandleConfirmCreateBlock` factory.

Public API is byte-identical for every touched module. The new helper siblings live alongside their parents, never under `store/` or `application/`, so `R-DexieImport`, `R-PersistStateImport`, and `R-AppDexieImport` invariants are preserved.

## Test plan

- [x] `pnpm -r build` (all packages green)
- [x] `pnpm --filter @kaiord/workout-spa-editor test` (369 files, 3323 tests pass without modification)
- [x] `pnpm test:scripts` (411 mechanical-guard tests pass — incl. `check-no-zustand-writethrough`)
- [x] `pnpm lint` (0 errors; pre-existing warnings unchanged)
- [x] Every touched file ≤ 100 LOC; every function ≤ 40 LOC (60 for components)

🤖 Generated with [Claude Code](https://claude.com/claude-code)