### PR TITLE
refactor(zwo): migrate power-zone table to core/domain helper (§6.2)

### DIFF
--- a/.changeset/zwo-migrate-power-zone-helper.md
+++ b/.changeset/zwo-migrate-power-zone-helper.md
@@ -1,0 +1,7 @@
+---
+"@kaiord/zwo": patch
+---
+
+Replace the inline 7-band Coggan power-zone table in `packages/zwo/src/adapters/target/power.converter.ts` with the canonical domain helper `zoneToPercentFtp` from `@kaiord/core` (added in W6.1). Public API of `@kaiord/zwo` is byte-identical — `convertPowerZoneToPercentFtp` is internal and unchanged at the call sites in `power-encoder.ts`.
+
+Internal contract change for invalid zones: the legacy adapter silently fell back to 100% FTP; the helper now throws `RangeError`. The KRD `powerValueSchema` already constrains `unit: "zone"` values to `int().min(1).max(7)`, so every in-flight caller receives a validated zone — the legacy fallback was dead code that masked invalid input. Settles §6.2 of `repo-quality-maintenance-waves`.

--- a/packages/zwo/src/adapters/target/power.converter.test.ts
+++ b/packages/zwo/src/adapters/target/power.converter.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-magic-numbers -- test fixtures use literal FTP/percent/zone values for clarity */
 import { describe, expect, it } from "vitest";
 
 import {
@@ -274,33 +275,36 @@ describe("convertPowerZoneToPercentFtp", () => {
     expect(result).toBe(200);
   });
 
-  it("should default to 100% for unknown zone", () => {
+  it("should throw RangeError for zone 0 (below range)", () => {
     // Arrange
+    const invalidZone = 0;
 
     // Act
-    const result = convertPowerZoneToPercentFtp(0);
+    const act = () => convertPowerZoneToPercentFtp(invalidZone);
 
     // Assert
-    expect(result).toBe(100);
+    expect(act).toThrow(RangeError);
   });
 
-  it("should default to 100% for zone 8 (out of range)", () => {
+  it("should throw RangeError for zone 8 (above range)", () => {
     // Arrange
+    const invalidZone = 8;
 
     // Act
-    const result = convertPowerZoneToPercentFtp(8);
+    const act = () => convertPowerZoneToPercentFtp(invalidZone);
 
     // Assert
-    expect(result).toBe(100);
+    expect(act).toThrow(RangeError);
   });
 
-  it("should default to 100% for negative zone", () => {
+  it("should throw RangeError for negative zone", () => {
     // Arrange
+    const invalidZone = -1;
 
     // Act
-    const result = convertPowerZoneToPercentFtp(-1);
+    const act = () => convertPowerZoneToPercentFtp(invalidZone);
 
     // Assert
-    expect(result).toBe(100);
+    expect(act).toThrow(RangeError);
   });
 });

--- a/packages/zwo/src/adapters/target/power.converter.ts
+++ b/packages/zwo/src/adapters/target/power.converter.ts
@@ -1,8 +1,4 @@
-import {
-  type Target,
-  targetTypeSchema,
-  zoneToPercentFtp,
-} from "@kaiord/core";
+import { type Target, targetTypeSchema, zoneToPercentFtp } from "@kaiord/core";
 
 /**
  * Convert Zwift power target (FTP percentage 0.0-3.0) to KRD power target

--- a/packages/zwo/src/adapters/target/power.converter.ts
+++ b/packages/zwo/src/adapters/target/power.converter.ts
@@ -1,4 +1,8 @@
-import { type Target, targetTypeSchema } from "@kaiord/core";
+import {
+  type Target,
+  targetTypeSchema,
+  zoneToPercentFtp,
+} from "@kaiord/core";
 
 /**
  * Convert Zwift power target (FTP percentage 0.0-3.0) to KRD power target
@@ -53,26 +57,19 @@ export const convertKrdPowerRangeToZwift = (
 };
 
 /**
- * Convert power zone (1-7) to percent FTP
- * Uses typical power zone definitions:
- * Zone 1 (Recovery): 55% FTP
- * Zone 2 (Endurance): 75% FTP
- * Zone 3 (Tempo): 90% FTP
- * Zone 4 (Threshold): 105% FTP
- * Zone 5 (VO2 Max): 120% FTP
- * Zone 6 (Anaerobic): 150% FTP
- * Zone 7 (Neuromuscular): 200% FTP
+ * Convert a Coggan power zone (1..7) to its percent-FTP value.
+ *
+ * Thin adapter-side delegate over the canonical domain helper
+ * `zoneToPercentFtp` from `@kaiord/core`: the table is a fitness-domain
+ * truth and lives in the domain layer, not in this format adapter.
+ *
+ * Contract is strict: invalid zones (non-integer, out of [1, 7], NaN,
+ * Infinity) propagate a `RangeError`. The KRD `powerValueSchema`
+ * already constrains `unit: "zone"` values to `int().min(1).max(7)`, so
+ * every in-flight call site receives a validated zone — there is no
+ * silent fallback to 100% FTP.
+ *
+ * @throws RangeError when `zone` is not an integer in [1, 7].
  */
-export const convertPowerZoneToPercentFtp = (zone: number): number => {
-  const zoneMap: Record<number, number> = {
-    1: 55,
-    2: 75,
-    3: 90,
-    4: 105,
-    5: 120,
-    6: 150,
-    7: 200,
-  };
-
-  return zoneMap[zone] || 100;
-};
+export const convertPowerZoneToPercentFtp = (zone: number): number =>
+  zoneToPercentFtp(zone);


### PR DESCRIPTION
## Summary

Settles §6.2 of `repo-quality-maintenance-waves`: replace zwo's inline 7-band Coggan power-zone table with the canonical domain helper `zoneToPercentFtp` from `@kaiord/core` (landed in W6.1 / #535).

- `packages/zwo/src/adapters/target/power.converter.ts` no longer holds an inline zone table — `convertPowerZoneToPercentFtp` is now a thin delegate that calls `zoneToPercentFtp` from `@kaiord/core`.
- Public API of `@kaiord/zwo` is byte-identical (`packages/zwo/src/index.ts` unchanged).
- Co-located test suite updated to assert the strict contract for invalid zones (see "Decision" below).

## Decision: RangeError handling

The W6.1 helper throws `RangeError` for invalid zones; the legacy zwo helper silently returned 100% FTP. Per §6.2's "preferred" reconciliation path, **adopt the strict contract** rather than wrap the helper in a try/catch:

- The KRD `powerValueSchema` already constrains `unit: "zone"` values to `z.number().int().min(1).max(7)`.
- Both call sites (`encodeSteadyStatePowerTarget`, `encodeRampPowerTarget`) only invoke the helper inside `if (step.target.value.unit === "zone")`, so every in-flight value has been Zod-validated.
- The legacy `|| 100` fallback was dead code that would have masked schema-bypass bugs by silently emitting wrong-zone power.
- Throwing `RangeError` makes any future schema-bypass loud and traceable.

The three legacy out-of-range tests (zone 0, zone 8, zone -1) now assert `RangeError` is thrown instead of asserting the 100% fallback. No production caller relied on that fallback.

## Test plan

- [x] `pnpm --filter @kaiord/zwo test` — 224/224 pass
- [x] `pnpm lint:architecture` — 0 errors
- [x] `pnpm exec depcruise packages/zwo/src --config .dependency-cruiser.cjs` — no `@kaiord/fit` or `@kaiord/tcx` imports (only pre-existing orphan/circular warnings, unrelated)
- [x] `git diff packages/zwo/src/index.ts` — empty (public API stable)
- [x] `pnpm --filter @kaiord/zwo build` — clean
- [x] Pre-commit / pre-push hooks pass (lint-staged `--max-warnings=0`, type check, scripts tests, full lint umbrella)

## Files

- `packages/zwo/src/adapters/target/power.converter.ts` — replace inline table with `import { zoneToPercentFtp } from "@kaiord/core"`; rewrite `convertPowerZoneToPercentFtp` as a thin delegate
- `packages/zwo/src/adapters/target/power.converter.test.ts` — three out-of-range tests now assert `RangeError`; add the established `no-magic-numbers` test-file disable (precedent: ProfileManager/ZoneEditor hook tests) so lint-staged passes on pre-existing literals
- `.changeset/zwo-migrate-power-zone-helper.md` — patch bump for `@kaiord/zwo` documenting the internal-contract change

🤖 Generated with [Claude Code](https://claude.com/claude-code)