### PR TITLE
fix(coaching): manual flow + bridge description truncation

### DIFF
--- a/.changeset/coaching-manual-template-on-legacy-raw.md
+++ b/.changeset/coaching-manual-template-on-legacy-raw.md
@@ -1,0 +1,7 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Fix coaching dialog "Edit manually" landing on "This workout has no structured data yet".
+
+When the coaching activity already had a workout from the legacy `convertCoachingActivity` path (state=raw, krd=null), `handleExistingManualWorkout` returned the existing id without populating its KRD. The editor then short-circuited to `EditorNoData`. The handler now detects the empty-krd case, writes the warmup template KRD, and transitions the workout to `state="structured"` so the editor renders a step the user can edit.

--- a/.changeset/train2go-bridge-description-truncation-fix.md
+++ b/.changeset/train2go-bridge-description-truncation-fix.md
@@ -1,0 +1,7 @@
+---
+"@kaiord/train2go-bridge": patch
+---
+
+Fix coaching activity description leaking the opening tag of the next sibling block (`<div class="`) into the rendered text.
+
+`extractDescription` used a lookahead on the literal substring `activity-hint-ecos`, so the captured chunk reached the position just before that text — which is INSIDE the opening `<div class="..."` of the hint-ecos sibling. The strip-divs-with-content regex below only matches complete `<div>...</div>` blocks, so the partial opening tag survived and ended up in the description. Anchored the lookahead on the full `<div[^>]*activity-hint-ecos` opener instead.

