### PR TITLE
fix(train2go-bridge): backfill date on read-day (closes 'card disappears on click' bug)

### DIFF
--- a/.changeset/expand-day-clobbers-date.md
+++ b/.changeset/expand-day-clobbers-date.md
@@ -1,0 +1,7 @@
+---
+"@kaiord/train2go-bridge": patch
+---
+
+Fix `read-day` clobbering activity dates with `""`. The daily HTML fragment from `/api/v2/workplan/daily/{date}` contains no date anchor (the weekly endpoint uses the CSS class `workplan-table-date-YYYY-MM-DD`, absent in the daily endpoint), so `parseDailyHtml` left every activity with `date: ""`. The bridge transport now backfills the date from the request param before returning, restoring the SPA's per-day calendar bucketing.
+
+Visible symptom this resolves: when the user clicked a Train2Go coaching activity card to open its detail dialog, the dialog's lazy description-fetch (`expandDay`) upserted the activity with `date: ""`, dropping it out of every calendar day bucket. The card vanished from the calendar the moment the dialog opened, even after the dialog was dismissed.

--- a/packages/train2go-bridge/background.js
+++ b/packages/train2go-bridge/background.js
@@ -128,7 +128,18 @@ const readDay = async (date, userId) => {
   if (!res?.ok) throw toBridgeError("Read day failed", res);
 
   const html = res.data?.data?.content ?? "";
-  return { activities: parser.parseDailyHtml(html) };
+  // Backfill `date` from the request param: the daily HTML fragment
+  // is single-day, so `parseDailyHtml` cannot extract the date the
+  // way `parseWeeklyHtml` does (via the `workplan-table-date-YYYY-MM-DD`
+  // CSS-class anchor — absent in the daily endpoint). Without this
+  // step, `expandDay` upserts records with `date: ""`, causing the
+  // activity to drop out of every per-day calendar bucket — the
+  // visible symptom is the card disappearing the moment the user
+  // opens its detail dialog (which lazy-fetches via expandDay).
+  const activities = parser
+    .parseDailyHtml(html)
+    .map((a) => ({ ...a, date }));
+  return { activities };
 };
 
 // Reads the server-rendered /user/details page and extracts a raw-shape

--- a/packages/train2go-bridge/test/background.test.js
+++ b/packages/train2go-bridge/test/background.test.js
@@ -242,7 +242,8 @@ describe("background service worker", () => {
       ).rejects.toThrow("Missing userId");
     });
 
-    it("read-day backfills the date param onto every parsed activity (the daily HTML fragment lacks a date anchor)", async () => {
+    it("should backfill the date param onto every parsed activity from read-day (the daily HTML fragment lacks a date anchor)", async () => {
+      // Arrange
       // Without backfill, expandDay would upsert records with date:""
       // and the activity would drop out of every per-day calendar
       // bucket — appearing as the card disappearing the moment the
@@ -258,12 +259,14 @@ describe("background service worker", () => {
         cb({ ok: true, status: 200, data: { data: { content: html } } })
       );
 
+      // Act
       const result = await handleAction({
         action: "read-day",
         date: "2026-05-07",
         userId: 28035,
       });
 
+      // Assert
       expect(result.activities).toHaveLength(1);
       expect(result.activities[0]).toMatchObject({
         id: 9001,

--- a/packages/train2go-bridge/test/background.test.js
+++ b/packages/train2go-bridge/test/background.test.js
@@ -242,6 +242,35 @@ describe("background service worker", () => {
       ).rejects.toThrow("Missing userId");
     });
 
+    it("read-day backfills the date param onto every parsed activity (the daily HTML fragment lacks a date anchor)", async () => {
+      // Without backfill, expandDay would upsert records with date:""
+      // and the activity would drop out of every per-day calendar
+      // bucket — appearing as the card disappearing the moment the
+      // user opened its detail dialog. Regression for that bug.
+      const html = `<div data-id="9001" data-status="0" class="activity activity-default">
+        <span class="activity-title"><strong>Test workout</strong></span>
+        <figure class="icon-sportscycling"></figure>
+        <span class="measured">60min</span>
+        <span class="workload-default" data-value="3"></span>
+      </div>`;
+      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
+      chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) =>
+        cb({ ok: true, status: 200, data: { data: { content: html } } })
+      );
+
+      const result = await handleAction({
+        action: "read-day",
+        date: "2026-05-07",
+        userId: 28035,
+      });
+
+      expect(result.activities).toHaveLength(1);
+      expect(result.activities[0]).toMatchObject({
+        id: 9001,
+        date: "2026-05-07",
+      });
+    });
+
     it("handles open-train2go action", async () => {
       await handleAction({ action: "open-train2go" });
       expect(chrome.tabs.create).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary

User-reported bug: clicking a Train2Go coaching activity card opens its detail dialog → the card vanishes from the calendar and never reappears, even after closing the dialog.

## Root cause

`parseDailyHtml` in the bridge returns activities with `date: ""` because the daily HTML fragment from `/api/v2/workplan/daily/{date}` has no date anchor (the weekly endpoint uses the CSS class `workplan-table-date-YYYY-MM-DD`, absent here).

When the dialog opens, `useCoachingDialog` calls `expandActivity` (lazy description fetch) → `expandDay` → `transport.readDay()` → returns activities with `date: ""` → `coaching.upsertMany(fetched)` overwrites the persisted record's `date` field. The calendar buckets activities by `a.date === day`, so the activity silently drops out of every per-day bucket. Symptom survives dialog dismissal because the DB mutation already happened.

## Fix

Backfill `date` from the request param at the bridge transport boundary (`background.js:readDay`), before returning. Parser stays pure — backfill at the boundary that already knows the date.

## Reproduction

1. Pablo's calendar with Train2Go coaching plans
2. Click any coaching activity card
3. Dialog opens with 'Loading description…'
4. Card disappears from the calendar
5. Close the dialog → card stays gone (DB record's date is now `""`, calendar can't bucket it)

## Test

Added a regression test in `test/background.test.js` that asserts `read-day` returns activities with the request-param date populated on each one. 125 bridge tests pass.

## Deploy note

Pablo loads the bridge as an unpacked extension. After this lands:
1. `git pull`
2. Reload the bridge in `chrome://extensions` (the kaiord-train2go-bridge tile)
3. Cards that have already had their date clobbered to `""` need to be re-fetched: trigger Sync from the calendar or run `/user/index` weekly read which uses `parseWeeklyHtml` (which DOES set the date) — that re-upsert restores the correct date.

## Test plan

- [x] 125 bridge unit tests pass
- [x] Typecheck clean
- [x] Pre-commit hook green
- [ ] CI green
- [ ] Manual verification: click coaching card, card stays visible after closing dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where activities would lose their date information, causing them to disappear from calendar views when accessed through certain dialogs.

* **Tests**
  * Added test coverage verifying that date information is correctly preserved when parsing activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->