### PR TITLE
fix(ci): build workspace before changesets-bot commits the version bump

### DIFF
--- a/scripts/changeset-version.sh
+++ b/scripts/changeset-version.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
+# Bumps versions for the Version Packages PR.
+#
+# Husky pre-commit hook (the changesets/action commit triggers it)
+# runs `pnpm -r tsc --noEmit --incremental` across every package.
+# Workspace packages that import each other via `@kaiord/<name>`
+# resolve through `package.json` `types`/`exports` → `./dist/*.d.ts`.
+# If `dist/` is missing, every dependent package's typecheck fails
+# with "Cannot find module '@kaiord/core'" and the commit is blocked,
+# which leaves the Version Packages PR unmergeable.
+#
+# Building the workspace AFTER the version bump (and before the
+# implicit `changesets/action` commit) populates the `dist/` cache
+# the pre-commit tsc needs. The build itself is fast — most packages
+# are pure TS with `tsup` — and runs in CI only.
 set -euo pipefail
 pnpm exec changeset version
 node scripts/sync-extension-version.mjs
 pnpm install --no-frozen-lockfile
+pnpm -r build


### PR DESCRIPTION
## Summary

Releases have been failing on every push to main for the past 4+ PRs (last successful Version Packages PR update: 2026-04-29). The failure is in the husky pre-commit hook that fires when `changesets/action` commits the version bump:

\`\`\`
🔍 Running incremental TypeScript type check...
##[error]src/adapters/execute-with-retry.ts(2,30): error TS2307: Cannot find module '@kaiord/core' or its corresponding type declarations.
##[error]src/adapters/reindex-steps.ts(1,30): error TS2307: ...
\`\`\`

## Root cause

\`scripts/changeset-version.sh\` does \`changeset version\` → \`sync-extension-version.mjs\` → \`pnpm install\` and then \`changesets/action\` commits. The pre-commit hook runs \`pnpm -r tsc --noEmit --incremental\` across every package. Workspace packages that import each other via \`@kaiord/<name>\` resolve through \`package.json\` \`types\`/\`exports\` → \`./dist/*.d.ts\`. The setup-pnpm composite action only installs deps; it never builds them, so \`@kaiord/core/dist/\` is missing and every dependent package's typecheck fails.

## Fix

Append \`pnpm -r build\` to the end of \`scripts/changeset-version.sh\`. The build runs after the version bump and before the bot's implicit commit, populating the \`dist/\` cache the pre-commit tsc needs. tsup is fast across the workspace — adds maybe 30-60s to the release job.

## Test plan

- [x] Local \`pnpm -r build\` from a clean checkout completes (verified before pushing this PR).
- [ ] After merge, the next push to main triggers Release workflow successfully and updates the Version Packages PR with the queued coaching changesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved development build process to ensure workspace dependencies are properly compiled during version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->