### PR TITLE
chore: autonomous-execution settings (bypassPermissions + Task)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,27 +5,26 @@
       "Edit",
       "Glob",
       "Grep",
-      "Read",
-      "Write",
-
-      "WebFetch",
-      "WebSearch",
-
       "mcp__context7__*",
       "mcp__ide__getDiagnostics",
       "mcp__kaiord__*",
       "mcp__playwright__*",
       "mcp__vitest__*",
-
-      "Skill(*)"
+      "Read",
+      "Skill(*)",
+      "Task",
+      "WebFetch",
+      "WebSearch",
+      "Write"
     ],
+    "defaultMode": "bypassPermissions",
     "deny": [
-      "Bash(rm -rf /)",
-      "Bash(rm -rf ~/*)",
       "Bash(git push --force *)",
       "Bash(git push -f *)",
       "Bash(npm publish*)",
-      "Bash(pnpm publish*)"
+      "Bash(pnpm publish*)",
+      "Bash(rm -rf /)",
+      "Bash(rm -rf ~/*)"
     ]
   },
   "enableAllProjectMcpServers": true,


### PR DESCRIPTION
## Summary

Three changes to `.claude/settings.json` so Claude Code can run autonomously (autopilot, ralph, ultrawork) without permission prompts blocking the loop:

- **Add `defaultMode: \"bypassPermissions\"`** — skips permission prompts for the `allow` list. The `deny` list still wins on every dispatch (force-push, `npm publish`, `pnpm publish`, `rm -rf /`, `rm -rf ~/*` are still blocked).
- **Add `Task` to `allow`** — some Claude Code versions gate sub-agent dispatch under `Task` even when `Bash`/`Edit`/etc. are broadly allowed. Without this, autopilot Phase-2 parallel agent fan-out can prompt mid-run.
- **Sort `allow`/`deny` case-insensitively and drop the visual-grouping blank lines** — keeps future diffs minimal when entries are added or removed.

No runtime/code change. Only affects how Claude Code authorises tool calls for contributors who pull this repo's project settings.

## Trade-offs

- `bypassPermissions` is the most aggressive permission mode; it trusts the agent. Mitigation: the existing `deny` list, the `Stop` hooks (architecture/schema-naming/file-size/test-needed checks), pre-commit lint, and CI all keep the safety net.
- Contributors who prefer prompt-on-everything semantics can override per-machine via `.claude/settings.local.json` (gitignored) with `\"defaultMode\": \"default\"`.

## Test plan

- [x] `jq '.permissions' .claude/settings.json` parses cleanly.
- [x] Allow + deny arrays sorted alphabetically (case-insensitive).
- [ ] CI lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)