### PR TITLE
fix(spa-editor): abort in-flight AI on coaching-dialog dismiss (closes #551)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialog.tsx
@@ -7,11 +7,12 @@
  * a profile switch does not reroute writes.
  */
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useLocation } from "wouter";
 
 import { usePickableWorkouts } from "../../../hooks/use-pickable-workouts";
 import type { CoachingActivity } from "../../../types/coaching-activity";
+import { buildCoachingDialogCloseHandler } from "./build-coaching-dialog-close-handler";
 import { CoachingDialogShell } from "./coaching-dialog-shell";
 import { CoachingActivityDialogContent } from "./CoachingActivityDialogContent";
 import { useCoachingDialog } from "./use-coaching-dialog";
@@ -44,11 +45,16 @@ export function CoachingActivityDialog({
       navigate(`/workout/${matchedId}`);
     }
   }, [matchedId, navigate, onClose]);
+  const { cancelAi } = dialog.ai;
+  const handleDialogClose = useMemo(
+    () => buildCoachingDialogCloseHandler(cancelAi, onClose),
+    [cancelAi, onClose]
+  );
 
   if (!activity) return null;
 
   return (
-    <CoachingDialogShell onClose={onClose}>
+    <CoachingDialogShell onClose={handleDialogClose}>
       <CoachingActivityDialogContent
         activity={activity}
         dialogState={dialog.dialogState}
@@ -59,7 +65,7 @@ export function CoachingActivityDialog({
         aiProcessing={dialog.ai.processing}
         aiFailure={dialog.ai.failure}
         manualCreating={dialog.manual.creating}
-        onClose={onClose}
+        onClose={handleDialogClose}
         onAiProcess={dialog.ai.startAi}
         onAiCancel={dialog.ai.cancelAi}
         onEditManually={dialog.manual.startManual}

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/build-coaching-dialog-close-handler.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/build-coaching-dialog-close-handler.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildCoachingDialogCloseHandler } from "./build-coaching-dialog-close-handler";
+
+describe("buildCoachingDialogCloseHandler", () => {
+  it("should invoke cancelAi before onClose so an in-flight abort lands first", () => {
+    // Arrange
+    const order: string[] = [];
+    const cancelAi = vi.fn(() => {
+      order.push("cancelAi");
+    });
+    const onClose = vi.fn(() => {
+      order.push("onClose");
+    });
+
+    // Act
+    buildCoachingDialogCloseHandler(cancelAi, onClose)();
+
+    // Assert
+    expect(cancelAi).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(["cancelAi", "onClose"]);
+  });
+
+  it("should still invoke onClose when no AI request is in flight (cancelAi is a no-op)", () => {
+    // Arrange
+    const cancelAi = vi.fn();
+    const onClose = vi.fn();
+
+    // Act
+    buildCoachingDialogCloseHandler(cancelAi, onClose)();
+
+    // Assert
+    expect(cancelAi).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+});

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/build-coaching-dialog-close-handler.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/build-coaching-dialog-close-handler.test.ts
@@ -34,5 +34,4 @@ describe("buildCoachingDialogCloseHandler", () => {
     expect(cancelAi).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
-
 });

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/build-coaching-dialog-close-handler.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/build-coaching-dialog-close-handler.ts
@@ -1,0 +1,16 @@
+/**
+ * Builds the close handler used by CoachingActivityDialog so every
+ * dismiss path (Radix `onOpenChange`, the inline `[Close]` button, and
+ * any future X affordance) aborts an in-flight AI request before
+ * delegating to the parent's `onClose`.
+ *
+ * `cancelAi` is a no-op when no request is pending (per
+ * `useCoachingAi`), so calling it eagerly is safe — this keeps the
+ * abort contract uniform across dismiss paths (per
+ * coaching-activity-dialog-redesign §6.8 / D2).
+ */
+export const buildCoachingDialogCloseHandler =
+  (cancelAi: () => void, onClose: () => void) => () => {
+    cancelAi();
+    onClose();
+  };


### PR DESCRIPTION
## Summary

- Wraps the `CoachingActivityDialog` `onClose` so every dismiss path (Radix `onOpenChange` covering Escape + outside-click + X, plus the inline `[Close]` button) calls `cancelAi()` before delegating to the parent's `onClose`. `cancelAi` is already a no-op when no request is pending, so calling it eagerly is safe and keeps the abort contract uniform across dismiss paths.
- Previously only the explicit `[Cancel]` button fired `AbortController.abort()`. Escape and outside-click closed the Radix Dialog and let the in-flight LLM call settle in the background, contradicting `spa-coaching-integration` "AI cancellation persists nothing" for those paths.
- Wrapper extracted to `buildCoachingDialogCloseHandler` so the "cancel-then-close" contract has a focused unit test independent of the full dialog harness.

## Test plan

- [x] New `buildCoachingDialogCloseHandler` unit tests cover: order is `cancelAi → onClose`, and `onClose` still fires when no AI is in flight (cancelAi is a no-op).
- [x] All 84 tests under `src/components/molecules/CoachingCard` pass.
- [x] `pnpm exec tsc --noEmit` clean.

The companion e2e test (LLM route-mock that hangs + Escape dismiss) is intentionally deferred to #555, which owns the shared LLM-route-mock helpers.

Closes #551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)