### PR TITLE
perf(spa-editor): cut SPA bundle by ~93KB via 4 targeted optimizations

### DIFF
--- a/.changeset/bundle-size-perf.md
+++ b/.changeset/bundle-size-perf.md
@@ -5,6 +5,6 @@
 
 perf(cli, mcp): defer adapter loading via tsup splitting + dynamic imports
 
-CLI's `krd-converter.ts` and MCP's `format-registry.ts` no longer statically import all four format adapters (fit, tcx, zwo, garmin) at module load. Each `case` now `await import("@kaiord/<adapter>")` only the format the user requests. Combined with `splitting: true` in both tsup configs, this lets each invocation ship only the requested adapter.
+CLI's `krd-converter.ts` and MCP's `format-registry.ts` no longer statically import all four format adapters (fit, tcx, zwo, garmin) at module load. Each `case` now `await import("@kaiord/<adapter>")` only the format the user requests. Combined with `splitting: true` in both tsup configs, this lets each invocation load only the requested adapter chunk at runtime. (The published package still contains the generated chunks for all adapters; the win is in cold-start runtime cost, which is what `total_js_bytes` measures because the metric counts every `.js` file in `dist/` regardless of which is dynamically imported — when one adapter is dropped from the eager dist, that chunk shrinks).
 
 Public API unchanged — both consumer-facing convert functions were already async. `cli` dist drops 4.5%; `mcp` grows 2.3% (per-chunk overhead, well within K007's 5% per-package tolerance). Net SPA monorepo-wide savings of −1,877 bytes from this change alone, contributing to a cumulative −93,176 byte (−3.86%) reduction in this PR.

--- a/.changeset/bundle-size-perf.md
+++ b/.changeset/bundle-size-perf.md
@@ -1,0 +1,10 @@
+---
+"@kaiord/cli": patch
+"@kaiord/mcp": patch
+---
+
+perf(cli, mcp): defer adapter loading via tsup splitting + dynamic imports
+
+CLI's `krd-converter.ts` and MCP's `format-registry.ts` no longer statically import all four format adapters (fit, tcx, zwo, garmin) at module load. Each `case` now `await import("@kaiord/<adapter>")` only the format the user requests. Combined with `splitting: true` in both tsup configs, this lets each invocation ship only the requested adapter.
+
+Public API unchanged — both consumer-facing convert functions were already async. `cli` dist drops 4.5%; `mcp` grows 2.3% (per-chunk overhead, well within K007's 5% per-package tolerance). Net SPA monorepo-wide savings of −1,877 bytes from this change alone, contributing to a cumulative −93,176 byte (−3.86%) reduction in this PR.

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ openspec/.cache/
 packages/docs/.vitepress/cache/
 *.gcn
 .claude/scheduled_tasks.lock
+
+# Self-improve git worktrees
+worktrees/

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
-      "eslint --fix --max-warnings=0"
+      "eslint --fix --max-warnings=0 --no-warn-ignored"
     ],
     "*.{md,json,yml,yaml}": [
       "prettier --write"

--- a/packages/cli/src/utils/krd-converter.ts
+++ b/packages/cli/src/utils/krd-converter.ts
@@ -1,14 +1,19 @@
 import type { KRD, Logger } from "@kaiord/core";
-import {
-  fromBinary,
-  fromText,
-  toBinary,
-  toText,
-  validateKrd,
-} from "@kaiord/core";
 
 import { readFile } from "./file-handler";
 import { detectFormat, type FileFormat } from "./format-detector";
+import {
+  fitToKrd,
+  gcnToKrd,
+  krdToFit,
+  krdToGcn,
+  krdToKrd,
+  krdToTcx,
+  krdToText,
+  krdToZwo,
+  tcxToKrd,
+  zwoToKrd,
+} from "./krd-loaders";
 
 /** Load a file and convert it to KRD format */
 export const loadFileAsKrd = async (
@@ -28,35 +33,6 @@ export const loadFileAsKrd = async (
   const fileData = await readFile(filePath, detectedFormat as FileFormat);
 
   return convertToKrd(fileData, detectedFormat, logger);
-};
-
-const fitToKrd = async (data: Uint8Array | string, logger: Logger) => {
-  if (!(data instanceof Uint8Array)) throw new Error("FIT input must be Uint8Array");
-  const { createFitReader } = await import("@kaiord/fit");
-  return fromBinary(data, createFitReader(logger), logger);
-};
-
-const tcxToKrd = async (data: Uint8Array | string, logger: Logger) => {
-  if (typeof data !== "string") throw new Error("TCX input must be string");
-  const { createTcxReader } = await import("@kaiord/tcx");
-  return fromText(data, createTcxReader(logger), logger);
-};
-
-const zwoToKrd = async (data: Uint8Array | string, logger: Logger) => {
-  if (typeof data !== "string") throw new Error("ZWO input must be string");
-  const { createZwiftReader } = await import("@kaiord/zwo");
-  return fromText(data, createZwiftReader(logger), logger);
-};
-
-const gcnToKrd = async (data: Uint8Array | string, logger: Logger) => {
-  if (typeof data !== "string") throw new Error("GCN input must be string");
-  const { createGarminReader } = await import("@kaiord/garmin");
-  return fromText(data, createGarminReader(logger), logger);
-};
-
-const krdToKrd = (data: Uint8Array | string): KRD => {
-  if (typeof data !== "string") throw new Error("KRD input must be string");
-  return validateKrd(JSON.parse(data));
 };
 
 /** Convert raw file data to KRD format */
@@ -82,26 +58,11 @@ export const convertFromKrd = async (
   logger: Logger
 ): Promise<Uint8Array | string> => {
   switch (format) {
-    case "fit": {
-      const { createFitWriter } = await import("@kaiord/fit");
-      return toBinary(krd, createFitWriter(logger), logger);
-    }
-    case "tcx": {
-      const { createTcxWriter } = await import("@kaiord/tcx");
-      return toText(krd, createTcxWriter(logger), logger);
-    }
-    case "zwo": {
-      const { createZwiftWriter } = await import("@kaiord/zwo");
-      return toText(krd, createZwiftWriter(logger), logger);
-    }
-    case "gcn": {
-      const { createGarminWriter } = await import("@kaiord/garmin");
-      return toText(krd, createGarminWriter(logger), logger);
-    }
-    case "krd":
-      validateKrd(krd);
-      return JSON.stringify(krd, null, 2);
-    default:
-      throw new Error(`Unsupported output format: ${format}`);
+    case "fit": return krdToFit(krd, logger);
+    case "tcx": return krdToTcx(krd, logger);
+    case "zwo": return krdToZwo(krd, logger);
+    case "gcn": return krdToGcn(krd, logger);
+    case "krd": return krdToText(krd);
+    default: throw new Error(`Unsupported output format: ${format}`);
   }
 };

--- a/packages/cli/src/utils/krd-converter.ts
+++ b/packages/cli/src/utils/krd-converter.ts
@@ -6,10 +6,7 @@ import {
   toText,
   validateKrd,
 } from "@kaiord/core";
-import { createFitReader, createFitWriter } from "@kaiord/fit";
-import { createGarminReader, createGarminWriter } from "@kaiord/garmin";
-import { createTcxReader, createTcxWriter } from "@kaiord/tcx";
-import { createZwiftReader, createZwiftWriter } from "@kaiord/zwo";
+
 import { readFile } from "./file-handler";
 import { detectFormat, type FileFormat } from "./format-detector";
 
@@ -33,6 +30,35 @@ export const loadFileAsKrd = async (
   return convertToKrd(fileData, detectedFormat, logger);
 };
 
+const fitToKrd = async (data: Uint8Array | string, logger: Logger) => {
+  if (!(data instanceof Uint8Array)) throw new Error("FIT input must be Uint8Array");
+  const { createFitReader } = await import("@kaiord/fit");
+  return fromBinary(data, createFitReader(logger), logger);
+};
+
+const tcxToKrd = async (data: Uint8Array | string, logger: Logger) => {
+  if (typeof data !== "string") throw new Error("TCX input must be string");
+  const { createTcxReader } = await import("@kaiord/tcx");
+  return fromText(data, createTcxReader(logger), logger);
+};
+
+const zwoToKrd = async (data: Uint8Array | string, logger: Logger) => {
+  if (typeof data !== "string") throw new Error("ZWO input must be string");
+  const { createZwiftReader } = await import("@kaiord/zwo");
+  return fromText(data, createZwiftReader(logger), logger);
+};
+
+const gcnToKrd = async (data: Uint8Array | string, logger: Logger) => {
+  if (typeof data !== "string") throw new Error("GCN input must be string");
+  const { createGarminReader } = await import("@kaiord/garmin");
+  return fromText(data, createGarminReader(logger), logger);
+};
+
+const krdToKrd = (data: Uint8Array | string): KRD => {
+  if (typeof data !== "string") throw new Error("KRD input must be string");
+  return validateKrd(JSON.parse(data));
+};
+
 /** Convert raw file data to KRD format */
 export const convertToKrd = async (
   data: Uint8Array | string,
@@ -40,38 +66,12 @@ export const convertToKrd = async (
   logger: Logger
 ): Promise<KRD> => {
   switch (format) {
-    case "fit": {
-      if (!(data instanceof Uint8Array)) {
-        throw new Error("FIT input must be Uint8Array");
-      }
-      return fromBinary(data, createFitReader(logger), logger);
-    }
-    case "tcx": {
-      if (typeof data !== "string") {
-        throw new Error("TCX input must be string");
-      }
-      return fromText(data, createTcxReader(logger), logger);
-    }
-    case "zwo": {
-      if (typeof data !== "string") {
-        throw new Error("ZWO input must be string");
-      }
-      return fromText(data, createZwiftReader(logger), logger);
-    }
-    case "gcn": {
-      if (typeof data !== "string") {
-        throw new Error("GCN input must be string");
-      }
-      return fromText(data, createGarminReader(logger), logger);
-    }
-    case "krd": {
-      if (typeof data !== "string") {
-        throw new Error("KRD input must be string");
-      }
-      return validateKrd(JSON.parse(data));
-    }
-    default:
-      throw new Error(`Unsupported format: ${format}`);
+    case "fit": return fitToKrd(data, logger);
+    case "tcx": return tcxToKrd(data, logger);
+    case "zwo": return zwoToKrd(data, logger);
+    case "gcn": return gcnToKrd(data, logger);
+    case "krd": return krdToKrd(data);
+    default: throw new Error(`Unsupported format: ${format}`);
   }
 };
 
@@ -82,14 +82,22 @@ export const convertFromKrd = async (
   logger: Logger
 ): Promise<Uint8Array | string> => {
   switch (format) {
-    case "fit":
+    case "fit": {
+      const { createFitWriter } = await import("@kaiord/fit");
       return toBinary(krd, createFitWriter(logger), logger);
-    case "tcx":
+    }
+    case "tcx": {
+      const { createTcxWriter } = await import("@kaiord/tcx");
       return toText(krd, createTcxWriter(logger), logger);
-    case "zwo":
+    }
+    case "zwo": {
+      const { createZwiftWriter } = await import("@kaiord/zwo");
       return toText(krd, createZwiftWriter(logger), logger);
-    case "gcn":
+    }
+    case "gcn": {
+      const { createGarminWriter } = await import("@kaiord/garmin");
       return toText(krd, createGarminWriter(logger), logger);
+    }
     case "krd":
       validateKrd(krd);
       return JSON.stringify(krd, null, 2);

--- a/packages/cli/src/utils/krd-loaders.ts
+++ b/packages/cli/src/utils/krd-loaders.ts
@@ -1,0 +1,68 @@
+import type { KRD, Logger } from "@kaiord/core";
+import {
+  fromBinary,
+  fromText,
+  toBinary,
+  toText,
+  validateKrd,
+} from "@kaiord/core";
+
+/**
+ * Per-format readers/writers loaded via dynamic import so each CLI invocation
+ * only pulls the adapter chunk it actually needs.
+ */
+
+export const fitToKrd = async (data: Uint8Array | string, logger: Logger) => {
+  if (!(data instanceof Uint8Array))
+    throw new Error("FIT input must be Uint8Array");
+  const { createFitReader } = await import("@kaiord/fit");
+  return fromBinary(data, createFitReader(logger), logger);
+};
+
+export const tcxToKrd = async (data: Uint8Array | string, logger: Logger) => {
+  if (typeof data !== "string") throw new Error("TCX input must be string");
+  const { createTcxReader } = await import("@kaiord/tcx");
+  return fromText(data, createTcxReader(logger), logger);
+};
+
+export const zwoToKrd = async (data: Uint8Array | string, logger: Logger) => {
+  if (typeof data !== "string") throw new Error("ZWO input must be string");
+  const { createZwiftReader } = await import("@kaiord/zwo");
+  return fromText(data, createZwiftReader(logger), logger);
+};
+
+export const gcnToKrd = async (data: Uint8Array | string, logger: Logger) => {
+  if (typeof data !== "string") throw new Error("GCN input must be string");
+  const { createGarminReader } = await import("@kaiord/garmin");
+  return fromText(data, createGarminReader(logger), logger);
+};
+
+export const krdToKrd = (data: Uint8Array | string): KRD => {
+  if (typeof data !== "string") throw new Error("KRD input must be string");
+  return validateKrd(JSON.parse(data));
+};
+
+export const krdToFit = async (krd: KRD, logger: Logger) => {
+  const { createFitWriter } = await import("@kaiord/fit");
+  return toBinary(krd, createFitWriter(logger), logger);
+};
+
+export const krdToTcx = async (krd: KRD, logger: Logger) => {
+  const { createTcxWriter } = await import("@kaiord/tcx");
+  return toText(krd, createTcxWriter(logger), logger);
+};
+
+export const krdToZwo = async (krd: KRD, logger: Logger) => {
+  const { createZwiftWriter } = await import("@kaiord/zwo");
+  return toText(krd, createZwiftWriter(logger), logger);
+};
+
+export const krdToGcn = async (krd: KRD, logger: Logger) => {
+  const { createGarminWriter } = await import("@kaiord/garmin");
+  return toText(krd, createGarminWriter(logger), logger);
+};
+
+export const krdToText = (krd: KRD): string => {
+  validateKrd(krd);
+  return JSON.stringify(krd, null, 2);
+};

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
   dts: false,
   clean: true,
   shims: true,
-  splitting: false,
+  splitting: true,
   bundle: true,
   banner: {
     js: "#!/usr/bin/env node",

--- a/packages/garmin-bridge/test/popup.test.js
+++ b/packages/garmin-bridge/test/popup.test.js
@@ -9,6 +9,8 @@ const PKG = dirname(HERE);
 const POPUP_HTML = readFileSync(join(PKG, "popup.html"), "utf8");
 const POPUP_JS = readFileSync(join(PKG, "popup.js"), "utf8");
 
+const MOCK_NOW_MS = new Date("2026-05-02T10:00:00Z").getTime();
+
 const setupDom = (chromeMock) => {
   const dom = new JSDOM(POPUP_HTML, {
     runScripts: "outside-only",
@@ -16,6 +18,11 @@ const setupDom = (chromeMock) => {
     url: "chrome-extension://fake/popup.html",
   });
   dom.window.chrome = chromeMock;
+  // popup.js runs inside the JSDOM window via `eval`, so it resolves
+  // `Date.now` against `dom.window.Date`, not the outer Node `Date`.
+  // Mock both so the staleness check (Date.now() - snapshot.receivedAt)
+  // sees a deterministic "now" relative to the fixture timestamps.
+  dom.window.Date.now = () => MOCK_NOW_MS;
   // Run the script body so listeners attach.
   dom.window.eval(POPUP_JS);
   return dom;
@@ -46,7 +53,7 @@ describe("Garmin popup", () => {
 
   beforeEach(() => {
     originalNow = Date.now;
-    Date.now = () => new Date("2026-05-02T10:00:00Z").getTime();
+    Date.now = () => MOCK_NOW_MS;
   });
 
   afterEach(() => {

--- a/packages/mcp/src/tools/convert-from-krd.ts
+++ b/packages/mcp/src/tools/convert-from-krd.ts
@@ -32,7 +32,9 @@ const writeBinaryOutput = async (
   if (!outputFile) {
     throw new Error("output_file is required for binary format (FIT)");
   }
-  const writer = FORMAT_REGISTRY[format].createWriter(logger) as BinaryWriter;
+  const writer = (await FORMAT_REGISTRY[format].createWriter(
+    logger
+  )) as BinaryWriter;
   const buffer = await toBinary(krd, writer, logger);
   await writeOutputFile(outputFile, buffer);
   return {
@@ -47,7 +49,9 @@ const writeTextOutput = async (
   outputFile: string | undefined,
   logger: Logger
 ): Promise<ConvertFromKrdResult> => {
-  const writer = FORMAT_REGISTRY[format].createWriter(logger) as TextWriter;
+  const writer = (await FORMAT_REGISTRY[format].createWriter(
+    logger
+  )) as TextWriter;
   const text = await toText(krd, writer, logger);
   if (outputFile) {
     await writeOutputFile(outputFile, text);

--- a/packages/mcp/src/tools/convert-to-krd.ts
+++ b/packages/mcp/src/tools/convert-to-krd.ts
@@ -44,12 +44,12 @@ const readBinaryInput = async (
   format: FileFormat,
   logger: Logger
 ): Promise<KRD> => {
-  const reader = (await FORMAT_REGISTRY[format].createReader(
-    logger
-  )) as BinaryReader;
   if (!inputFile && inputContent === undefined) {
     throw new Error("Provide either input_file or input_content");
   }
+  const reader = (await FORMAT_REGISTRY[format].createReader(
+    logger
+  )) as BinaryReader;
   const buffer = inputFile
     ? await readFileAsBuffer(inputFile)
     : decodeBase64(inputContent as string);
@@ -62,12 +62,12 @@ const readTextInput = async (
   format: FileFormat,
   logger: Logger
 ): Promise<KRD> => {
-  const reader = (await FORMAT_REGISTRY[format].createReader(
-    logger
-  )) as TextReader;
   if (!inputFile && inputContent === undefined) {
     throw new Error("Provide either input_file or input_content");
   }
+  const reader = (await FORMAT_REGISTRY[format].createReader(
+    logger
+  )) as TextReader;
   const text = inputFile
     ? await readFileAsText(inputFile)
     : (inputContent as string);

--- a/packages/mcp/src/tools/convert-to-krd.ts
+++ b/packages/mcp/src/tools/convert-to-krd.ts
@@ -44,7 +44,9 @@ const readBinaryInput = async (
   format: FileFormat,
   logger: Logger
 ): Promise<KRD> => {
-  const reader = FORMAT_REGISTRY[format].createReader(logger) as BinaryReader;
+  const reader = (await FORMAT_REGISTRY[format].createReader(
+    logger
+  )) as BinaryReader;
   if (!inputFile && inputContent === undefined) {
     throw new Error("Provide either input_file or input_content");
   }
@@ -60,7 +62,9 @@ const readTextInput = async (
   format: FileFormat,
   logger: Logger
 ): Promise<KRD> => {
-  const reader = FORMAT_REGISTRY[format].createReader(logger) as TextReader;
+  const reader = (await FORMAT_REGISTRY[format].createReader(
+    logger
+  )) as TextReader;
   if (!inputFile && inputContent === undefined) {
     throw new Error("Provide either input_file or input_content");
   }

--- a/packages/mcp/src/utils/detect-format-from-path.ts
+++ b/packages/mcp/src/utils/detect-format-from-path.ts
@@ -1,0 +1,13 @@
+import { extname } from "path";
+
+import type { FileFormat } from "../types/tool-schemas";
+import { FORMAT_REGISTRY } from "./format-registry";
+
+export const detectFormatFromPath = (filePath: string): FileFormat | null => {
+  const ext = extname(filePath).toLowerCase();
+  if (!ext) return null;
+  const entry = Object.entries(FORMAT_REGISTRY).find(
+    ([, desc]) => desc.extension === ext
+  );
+  return entry ? (entry[0] as FileFormat) : null;
+};

--- a/packages/mcp/src/utils/format-registry.ts
+++ b/packages/mcp/src/utils/format-registry.ts
@@ -6,16 +6,11 @@ import type {
   TextWriter,
 } from "@kaiord/core";
 import { validateKrd } from "@kaiord/core";
-import { createFitReader, createFitWriter } from "@kaiord/fit";
-import { createGarminReader, createGarminWriter } from "@kaiord/garmin";
-import { createTcxReader, createTcxWriter } from "@kaiord/tcx";
-import { createZwiftReader, createZwiftWriter } from "@kaiord/zwo";
-import { extname } from "path";
 
 import type { FileFormat } from "../types/tool-schemas";
 
-type ReaderFactory = (logger: Logger) => BinaryReader | TextReader;
-type WriterFactory = (logger: Logger) => BinaryWriter | TextWriter;
+type ReaderFactory = (logger: Logger) => Promise<BinaryReader | TextReader>;
+type WriterFactory = (logger: Logger) => Promise<BinaryWriter | TextWriter>;
 
 export type FormatDescriptor = {
   readonly name: string;
@@ -40,48 +35,65 @@ export const FORMAT_REGISTRY: Record<FileFormat, FormatDescriptor> = {
     extension: ".fit",
     description: "Garmin FIT binary protocol",
     binary: true,
-    createReader: (l) => createFitReader(l),
-    createWriter: (l) => createFitWriter(l),
+    createReader: async (l) => {
+      const { createFitReader } = await import("@kaiord/fit");
+      return createFitReader(l);
+    },
+    createWriter: async (l) => {
+      const { createFitWriter } = await import("@kaiord/fit");
+      return createFitWriter(l);
+    },
   },
   tcx: {
     name: "TCX",
     extension: ".tcx",
     description: "Training Center XML",
     binary: false,
-    createReader: (l) => createTcxReader(l),
-    createWriter: (l) => createTcxWriter(l),
+    createReader: async (l) => {
+      const { createTcxReader } = await import("@kaiord/tcx");
+      return createTcxReader(l);
+    },
+    createWriter: async (l) => {
+      const { createTcxWriter } = await import("@kaiord/tcx");
+      return createTcxWriter(l);
+    },
   },
   zwo: {
     name: "ZWO",
     extension: ".zwo",
     description: "Zwift workout XML",
     binary: false,
-    createReader: (l) => createZwiftReader(l),
-    createWriter: (l) => createZwiftWriter(l),
+    createReader: async (l) => {
+      const { createZwiftReader } = await import("@kaiord/zwo");
+      return createZwiftReader(l);
+    },
+    createWriter: async (l) => {
+      const { createZwiftWriter } = await import("@kaiord/zwo");
+      return createZwiftWriter(l);
+    },
   },
   gcn: {
     name: "GCN",
     extension: ".gcn",
     description: "Garmin Connect workout JSON",
     binary: false,
-    createReader: (l) => createGarminReader(l),
-    createWriter: (l) => createGarminWriter(l),
+    createReader: async (l) => {
+      const { createGarminReader } = await import("@kaiord/garmin");
+      return createGarminReader(l);
+    },
+    createWriter: async (l) => {
+      const { createGarminWriter } = await import("@kaiord/garmin");
+      return createGarminWriter(l);
+    },
   },
   krd: {
     name: "KRD",
     extension: ".krd",
     description: "Kaiord canonical JSON format",
     binary: false,
-    createReader: () => createKrdReader(),
-    createWriter: () => createKrdWriter(),
+    createReader: async () => createKrdReader(),
+    createWriter: async () => createKrdWriter(),
   },
 };
 
-export const detectFormatFromPath = (filePath: string): FileFormat | null => {
-  const ext = extname(filePath).toLowerCase();
-  if (!ext) return null;
-  const entry = Object.entries(FORMAT_REGISTRY).find(
-    ([, desc]) => desc.extension === ext
-  );
-  return entry ? (entry[0] as FileFormat) : null;
-};
+export { detectFormatFromPath } from "./detect-format-from-path";

--- a/packages/mcp/tsup.config.ts
+++ b/packages/mcp/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig([
     dts: true,
     clean: true,
     shims: true,
-    splitting: false,
+    splitting: true,
     treeshake: true,
     onSuccess: async () => {
       writeFileSync(
@@ -21,7 +21,7 @@ export default defineConfig([
     entry: { "bin/kaiord-mcp": "src/bin/kaiord-mcp.ts" },
     format: ["esm"],
     shims: true,
-    splitting: false,
+    splitting: true,
     treeshake: true,
     banner: { js: "#!/usr/bin/env node" },
   },

--- a/packages/workout-spa-editor/package.json
+++ b/packages/workout-spa-editor/package.json
@@ -45,7 +45,6 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-toast": "^1.2.15",
-    "@radix-ui/react-tooltip": "^1.2.8",
     "ai": "^6.0.175",
     "dexie": "^4.4.2",
     "dexie-react-hooks": "^4.4.0",

--- a/packages/workout-spa-editor/src/components/atoms/Tooltip/Tooltip.test.tsx
+++ b/packages/workout-spa-editor/src/components/atoms/Tooltip/Tooltip.test.tsx
@@ -1,77 +1,60 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Tooltip } from "./Tooltip";
 
 describe("Tooltip", () => {
   describe("rendering", () => {
     it("should render trigger element", () => {
-      // Arrange & Act
       // Arrange
 
+      // Act
       render(
         <Tooltip content="Tooltip content">
           <button>Hover me</button>
         </Tooltip>
       );
-
-      // Assert
-
-      // Act
-
       const trigger = screen.getByRole("button", { name: "Hover me" });
 
       // Assert
-
       expect(trigger).toBeInTheDocument();
     });
 
     it("should render children when disabled", () => {
-      // Arrange & Act
       // Arrange
 
+      // Act
       render(
         <Tooltip content="Tooltip content" disabled>
           <button>Hover me</button>
         </Tooltip>
       );
-
-      // Assert
-
-      // Act
-
       const trigger = screen.getByRole("button", { name: "Hover me" });
 
       // Assert
-
       expect(trigger).toBeInTheDocument();
     });
 
     it("should render with text content", () => {
-      // Arrange & Act
       // Arrange
 
+      // Act
       render(
         <Tooltip content="Simple text tooltip">
           <button>Hover me</button>
         </Tooltip>
       );
-
-      // Assert
-
-      // Act
-
       const trigger = screen.getByRole("button", { name: "Hover me" });
 
       // Assert
-
       expect(trigger).toBeInTheDocument();
     });
 
     it("should render with complex content", () => {
-      // Arrange & Act
       // Arrange
 
+      // Act
       render(
         <Tooltip
           content={
@@ -84,87 +67,63 @@ describe("Tooltip", () => {
           <button>Hover me</button>
         </Tooltip>
       );
-
-      // Assert
-
-      // Act
-
       const trigger = screen.getByRole("button", { name: "Hover me" });
 
       // Assert
-
       expect(trigger).toBeInTheDocument();
     });
   });
 
   describe("props", () => {
     it("should accept side prop", () => {
-      // Arrange & Act
       // Arrange
 
+      // Act
       render(
         <Tooltip content="Tooltip content" side="right">
           <button>Hover me</button>
         </Tooltip>
       );
-
-      // Assert
-
-      // Act
-
       const trigger = screen.getByRole("button", { name: "Hover me" });
 
       // Assert
-
       expect(trigger).toBeInTheDocument();
     });
 
     it("should accept align prop", () => {
-      // Arrange & Act
       // Arrange
 
+      // Act
       render(
         <Tooltip content="Tooltip content" align="start">
           <button>Hover me</button>
         </Tooltip>
       );
-
-      // Assert
-
-      // Act
-
       const trigger = screen.getByRole("button", { name: "Hover me" });
 
       // Assert
-
       expect(trigger).toBeInTheDocument();
     });
 
     it("should accept delayDuration prop", () => {
-      // Arrange & Act
       // Arrange
 
+      // Act
       render(
         <Tooltip content="Tooltip content" delayDuration={0}>
           <button>Hover me</button>
         </Tooltip>
       );
-
-      // Assert
-
-      // Act
-
       const trigger = screen.getByRole("button", { name: "Hover me" });
 
       // Assert
-
       expect(trigger).toBeInTheDocument();
     });
 
     it("should accept all positioning combinations", () => {
-      // Arrange & Act
       // Arrange
 
+      // Act
       render(
         <Tooltip
           content="Tooltip content"
@@ -175,71 +134,71 @@ describe("Tooltip", () => {
           <button>Hover me</button>
         </Tooltip>
       );
-
-      // Assert
-
-      // Act
-
       const trigger = screen.getByRole("button", { name: "Hover me" });
 
       // Assert
-
       expect(trigger).toBeInTheDocument();
     });
   });
 
   describe("disabled state", () => {
     it("should render only children when disabled", () => {
-      // Arrange & Act
       // Arrange
 
+      // Act
       render(
         <Tooltip content="Tooltip content" disabled>
           <button>Hover me</button>
         </Tooltip>
       );
-
-      // Assert
-
-      // Act
-
       const trigger = screen.getByRole("button", { name: "Hover me" });
 
       // Assert
-
       expect(trigger).toBeInTheDocument();
     });
 
-    it("should not wrap children in Radix components when disabled", () => {
-      // Arrange & Act
+    it("should not wrap children in extra DOM when disabled", () => {
       // Arrange
 
+      // Act
       const { container } = render(
         <Tooltip content="Tooltip content" disabled>
           <button>Hover me</button>
         </Tooltip>
       );
-
-      // Assert
-
-      // Act
-
       const button = screen.getByRole("button", { name: "Hover me" });
 
       // Assert
-
       expect(button).toBeInTheDocument();
       expect(container.querySelector("button")).toBe(button);
+    });
+
+    it("should not register hover handlers when disabled", async () => {
+      // Arrange
+      const user = userEvent.setup();
+
+      // Act
+      render(
+        <Tooltip content="Tooltip content when disabled" disabled>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button", { name: "Hover me" });
+      await user.hover(trigger);
+
+      // Assert
+      expect(
+        screen.queryByText("Tooltip content when disabled")
+      ).not.toBeInTheDocument();
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
     });
   });
 
   describe("children", () => {
     it("should render button children", () => {
-      // Arrange & Act
       // Arrange
 
       // Act
-
       render(
         <Tooltip content="Tooltip content">
           <button>Click me</button>
@@ -247,20 +206,15 @@ describe("Tooltip", () => {
       );
 
       // Assert
-
-      // Assert
-
       expect(
         screen.getByRole("button", { name: "Click me" })
       ).toBeInTheDocument();
     });
 
     it("should render div children", () => {
-      // Arrange & Act
       // Arrange
 
       // Act
-
       render(
         <Tooltip content="Tooltip content">
           <div>Hover over me</div>
@@ -268,18 +222,13 @@ describe("Tooltip", () => {
       );
 
       // Assert
-
-      // Assert
-
       expect(screen.getByText("Hover over me")).toBeInTheDocument();
     });
 
     it("should render span children", () => {
-      // Arrange & Act
       // Arrange
 
       // Act
-
       render(
         <Tooltip content="Tooltip content">
           <span>Info icon</span>
@@ -287,10 +236,115 @@ describe("Tooltip", () => {
       );
 
       // Assert
+      expect(screen.getByText("Info icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("hover behavior", () => {
+    it("should show tooltip with role tooltip when delayDuration is zero on hover", async () => {
+      // Arrange
+      const user = userEvent.setup();
+
+      // Act
+      render(
+        <Tooltip content="Visible tip" delayDuration={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button", { name: "Hover me" });
+      await user.hover(trigger);
 
       // Assert
+      const tip = await screen.findByRole("tooltip");
+      expect(tip).toHaveTextContent("Visible tip");
+    });
 
-      expect(screen.getByText("Info icon")).toBeInTheDocument();
+    it("should hide tooltip on unhover", async () => {
+      // Arrange
+      const user = userEvent.setup();
+
+      // Act
+      render(
+        <Tooltip content="Hide me" delayDuration={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button", { name: "Hover me" });
+      await user.hover(trigger);
+      await screen.findByRole("tooltip");
+      await user.unhover(trigger);
+
+      // Assert
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+
+    it("should set aria-describedby on the wrapping span when open", async () => {
+      // Arrange
+      const user = userEvent.setup();
+
+      // Act
+      const { container } = render(
+        <Tooltip content="Described tip" delayDuration={0}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button", { name: "Hover me" });
+      await user.hover(trigger);
+      const tip = await screen.findByRole("tooltip");
+
+      // Assert
+      const wrappers = container.querySelectorAll("span[aria-describedby]");
+      const describedBy = wrappers[0]?.getAttribute("aria-describedby");
+      expect(describedBy).toBe(tip.id);
+    });
+  });
+
+  describe("delayDuration timing", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("should not show tooltip before delayDuration elapses", () => {
+      // Arrange
+      render(
+        <Tooltip content="Delayed tip" delayDuration={500}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button", { name: "Hover me" });
+
+      // Act
+      act(() => {
+        fireEvent.mouseEnter(trigger.parentElement as HTMLElement);
+        vi.advanceTimersByTime(200);
+      });
+
+      // Assert
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+
+    it("should show tooltip after delayDuration elapses", () => {
+      // Arrange
+      render(
+        <Tooltip content="Delayed tip" delayDuration={300}>
+          <button>Hover me</button>
+        </Tooltip>
+      );
+      const trigger = screen.getByRole("button", { name: "Hover me" });
+
+      // Act
+      const ELAPSED_MS = 350;
+      act(() => {
+        fireEvent.mouseEnter(trigger.parentElement as HTMLElement);
+        vi.advanceTimersByTime(ELAPSED_MS);
+      });
+
+      // Assert
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Delayed tip");
     });
   });
 });

--- a/packages/workout-spa-editor/src/components/atoms/Tooltip/Tooltip.tsx
+++ b/packages/workout-spa-editor/src/components/atoms/Tooltip/Tooltip.tsx
@@ -1,11 +1,14 @@
-import * as TooltipPrimitive from "@radix-ui/react-tooltip";
-import { type ReactNode } from "react";
+import { type ReactNode, useId } from "react";
+import { createPortal } from "react-dom";
+
+import { type Align, type Side } from "./compute-position";
+import { useTooltipState } from "./use-tooltip-state";
 
 export type TooltipProps = {
   children: ReactNode;
   content: ReactNode;
-  side?: "top" | "right" | "bottom" | "left";
-  align?: "start" | "center" | "end";
+  side?: Side;
+  align?: Align;
   delayDuration?: number;
   disabled?: boolean;
 };
@@ -18,26 +21,49 @@ export const Tooltip = ({
   delayDuration = 200,
   disabled = false,
 }: TooltipProps) => {
-  if (disabled) {
-    return <>{children}</>;
-  }
+  const id = useId();
+  const tooltipId = `tooltip-${id}`;
+  const { open, position, triggerRef, tooltipRef, handleShow, handleHide } =
+    useTooltipState(delayDuration, side, align);
+
+  if (disabled) return <>{children}</>;
 
   return (
-    <TooltipPrimitive.Provider delayDuration={delayDuration}>
-      <TooltipPrimitive.Root>
-        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
-        <TooltipPrimitive.Portal>
-          <TooltipPrimitive.Content
-            side={side}
-            align={align}
-            sideOffset={5}
-            className="z-50 overflow-hidden rounded-md bg-gray-900 px-3 py-1.5 text-sm text-white shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:bg-gray-50 dark:text-gray-900"
+    <>
+      <span
+        ref={triggerRef}
+        onMouseEnter={handleShow}
+        onMouseLeave={handleHide}
+        onFocus={handleShow}
+        onBlur={handleHide}
+        aria-describedby={open ? tooltipId : undefined}
+        style={{ display: "contents" }}
+      >
+        {children}
+      </span>
+      {open &&
+        typeof document !== "undefined" &&
+        createPortal(
+          <div
+            ref={tooltipRef}
+            id={tooltipId}
+            role="tooltip"
+            data-side={side}
+            data-align={align}
+            style={{
+              position: "absolute",
+              top: position?.top ?? 0,
+              left: position?.left ?? 0,
+              visibility: position ? "visible" : "hidden",
+              pointerEvents: "none",
+              zIndex: 50,
+            }}
+            className="overflow-hidden rounded-md bg-gray-900 px-3 py-1.5 text-sm text-white shadow-md dark:bg-gray-50 dark:text-gray-900"
           >
             {content}
-            <TooltipPrimitive.Arrow className="fill-gray-900 dark:fill-gray-50" />
-          </TooltipPrimitive.Content>
-        </TooltipPrimitive.Portal>
-      </TooltipPrimitive.Root>
-    </TooltipPrimitive.Provider>
+          </div>,
+          document.body
+        )}
+    </>
   );
 };

--- a/packages/workout-spa-editor/src/components/atoms/Tooltip/compute-position.ts
+++ b/packages/workout-spa-editor/src/components/atoms/Tooltip/compute-position.ts
@@ -1,0 +1,34 @@
+export type Position = { top: number; left: number };
+export type Side = "top" | "right" | "bottom" | "left";
+export type Align = "start" | "center" | "end";
+
+const SIDE_OFFSET = 5;
+
+export const computeTooltipPosition = (
+  triggerRect: DOMRect,
+  tooltipRect: DOMRect,
+  side: Side,
+  align: Align
+): Position => {
+  let top = 0;
+  let left = 0;
+  if (side === "top") {
+    top = triggerRect.top - tooltipRect.height - SIDE_OFFSET;
+  } else if (side === "bottom") {
+    top = triggerRect.bottom + SIDE_OFFSET;
+  } else if (side === "left") {
+    left = triggerRect.left - tooltipRect.width - SIDE_OFFSET;
+  } else {
+    left = triggerRect.right + SIDE_OFFSET;
+  }
+  if (side === "top" || side === "bottom") {
+    if (align === "start") left = triggerRect.left;
+    else if (align === "end") left = triggerRect.right - tooltipRect.width;
+    else left = triggerRect.left + (triggerRect.width - tooltipRect.width) / 2;
+  } else {
+    if (align === "start") top = triggerRect.top;
+    else if (align === "end") top = triggerRect.bottom - tooltipRect.height;
+    else top = triggerRect.top + (triggerRect.height - tooltipRect.height) / 2;
+  }
+  return { top: top + window.scrollY, left: left + window.scrollX };
+};

--- a/packages/workout-spa-editor/src/components/atoms/Tooltip/use-tooltip-state.ts
+++ b/packages/workout-spa-editor/src/components/atoms/Tooltip/use-tooltip-state.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  type Align,
+  computeTooltipPosition,
+  type Position,
+  type Side,
+} from "./compute-position";
+
+export const useTooltipState = (
+  delayDuration: number,
+  side: Side,
+  align: Align
+) => {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState<Position | null>(null);
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const handleShow = useCallback(() => {
+    clearTimer();
+    if (delayDuration <= 0) {
+      setOpen(true);
+      return;
+    }
+    timerRef.current = setTimeout(() => setOpen(true), delayDuration);
+  }, [clearTimer, delayDuration]);
+
+  const handleHide = useCallback(() => {
+    clearTimer();
+    setOpen(false);
+  }, [clearTimer]);
+
+  useEffect(() => () => clearTimer(), [clearTimer]);
+
+  useEffect(() => {
+    if (!open) {
+      setPosition(null);
+      return;
+    }
+    const trigger = triggerRef.current;
+    const tooltip = tooltipRef.current;
+    if (!trigger || !tooltip) return;
+    setPosition(
+      computeTooltipPosition(
+        trigger.getBoundingClientRect(),
+        tooltip.getBoundingClientRect(),
+        side,
+        align
+      )
+    );
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") handleHide();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, side, align, handleHide]);
+
+  return { open, position, triggerRef, tooltipRef, handleShow, handleHide };
+};

--- a/packages/workout-spa-editor/src/components/molecules/RepetitionBlockCard/RepetitionBlockHeaderRight.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/RepetitionBlockCard/RepetitionBlockHeaderRight.tsx
@@ -1,7 +1,7 @@
-import * as Tooltip from "@radix-ui/react-tooltip";
 import { Trash2 } from "lucide-react";
 
 import type { RepetitionBlock } from "../../../types/krd";
+import { Tooltip } from "../../atoms/Tooltip";
 import { RepetitionBlockContextMenu } from "./RepetitionBlockContextMenu";
 
 type RepetitionBlockHeaderRightProps = {
@@ -26,29 +26,16 @@ export const RepetitionBlockHeaderRight = ({
       </div>
 
       {onDelete && (
-        <Tooltip.Provider>
-          <Tooltip.Root>
-            <Tooltip.Trigger asChild>
-              <button
-                onClick={onDelete}
-                className="p-1 text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-900/30 rounded transition-colors"
-                aria-label="Delete repetition block"
-                data-testid="delete-block-button"
-              >
-                <Trash2 className="h-4 w-4" />
-              </button>
-            </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Content
-                className="bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 px-3 py-2 rounded text-sm shadow-lg z-50"
-                sideOffset={5}
-              >
-                Delete repetition block
-                <Tooltip.Arrow className="fill-gray-900 dark:fill-gray-100" />
-              </Tooltip.Content>
-            </Tooltip.Portal>
-          </Tooltip.Root>
-        </Tooltip.Provider>
+        <Tooltip content="Delete repetition block" delayDuration={0}>
+          <button
+            onClick={onDelete}
+            className="p-1 text-red-600 hover:text-red-700 hover:bg-red-50 dark:text-red-400 dark:hover:text-red-300 dark:hover:bg-red-900/30 rounded transition-colors"
+            aria-label="Delete repetition block"
+            data-testid="delete-block-button"
+          >
+            <Trash2 className="h-4 w-4" />
+          </button>
+        </Tooltip>
       )}
 
       {(onAddStep || onUngroup || onDelete) && (

--- a/packages/workout-spa-editor/src/lib/ai-sdk-gateway-stub.ts
+++ b/packages/workout-spa-editor/src/lib/ai-sdk-gateway-stub.ts
@@ -1,0 +1,41 @@
+/**
+ * Stub for `@ai-sdk/gateway` exports referenced (statically) by the `ai` SDK.
+ *
+ * The SPA always passes a concrete `LanguageModel` instance from
+ * `provider-factory.ts` (createAnthropic / createOpenAI / createGoogleGenerativeAI),
+ * so the `globalThis.AI_SDK_DEFAULT_PROVIDER ?? gateway` fallback path is never
+ * reached at runtime. Aliasing `@ai-sdk/gateway` to this stub at the SPA build
+ * boundary lets rolldown drop the full gateway package (~60 KB raw, includes
+ * the entire GatewayModelId catalog and thousands of model name strings).
+ *
+ * Same pattern as the round-5 zod/v3 stub.
+ *
+ * Vite alias only affects bundling — TypeScript type-checking still resolves
+ * the real `.d.ts` from node_modules, so stub return types do not need to
+ * match the published `Schema<T>` signatures.
+ */
+
+const unreachable = (): never => {
+  throw new Error(
+    "@ai-sdk/gateway is intentionally stubbed in the SPA build. " +
+      "All AI calls must route through provider-factory.ts (concrete model instance)."
+  );
+};
+
+export const createGateway = unreachable;
+
+export const gateway = new Proxy(
+  {},
+  {
+    get: () => unreachable,
+    apply: () => unreachable(),
+  }
+);
+
+export class GatewayAuthenticationError extends Error {
+  static readonly name = "GatewayAuthenticationError";
+  constructor(message?: string) {
+    super(message ?? "GatewayAuthenticationError");
+    this.name = "GatewayAuthenticationError";
+  }
+}

--- a/packages/workout-spa-editor/src/lib/ai-sdk-gateway-stub.ts
+++ b/packages/workout-spa-editor/src/lib/ai-sdk-gateway-stub.ts
@@ -33,7 +33,6 @@ export const gateway = new Proxy(
 );
 
 export class GatewayAuthenticationError extends Error {
-  static readonly name = "GatewayAuthenticationError";
   constructor(message?: string) {
     super(message ?? "GatewayAuthenticationError");
     this.name = "GatewayAuthenticationError";

--- a/packages/workout-spa-editor/src/lib/zod-v3-stub.ts
+++ b/packages/workout-spa-editor/src/lib/zod-v3-stub.ts
@@ -1,0 +1,52 @@
+/**
+ * Stub for `zod/v3` exports referenced (statically) by `@ai-sdk/provider-utils`.
+ *
+ * The SPA only uses zod v4 (aiWorkoutSchema is v4). provider-utils's `zodSchema()`
+ * dispatcher checks `isZod4Schema(s)` and routes v4 schemas through the v4 path,
+ * never invoking the v3-to-json-schema parsers — but rolldown still bundles the
+ * v3 parser modules because they are statically reachable via named imports of
+ * `ZodFirstPartyTypeKind` from `zod/v3`. Aliasing `zod/v3` to this stub at the
+ * SPA build boundary lets rolldown drop the full v3 module (~86 KB rendered).
+ *
+ * Only the `ZodFirstPartyTypeKind` symbol is needed; provider-utils consumes it
+ * for `def.typeName === ZodFirstPartyTypeKind.<name>` comparisons inside the v3
+ * parsers — never executed for v4 schemas at runtime.
+ */
+export const ZodFirstPartyTypeKind = Object.freeze({
+  ZodString: "ZodString",
+  ZodNumber: "ZodNumber",
+  ZodNaN: "ZodNaN",
+  ZodBigInt: "ZodBigInt",
+  ZodBoolean: "ZodBoolean",
+  ZodDate: "ZodDate",
+  ZodSymbol: "ZodSymbol",
+  ZodUndefined: "ZodUndefined",
+  ZodNull: "ZodNull",
+  ZodAny: "ZodAny",
+  ZodUnknown: "ZodUnknown",
+  ZodNever: "ZodNever",
+  ZodVoid: "ZodVoid",
+  ZodArray: "ZodArray",
+  ZodObject: "ZodObject",
+  ZodUnion: "ZodUnion",
+  ZodDiscriminatedUnion: "ZodDiscriminatedUnion",
+  ZodIntersection: "ZodIntersection",
+  ZodTuple: "ZodTuple",
+  ZodRecord: "ZodRecord",
+  ZodMap: "ZodMap",
+  ZodSet: "ZodSet",
+  ZodFunction: "ZodFunction",
+  ZodLazy: "ZodLazy",
+  ZodLiteral: "ZodLiteral",
+  ZodEnum: "ZodEnum",
+  ZodEffects: "ZodEffects",
+  ZodNativeEnum: "ZodNativeEnum",
+  ZodOptional: "ZodOptional",
+  ZodNullable: "ZodNullable",
+  ZodDefault: "ZodDefault",
+  ZodCatch: "ZodCatch",
+  ZodPromise: "ZodPromise",
+  ZodBranded: "ZodBranded",
+  ZodPipeline: "ZodPipeline",
+  ZodReadonly: "ZodReadonly",
+} as const);

--- a/packages/workout-spa-editor/vite.config.ts
+++ b/packages/workout-spa-editor/vite.config.ts
@@ -20,6 +20,24 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // Stub zod/v3 to prune the v3 module from the SPA bundle.
+      // @ai-sdk/provider-utils statically imports `ZodFirstPartyTypeKind` from
+      // `zod/v3` for its v3-to-json-schema parsers. Our schemas are zod v4 only,
+      // so the v3 dispatcher is never executed at runtime — but rolldown bundles
+      // it as statically reachable. The stub provides just the named export(s)
+      // used at module-load time, allowing the rest of the v3 module to be
+      // tree-shaken out of vendor-zod.
+      "zod/v3": path.resolve(__dirname, "./src/lib/zod-v3-stub.ts"),
+      // Stub @ai-sdk/gateway — the `ai` SDK statically imports `createGateway`,
+      // `gateway`, and `GatewayAuthenticationError` for its
+      // `globalThis.AI_SDK_DEFAULT_PROVIDER ?? gateway` fallback. We always pass
+      // a concrete model from provider-factory.ts, so this fallback is
+      // unreachable. The stub lets rolldown drop the full gateway package
+      // (~60KB raw, includes a multi-thousand-string GatewayModelId catalog).
+      "@ai-sdk/gateway": path.resolve(
+        __dirname,
+        "./src/lib/ai-sdk-gateway-stub.ts"
+      ),
     },
   },
   // GitHub Pages deployment configuration

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,9 +585,6 @@ importers:
       '@radix-ui/react-toast':
         specifier: ^1.2.15
         version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-tooltip':
-        specifier: ^1.2.8
-        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       ai:
         specifier: ^6.0.175
         version: 6.0.175(zod@4.4.3)
@@ -2951,19 +2948,6 @@ packages:
 
   '@radix-ui/react-toast@1.2.15':
     resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-tooltip@1.2.8':
-    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -9539,26 +9523,6 @@ snapshots:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
       '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)


### PR DESCRIPTION
## Summary

Bundle-size reduction across the kaiord monorepo. **Total: −93,176 bytes (−3.86%)** across 4 commits, validated via 7 iterations of evidence-based experimentation (the loop discarded ~10 ideas that the rolldown bundler already optimized or that broke tests).

| Metric | Before | After | Δ |
|---|---|---|---|
| `total_js_bytes` | 2,413,405 | **2,320,229** | **−93,176 (−3.86%)** |
| `vendor-zod` chunk | 134,355 | 77,677 | −56,678 (−42%) |
| `generate-workout` chunk | 115,976 | 87,212 | −28,764 (−25%) |
| `workout-spa-editor` total | ~1,932K | 1,841K | −91 KB |
| `cli` package | 69,586 | 66,419 | −3,167 (−4.5%) |

Tests: **3,505 / 3,505 passing** at HEAD.

## Changes

### 1. `tsup splitting:true` + dynamic adapter imports in CLI/MCP (commit `e617b11a`)
- `packages/cli/tsup.config.ts`, `packages/mcp/tsup.config.ts`: `splitting: false → true`
- `packages/cli/src/utils/krd-converter.ts`: each format `case` now `await import("@kaiord/<adapter>")` instead of all 4 adapters being statically imported at module load
- `packages/mcp/src/utils/format-registry.ts`: same pattern; format-registry split via `detect-format-from-path.ts` to satisfy max-lines rule
- A typical `kaiord convert --in x.tcx --out y.krd` now loads only the requested adapter
- Δ: −1,877 bytes (cli −3,167; mcp +1,290 — chunk overhead, well within K007 5% tolerance)

### 2. Replace `@radix-ui/react-tooltip` with native HTML+CSS portal (commit `3f8d51c2`)
- `packages/workout-spa-editor/src/components/atoms/Tooltip/`: Tooltip.tsx + compute-position.ts + use-tooltip-state.ts (split for max-lines compliance)
- Public Tooltip atom prop signature unchanged → all consumers untouched
- Removed `@radix-ui/react-tooltip` dep from `packages/workout-spa-editor/package.json`
- Δ: −6,895 bytes pre-merge, −6,736 post-merge after refactor

### 3. Stub `zod/v3` via vite resolve.alias (commit `85bb549e`) — biggest win
- `packages/workout-spa-editor/src/lib/zod-v3-stub.ts`: 36-line stub exporting only `ZodFirstPartyTypeKind` (a frozen object of zod-v3 type-name strings)
- `packages/workout-spa-editor/vite.config.ts`: `resolve.alias["zod/v3"]` → stub
- `@ai-sdk/provider-utils` statically imports `ZodFirstPartyTypeKind` from `zod/v3` for its v3-to-json-schema parsers. `aiWorkoutSchema` is zod v4, so the v3 parsers are statically reachable but never executed at runtime — but rolldown bundles the full v3 module. The stub satisfies static-import resolution; the rest of v3 tree-shakes out
- Also: `package.json` lint-staged eslint gets `--no-warn-ignored` to silence the meta-warning on intentionally-ignored config files
- Δ: −55,865 bytes (vendor-zod chunk −42%)

### 4. Stub `@ai-sdk/gateway` via vite resolve.alias (commit `8669c272`)
- `packages/workout-spa-editor/src/lib/ai-sdk-gateway-stub.ts`: stub exporting throwing `createGateway`, throwing-Proxy `gateway`, and `GatewayAuthenticationError` Error subclass
- `packages/workout-spa-editor/vite.config.ts`: `resolve.alias["@ai-sdk/gateway"]` → stub
- The `ai` SDK statically imports `createGateway`, `gateway`, `GatewayAuthenticationError` for its `globalThis.AI_SDK_DEFAULT_PROVIDER ?? gateway` fallback path. `provider-factory.ts` always passes a concrete model instance from `createAnthropic` / `createOpenAI` / `createGoogleGenerativeAI`, so the fallback is unreachable
- Stubbing drops the ~60 KB raw gateway package (includes a multi-thousand-string `GatewayModelId` catalog of model IDs)
- Δ: −28,698 bytes (`generate-workout` chunk −25%)

### Bonus: `rollup-plugin-visualizer` as a gated dev tool (commit `1bf65c19`)
- Activated by `ANALYZE=1 pnpm build`; produces `dist/stats.json` for chunk dissection
- Was the diagnostic that revealed the zod-v3 dual-bundling and the gateway dead-weight; useful for future rounds

## Test plan
- [x] `pnpm -r test` — 3,505 tests passing
- [x] `pnpm -r build` — clean exit
- [x] `pnpm lint` — clean
- [x] CLI smoke tests (round-trip preserved via the existing test suite)
- [x] No public API changes to adapter packages
- [ ] CodeRabbit review pass

## Notes for review
- The two `vite resolve.alias` stubs (`zod/v3`, `@ai-sdk/gateway`) are runtime-safe **only** because of specific properties of how kaiord uses these libraries. Each stub file's docblock spells out the invariant. If those invariants ever change (e.g., switching to a zod v3 schema, or removing concrete-model-only `provider-factory.ts`), the stubs must be removed.
- Round-trip test fixtures, ZodError type guards, and `useLiveQuery` reactivity are all unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom tooltip with precise positioning, accessible behavior, and a new hook for placement/state.

* **Improvements**
  * Deferred (lazy) loading of format converters and async reader/writer factories to reduce bundle impact.
  * Build configs updated to enable code splitting.

* **Chores**
  * Updated Radix UI dependencies, added bundling stubs, tightened staged lint flag, and added worktrees/ to .gitignore.

* **Tests**
  * Expanded tooltip tests and made popup tests use a deterministic timestamp.

* **Documentation**
  * Added a changeset documenting bundle-size/performance effects.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/572)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->