### PR TITLE
refactor(spa-editor): rename SessionMatchSource auto-conversion to auto-coaching (closes #556)

### DIFF
--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v10-migration.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v10-migration.ts
@@ -5,7 +5,7 @@
  * `workouts` table by `(source, namespacedSourceId)`, and writes a fresh
  * `sessionMatches` row for every pair that is missing one. Source =
  * `"auto-coaching-v10-migration"` so analytics can distinguish retro-
- * matched rows from per-call auto-conversions (per design D8).
+ * matched rows from per-call auto-coaching matches (per design D8).
  *
  * Idempotent at the row level: existing matches are never overwritten,
  * existing rows from another `source` are skipped. A re-run produces

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v11-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v11-migration.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Forward migration v10 → v11 — `SessionMatch.source` rename.
+ *
+ * Rewrites legacy `auto-conversion` rows to the canonical
+ * `auto-coaching` value. Idempotent.
+ */
+import "fake-indexeddb/auto";
+
+import Dexie, { type Transaction } from "dexie";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { applyV11Upgrade } from "./dexie-v11-migration";
+
+const dbName = (suffix: string) =>
+  `kaiord-test-v11-${suffix}-${Date.now()}-${Math.random()}`;
+
+const NOW = "2026-05-08T10:00:00.000Z";
+const SCHEMA_V10 = 10;
+const SCHEMA_V11 = 11;
+
+const stores = {
+  sessionMatches:
+    "id, [profileId+coachingActivityId], [profileId+workoutId], [profileId+date], coachingActivityId, workoutId, profileId",
+} as const;
+
+const seedRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "M1",
+  profileId: "p1",
+  coachingActivityId: "p1:train2go:12345",
+  workoutId: "w-1",
+  date: "2026-04-29",
+  createdAt: NOW,
+  source: "auto-conversion",
+  ...overrides,
+});
+
+const seedV10 = async (
+  name: string,
+  rows: ReadonlyArray<Record<string, unknown>>
+): Promise<void> => {
+  const v10 = new Dexie(name);
+  v10.version(SCHEMA_V10).stores(stores);
+  await v10.open();
+  if (rows.length > 0) {
+    await v10.table("sessionMatches").bulkAdd([...rows]);
+  }
+  v10.close();
+};
+
+const openWithV11Migration = async (name: string): Promise<Dexie> => {
+  const db = new Dexie(name);
+  db.version(SCHEMA_V11).stores(stores).upgrade(applyV11Upgrade);
+  await db.open();
+  return db;
+};
+
+describe("Dexie v10 → v11 migration (SessionMatch.source rename)", () => {
+  let name: string;
+
+  beforeEach(() => {
+    name = dbName("apply");
+  });
+
+  afterEach(async () => {
+    await Dexie.delete(name);
+  });
+
+  it("should rewrite auto-conversion rows to auto-coaching", async () => {
+    // Arrange
+    await seedV10(name, [
+      seedRow({ id: "M1", source: "auto-conversion" }),
+      seedRow({ id: "M2", source: "auto-conversion", workoutId: "w-2" }),
+    ]);
+
+    // Act
+    const db = await openWithV11Migration(name);
+
+    // Assert
+    const rows = (await db.table("sessionMatches").toArray()) as Array<{
+      id: string;
+      source: string;
+    }>;
+    expect(rows.map((r) => r.source).sort()).toEqual([
+      "auto-coaching",
+      "auto-coaching",
+    ]);
+    db.close();
+  });
+
+  it("should leave manual, auto-suggestion, and v10-migration rows untouched", async () => {
+    // Arrange
+    await seedV10(name, [
+      seedRow({ id: "M1", source: "manual" }),
+      seedRow({ id: "M2", source: "auto-suggestion", workoutId: "w-2" }),
+      seedRow({
+        id: "M3",
+        source: "auto-coaching-v10-migration",
+        workoutId: "w-3",
+      }),
+    ]);
+
+    // Act
+    const db = await openWithV11Migration(name);
+
+    // Assert
+    const rows = (await db.table("sessionMatches").toArray()) as Array<{
+      id: string;
+      source: string;
+    }>;
+    const sourcesById = new Map(rows.map((r) => [r.id, r.source]));
+    expect(sourcesById.get("M1")).toBe("manual");
+    expect(sourcesById.get("M2")).toBe("auto-suggestion");
+    expect(sourcesById.get("M3")).toBe("auto-coaching-v10-migration");
+    db.close();
+  });
+
+  it("should be idempotent on re-run (no auto-conversion rows remain to rewrite)", async () => {
+    // Arrange
+    await seedV10(name, [
+      seedRow({ id: "M1", source: "auto-conversion" }),
+      seedRow({ id: "M2", source: "manual", workoutId: "w-2" }),
+    ]);
+    const first = await openWithV11Migration(name);
+    first.close();
+
+    // Act
+    const second = new Dexie(name);
+    second.version(SCHEMA_V11).stores(stores);
+    await second.open();
+    await second.transaction("rw", ["sessionMatches"], async (tx) =>
+      applyV11Upgrade(tx as unknown as Transaction)
+    );
+
+    // Assert
+    const rows = (await second.table("sessionMatches").toArray()) as Array<{
+      id: string;
+      source: string;
+    }>;
+    const sourcesById = new Map(rows.map((r) => [r.id, r.source]));
+    expect(sourcesById.get("M1")).toBe("auto-coaching");
+    expect(sourcesById.get("M2")).toBe("manual");
+    second.close();
+  });
+
+  it("should be a no-op on a clean database with no rows", async () => {
+    // Arrange
+    await seedV10(name, []);
+
+    // Act
+    const db = await openWithV11Migration(name);
+
+    // Assert
+    expect(await db.table("sessionMatches").toArray()).toHaveLength(0);
+    db.close();
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v11-migration.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v11-migration.ts
@@ -1,0 +1,25 @@
+/**
+ * v10 → v11 migration — `SessionMatch.source` rename.
+ *
+ * Rewrites every `sessionMatches` row whose `source` is the legacy
+ * `"auto-conversion"` value to the canonical `"auto-coaching"`. The
+ * v10-migration source (`"auto-coaching-v10-migration"`) and `"manual"`
+ * / `"auto-suggestion"` rows are left untouched.
+ *
+ * Idempotent: a re-run sees no `"auto-conversion"` rows and writes
+ * nothing.
+ */
+import type { Transaction } from "dexie";
+
+type MatchRow = { id: string; source: string };
+
+export const applyV11Upgrade = async (tx: Transaction): Promise<void> => {
+  await tx
+    .table("sessionMatches")
+    .toCollection()
+    .modify((row: MatchRow) => {
+      if (row.source === "auto-conversion") {
+        row.source = "auto-coaching";
+      }
+    });
+};

--- a/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions.ts
@@ -17,6 +17,7 @@ import {
 } from "./dexie-migrations";
 import { backfillLinkedAccounts, SCHEMAS } from "./dexie-schemas";
 import { applyV10Upgrade } from "./dexie-v10-migration";
+import { applyV11Upgrade } from "./dexie-v11-migration";
 
 // Narrowed handle: only `version()` is needed and Dexie's full surface
 // causes "Type instantiation is excessively deep" when passed as a
@@ -73,17 +74,21 @@ const registerV7ToV9 = (db: DexieVersionHost): void => {
   db.version(9).stores(SCHEMAS.v8).upgrade(applyV9Upgrade);
 };
 
-const registerV10 = (db: DexieVersionHost): void => {
+const registerV10ToV11 = (db: DexieVersionHost): void => {
   // v10 — coaching auto-match retro-fix (per coaching-activity-dialog-
   // redesign / D8). Schema is unchanged from v8; only the data-side
   // upgrade fires, scanning coachingActivities × workouts for pairs
   // that lack a sessionMatch and writing the missing rows.
   db.version(10).stores(SCHEMAS.v8).upgrade(applyV10Upgrade);
+  // v11 — SessionMatch.source rename: legacy "auto-conversion" rows are
+  // rewritten to the canonical "auto-coaching" value (coaching-activity-
+  // dialog-redesign §1.4 follow-up). Schema unchanged from v8; data-only.
+  db.version(11).stores(SCHEMAS.v8).upgrade(applyV11Upgrade);
 };
 
 export const registerKaiordVersions = (db: DexieVersionHost): void => {
   registerV1ToV3(db);
   registerV4ToV6(db);
   registerV7ToV9(db);
-  registerV10(db);
+  registerV10ToV11(db);
 };

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual-helpers.ts
@@ -11,7 +11,7 @@ import type {
 } from "./convert-coaching-activity-manual-types";
 import { ensureSessionMatch } from "./ensure-session-match";
 
-export const manualMatchSource: SessionMatchSource = "auto-conversion";
+export const manualMatchSource: SessionMatchSource = "auto-coaching";
 
 export const handleExistingManualWorkout = async (
   deps: ConvertManualDeps,

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.test.ts
@@ -64,7 +64,7 @@ describe("convertCoachingActivityManual", () => {
     // Assert
     const match = await deps.sessionMatches.getByActivityId("p1", activity.id);
     expect(match?.workoutId).toBe("w-new");
-    expect(match?.source).toBe("auto-conversion");
+    expect(match?.source).toBe("auto-coaching");
   });
 
   it("should be idempotent and return the existing workout on re-call", async () => {

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai-helpers.ts
@@ -39,7 +39,7 @@ const persistFreshWorkout = async (
     coachingActivityId: activity.id,
     workoutId: workout.id,
     date: activity.date,
-    source: "auto-conversion",
+    source: "auto-coaching",
     newId: deps.newMatchId,
     clock: deps.clock,
   });

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai-idempotency.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai-idempotency.ts
@@ -24,7 +24,7 @@ export const ensureMatchForExisting = async (
     coachingActivityId: activity.id,
     workoutId,
     date: activity.date,
-    source: "auto-conversion",
+    source: "auto-coaching",
     newId: deps.newMatchId,
     clock: deps.clock,
   });

--- a/packages/workout-spa-editor/src/application/convert-and-auto-match.test.ts
+++ b/packages/workout-spa-editor/src/application/convert-and-auto-match.test.ts
@@ -71,7 +71,7 @@ const stubWorkoutRepo = (rows: WorkoutRecord[] = []): WorkoutRepository => {
 const fixedClock = () => "2026-05-01T12:00:00.000Z";
 
 describe("convertAndAutoMatch", () => {
-  it("should create workout AND SessionMatch with source: auto-conversion on first-time conversion", async () => {
+  it("should create workout AND SessionMatch with source: auto-coaching on first-time conversion", async () => {
     // Arrange
     const activity = stubActivity();
     const coaching = stubCoachingRepo([activity]);
@@ -98,7 +98,7 @@ describe("convertAndAutoMatch", () => {
     expect(match).toMatchObject({
       coachingActivityId: activity.id,
       workoutId: "w-new",
-      source: "auto-conversion",
+      source: "auto-coaching",
     });
   });
 
@@ -187,7 +187,7 @@ describe("convertAndAutoMatch", () => {
     expect(healed).toMatchObject({
       coachingActivityId: activity.id,
       workoutId: "w-converted-no-match",
-      source: "auto-conversion",
+      source: "auto-coaching",
     });
   });
 

--- a/packages/workout-spa-editor/src/application/convert-and-auto-match.ts
+++ b/packages/workout-spa-editor/src/application/convert-and-auto-match.ts
@@ -64,7 +64,7 @@ export async function convertAndAutoMatch(
     coachingActivityId: activity.id,
     workoutId: conversion.workoutId,
     date: activity.date,
-    source: "auto-conversion",
+    source: "auto-coaching",
     newId: deps.newMatchId,
     clock: deps.clock,
   });

--- a/packages/workout-spa-editor/src/application/match-session.test.ts
+++ b/packages/workout-spa-editor/src/application/match-session.test.ts
@@ -116,7 +116,7 @@ describe("matchSession", () => {
         profileId: "p1",
         coachingActivityId: activity.id,
         workoutId: workout.id,
-        source: "auto-conversion",
+        source: "auto-coaching",
       },
       {
         clock: fixedClock,
@@ -128,7 +128,7 @@ describe("matchSession", () => {
     );
 
     // Assert
-    expect(result.source).toBe("auto-conversion");
+    expect(result.source).toBe("auto-coaching");
   });
 
   it("should throw CoachingActivityNotFoundError when the activity is missing", async () => {

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/use-coaching-sidebar.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/use-coaching-sidebar.ts
@@ -26,7 +26,7 @@ export type CoachingSidebarData = {
 };
 
 const COACHING_SOURCES: ReadonlyArray<SessionMatch["source"]> = [
-  "auto-conversion",
+  "auto-coaching",
   "auto-coaching-v10-migration",
   "manual",
 ];

--- a/packages/workout-spa-editor/src/types/session-match.test.ts
+++ b/packages/workout-spa-editor/src/types/session-match.test.ts
@@ -28,8 +28,8 @@ describe("sessionMatchSourceSchema", () => {
     expect(sessionMatchSourceSchema.parse("auto-suggestion")).toBe(
       "auto-suggestion"
     );
-    expect(sessionMatchSourceSchema.parse("auto-conversion")).toBe(
-      "auto-conversion"
+    expect(sessionMatchSourceSchema.parse("auto-coaching")).toBe(
+      "auto-coaching"
     );
   });
 
@@ -59,8 +59,8 @@ describe("sessionMatchSchema", () => {
       sessionMatchSchema.parse(baseRow({ source: "auto-suggestion" })).source
     ).toBe("auto-suggestion");
     expect(
-      sessionMatchSchema.parse(baseRow({ source: "auto-conversion" })).source
-    ).toBe("auto-conversion");
+      sessionMatchSchema.parse(baseRow({ source: "auto-coaching" })).source
+    ).toBe("auto-coaching");
   });
 
   it("should require non-empty id, profileId, coachingActivityId, workoutId", () => {

--- a/packages/workout-spa-editor/src/types/session-match.ts
+++ b/packages/workout-spa-editor/src/types/session-match.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 export const sessionMatchSourceSchema = z.enum([
   "manual",
   "auto-suggestion",
-  "auto-conversion",
+  "auto-coaching",
   "auto-coaching-v10-migration",
 ]);
 


### PR DESCRIPTION
## Summary

- Renames the `SessionMatchSource` Zod enum value `"auto-conversion"` → `"auto-coaching"` to match the canonical name in the `spa-coaching-integration` spec (per coaching-activity-dialog-redesign §1.4 / D8).
- Adds a forward-only Dexie v11 data migration that rewrites every legacy `sessionMatches.source = "auto-conversion"` row to `"auto-coaching"` inside the upgrade transaction. Idempotent on re-run; leaves `"manual"`, `"auto-suggestion"`, and `"auto-coaching-v10-migration"` rows untouched.
- Updates all four call sites that wrote the legacy value (`convert-and-auto-match`, `convert-coaching-activity-with-ai-helpers`, `convert-coaching-activity-with-ai-idempotency`, `convert-coaching-activity-manual-helpers`) plus the `COACHING_SOURCES` allowlist used by the editor sidebar live query, so future writes use the canonical value end-to-end.
- Updates the four affected vitest files to assert the new value.

## Test plan

- [x] `pnpm test` covering session-match, dexie-v10/v11 migrations, convert-and-auto-match, match-session, convert-coaching-activity-{manual,with-ai}, CoachingSidebar — 59/59 passed locally.
- [x] `pnpm exec tsc --noEmit` clean.
- [x] Pre-commit hooks (`lint-staged`, AAA test-format guards, archive lints) green.

The two pre-existing UsageTab/UsageTable failures (locale-dependent number formatting) are out of scope and reproduce on `main`.

Closes #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)