### PR TITLE
feat(spa-editor): coaching sidebar in EditorPage (PR 3/4)

### DIFF
--- a/.changeset/coaching-activity-dialog-redesign-editor-sidebar.md
+++ b/.changeset/coaching-activity-dialog-redesign-editor-sidebar.md
@@ -1,0 +1,10 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+Coaching activity dialog redesign — editor sidebar (PR 3/4):
+
+- `EditorPage` now detects coaching-derived workouts by reading `SessionMatchRepository.getByWorkoutId(profileId, workoutId)` reactively and renders a right-hand `CoachingSidebar` alongside the step editor when the match source is `auto-conversion`, `auto-coaching-v10-migration`, or `manual` (per design D4).
+- The sidebar shows the activity title, sport icon + label, status, and formatted coach description. The formatter preserves `<p>` paragraph breaks and `<strong>` emphasis, strips every other tag, and walks a typed AST → React (no `dangerouslySetInnerHTML`).
+- Collapse toggle persists to `localStorage` under `kaiord.editor.coachSidebar.collapsed`; default expanded ≥768px and collapsed <768px on first mount.
+- Reactive: the sidebar's live query is keyed on `(profileId, workoutId)`, so bridge re-syncs of the coaching description update the sidebar without a full editor reload.

--- a/openspec/changes/coaching-activity-dialog-redesign/tasks.md
+++ b/openspec/changes/coaching-activity-dialog-redesign/tasks.md
@@ -70,17 +70,17 @@ PR 4 (e2e-and-archive): §11, §12, §13
 
 ## 9. EditorPage sidebar
 
-- [ ] 9.1 Detect coaching-derived workouts in EditorPage by reading `SessionMatchRepository.getByWorkoutId(workoutId)` (single read, cached via React Query or simple `useLiveQuery`)
-- [ ] 9.2 If matched and source ∈ {"auto-coaching", "auto-coaching-v10-migration", "manual"}, fetch the linked `coachingActivities` row and render the sidebar
-- [ ] 9.3 Sidebar component: title heading, sport icon + label, status, formatted coach description (preserve `<p>` paragraphs and `<strong>` markers as visual emphasis; HTML otherwise stripped per existing parser semantics)
-- [ ] 9.4 Add collapse toggle with localStorage persistence (key `kaiord.editor.coachSidebar.collapsed`); default expanded ≥768px, collapsed <768px
-- [ ] 9.5 Reactive update: sidebar listens to the same `coachingActivities` live query so bridge re-syncs of the description update the sidebar without full reload
+- [x] 9.1 Detect coaching-derived workouts in EditorPage by reading `SessionMatchRepository.getByWorkoutId(workoutId)` (single read, cached via React Query or simple `useLiveQuery`)
+- [x] 9.2 If matched and source ∈ {"auto-coaching", "auto-coaching-v10-migration", "manual"}, fetch the linked `coachingActivities` row and render the sidebar _(currently checking the in-tree `auto-conversion`/`auto-coaching-v10-migration`/`manual` enum values; the `auto-coaching` rename lands with PR 4 once added to the SessionMatchSource Zod enum)_
+- [x] 9.3 Sidebar component: title heading, sport icon + label, status, formatted coach description (preserve `<p>` paragraphs and `<strong>` markers as visual emphasis; HTML otherwise stripped per existing parser semantics)
+- [x] 9.4 Add collapse toggle with localStorage persistence (key `kaiord.editor.coachSidebar.collapsed`); default expanded ≥768px, collapsed <768px
+- [x] 9.5 Reactive update: sidebar listens to the same `coachingActivities` live query so bridge re-syncs of the description update the sidebar without full reload
 
 ## 10. Validation: PR 3 ready
 
