### PR TITLE
test(spa-editor): rename 'should do NOT consume' to 'should not consume'

### DIFF
--- a/packages/workout-spa-editor/src/store/train2go-extension-read-zones.test.ts
+++ b/packages/workout-spa-editor/src/store/train2go-extension-read-zones.test.ts
@@ -74,7 +74,7 @@ describe("readZones", () => {
     expect(res).toEqual({ ok: false, error: "Aborted" });
   });
 
-  it("should do NOT consume a queue slot when aborted pre-call", async () => {
+  it("should not consume a queue slot when aborted pre-call", async () => {
     // Arrange
     const ac = new AbortController();
     ac.abort();


### PR DESCRIPTION
Closes #494.

## Summary

Trivial test-title rename. The original codemod (PR #485) had a case-sensitive negation-elision rule that didn't recognize uppercase `NOT`, so `does NOT consume` got rewritten as `should do NOT consume` (double-negation). This PR fixes the awkward title to `should not consume`.

## Test plan

- [x] `pnpm lint` clean (vitest/valid-title still passes — `should` prefix preserved)
- [x] Pre-commit hooks green (now running serially after #519)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test naming for clarity in queue slot consumption verification scenarios.

---

**Note:** This is a maintenance update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->