### PR TITLE
fix(spa-editor): render coaching description bold (handle <strong> AND **markdown**)

### DIFF
--- a/.changeset/coaching-description-bold-rendering.md
+++ b/.changeset/coaching-description-bold-rendering.md
@@ -1,0 +1,9 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Render coaching activity descriptions with bold emphasis instead of literal `**` markers.
+
+The train2go-bridge converts Train2Go's `<strong>X</strong>` HTML to markdown `**X**` before storing the description in Dexie. The dialog rendered the raw text via `whitespace-pre-line`, so users saw literal asterisks (`**Calentamiento:** 20 Z1 + 15' Z2`) instead of bold (`**Calentamiento:**` 20 Z1 + 15' Z2).
+
+`formatCoachingDescription` now recognizes both shapes (`<strong>` HTML + `**markdown**`), and `DialogDescription` walks the same AST → `<strong>` React tree the sidebar already uses. Bold renders consistently in dialog and sidebar regardless of whether the upstream stored HTML or the bridge-converted markdown markers.

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-parts.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-parts.tsx
@@ -7,6 +7,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 
 import type { CoachingActivity } from "../../../types/coaching-activity";
+import { formatCoachingDescription } from "../../organisms/CoachingSidebar/format-coaching-description";
 
 export const STATUS_LABEL: Record<string, string> = {
   pending: "Pending",
@@ -54,9 +55,23 @@ export const DialogDescription = ({
     );
   }
   if (!activity.description) return null;
+  const paragraphs = formatCoachingDescription(activity.description);
   return (
-    <div className="whitespace-pre-line border-t pt-3 text-sm">
-      {activity.description}
+    <div className="space-y-2 border-t pt-3 text-sm leading-relaxed">
+      {paragraphs.map((p, pi) => (
+        <p key={pi}>
+          {p.inlines.map((inline, ii) =>
+            inline.kind === "strong" ? (
+              <strong key={ii}>{inline.value}</strong>
+            ) : (
+              <span key={ii}>
+                {ii > 0 ? " " : ""}
+                {inline.value}
+              </span>
+            )
+          )}
+        </p>
+      ))}
     </div>
   );
 };

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
@@ -66,6 +66,29 @@ describe("formatCoachingDescription", () => {
     expect(result[1]?.inlines[0]?.value).toBe("Then 4×5 min Z4.");
   });
 
+  it("should recognize markdown **bold** as strong (bridge converts <strong> → ** before storing)", () => {
+    // Arrange
+    const text =
+      "Avituallamiento intraentreno\n\n**Calentamiento:** 20 Z1 + 15' Z2.\n\n**Parte Principal:**\n\n3x15' Z3 d/5' Z1";
+
+    // Act
+    const result = formatCoachingDescription(text);
+
+    // Assert
+    const calentamiento = result.find((p) =>
+      p.inlines.some(
+        (i) => i.kind === "strong" && i.value === "Calentamiento:"
+      )
+    );
+    expect(calentamiento).toBeDefined();
+    const parte = result.find((p) =>
+      p.inlines.some(
+        (i) => i.kind === "strong" && i.value === "Parte Principal:"
+      )
+    );
+    expect(parte).toBeDefined();
+  });
+
   it("should preserve <strong> with attributes", () => {
     // Arrange
     const html = '<p>Effort <strong class="zone-4">Z4</strong></p>';

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
@@ -76,9 +76,7 @@ describe("formatCoachingDescription", () => {
 
     // Assert
     const calentamiento = result.find((p) =>
-      p.inlines.some(
-        (i) => i.kind === "strong" && i.value === "Calentamiento:"
-      )
+      p.inlines.some((i) => i.kind === "strong" && i.value === "Calentamiento:")
     );
     expect(calentamiento).toBeDefined();
     const parte = result.find((p) =>

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts
@@ -1,12 +1,15 @@
 /**
- * Minimal HTML formatter for coaching descriptions: preserves `<p>`
- * paragraph breaks and `<strong>` emphasis, strips every other tag
- * (per design D4 / spec §9.3). Returns a structured AST so the
- * renderer can map to React without using `dangerouslySetInnerHTML`.
+ * Minimal formatter for coaching descriptions: preserves paragraph
+ * breaks and bold emphasis, strips every other tag (per design D4 /
+ * spec §9.3). Returns a structured AST so the renderer can map to
+ * React without using `dangerouslySetInnerHTML`.
+ *
+ * Bold input shapes (both supported):
+ *   - HTML  `<strong>X</strong>` — what Train2Go ships natively.
+ *   - Markdown `**X**` — what the train2go-bridge currently stores
+ *     after its HTML→text conversion (`<strong>` → `**`).
  *
  * Out of scope: full HTML, links, lists, line breaks via `<br>`.
- * Train2Go descriptions are short prose with optional bold; richer
- * markup falls back to plain text inside paragraphs.
  */
 
 export type DescriptionInline =
@@ -17,7 +20,8 @@ export type DescriptionParagraph = {
   inlines: DescriptionInline[];
 };
 
-const STRONG_RE = /<strong\b[^>]*>([\s\S]*?)<\/strong>/gi;
+const STRONG_RE =
+  /<strong\b[^>]*>([\s\S]*?)<\/strong>|\*\*([^*\n][^*]*?)\*\*/gi;
 
 const stripTagsExceptStrong = (html: string): string => {
   // Remove every tag except <strong>...</strong> markers (the strong
@@ -45,7 +49,11 @@ const splitInlines = (paragraph: string): DescriptionInline[] => {
       );
       if (text) inlines.push({ kind: "text", value: text });
     }
-    const inner = decodeEntities(stripTagsExceptStrong(match[1] ?? ""));
+    // Two capture groups: HTML `<strong>...</strong>` (group 1) OR
+    // markdown `**...**` (group 2). Whichever matched is the bold body.
+    const inner = decodeEntities(
+      stripTagsExceptStrong(match[1] ?? match[2] ?? "")
+    );
     if (inner) inlines.push({ kind: "strong", value: inner });
     lastIndex = start + match[0].length;
   }


### PR DESCRIPTION
## What

\`formatCoachingDescription\` now recognizes both bold input shapes:
- HTML \`<strong>X</strong>\` (Train2Go ships natively)
- Markdown \`**X**\` (what train2go-bridge stores after its HTML→text conversion)

\`DialogDescription\` now uses the same formatter the sidebar already uses, so the dialog renders proper \`<strong>\` instead of literal \`**Calentamiento:**\` asterisks.

## Why

User reported: \"en train2go me sale en negrita, y aqui como **\". The dialog rendered \`whitespace-pre-line\` plain text, so the markdown markers from the bridge leaked through unrendered.

## Test plan

- [x] \`pnpm --filter @kaiord/workout-spa-editor test\` — 410 files / 3493 tests green (added 1 regression test for markdown bold)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)