--- a/packages/train2go-bridge/parser.js
+++ b/packages/train2go-bridge/parser.js
@@ -130,8 +130,14 @@ const parseDailyHtml = (html) => {
 };
 
 const extractDescription = (block) => {
+  // The lookahead boundary MUST stop at the start of the next sibling
+  // tag (the `<div class="activity-hint-ecos ...">` block, or the form
+  // / aside close), not at the substring "activity-hint-ecos" — otherwise
+  // the captured chunk includes the partial opening `<div class="` and
+  // leaks it into the rendered description (the trailing tag has no `>`
+  // so the strip-divs-with-content regex below never matches it).
   const descMatch = block.match(
-    /activity-description[^>]*>([\s\S]*?)(?=activity-hint-ecos|<\/form>|<\/aside>|$)/
+    /activity-description[^>]*>([\s\S]*?)(?=<div[^>]*activity-hint-ecos|<\/form>|<\/aside>|$)/
   );
   if (!descMatch) return "";
 

--- a/packages/train2go-bridge/test/parser.test.js
+++ b/packages/train2go-bridge/test/parser.test.js
@@ -162,6 +162,42 @@ describe("parser", () => {
       expect(activities[0].description).toContain("**Calentamiento:**");
       expect(activities[0].description).toContain("3x15' Z3 d/5' Z1");
     });
+
+    it("should not leak the opening tag of the next sibling block into the description (regression: <div class=\" trailing fragment)", () => {
+      // Arrange
+      // The live T2G response has the activity-description block followed
+      // by an `activity-hint-ecos` div. The previous lookahead matched the
+      // substring "activity-hint-ecos" but the captured chunk reached up
+      // to (but not including) that substring — which means the opening
+      // `<div class="` of the hint-ecos div leaked through. The strip-divs
+      // regex below `extractDescription` only matches complete
+      // `<div>...</div>` blocks, so the partial opening tag survived and
+      // ended up in the rendered description as a literal `<div class="`.
+      const html = `<aside><div class="activity activity-default  activity-expanded  " data-status="0" data-id="1">
+        <figure class="icon icon-sportscycling"></figure>
+        <span class="measured">1:55 h</span>
+        <div class="workload workload-default" data-value="2"></div>
+        <div class="activity-title"><strong>Test</strong></div>
+        <div class="activity-description  activity-description-empty ">
+          <p>Avituallamiento intraentreno con 60grHC</p>
+          <p><strong>Calentamiento:</strong> 20 Z1 + 15' Z2.</p>
+          <p>10' Soltar Z2-1.</p>
+          <div class="activity-hint-ecos d-flex flex-row">
+            <div class="activity-hint-ecos-count"><strong>0</strong></div>
+          </div>
+        </div>
+      </div></aside>`;
+
+      // Act
+      const activities = parseDailyHtml(html);
+
+      // Assert
+      expect(activities).toHaveLength(1);
+      expect(activities[0].description).not.toContain("<div");
+      expect(activities[0].description).not.toContain("class=");
+      expect(activities[0].description).toContain("Avituallamiento");
+      expect(activities[0].description).toContain("Soltar Z2-1");
+    });
   });
 
   describe("parsePingJson", () => {

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual-helpers.ts
@@ -3,6 +3,7 @@
  * the use-case file stays under the per-file line cap.
  */
 import type { SessionMatchSource } from "../../types/session-match";
+import { buildCoachingTemplateKrd } from "./coaching-template";
 import type {
   CoachingActivityForConvert,
   ConvertManualDeps,
@@ -17,6 +18,21 @@ export const handleExistingManualWorkout = async (
   activity: CoachingActivityForConvert,
   existingWorkoutId: string
 ): Promise<ConvertManualResult> => {
+  // If the existing workout was created by the legacy
+  // `convertCoachingActivity` it sits in `state="raw"` with `krd=null`
+  // and the editor lands on `EditorNoData` ("This workout has no
+  // structured data yet") — a dead end. Manual is meant to give the
+  // user a non-empty KRD; populate the template here when the existing
+  // record is empty so the editor renders a step the user can edit.
+  const existing = await deps.workouts.getById(existingWorkoutId);
+  if (existing && !existing.krd) {
+    await deps.workouts.put({
+      ...existing,
+      state: "structured",
+      krd: buildCoachingTemplateKrd(activity.sport),
+      updatedAt: deps.clock(),
+    });
+  }
   await ensureSessionMatch(deps.sessionMatches, {
     profileId: activity.profileId,
     coachingActivityId: activity.id,

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.test.ts
@@ -161,6 +161,7 @@ describe("convertCoachingActivityManual", () => {
     const stored = await deps.workouts.getById("w-legacy-raw");
     expect(stored?.krd).not.toBeNull();
     expect(stored?.state).toBe("structured");
+    expect(stored?.updatedAt).toBe(NOW);
   });
 
   it("should emit invoked + success analytics events", async () => {

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.test.ts
@@ -135,6 +135,34 @@ describe("convertCoachingActivityManual", () => {
     expect(stored?.raw?.description).toBe("Specific Z2 endurance ride 90 min");
   });
 
+  it("should populate the template KRD when an existing workout has krd=null (legacy raw)", async () => {
+    // Arrange
+    const activity = stubActivity();
+    const existing: WorkoutRecord = {
+      id: "w-legacy-raw",
+      date: activity.date,
+      sport: activity.sport,
+      source: activity.source,
+      state: "raw",
+      krd: null,
+      updatedAt: "2026-01-01T00:00:00Z",
+    } as WorkoutRecord;
+    const workouts = buildStubWorkoutRepo([existing]);
+    workouts.setSourceLookup(existing);
+    const deps = buildDeps({
+      coaching: buildStubCoachingRepo([activity]),
+      workouts,
+    });
+
+    // Act
+    await convertCoachingActivityManual({ activityId: activity.id }, deps);
+
+    // Assert
+    const stored = await deps.workouts.getById("w-legacy-raw");
+    expect(stored?.krd).not.toBeNull();
+    expect(stored?.state).toBe("structured");
+  });
+
   it("should emit invoked + success analytics events", async () => {
     // Arrange
     const activity = stubActivity();


### PR DESCRIPTION
## Two regressions surfaced by user testing on production

### Bug 1 — \`Edit manually\` lands on \"This workout has no structured data yet\"

When the activity already had a workout from the legacy \`convertCoachingActivity\` (state=raw, krd=null), \`handleExistingManualWorkout\` returned the existing id without populating its KRD. The editor's \`if (id && record && !record.krd) return <EditorNoData />\` short-circuit then rendered the dead-end \"This workout has no structured data yet.\" message.

**Fix**: \`handleExistingManualWorkout\` now detects empty-krd and writes the warmup template + transitions state to \`structured\`. Idempotent re-call still works (subsequent calls find a populated krd and skip the update). Regression test added (\`should populate the template KRD when an existing workout has krd=null (legacy raw)\`).

### Bug 2 — Coaching description leaks \`<div class=\"\` into the rendered text

\`extractDescription\` in the train2go-bridge anchored the lookahead on the literal substring \`activity-hint-ecos\`, so the captured chunk ended INSIDE the opening tag of the next sibling div (\`<div class=\"activity-hint-ecos ...\">\`). The strip-divs-with-content regex below only matched complete \`<div>...</div>\` blocks, so the orphan opening tag (\`<div class=\"\`) survived and was rendered literally.

**Fix**: anchor the lookahead on the full opening tag (\`<div[^>]*activity-hint-ecos\`) so the captured chunk stops BEFORE that tag. Regression test added.

This explains the trailing \`<div class=\"\` in the dialog screenshot from the user. Existing data on production heals on the next bridge re-sync.

## Test plan

- [x] \`pnpm --filter @kaiord/workout-spa-editor test\` — 410 files / 3492 tests green
- [x] \`pnpm --filter @kaiord/train2go-bridge test\` — 45/45 green (1 new regression test)
- [x] \`pnpm lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Edit manually" flow for legacy workouts without structured data—now properly initializes editable content
  * Fixed description extraction leaking malformed HTML fragments from sibling content blocks

* **Tests**
  * Added regression test coverage for activity parsing edge cases and legacy workout handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->