### PR TITLE
fix(spa-editor): coaching dialog stuck on "Loading description…"

### DIFF
--- a/.changeset/coaching-dialog-live-description.md
+++ b/.changeset/coaching-dialog-live-description.md
@@ -1,0 +1,9 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Fix coaching activity dialog stuck on "Loading description…" indefinitely.
+
+`selectedActivity` was held as plain `useState<CoachingActivity>` in `useCalendarPage`, which froze the original reference at click time. When `expandActivity` populated the description into Dexie out-of-band, the live-query refresh updated `coaching.byDay` but the dialog's `activity` prop kept the stale `description: undefined` reference and the loading placeholder never disappeared.
+
+Replaced with `useSelectedActivity(byDay)` which captures the click target by id only and re-derives the live view-model from `byDay` on every render — Dexie updates now propagate into the open dialog.

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-page.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-page.ts
@@ -12,7 +12,7 @@
  * id), so the view falls back to a profile-less calendar without crashing.
  */
 
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 
 import type { MatchSuggestion } from "../../application/match-suggestion";
 import { useActiveProfileLive } from "../../hooks/use-active-profile-live";
@@ -29,6 +29,7 @@ import { useUserPreferences } from "../../hooks/use-user-preferences";
 import type { CoachingActivity } from "../../types/coaching-activity";
 import { buildCalendarBuckets, type CalendarBuckets } from "./calendar-buckets";
 import { useCalendarState } from "./use-calendar-state";
+import { useSelectedActivity } from "./use-selected-activity";
 
 const viewportDefaultDensity = (): "compact" | "comfortable" =>
   typeof window !== "undefined" && window.innerWidth >= 768
