### PR TITLE
fix(train2go-bridge): split daily HTML across all activity intensity levels

### DIFF
--- a/.changeset/parse-daily-activity-intensity.md
+++ b/.changeset/parse-daily-activity-intensity.md
@@ -1,0 +1,7 @@
+---
+"@kaiord/train2go-bridge": patch
+---
+
+Fix `parseDailyHtml` returning empty descriptions for non-default-intensity activities. T2G's daily HTML labels each activity wrapper with `activity activity-{level}` where `{level}` mirrors the workload intensity (`default` | `low` | `medium` | `high`). The split-on-activity-boundary regex was anchored on `activity-default` only, so any other intensity left `extractDescription` running on an empty slice and persisting `description: ""`.
+
+Visible symptom: clicking a coaching card with non-default intensity opened a dialog whose description never populated (the upsert ran with `description: ""`, so subsequent renders showed neither the loading state nor the actual content). After this fix all four documented intensity levels split correctly and the description body is extracted.

--- a/packages/train2go-bridge/parser.js
+++ b/packages/train2go-bridge/parser.js
@@ -97,8 +97,16 @@ const parseDailyHtml = (html) => {
   ];
   const statusMatches = [...html.matchAll(/data-status="([^"]+)"/g)];
 
-  // Split on activity boundaries to extract descriptions
-  const activityBlocks = html.split(/class="activity activity-default/);
+  // Split on activity boundaries to extract descriptions. T2G's
+  // daily HTML labels each activity wrapper with
+  // `activity activity-{level}` where `{level}` mirrors the workload
+  // intensity (default | low | medium | high). The previous regex
+  // only matched `-default` and therefore failed to split blocks for
+  // any other intensity, leaving `extractDescription("")` to return
+  // `""` even when the response carried a populated description.
+  // Loosened to match any `activity-<word>` suffix so all intensity
+  // levels split correctly.
+  const activityBlocks = html.split(/class="activity activity-\w+/);
 
   for (let i = 0; i < titleMatches.length; i++) {
     const block = activityBlocks[i + 1] ?? "";

--- a/packages/train2go-bridge/test/parser.test.js
+++ b/packages/train2go-bridge/test/parser.test.js
@@ -131,6 +131,37 @@ describe("parser", () => {
     it("returns empty array on null input", () => {
       expect(parseDailyHtml(null)).toEqual([]);
     });
+
+    it("should extract description for activity intensities other than default (regression: -medium/-low/-high)", () => {
+      // Arrange
+      // Real T2G daily HTML labels each activity wrapper with
+      // `activity activity-{level}` where {level} matches the
+      // workload intensity. The previous split regex anchored on
+      // `activity-default` only, so any non-default intensity left
+      // `extractDescription` running on an empty slice and returning
+      // "". This fixture mirrors the live response Pablo captured for
+      // a `-medium` activity.
+      const html = `<aside><div class="activity activity-medium  activity-expanded  " data-status="0" data-id="18012835">
+        <figure class="icon icon-sportscycling"></figure>
+        <span class="measured">1:55 h</span>
+        <div class="workload workload-default" data-value="2"></div>
+        <div class="activity-title"><strong>Arrancadas</strong></div>
+        <div class="activity-description  activity-description-empty ">
+          <p>Avituallamiento intraentreno con 60grHC.</p>
+          <p><strong>Calentamiento:</strong> 20 Z1 + 15' Z2.</p>
+          <p>3x15' Z3 d/5' Z1</p>
+        </div>
+      </div></aside>`;
+
+      // Act
+      const activities = parseDailyHtml(html);
+
+      // Assert
+      expect(activities).toHaveLength(1);
+      expect(activities[0].description).toContain("Avituallamiento intraentreno");
+      expect(activities[0].description).toContain("**Calentamiento:**");
+      expect(activities[0].description).toContain("3x15' Z3 d/5' Z1");
+    });
   });
 
   describe("parsePingJson", () => {


### PR DESCRIPTION
## Summary

**Root cause confirmed.** Pablo captured the actual T2G daily endpoint response. The activity wrapper in real production HTML uses:

```html
<div class="activity activity-medium  activity-expanded  " data-id="18012835">
```

But `parseDailyHtml` was splitting on:

```js
html.split(/class="activity activity-default/)
```

Only `-default` matched. For `-medium`/`-low`/`-high` activities the split returned a 1-element array, `activityBlocks[i + 1]` came back undefined, and `extractDescription("")` returned `""`.

## Symptoms this resolves

Three coupled issues from previous reports — all root-cause the same parser bug:

1. **"Loading description..." never resolves** — the upsert wrote `description: ""` (not undefined), but the dialog rendered nothing in that intermediate render window where Dexie liveQuery hadn't fired yet.
2. **Description shows empty after dialog opens** — same upsert, persisted `description: ""` in IndexedDB.
3. **Convert-to-workout creates empty workout** — `raw.description` ends up `""` because the activity record's description is `""`.

Pablo's actual response had ~3 paragraphs of training content (warmup, main set, recovery) all under the `activity-description` block — the regex would have captured them if the split worked.

## Fix

Loosened the split regex to match any `activity-<word>` suffix:

```diff
- html.split(/class="activity activity-default/)
+ html.split(/class="activity activity-\\w+/)
```

Catches `-default`, `-low`, `-medium`, `-high`, and any future intensity levels T2G might add.

## Test

Added a regression test mirroring Pablo's captured `-medium` HTML (3 paragraphs of workout content with `<strong>`-marked intro). Test asserts the description contains expected substrings. 126 bridge tests pass.

## Deploy note for Pablo

After this lands and you reload the bridge, click the "Arrancadas" card again. The dialog should now show the full coach description (avituallamiento intra-entreno, calentamiento, parte principal, etc). The `description: ""` records already in IndexedDB will be re-upserted with full content on the next click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where activity descriptions were not displayed when activities had non-default intensity levels (low, medium, high). Descriptions now properly populate in the UI.

* **Tests**
  * Added regression test to verify correct description extraction for non-default intensity activities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->