### PR TITLE
chore: ignore .omc/ runtime directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ metrics/DASHBOARD.md
 .claude/worktrees/
 .claude/settings.local.json
 
+# oh-my-claudecode runtime (state, sessions, notepad, plans, research, logs)
+.omc/
+
 # GitHub Actions local testing (act)
 .secrets
 .actrc.local


### PR DESCRIPTION
## Summary

- Adds `.omc/` to `.gitignore` so the local oh-my-claudecode runtime directory (sessions, notepad, plans, research, logs) stops showing as untracked.
- Mirrors the intent of the existing `.claude/worktrees/` and `.claude/settings.local.json` ignores — local AI tooling state, not source.

## Test plan
- [x] `git status` no longer lists `.omc/` as untracked locally
- [x] No source files affected; CI lint/tests should be unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to ignore temporary runtime artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->