@@ -57,8 +58,9 @@ export function useCalendarPage(): CalendarPageState {
   const s = useCalendarState();
   const coaching = useCoachingActivities(s.data.days);
   useCoachingAutoSync(coaching.syncSources, s.data.days[0]);
-  const [selectedActivity, setSelectedActivity] =
-    useState<CoachingActivity | null>(null);
+  const { selectedActivity, setSelectedActivity } = useSelectedActivity(
+    coaching.byDay
+  );
   const profileId = useActiveProfileLive()?.id ?? null;
   const weekStart = s.data.days[0] ?? "";
   const rawMatched = useMatchedSessions(profileId, s.data.days);

--- a/packages/workout-spa-editor/src/components/pages/use-selected-activity.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/use-selected-activity.test.tsx
@@ -43,7 +43,6 @@ describe("useSelectedActivity", () => {
       { initialProps: { byDay: byDayInitial } }
     );
     act(() => result.current.setSelectedActivity(baseActivity));
-    expect(result.current.selectedActivity?.description).toBeUndefined();
 
     // Act
     // Live-query tick — byDay flips to a new object with the description populated.
@@ -63,7 +62,6 @@ describe("useSelectedActivity", () => {
     const byDay = { "2026-04-13": [baseActivity] };
     const { result } = renderHook(() => useSelectedActivity(byDay));
     act(() => result.current.setSelectedActivity(baseActivity));
-    expect(result.current.selectedActivity).not.toBeNull();
 
     // Act
     act(() => result.current.setSelectedActivity(null));

--- a/packages/workout-spa-editor/src/components/pages/use-selected-activity.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/use-selected-activity.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for `useSelectedActivity` — verifies the live-derive behavior
+ * that fixes the "Loading description…" stuck state when `expandActivity`
+ * upserts the description into Dexie out-of-band.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { CoachingActivity } from "../../types/coaching-activity";
+import { useSelectedActivity } from "./use-selected-activity";
+
+const baseActivity: CoachingActivity = {
+  id: "train2go:abc",
+  source: "train2go",
+  sourceBadge: "T2G",
+  date: "2026-04-13",
+  sport: { label: "Cycling", icon: "🚴" },
+  title: "Sweet spot intervals",
+  duration: "01:00:00",
+  effort: 4,
+  status: "pending",
+  description: undefined,
+};
+
+describe("useSelectedActivity", () => {
+  it("should return null when no activity is selected", () => {
+    // Arrange
+    const byDay = { "2026-04-13": [baseActivity] };
+
+    // Act
+    const { result } = renderHook(() => useSelectedActivity(byDay));
+
+    // Assert
+    expect(result.current.selectedActivity).toBeNull();
+  });
+
+  it("should re-derive the selected activity from byDay so live-query updates propagate", () => {
+    // Arrange
+    // Initial byDay has the activity with no description.
+    const byDayInitial = { "2026-04-13": [baseActivity] };
+    const { result, rerender } = renderHook(
+      ({ byDay }) => useSelectedActivity(byDay),
+      { initialProps: { byDay: byDayInitial } }
+    );
+    act(() => result.current.setSelectedActivity(baseActivity));
+    expect(result.current.selectedActivity?.description).toBeUndefined();
+
+    // Act
+    // Live-query tick — byDay flips to a new object with the description populated.
+    const byDayPopulated = {
+      "2026-04-13": [{ ...baseActivity, description: "Coach prescription" }],
+    };
+    rerender({ byDay: byDayPopulated });
+
+    // Assert
+    expect(result.current.selectedActivity?.description).toBe(
+      "Coach prescription"
+    );
+  });
+
+  it("should clear when setSelectedActivity is called with null", () => {
+    // Arrange
+    const byDay = { "2026-04-13": [baseActivity] };
+    const { result } = renderHook(() => useSelectedActivity(byDay));
+    act(() => result.current.setSelectedActivity(baseActivity));
+    expect(result.current.selectedActivity).not.toBeNull();
+
+    // Act
+    act(() => result.current.setSelectedActivity(null));
+
+    // Assert
+    expect(result.current.selectedActivity).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/use-selected-activity.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-selected-activity.ts
@@ -1,0 +1,36 @@
+/**
+ * `useSelectedActivity` — keeps the dialog's coaching activity in sync
+ * with the live `coaching.byDay` map.
+ *
+ * The clicked activity is captured by id only. The view-model itself is
+ * re-derived on every render so the live-query update from
+ * `expandActivity` (which writes the description into Dexie out-of-band)
+ * propagates into the open dialog. A plain `useState<CoachingActivity>`
+ * would freeze the original reference with `description: undefined` and
+ * the dialog would stay on "Loading description…" forever.
+ */
+import { useMemo, useState } from "react";
+
+import type { CoachingActivity } from "../../types/coaching-activity";
+
+export type UseSelectedActivity = {
+  selectedActivity: CoachingActivity | null;
+  setSelectedActivity: (a: CoachingActivity | null) => void;
+};
+
+export const useSelectedActivity = (
+  byDay: Record<string, CoachingActivity[]>
+): UseSelectedActivity => {
+  const [id, setId] = useState<string | null>(null);
+  const selectedActivity = useMemo<CoachingActivity | null>(() => {
+    if (!id) return null;
+    for (const day of Object.values(byDay)) {
+      const found = day.find((a) => a.id === id);
+      if (found) return found;
+    }
+    return null;
+  }, [id, byDay]);
+  const setSelectedActivity = (a: CoachingActivity | null): void =>
+    setId(a?.id ?? null);
+  return { selectedActivity, setSelectedActivity };
+};

--- a/packages/workout-spa-editor/src/components/pages/use-selected-activity.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-selected-activity.ts
@@ -9,7 +9,7 @@
  * would freeze the original reference with `description: undefined` and
  * the dialog would stay on "Loading description…" forever.
  */
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import type { CoachingActivity } from "../../types/coaching-activity";
 
@@ -30,7 +30,9 @@ export const useSelectedActivity = (
     }
     return null;
   }, [id, byDay]);
-  const setSelectedActivity = (a: CoachingActivity | null): void =>
-    setId(a?.id ?? null);
+  const setSelectedActivity = useCallback(
+    (a: CoachingActivity | null): void => setId(a?.id ?? null),
+    []
+  );
   return { selectedActivity, setSelectedActivity };
 };


### PR DESCRIPTION
## Bug

User reports: clicking a Train2Go coaching activity opens the dialog but the description is stuck on "Loading description…" indefinitely. Reproduced on production (kaiord.com/editor/calendar) — see screenshot in the conversation.

## Root cause

\`useCalendarPage\` held the clicked activity in plain \`useState<CoachingActivity | null>\`. The reference is captured at click time with \`description: undefined\` (the lazy field). \`expandActivity\` then fetches via the bridge and \`upsertMany\`s the populated activity into Dexie, which triggers a live-query refresh on \`coaching.byDay\` — but the dialog's \`activity\` prop still points at the original frozen reference, so the \"Loading description…\" placeholder never disappears.

This bug was present before the dialog redesign but masked by the existing e2e (\`coaching-dialog-train2go.spec.ts\`) which pre-seeds the description directly into Dexie, never exercising the lazy-load → re-render path.

## Fix

Replaced \`useState<CoachingActivity>\` with \`useSelectedActivity(byDay)\` — captures the click target by **id** only and re-derives the live view-model from \`coaching.byDay\` on every render. Dexie updates now propagate into the open dialog.

## Test plan

- [x] \`useSelectedActivity.test.tsx\` (3 tests) — verifies the live-derive behavior including the "stale description → populated description" transition that was previously broken.
- [x] Full SPA suite — 410 files / 3491 tests green.
- [x] \`pnpm lint\` clean (file split because the inline hook pushed \`use-calendar-page.ts\` past the 80-line cap).
- [ ] Manual verification on production after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed coaching activity dialog stuck displaying "Loading description…" indefinitely; activity descriptions now update properly as data changes.

* **Tests**
  * Added test coverage for activity selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->