### PR TITLE
fix(spa-editor): add Dialog.Description to silence Radix a11y warning

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialog.tsx
@@ -48,6 +48,9 @@ export function CoachingActivityDialog({
           data-testid="coaching-activity-dialog"
           className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800"
         >
+          <Dialog.Description className="sr-only">
+            Coaching activity details with match-to-workout and split actions.
+          </Dialog.Description>
           <CoachingActivityDialogContent
             activity={activity}
             error={dialog.error}

--- a/packages/workout-spa-editor/src/components/molecules/EmptyDayDialog/EmptyDayChoices.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/EmptyDayDialog/EmptyDayChoices.tsx
@@ -32,9 +32,9 @@ export function EmptyDayChoices({
           </button>
         </Dialog.Close>
       </div>
-      <p className="text-sm text-muted-foreground">
+      <Dialog.Description className="text-sm text-muted-foreground">
         {formatDateLabel(date ?? "")}
-      </p>
+      </Dialog.Description>
       <div className="flex flex-col gap-2">
         <button
           type="button"

--- a/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/RawWorkoutDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/RawWorkoutDialog.tsx
@@ -34,6 +34,10 @@ export function RawWorkoutDialog({
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
         <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800">
+          <Dialog.Description className="sr-only">
+            Raw workout details with coach description, comment selection, and
+            actions to process or skip.
+          </Dialog.Description>
           {workout && (
             <RawWorkoutContent
               workout={workout}


### PR DESCRIPTION
## Summary

Three Radix `Dialog.Content` sites lacked an associated `Dialog.Description`, triggering the runtime/test warning Pablo observed:

> Warning: Missing `Description` or `aria-describedby={undefined}` for {DialogContent}.

## Changes

| Dialog | Fix |
|---|---|
| `EmptyDayDialog` (via `EmptyDayChoices`) | Existing `<p>` with formatted date converted to `Dialog.Description` — the date IS the description |
| `RawWorkoutDialog` | Added sr-only `Dialog.Description` summarizing the dialog's purpose. Body is dynamic per-workout, so an sr-only generic summary gives screen readers context without competing with the visual UI |
| `CoachingActivityDialog` | Same sr-only pattern — describes the match-to-workout / split actions |

## False positives ruled out

Three other `Dialog.Content` sites flagged by initial grep already have descriptions in their sub-components (Radix auto-detects descendants via composition):

- `ConfirmationModal` → has `Dialog.Description` in `ConfirmationModalPanel`
- `BatchCostConfirmation` → has it in `BatchCostConfirmationPanel`
- `CreateRepetitionBlockDialog` → not Radix at all (custom div-based dialog)

## Test plan

- [x] All 81 dialog tests pass (`EmptyDayDialog`, `RawWorkoutDialog`, `CoachingCard`)
- [x] Typecheck clean
- [x] No new warnings in test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced screen reader support by adding accessible description elements to dialog components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->