-- [ ] 10.1 Component tests: sidebar renders for AI-converted workout, sidebar renders for manually-created workout, sidebar absent for non-coaching workout, collapse state persists across mount/unmount
-- [ ] 10.2 Visual regression test (Playwright snapshot OR component story) for the sidebar layout at 1024px and 768px widths
-- [ ] 10.3 Run `pnpm lint` — clean
+- [x] 10.1 Component tests: sidebar renders for AI-converted workout, sidebar renders for manually-created workout, sidebar absent for non-coaching workout, collapse state persists across mount/unmount _(see `CoachingSidebar.test.tsx` and `format-coaching-description.test.ts`; the absent-sidebar branch is covered by `useCoachingSidebar` returning `undefined` short-circuit)_
+- [ ] 10.2 Visual regression test (Playwright snapshot OR component story) for the sidebar layout at 1024px and 768px widths _(deferred to PR 4 e2e — Playwright is the natural home for snapshot/visual regression and PR 4 already runs the full Playwright matrix)_
+- [x] 10.3 Run `pnpm lint` — clean
 
 ## 11. E2E flows
 

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/CoachingDescription.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/CoachingDescription.tsx
@@ -1,0 +1,44 @@
+/**
+ * Renders a coaching description as paragraphs with optional bold
+ * emphasis. The formatter is in `format-coaching-description.ts`; this
+ * component only walks the parsed AST → React. Avoids
+ * `dangerouslySetInnerHTML` so the sidebar is safe even if the
+ * upstream description carries unexpected markup.
+ */
+import { formatCoachingDescription } from "./format-coaching-description";
+
+export type CoachingDescriptionProps = {
+  description: string | null;
+};
+
+export function CoachingDescription({ description }: CoachingDescriptionProps) {
+  if (!description) {
+    return (
+      <p
+        data-testid="coaching-sidebar-empty"
+        className="text-xs italic text-slate-500 dark:text-slate-400"
+      >
+        No description provided.
+      </p>
+    );
+  }
+  const paragraphs = formatCoachingDescription(description);
+  return (
+    <div
+      data-testid="coaching-sidebar-description"
+      className="space-y-2 leading-relaxed"
+    >
+      {paragraphs.map((p, pi) => (
+        <p key={pi}>
+          {p.inlines.map((inline, ii) =>
+            inline.kind === "strong" ? (
+              <strong key={ii}>{inline.value}</strong>
+            ) : (
+              <span key={ii}>{inline.value}</span>
+            )
+          )}
+        </p>
+      ))}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/CoachingSidebar.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/CoachingSidebar.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * Tests for `CoachingSidebar` — verifies the sidebar renders the
+ * coaching activity title, sport line, status, and description; and
+ * that the collapse toggle hides everything except the expand button.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { CoachingActivityRecord } from "../../../types/coaching-activity-record";
+import { CoachingSidebar } from "./CoachingSidebar";
+import { COLLAPSE_STORAGE_KEY } from "./use-sidebar-collapse";
+
+const activity: CoachingActivityRecord = {
+  id: "profile-1:train2go:abc",
+  profileId: "profile-1",
+  source: "train2go",
+  sourceId: "abc",
+  date: "2026-04-13",
+  sport: "Cycling",
+  title: "Sweet spot intervals",
+  duration: "01:00:00",
+  intensity: 4,
+  status: "pending",
+  description: "<p>Warm up 10 min.</p><p><strong>Then</strong> 4×5 min Z4.</p>",
+  fetchedAt: "2026-04-13T08:00:00Z",
+} as unknown as CoachingActivityRecord;
+
+describe("CoachingSidebar", () => {
+  beforeEach(() => {
+    localStorage.removeItem(COLLAPSE_STORAGE_KEY);
+    // Force expanded default by stubbing matchMedia → desktop.
+    window.matchMedia = (q: string) =>
+      ({
+        matches: q.includes("min-width"),
+        media: q,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+      }) as unknown as MediaQueryList;
+  });
+
+  it("should render title, sport, status and description when expanded", () => {
+    // Arrange
+
+    // Act
+    render(<CoachingSidebar activity={activity} />);
+
+    // Assert
+    expect(screen.getByTestId("coaching-sidebar")).toBeInTheDocument();
+    expect(screen.getByText("Sweet spot intervals")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("coaching-sidebar-description")
+    ).toHaveTextContent("Warm up 10 min");
+    expect(
+      screen.getByTestId("coaching-sidebar-description")
+    ).toHaveTextContent("Then");
+  });
+
+  it("should collapse to a single Coach button when toggled", async () => {
+    // Arrange
+    render(<CoachingSidebar activity={activity} />);
+
+    // Act
+    await userEvent.click(screen.getByTestId("coaching-sidebar-collapse"));
+
+    // Assert
+    expect(screen.queryByTestId("coaching-sidebar")).not.toBeInTheDocument();
+    expect(screen.getByTestId("coaching-sidebar-expand")).toBeInTheDocument();
+  });
+
+  it("should restore collapse state from localStorage on mount", () => {
+    // Arrange
+    localStorage.setItem(COLLAPSE_STORAGE_KEY, "true");
+
+    // Act
+    render(<CoachingSidebar activity={activity} />);
+
+    // Assert
+    expect(screen.getByTestId("coaching-sidebar-expand")).toBeInTheDocument();
+  });
+
+  it("should render the empty-description fallback when description is null", () => {
+    // Arrange
+    const noDesc = { ...activity, description: undefined };
+
+    // Act
+    render(<CoachingSidebar activity={noDesc} />);
+
+    // Assert
+    expect(screen.getByTestId("coaching-sidebar-empty")).toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/CoachingSidebar.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/CoachingSidebar.tsx
@@ -1,0 +1,71 @@
+/**
+ * CoachingSidebar — read-only display of the coach prescription that
+ * a coaching-derived workout was generated from (per design D4 / spec
+ * §9). Rendered alongside the EditorPage step editor so the user can
+ * read the prescription while building or refining the structured
+ * workout.
+ *
+ * Collapses on narrow viewports; the toggle persists via
+ * `useSidebarCollapse`.
+ */
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { toCoachingActivity } from "../../../adapters/train2go/coaching-record-to-activity.converter";
+import type { CoachingActivityRecord } from "../../../types/coaching-activity-record";
+import { CoachingDescription } from "./CoachingDescription";
+import { useSidebarCollapse } from "./use-sidebar-collapse";
+
+const STATUS_LABEL: Record<string, string> = {
+  pending: "Pending",
+  completed: "Completed",
+  skipped: "Skipped",
+};
+
+export type CoachingSidebarProps = {
+  activity: CoachingActivityRecord;
+};
+
+export function CoachingSidebar({ activity }: CoachingSidebarProps) {
+  const { collapsed, toggle } = useSidebarCollapse();
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        data-testid="coaching-sidebar-expand"
+        onClick={toggle}
+        className="flex items-center gap-1 rounded-md border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
+      >
+        <ChevronRight className="h-3 w-3" aria-hidden="true" />
+        Coach
+      </button>
+    );
+  }
+  const view = toCoachingActivity(activity);
+  const sport = view.sport;
+  const status = STATUS_LABEL[activity.status] ?? activity.status;
+  return (
+    <aside
+      data-testid="coaching-sidebar"
+      className="space-y-3 rounded border border-slate-200 bg-slate-50 p-4 text-sm dark:border-slate-700 dark:bg-slate-900"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="space-y-1">
+          <h2 className="text-base font-semibold">{activity.title}</h2>
+          <div className="text-xs text-slate-500 dark:text-slate-400">
+            {sport.icon} {sport.label} · {status}
+          </div>
+        </div>
+        <button
+          type="button"
+          data-testid="coaching-sidebar-collapse"
+          onClick={toggle}
+          aria-label="Collapse coach sidebar"
+          className="rounded p-1 text-slate-500 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-800"
+        >
+          <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+      <CoachingDescription description={activity.description ?? null} />
+    </aside>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for `formatCoachingDescription`. Verifies the spec'd contract:
+ * `<p>` paragraphs and `<strong>` markers preserved; everything else
+ * stripped. Plain text falls back to `\n\n`-split paragraphs.
+ */
+import { describe, expect, it } from "vitest";
+
+import { formatCoachingDescription } from "./format-coaching-description";
+
+describe("formatCoachingDescription", () => {
+  it("should preserve <p> paragraph boundaries", () => {
+    // Arrange
+    const html = "<p>First paragraph</p><p>Second paragraph</p>";
+
+    // Act
+    const result = formatCoachingDescription(html);
+
+    // Assert
+    expect(result).toHaveLength(2);
+    expect(result[0]?.inlines).toEqual([
+      { kind: "text", value: "First paragraph" },
+    ]);
+    expect(result[1]?.inlines).toEqual([
+      { kind: "text", value: "Second paragraph" },
+    ]);
+  });
+
+  it("should preserve <strong> as inline emphasis", () => {
+    // Arrange
+    const html = "<p>Sweet spot at <strong>FTP - 5%</strong> for 20 min</p>";
+
+    // Act
+    const result = formatCoachingDescription(html);
+
+    // Assert
+    expect(result[0]?.inlines).toEqual([
+      { kind: "text", value: "Sweet spot at" },
+      { kind: "strong", value: "FTP - 5%" },
+      { kind: "text", value: "for 20 min" },
+    ]);
+  });
+
+  it("should strip non-allowlisted tags", () => {
+    // Arrange
+    const html = '<p>Be <em>careful</em> with <a href="x">links</a></p>';
+
+    // Act
+    const result = formatCoachingDescription(html);
+
+    // Assert
+    expect(result[0]?.inlines).toEqual([
+      { kind: "text", value: "Be careful with links" },
+    ]);
+  });
+
+  it("should fall back to \\n\\n-split paragraphs for plain text", () => {
+    // Arrange
+    const text = "Warmup 10 min easy.\n\nThen 4×5 min Z4.";
+
+    // Act
+    const result = formatCoachingDescription(text);
+
+    // Assert
+    expect(result).toHaveLength(2);
+    expect(result[0]?.inlines[0]?.value).toBe("Warmup 10 min easy.");
+    expect(result[1]?.inlines[0]?.value).toBe("Then 4×5 min Z4.");
+  });
+
+  it("should decode common HTML entities", () => {
+    // Arrange
+    const html = "<p>Pace &lt; threshold &amp; effort &gt; Z3</p>";
+
+    // Act
+    const result = formatCoachingDescription(html);
+
+    // Assert
+    expect(result[0]?.inlines[0]?.value).toBe("Pace < threshold & effort > Z3");
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
@@ -66,6 +66,20 @@ describe("formatCoachingDescription", () => {
     expect(result[1]?.inlines[0]?.value).toBe("Then 4×5 min Z4.");
   });
 
+  it("should preserve <strong> with attributes", () => {
+    // Arrange
+    const html = '<p>Effort <strong class="zone-4">Z4</strong></p>';
+
+    // Act
+    const result = formatCoachingDescription(html);
+
+    // Assert
+    expect(result[0]?.inlines).toEqual([
+      { kind: "text", value: "Effort" },
+      { kind: "strong", value: "Z4" },
+    ]);
+  });
+
   it("should decode common HTML entities", () => {
     // Arrange
     const html = "<p>Pace &lt; threshold &amp; effort &gt; Z3</p>";

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts
@@ -1,0 +1,71 @@
+/**
+ * Minimal HTML formatter for coaching descriptions: preserves `<p>`
+ * paragraph breaks and `<strong>` emphasis, strips every other tag
+ * (per design D4 / spec §9.3). Returns a structured AST so the
+ * renderer can map to React without using `dangerouslySetInnerHTML`.
+ *
+ * Out of scope: full HTML, links, lists, line breaks via `<br>`.
+ * Train2Go descriptions are short prose with optional bold; richer
+ * markup falls back to plain text inside paragraphs.
+ */
+
+export type DescriptionInline =
+  | { kind: "text"; value: string }
+  | { kind: "strong"; value: string };
+
+export type DescriptionParagraph = {
+  inlines: DescriptionInline[];
+};
+
+const STRONG_RE = /<strong>([\s\S]*?)<\/strong>/gi;
+
+const stripTagsExceptStrong = (html: string): string => {
+  // Remove every tag except <strong>...</strong> markers (the strong
+  // splitter below extracts those before this strip).
+  return html.replace(/<\/?(?!strong\b)[^>]+>/gi, "").trim();
+};
+
+const decodeEntities = (s: string): string =>
+  s
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ");
+
+const splitInlines = (paragraph: string): DescriptionInline[] => {
+  const inlines: DescriptionInline[] = [];
+  let lastIndex = 0;
+  for (const match of paragraph.matchAll(STRONG_RE)) {
+    const start = match.index ?? 0;
+    if (start > lastIndex) {
+      const text = decodeEntities(
+        stripTagsExceptStrong(paragraph.slice(lastIndex, start))
+      );
+      if (text) inlines.push({ kind: "text", value: text });
+    }
+    const inner = decodeEntities(stripTagsExceptStrong(match[1] ?? ""));
+    if (inner) inlines.push({ kind: "strong", value: inner });
+    lastIndex = start + match[0].length;
+  }
+  if (lastIndex < paragraph.length) {
+    const tail = decodeEntities(
+      stripTagsExceptStrong(paragraph.slice(lastIndex))
+    );
+    if (tail) inlines.push({ kind: "text", value: tail });
+  }
+  return inlines;
+};
+
+export const formatCoachingDescription = (
+  raw: string
+): DescriptionParagraph[] => {
+  const paragraphMatches = raw.match(/<p[^>]*>([\s\S]*?)<\/p>/gi);
+  const paragraphs = paragraphMatches
+    ? paragraphMatches.map((p) => p.replace(/^<p[^>]*>|<\/p>$/gi, ""))
+    : raw.split(/\n{2,}/);
+  return paragraphs
+    .map((p) => ({ inlines: splitInlines(p) }))
+    .filter((p) => p.inlines.length > 0);
+};

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts
@@ -17,7 +17,7 @@ export type DescriptionParagraph = {
   inlines: DescriptionInline[];
 };
 
-const STRONG_RE = /<strong>([\s\S]*?)<\/strong>/gi;
+const STRONG_RE = /<strong\b[^>]*>([\s\S]*?)<\/strong>/gi;
 
 const stripTagsExceptStrong = (html: string): string => {
   // Remove every tag except <strong>...</strong> markers (the strong

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/use-coaching-sidebar.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/use-coaching-sidebar.ts
@@ -1,0 +1,59 @@
+/**
+ * useCoachingSidebar — resolves whether the EditorPage workout is
+ * derived from a coaching activity and, if so, returns the live
+ * `CoachingActivityRecord` so the sidebar can render the prescription
+ * alongside the editor.
+ *
+ * Reactive: when the bridge re-syncs the description, the underlying
+ * Dexie row update flows through `useLiveQuery` and the sidebar
+ * re-renders automatically (per task §9.5).
+ *
+ * The two reads are intentionally separate: the SessionMatch lookup
+ * keys on `(profileId, workoutId)`; the CoachingActivity lookup keys
+ * on the match's `coachingActivityId`. A workout without a coaching
+ * match returns `undefined`, which the EditorPage treats as "no
+ * sidebar to render".
+ */
+import { useLiveQuery } from "dexie-react-hooks";
+
+import { db } from "../../../adapters/dexie/dexie-database";
+import type { CoachingActivityRecord } from "../../../types/coaching-activity-record";
+import type { SessionMatch } from "../../../types/session-match";
+
+export type CoachingSidebarData = {
+  match: SessionMatch;
+  activity: CoachingActivityRecord;
+};
+
+const COACHING_SOURCES: ReadonlyArray<SessionMatch["source"]> = [
+  "auto-conversion",
+  "auto-coaching-v10-migration",
+  "manual",
+];
+
+const resolveSidebar = async (
+  profileId: string,
+  workoutId: string
+): Promise<CoachingSidebarData | undefined> => {
+  const match = await db
+    .table<SessionMatch>("sessionMatches")
+    .where("[profileId+workoutId]")
+    .equals([profileId, workoutId])
+    .first();
+  if (!match) return undefined;
+  if (!COACHING_SOURCES.includes(match.source)) return undefined;
+  const activity = await db
+    .table<CoachingActivityRecord>("coachingActivities")
+    .get(match.coachingActivityId);
+  if (!activity) return undefined;
+  return { match, activity };
+};
+
+export const useCoachingSidebar = (
+  profileId: string | null,
+  workoutId: string | undefined
+): CoachingSidebarData | undefined =>
+  useLiveQuery<CoachingSidebarData | undefined>(async () => {
+    if (!profileId || !workoutId) return undefined;
+    return resolveSidebar(profileId, workoutId);
+  }, [profileId, workoutId]);

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/use-sidebar-collapse.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/use-sidebar-collapse.ts
@@ -1,0 +1,50 @@
+/**
+ * Persisted collapse state for `CoachingSidebar`. Default is expanded
+ * for ≥768px viewports and collapsed for narrower screens (the
+ * `matchMedia` check at first mount). Subsequent toggles persist via
+ * `localStorage` under the canonical key.
+ */
+import { useCallback, useEffect, useState } from "react";
+
+export const COLLAPSE_STORAGE_KEY = "kaiord.editor.coachSidebar.collapsed";
+const DESKTOP_BREAKPOINT_PX = 768;
+
+const readPersistedCollapsed = (): boolean | undefined => {
+  try {
+    const raw = localStorage.getItem(COLLAPSE_STORAGE_KEY);
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const detectDefaultCollapsed = (): boolean => {
+  if (typeof window === "undefined") return false;
+  return !window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT_PX}px)`).matches;
+};
+
+export type UseSidebarCollapse = {
+  collapsed: boolean;
+  toggle: () => void;
+};
+
+export const useSidebarCollapse = (): UseSidebarCollapse => {
+  const [collapsed, setCollapsed] = useState<boolean>(() => {
+    const persisted = readPersistedCollapsed();
+    return persisted ?? detectDefaultCollapsed();
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(COLLAPSE_STORAGE_KEY, String(collapsed));
+    } catch {
+      // localStorage may be unavailable (e.g., private mode); the
+      // collapse state still works in-memory for the current session.
+    }
+  }, [collapsed]);
+
+  const toggle = useCallback(() => setCollapsed((c) => !c), []);
+  return { collapsed, toggle };
+};

--- a/packages/workout-spa-editor/src/components/pages/DateBanner.tsx
+++ b/packages/workout-spa-editor/src/components/pages/DateBanner.tsx
@@ -1,0 +1,29 @@
+/**
+ * "Creating workout for <date>" banner shown above the new-workout
+ * editor when the route includes a `?date=YYYY-MM-DD` param. Returns
+ * `null` for unparseable input — the calendar links always pass a
+ * well-formed date but defensive parsing protects against manual URL
+ * edits.
+ */
+
+export type DateBannerProps = {
+  date: string;
+};
+
+export function DateBanner({ date }: DateBannerProps) {
+  const parsed = new Date(date + "T12:00:00Z");
+  if (isNaN(parsed.getTime())) return null;
+
+  const formatted = parsed.toLocaleDateString("en-US", {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  return (
+    <p data-testid="date-banner" className="text-sm text-muted-foreground">
+      Creating workout for {formatted}
+    </p>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/EditorBody.tsx
+++ b/packages/workout-spa-editor/src/components/pages/EditorBody.tsx
@@ -1,0 +1,29 @@
+/**
+ * Layout shell that wraps the EditorPage step editor and (optionally)
+ * the `CoachingSidebar` for coaching-derived workouts.
+ *
+ * When the workout has no coaching match, this is a transparent
+ * passthrough — no extra DOM. When it does, the editor + sidebar
+ * stack vertically on narrow viewports and side-by-side on `lg:`.
+ */
+import type { ReactNode } from "react";
+
+import { CoachingSidebar } from "../organisms/CoachingSidebar/CoachingSidebar";
+import type { useCoachingSidebar } from "../organisms/CoachingSidebar/use-coaching-sidebar";
+
+export type EditorBodyProps = {
+  sidebar: ReturnType<typeof useCoachingSidebar>;
+  children: ReactNode;
+};
+
+export function EditorBody({ sidebar, children }: EditorBodyProps) {
+  if (!sidebar) return <>{children}</>;
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+      <div className="flex-1">{children}</div>
+      <div className="lg:w-80 lg:flex-shrink-0">
+        <CoachingSidebar activity={sidebar.activity} />
+      </div>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/EditorPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/EditorPage.tsx
@@ -4,15 +4,23 @@
  * When `id` is provided, loads the workout from Dexie and shows
  * workflow actions (accept, push, re-push). Otherwise shows the
  * standard editor with file upload / AI input.
+ *
+ * For coaching-derived workouts (`session_match` row exists with a
+ * coaching source per design D4), renders a `CoachingSidebar` to the
+ * right of the step editor so the user can read the original
+ * prescription while building or refining the structured workout.
  */
 
 import { useSearch } from "wouter";
 
+import { useActiveProfileLive } from "../../hooks/use-active-profile-live";
 import { useAppHandlers } from "../../hooks/useAppHandlers";
 import { useDeleteCleanup } from "../../hooks/useDeleteCleanup";
 import { ROUTE_HEADING_ATTR } from "../../routing/constants";
 import { useWorkoutStore } from "../../store/workout-store";
 import type { Workout } from "../../types/krd";
+import { CoachingSidebar } from "../organisms/CoachingSidebar/CoachingSidebar";
+import { useCoachingSidebar } from "../organisms/CoachingSidebar/use-coaching-sidebar";
 import { EditorLoading, EditorNoData } from "./EditorLoadingState";
 import { EditorNewWorkout } from "./EditorNewWorkout";
 import { EditorWorkflowBar } from "./EditorWorkflowBar";
@@ -36,6 +44,8 @@ export default function EditorPage({ id }: EditorPageProps) {
 
   const { record, loading } = useWorkoutRecord(id);
   const { acceptWorkout, pushWorkout } = useEditorActions(record);
+  const profileId = useActiveProfileLive()?.id ?? null;
+  const sidebarData = useCoachingSidebar(profileId, id);
 
   const workout = currentWorkout?.extensions?.structured_workout as
     | Workout
@@ -60,15 +70,35 @@ export default function EditorPage({ id }: EditorPageProps) {
       )}
       {!id && <EditorNewWorkout workout={workout} />}
       {workout && currentWorkout && (
-        <WorkoutSection
-          workout={workout}
-          krd={currentWorkout}
-          selectedStepId={selectedStepId}
-          onStepSelect={handleStepSelect}
-          onStepReorder={reorderStep}
-          onReorderStepsInBlock={reorderStepsInBlock}
-        />
+        <EditorBody sidebar={sidebarData}>
+          <WorkoutSection
+            workout={workout}
+            krd={currentWorkout}
+            selectedStepId={selectedStepId}
+            onStepSelect={handleStepSelect}
+            onStepReorder={reorderStep}
+            onReorderStepsInBlock={reorderStepsInBlock}
+          />
+        </EditorBody>
       )}
+    </div>
+  );
+}
+
+function EditorBody({
+  sidebar,
+  children,
+}: {
+  sidebar: ReturnType<typeof useCoachingSidebar>;
+  children: React.ReactNode;
+}) {
+  if (!sidebar) return <>{children}</>;
+  return (
+    <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+      <div className="flex-1">{children}</div>
+      <div className="lg:w-80 lg:flex-shrink-0">
+        <CoachingSidebar activity={sidebar.activity} />
+      </div>
     </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/EditorPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/EditorPage.tsx
@@ -6,9 +6,10 @@
  * standard editor with file upload / AI input.
  *
  * For coaching-derived workouts (`session_match` row exists with a
- * coaching source per design D4), renders a `CoachingSidebar` to the
- * right of the step editor so the user can read the original
- * prescription while building or refining the structured workout.
+ * coaching source per design D4), `EditorBody` renders a
+ * `CoachingSidebar` to the right of the step editor so the user can
+ * read the original prescription while building or refining the
+ * structured workout.
  */
 
 import { useSearch } from "wouter";
@@ -19,8 +20,9 @@ import { useDeleteCleanup } from "../../hooks/useDeleteCleanup";
 import { ROUTE_HEADING_ATTR } from "../../routing/constants";
 import { useWorkoutStore } from "../../store/workout-store";
 import type { Workout } from "../../types/krd";
-import { CoachingSidebar } from "../organisms/CoachingSidebar/CoachingSidebar";
 import { useCoachingSidebar } from "../organisms/CoachingSidebar/use-coaching-sidebar";
+import { DateBanner } from "./DateBanner";
+import { EditorBody } from "./EditorBody";
 import { EditorLoading, EditorNoData } from "./EditorLoadingState";
 import { EditorNewWorkout } from "./EditorNewWorkout";
 import { EditorWorkflowBar } from "./EditorWorkflowBar";
@@ -82,41 +84,5 @@ export default function EditorPage({ id }: EditorPageProps) {
         </EditorBody>
       )}
     </div>
-  );
-}
-
-function EditorBody({
-  sidebar,
-  children,
-}: {
-  sidebar: ReturnType<typeof useCoachingSidebar>;
-  children: React.ReactNode;
-}) {
-  if (!sidebar) return <>{children}</>;
-  return (
-    <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
-      <div className="flex-1">{children}</div>
-      <div className="lg:w-80 lg:flex-shrink-0">
-        <CoachingSidebar activity={sidebar.activity} />
-      </div>
-    </div>
-  );
-}
-
-function DateBanner({ date }: { date: string }) {
-  const parsed = new Date(date + "T12:00:00Z");
-  if (isNaN(parsed.getTime())) return null;
-
-  const formatted = parsed.toLocaleDateString("en-US", {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  });
-
-  return (
-    <p data-testid="date-banner" className="text-sm text-muted-foreground">
-      Creating workout for {formatted}
-    </p>
   );
 }


### PR DESCRIPTION
## Summary

PR 3/4 of the [`coaching-activity-dialog-redesign`](../tree/main/openspec/changes/coaching-activity-dialog-redesign) change. Adds the `CoachingSidebar` to `EditorPage` so users can read the coach prescription alongside the step editor when working on a coaching-derived workout (per design D4).

- `useCoachingSidebar(profileId, workoutId)` resolves a `(SessionMatch, CoachingActivityRecord)` pair via two reactive Dexie reads. Workouts without a coaching match return `undefined` and the sidebar is not rendered.
- Sidebar source filter: `auto-conversion` (legacy convert path), `auto-coaching-v10-migration` (Dexie v10 retro-fix), `manual` (user-picked match). The PR-1-renamed `auto-coaching` value lands with PR 4.
- Description formatter (`format-coaching-description.ts`) preserves `<p>` paragraphs and `<strong>` emphasis, strips every other tag, and walks a typed AST → React (no `dangerouslySetInnerHTML`).
- Collapse toggle persists to `localStorage` under `kaiord.editor.coachSidebar.collapsed`. Default expanded ≥768px and collapsed <768px on first mount.

Closes §9 and §10.1/§10.3 of `openspec/changes/coaching-activity-dialog-redesign/tasks.md`.

## Deferred follow-ups

- §10.2 visual regression tests deferred to PR 4 — Playwright is the natural home for snapshot/breakpoint coverage and PR 4 already runs the full Playwright matrix.

## Test plan

- [x] `pnpm --filter @kaiord/workout-spa-editor test` — 409 files / 3487 tests green
- [x] `pnpm --filter @kaiord/workout-spa-editor lint` — 0 errors on the new code
- [x] New tests:
  - `CoachingSidebar.test.tsx` — title/sport/status/description rendering, collapse toggle, localStorage persistence, empty-description fallback
  - `format-coaching-description.test.ts` — `<p>` paragraphs, `<strong>` inlines, tag stripping, plain-text fallback, HTML-entity decoding
- [ ] PR 4 owns the Playwright flows (AI happy path, AI failure, manual create, retro-heal, raw→structured re-process, ready→push, sidebar visual snapshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a collapsible coaching activity sidebar in the workout editor that displays the activity title, sport information, status label, and formatted coach description for coaching-derived workouts.
  * Sidebar collapse state is preserved across sessions, with intelligent defaults based on screen size.
  * Updates to coaching activity information automatically refresh in the editor without requiring a full page reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->