### PR TITLE
chore(release): verify W6 round-trip + zone helper integration (§6.3)

### DIFF
--- a/.changeset/w6-roundtrip-verify.md
+++ b/.changeset/w6-roundtrip-verify.md
@@ -1,0 +1,27 @@
+---
+"@kaiord/zwo": none
+---
+
+chore(verify): confirm W6 round-trip integrity post power-zone migration (§6.3)
+
+Read-only verification pass confirming that the W6.1 + W6.2 power-zone domain
+extraction introduced no regressions in any adapter round-trip suite. All
+tolerances held within spec limits (time ±1s, power ±1W or ±1%FTP, HR ±1bpm,
+cadence ±1rpm, distance ±1m).
+
+Test matrix results:
+
+| Suite                       | Files | Tests | Result |
+| --------------------------- | ----- | ----- | ------ |
+| `@kaiord/core` zones (§6.1) | 1     | 64    | PASS   |
+| `@kaiord/core` round-trip   | 1     | 11    | PASS   |
+| `@kaiord/zwo` (incl. RT)    | 14    | 224   | PASS   |
+| `@kaiord/fit` (incl. RT)    | 32    | 441   | PASS   |
+| `@kaiord/tcx` (incl. RT)    | 28    | 386   | PASS   |
+| `@kaiord/garmin` round-trip | 1     | 6     | PASS   |
+
+W6.1 took the exhaustive-enumeration path for property coverage (no fast-check
+dependency added) — all 7 Coggan power zones exercised via named constants.
+No tolerance has tightened in practice; proposed table is unchanged.
+
+Settles §6.3 of `repo-quality-maintenance-waves`.


### PR DESCRIPTION
## Summary

- Read-only verification confirming W6.1 (#535) + W6.2 (#537) introduced no regressions in any adapter round-trip suite.
- Ships a `none`-bump changeset entry (`@kaiord/zwo: none`) documenting the full test matrix.
- No source code changes — only `.changeset/w6-roundtrip-verify.md` is added.

## §6.3 Acceptance Criteria

| Criterion | Status |
| --- | --- |
| `pnpm -r test:roundtrip` (equivalent) passes within tolerance | PASS — all round-trip test files green, see matrix |
| ZWO round-trip suite passes (only family that could reflect W6 regression) | PASS — 14 files, 224 tests |
| `pnpm --filter @kaiord/core test -- zones` shows exhaustive enumeration green | PASS — 1 file, 64 tests |
| No tolerance has tightened; table unchanged | CONFIRMED |
| Changeset entry shipped | DONE — `.changeset/w6-roundtrip-verify.md` |

## Test Matrix

| Suite | Files | Tests | Result |
| --- | --- | --- | --- |
| `@kaiord/core` zones (`domain/zones/`) | 1 | 64 | PASS |
| `@kaiord/core` round-trip (`src/tests/round-trip/`) | 1 | 11 | PASS |
| `@kaiord/zwo` full suite (incl. round-trip) | 14 | 224 | PASS |
| `@kaiord/fit` full suite (incl. round-trip) | 32 | 441 | PASS |
| `@kaiord/tcx` full suite (incl. round-trip) | 28 | 386 | PASS |
| `@kaiord/garmin` round-trip | 1 | 6 | PASS |
| **Total** | **77** | **1,132** | **PASS** |

## Tolerance Verification

No tolerance has tightened in practice after the W6 migration. The current tolerance table remains:

| Field | Tolerance |
| --- | --- |
| Time | ±1 second |
| Power | ±1 watt or ±1% FTP |
| Heart Rate | ±1 bpm |
| Cadence | ±1 rpm |
| Distance | ±1 meter |

## Zone Helper Path (W6.1)

W6.1 took the **exhaustive-enumeration path** (not property-based / fast-check). All 7 Coggan power zones are covered via named constants (`ZONE_TO_PERCENT_TABLE`, `PERCENT_TO_ZONE_TABLE`). No `fast-check` dependency was added. Boundary inputs (`0`, `8`, `-1`, `NaN`, `Infinity`, `1.5`) are covered explicitly. Per-domain coverage on `domain/zones/` is 100%.

## Notes

- FIT and TCX adapters were not touched in W6 (design D2). Any pre-existing FIT-only or TCX-only failures are out of scope for §6.3. In this run all FIT and TCX tests pass regardless.
- A transient `check-extension-icons-distinct` flake was observed in the first pre-commit attempt; it resolved on retry and `pnpm test:scripts` runs cleanly at 411/411 on both direct invocation and the second commit attempt. This is a known race in the icons test suite under lint-staged state management (unrelated to §6.3).

Closes §6.3 of `repo-quality-maintenance-waves`. Next: §7.1 closing tally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)