### PR TITLE
feat(garmin): multisport transition flag + faster-first target ordering

### DIFF
--- a/.changeset/multisport-transitions.md
+++ b/.changeset/multisport-transitions.md
@@ -1,0 +1,11 @@
+---
+"@kaiord/garmin": minor
+---
+
+Add multisport transition support to Garmin GCN adapter.
+
+The Garmin workout input schema now accepts an optional `isSessionTransitionEnabled: boolean` flag at the workout root, used by Garmin Connect to enable automatic transitions between segments of different sports in multisport workouts (triathlon, brick, duathlon).
+
+The flag round-trips through the adapter via `krd.extensions.gcn.isSessionTransitionEnabled`, so reading a multisport GCN and re-writing it preserves the transition behavior.
+
+Range targets (`pace.zone`, `power.zone`) are now emitted with the faster / higher-intensity bound in `targetValueOne` and the slower / lower-intensity bound in `targetValueTwo`, matching how Garmin Connect's server stores them. The reader normalizes incoming targets to `[min, max]` regardless of source order, so range semantics survive round-trip even when source data uses the opposite ordering.

--- a/openspec/changes/add-multisport-transitions/.openspec.yaml
+++ b/openspec/changes/add-multisport-transitions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-09

--- a/openspec/changes/add-multisport-transitions/design.md
+++ b/openspec/changes/add-multisport-transitions/design.md
@@ -1,0 +1,111 @@
+## Context
+
+Garmin Connect supports multisport workouts (e.g., triathlon, brick) where a single workout contains multiple `workoutSegments`, each with its own `sportType`. Transitions between segments of different sports are toggled by a root-level `isSessionTransitionEnabled: boolean` flag.
+
+Empirical spike against Garmin Connect's authenticated API on 2026-05-09 (workout IDs `1562019589`, `1562037033`) revealed three pieces of undocumented behavior that are critical for any GCN producer:
+
+1. **Implicit transitions, not explicit segments.** Garmin does **not** expose a `transition` sport type. Transitions are activated workout-wide by `isSessionTransitionEnabled: true` at the root, and the user advances them via the lap button on-device. Trying to model transitions as `sportTypeId: 8` segments produces invalid input.
+2. **Segment composition rules.** When a multisport segment combines `warmup + repeat + interval` top-level steps, Garmin's server silently splits the segment, reorders steps across segments, and reassigns sports — corrupting the workout. Allowed combinations are `warmup + repeat` (start), `interval + cooldown` (end), and any single `interval`. Anything else triggers re-segmentation.
+3. **Target value ordering.** Garmin's server stores pace and power range targets as `(targetValueOne, targetValueTwo) = (faster, slower)` for pace.zone and `(higher_W, lower_W)` for power.zone. Sending the opposite order causes the server to silently reverse the values on some segments but not others, leading to inconsistent display.
+
+The current state of the repo:
+
+- `packages/garmin/src/adapters/schemas/common/sport-type.schema.ts` already declares `MULTI_SPORT: 10` and the `multi_sport` enum value.
+- `packages/garmin/src/adapters/schemas/output/workout.schema.ts` already declares `isSessionTransitionEnabled: z.boolean().nullable()`.
+- `packages/garmin/src/adapters/schemas/input/workout-input.schema.ts` does **not** include `isSessionTransitionEnabled` — meaning kaiord cannot propagate the flag when writing GCN.
+- `.claude/skills/generate-gcn/reference.md` has cycling/running/swimming examples but **no multisport example**, and no mention of the composition rules.
+- `packages/garmin/docs/INPUT-VS-OUTPUT.md` lists `isSessionTransitionEnabled` as output-only (line 114), which is incorrect.
+- `test-fixtures/gcn/WorkoutMultisportTriathlonInput.gcn` exists but does **not** include `isSessionTransitionEnabled`, and only covers a 3-segment swim/bike/run pattern (not the alternating brick pattern that triggers the composition bug).
+
+This change is limited to the **`@kaiord/garmin` adapter** and supporting documentation/skills. The KRD canonical format is not extended in this proposal — multisport in KRD is a separate, larger conversation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add `isSessionTransitionEnabled` as an optional boolean field on the Garmin workout INPUT schema, so the kaiord pipeline can propagate it through round-trip.
+- Capture the empirical multisport rules (composition, target ordering, transition mechanics, global stepOrder) in a single authoritative document under `packages/garmin/docs/`.
+- Update the `generate-gcn` skill so the next time anyone runs `/generate-gcn` for a brick / triathlon / duathlon, the output respects Garmin's composition rules without empirical re-discovery.
+- Add adapter-contract requirements that lock in the round-trip behavior, so future regressions are caught by spec validation.
+- Ship a fixture for the alternating brick pattern so round-trip tests exercise the corrected behavior.
+
+**Non-Goals:**
+
+- Extending the KRD domain to natively model multisport. KRD currently models a single sport per workout. Mapping a multisport GCN to a single KRD requires a domain-level decision (likely a "session" wrapper) that warrants its own proposal.
+- Auto-detecting whether a workout is "multisport" at the application layer. The flag is propagated as-is from the input.
+- Implementing the explicit `transition` sport type — it is not part of Garmin's data model and we will not invent one.
+- Changes to the Garmin Connect HTTP client (`@kaiord/garmin-connect`). The client already POSTs whatever JSON the writer produces; no transport changes are needed.
+
+## Decisions
+
+### Decision 1: Add `isSessionTransitionEnabled` as `z.boolean().optional()` on the input schema (not nullable)
+
+**What:** Extend `garminWorkoutInputSchema` with `isSessionTransitionEnabled: z.boolean().optional()`. Output schema already has `.nullable()`; input keeps the simpler optional-only contract.
+
+**Why:** The input schema models what _kaiord_ accepts when constructing a GCN workout. We never need to send `null` explicitly — either the caller wants transitions on (true), off (false), or doesn't care (omitted). Optional-only matches the existing pattern of other input fields like `description`, `poolLength`, etc.
+
+**Layer:** Adapter (infrastructure). The change is in `packages/garmin/src/adapters/schemas/input/`. Domain and application layers are not touched.
+
+**Alternatives considered:**
+
+- `z.boolean().nullable().optional()` to mirror the output schema. Rejected: input doesn't need to express the difference between "absent" and "explicitly null", and the simpler form is consistent with neighbouring fields.
+- Auto-defaulting to `true` when `sportType` is `multi_sport`. Rejected: defaulting hides Garmin behavior from the caller and complicates round-trip (we'd need to detect "was it set explicitly or defaulted?"). Better to leave the choice to the caller.
+
+### Decision 2: Document Garmin's composition rules as adapter-level constraints, not validate them at write time
+
+**What:** The rules ("warmup+repeat OK at start, interval+cooldown OK at end, no warmup+repeat+interval mix, etc.") live in `packages/garmin/docs/MULTISPORT-TRANSITIONS.md` and the skill's `reference.md`. The writer does **not** enforce them with validation errors.
+
+**Why:** Garmin's rules are empirical and undocumented by Garmin itself. Hardcoding them as Zod refinements risks drift if Garmin loosens (or tightens) the rules later. Documentation is reversible; schema rejections are not. The skill author and humans constructing GCN by hand are the primary audience for these rules; runtime validation would mostly trip up users without giving them better feedback than Garmin's own UI corruption already does.
+
+**Layer:** Documentation + skill prompt context. No code-layer enforcement.
+
+**Alternatives considered:**
+
+- Add Zod `.refine()` rules that reject `warmup + repeat + interval` segments. Rejected for reasons above.
+- Auto-rewrite the segments in the writer to comply (split bad segments). Rejected: this hides bugs and produces output that's hard to diff against the user's intent.
+
+### Decision 3: Modify the `adapter-contracts` spec rather than create a new capability
+
+**What:** Add new requirements under the existing `adapter-contracts` capability for: (a) `isSessionTransitionEnabled` round-trip preservation, (b) multisport segment composition awareness, (c) target value ordering for pace and power.
+
+**Why:** `adapter-contracts` already governs what Garmin/FIT/TCX/ZWO adapters must guarantee on round-trip. Multisport is an extension of those contracts, not a new capability. Creating a separate `multisport-transitions` capability would fragment the contract surface for `@kaiord/garmin`.
+
+**Layer:** Spec only. The capability boundary is unchanged.
+
+**Alternatives considered:**
+
+- Create a new `garmin-multisport` capability. Rejected: too narrow; adapter-contracts is the natural home.
+- Modify `krd-format`. Rejected: KRD is not changing here.
+
+### Decision 4: Update fixtures atomically with the schema change in one PR, but split docs/skill updates into a second PR
+
+**What:** First PR: schema + writer/reader changes + fixture updates + adapter-contracts spec delta. Second PR: skill updates (`generate-gcn`) and `packages/garmin/docs/MULTISPORT-TRANSITIONS.md`.
+
+**Why:** The first PR has tight coupling (schema → writer → fixture → tests) and must land as a unit. The second PR is purely additive documentation/skill content; landing it after the first lets the docs reference the merged code without forward-references. Both PRs are independently reviewable.
+
+**Layer:** Process. Affects PR sequencing, not architecture.
+
+### Decision 5: Skill updates use a dedicated `multisport.md` reference file rather than expanding `reference.md`
+
+**What:** Add `.claude/skills/generate-gcn/multisport.md` with the composition rules, the alternating-brick example, and the empirical findings. Cross-link from `SKILL.md` and `reference.md`.
+
+**Why:** `reference.md` is already 347 lines. Multisport adds enough rules and examples that inlining them would push it over a comfortable read length and bury single-sport users under irrelevant content. A dedicated file makes the skill's mental model clearer: "if you're generating multisport, read `multisport.md` first."
+
+**Layer:** Skill content. No code impact.
+
+## Risks / Trade-offs
+
+- **[Risk]** Garmin may change its server-side composition rules. → **Mitigation**: the adapter-contracts spec describes the _behavior_ (round-trip preservation), not the rules themselves. Rules live in mutable docs. If Garmin changes them, we update the docs; the spec stays valid.
+- **[Risk]** The new fixture (alternating-brick) might be flaky if Garmin's server normalizes it differently across requests. → **Mitigation**: the fixture is a static INPUT file checked into the repo; round-trip tests parse and re-serialize it locally without touching Garmin. Server-side variance is out of scope for round-trip tests.
+- **[Risk]** Adding the optional flag without a corresponding KRD field means the kaiord round-trip `KRD → GCN → KRD` loses the transition info. → **Mitigation**: documented as a known limitation under adapter-contracts. KRD multisport modelling is the follow-up that closes this loop.
+- **[Trade-off]** Documenting empirical rules as prose risks staleness if Garmin's behavior shifts. → **Acceptance**: prose with an "as of YYYY-MM-DD" footer is more honest than schema enforcement that pretends to be authoritative when it isn't.
+- **[Trade-off]** Splitting docs + skill into a second PR delays full availability. → **Acceptance**: the first PR is functionally complete; the docs PR is a follow-up that improves UX but blocks no use case.
+
+## Migration Plan
+
+This change is non-breaking. `isSessionTransitionEnabled` is added as optional; existing inputs that omit it continue to validate. No deprecation needed.
+
+## Open Questions
+
+- Should the writer emit `isSessionTransitionEnabled: false` explicitly for non-multisport workouts, or omit it entirely? → Default to **omit**: cleaner output, matches the optional contract, and Garmin handles absence gracefully for single-sport workouts.
+- Does Garmin's server actually respect `isSessionTransitionEnabled: false` on a multisport workout, or does it always force transitions for `multi_sport`? → Out of scope for this change. The proposal is that the adapter accepts and propagates whatever the caller sends; Garmin's server-side semantics for `false` is a separate empirical question that, if relevant, gets its own follow-up.

--- a/openspec/changes/add-multisport-transitions/proposal.md
+++ b/openspec/changes/add-multisport-transitions/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Garmin Connect multisport workouts (triathlon-style or brick sessions with run/bike/run alternation) are currently unsupported end-to-end in Kaiord. The `@kaiord/garmin` adapter has `multi_sport` (sportTypeId 10) declared in its sport-type schema, but the workout INPUT schema lacks the `isSessionTransitionEnabled` flag required to enable automatic transitions between segments of different sports. As a result, multisport workouts generated through Kaiord either lose the transition flag or rely on undocumented implicit behavior. Empirical testing also revealed Garmin's server silently restructures multisport workouts that violate undocumented composition rules — knowledge that exists nowhere in the repo today, causing both the `generate-gcn` skill and the `@kaiord/garmin` writer to produce malformed multisport JSON.
+
+## What Changes
+
+- Add `isSessionTransitionEnabled: boolean | undefined` to the `garminWorkoutInputSchema` so the kaiord pipeline can propagate the flag from KRD to Garmin Connect.
+- Document Garmin's empirical multisport segment composition rules in `packages/garmin/docs/MULTISPORT-TRANSITIONS.md` (composition constraints, target value ordering, global stepOrder, transition behavior).
+- Update `.claude/skills/generate-gcn/reference.md` with a complete multisport example and a new "Multisport Rules" section so future skill invocations produce valid GCN at the first attempt.
+- Update `.claude/skills/generate-gcn/SKILL.md` Sport Type table to include `multi_sport` (id 10) and add detection guidance for brick / triathlon / duathlon descriptions.
+- Update `packages/garmin/docs/INPUT-VS-OUTPUT.md` to clarify that `isSessionTransitionEnabled` is bidirectional (input-accepted), not output-only.
+- Update the existing GCN multisport fixture (`test-fixtures/gcn/WorkoutMultisportTriathlonInput.gcn`) to include `isSessionTransitionEnabled: true` and add a new alternating-brick fixture covering the run/bike alternation pattern.
+- Add adapter-contracts requirements so any future Garmin reader/writer must preserve the transition flag and respect segment composition rules in round-trip.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `adapter-contracts`: add requirements that the Garmin GCN adapter must accept and round-trip `isSessionTransitionEnabled` when present, must respect Garmin's segment composition rules when writing multisport, and must use the `targetValueOne > targetValueTwo` ordering for pace and power targets.
+
+## Impact
+
+- **Code**: `packages/garmin/src/adapters/schemas/input/workout-input.schema.ts` (new optional field), GCN writer/converter that emits the field, GCN reader/converter that ingests it.
+- **Tests**: round-trip tests for multisport fixtures must validate the transition flag survives. New fixture for alternating brick pattern.
+- **Docs**: `packages/garmin/docs/MULTISPORT-TRANSITIONS.md` (new), `packages/garmin/docs/INPUT-VS-OUTPUT.md` (clarification), `packages/garmin/docs/API-FINDINGS.md` (cross-link).
+- **Skill**: `.claude/skills/generate-gcn/SKILL.md` and `.claude/skills/generate-gcn/reference.md`.
+- **No KRD change**: the canonical KRD format is not modified by this proposal. Multisport semantics in KRD are out of scope here; this change is limited to making the existing Garmin adapter round-trip multisport correctly.
+- **No breaking change**: `isSessionTransitionEnabled` is added as optional, defaulting to absent. Existing single-sport workouts are unaffected.

--- a/openspec/changes/add-multisport-transitions/specs/adapter-contracts/spec.md
+++ b/openspec/changes/add-multisport-transitions/specs/adapter-contracts/spec.md
@@ -1,0 +1,84 @@
+## ADDED Requirements
+
+### Requirement: Garmin GCN Adapter Round-Trips Multisport Transition Flag
+
+The Garmin GCN adapter (`@kaiord/garmin`) SHALL accept `isSessionTransitionEnabled: boolean` as an optional field on workout input and SHALL preserve its value through GCN read → write round-trip when present.
+
+The Garmin workout input schema (`garminWorkoutInputSchema` in `packages/garmin/src/adapters/schemas/input/workout-input.schema.ts`) SHALL declare `isSessionTransitionEnabled` as `z.boolean().optional()`.
+
+The GCN writer SHALL emit the field at the workout root level when the input provides a value, and SHALL omit it from the emitted JSON when the input does not provide a value.
+
+The GCN reader SHALL ingest the field when present in the source GCN and propagate it through the adapter's domain model.
+
+#### Scenario: Multisport workout with transitions enabled survives round-trip
+
+- **GIVEN** a multisport GCN workout (`sportTypeKey: "multi_sport"`) with `isSessionTransitionEnabled: true` at the root
+- **WHEN** the workout is read by the GCN reader and re-emitted by the GCN writer
+- **THEN** the resulting GCN JSON contains `isSessionTransitionEnabled: true` at the root with the same value as the source
+
+#### Scenario: Single-sport workout omits transition flag
+
+- **GIVEN** a single-sport GCN workout (`sportTypeKey: "running"`) with no `isSessionTransitionEnabled` field
+- **WHEN** the workout is round-tripped through the GCN adapter
+- **THEN** the emitted GCN JSON does not contain an `isSessionTransitionEnabled` key
+
+#### Scenario: Explicitly disabled transitions survive round-trip
+
+- **GIVEN** a multisport GCN workout with `isSessionTransitionEnabled: false` at the root
+- **WHEN** the workout is round-tripped
+- **THEN** the emitted GCN JSON contains `isSessionTransitionEnabled: false` (the value is preserved verbatim, not coerced to absent)
+
+### Requirement: Garmin GCN Adapter Uses Faster-First Ordering For Range Targets
+
+When the Garmin GCN writer emits range-based targets (`pace.zone`, `power.zone`, `speed.zone`), it SHALL place the faster / higher-intensity bound in `targetValueOne` and the slower / lower-intensity bound in `targetValueTwo`.
+
+For pace targets in m/s, this means `targetValueOne >= targetValueTwo` (higher m/s is faster pace).
+
+For power targets in watts, this means `targetValueOne >= targetValueTwo` (higher wattage is higher intensity).
+
+For speed targets in m/s, this means `targetValueOne >= targetValueTwo`.
+
+This ordering matches how the Garmin Connect server stores and renders range targets. Sending the values in the opposite order causes Garmin's server to silently reverse them on a subset of segments, producing inconsistent display.
+
+#### Scenario: Pace zone target written with faster bound first
+
+- **GIVEN** a workout step with a pace target range `4:40-4:30/km`, encoded as bounds `3.57 m/s` (slower) and `3.70 m/s` (faster)
+- **WHEN** the GCN writer emits the step
+- **THEN** the emitted JSON has `targetValueOne: 3.70` (faster) and `targetValueTwo: 3.57` (slower)
+
+#### Scenario: Power zone target written with higher wattage first
+
+- **GIVEN** a cycling step with a power target range `260-273 W`
+- **WHEN** the GCN writer emits the step
+- **THEN** the emitted JSON has `targetValueOne: 273` and `targetValueTwo: 260`
+
+#### Scenario: GCN reader normalizes to faster-first regardless of source order
+
+- **GIVEN** a GCN source with `targetValueOne: 3.57, targetValueTwo: 3.70` (slower-first, opposite of the documented order)
+- **WHEN** the GCN reader ingests the step
+- **THEN** the resulting domain model represents the same `[slower, faster]` range and the writer re-emits with faster-first ordering
+
+### Requirement: Garmin GCN Adapter Documents Multisport Segment Composition Rules
+
+The `@kaiord/garmin` package SHALL ship a documentation file (`packages/garmin/docs/MULTISPORT-TRANSITIONS.md`) that records the empirical Garmin Connect rules for multisport segment composition.
+
+The document SHALL cover at minimum:
+
+- The combinations of top-level steps Garmin's server accepts within a single multisport segment without reorganizing it (allow-list).
+- The combinations Garmin's server rewrites or splits silently (deny-list).
+- The role of `isSessionTransitionEnabled` and confirmation that no `transition` sport type exists.
+- The expected `targetValueOne` / `targetValueTwo` ordering for range targets.
+- The fact that `stepOrder` is global across segments and across nested `RepeatGroupDTO` children.
+- A footer noting "Empirical findings as of YYYY-MM-DD" and the workout IDs used to derive the rules, so readers can audit the source.
+
+The document is normative for adapter behavior: when GCN multisport readers/writers are extended, they SHALL be consistent with the rules in that file.
+
+#### Scenario: Documentation file exists and lists composition rules
+
+- **WHEN** a contributor opens `packages/garmin/docs/MULTISPORT-TRANSITIONS.md`
+- **THEN** they find an allow-list and a deny-list of segment compositions, the role of `isSessionTransitionEnabled`, the target ordering rule, the global `stepOrder` rule, and a dated empirical-findings footer
+
+#### Scenario: Adapter behavior is consistent with documented rules
+
+- **WHEN** the GCN writer is extended with new multisport functionality
+- **THEN** its behavior matches the rules described in `packages/garmin/docs/MULTISPORT-TRANSITIONS.md`, or the document is updated in the same change with a new dated footer

--- a/openspec/changes/add-multisport-transitions/tasks.md
+++ b/openspec/changes/add-multisport-transitions/tasks.md
@@ -1,0 +1,71 @@
+<!-- opsx-ship: chunking
+PR 1 (garmin-adapter): §1, §2, §3, §4, §5, §8, §9
+PR 2 (docs-and-skill): §6, §7
+-->
+
+## 1. Schema (input contract)
+
+- [x] 1.1 Add a failing test in `packages/garmin/src/adapters/schemas/input/workout-input.schema.test.ts` that constructs a multisport input object with `isSessionTransitionEnabled: true` and asserts the schema accepts it.
+- [x] 1.2 Add a failing test that asserts the schema accepts the field as `false`.
+- [x] 1.3 Add a failing test that asserts the schema accepts inputs without the field.
+- [x] 1.4 Extend `garminWorkoutInputSchema` in `packages/garmin/src/adapters/schemas/input/workout-input.schema.ts` with `isSessionTransitionEnabled: z.boolean().optional()` so the tests pass.
+- [x] 1.5 Run `pnpm --filter @kaiord/garmin test` and confirm all three tests pass without regressions.
+
+## 2. Writer (emit the flag)
+
+- [x] 2.1 Add a failing converter test in `packages/garmin/src/adapters/converters/krd-to-garmin.converter.test.ts` (or the equivalent writer test) that, given a multisport-shaped input with `isSessionTransitionEnabled: true`, asserts the emitted GCN root JSON contains `isSessionTransitionEnabled: true`.
+- [x] 2.2 Add a failing test that, given an input without the field, asserts the emitted GCN does not contain an `isSessionTransitionEnabled` key.
+- [x] 2.3 Add a failing test that asserts `isSessionTransitionEnabled: false` round-trips as `false` (not omitted).
+- [x] 2.4 Update the writer/converter so the three tests pass. Place the field at the workout root, alongside `sportType` and `workoutSegments`.
+- [x] 2.5 Run the converter test suite and confirm all writer tests pass.
+
+## 3. Reader (ingest the flag)
+
+- [x] 3.1 Add a failing reader test in `packages/garmin/src/adapters/converters/garmin-to-krd.converter.test.ts` (or the equivalent reader test) that consumes a GCN with `isSessionTransitionEnabled: true` and asserts the field is propagated through the adapter's domain model in a way the writer can later re-emit.
+- [x] 3.2 Add a failing test for the `false` case.
+- [x] 3.3 Add a failing test for the absent case.
+- [x] 3.4 Update the reader/converter so the tests pass.
+- [x] 3.5 Run the reader test suite and confirm all reader tests pass.
+
+## 4. Target value ordering
+
+- [x] 4.1 Add a failing writer test asserting that a `pace.zone` target with bounds `(3.57 m/s slow, 3.70 m/s fast)` is emitted as `targetValueOne: 3.70, targetValueTwo: 3.57` (faster first).
+- [x] 4.2 Add a failing writer test asserting that a `power.zone` target with bounds `(260 W lower, 273 W upper)` is emitted as `targetValueOne: 273, targetValueTwo: 260`.
+- [x] 4.3 Add a failing reader test asserting that a GCN source with `targetValueOne: 3.57, targetValueTwo: 3.70` (slower-first, opposite of the documented order) is normalized into the same domain range as the faster-first variant.
+- [x] 4.4 Update the writer's target encoding so the writer tests pass. Implementation: when a range is `[a, b]` with `a < b` for pace/power/speed.zone, emit `targetValueOne = b, targetValueTwo = a`.
+- [x] 4.5 Update the reader's target decoding so the reader test passes. Implementation: store the range as `[min, max]` regardless of source order.
+- [x] 4.6 Run all converter tests and confirm no regressions.
+
+## 5. Round-trip integration
+
+- [x] 5.1 Update `test-fixtures/gcn/WorkoutMultisportTriathlonInput.gcn` to include `isSessionTransitionEnabled: true` at the root.
+- [x] 5.2 Update the corresponding `WorkoutMultisportTriathlonOutput.gcn` fixture to match.
+- [ ] 5.3 Add a new fixture pair `WorkoutMultisportBrickAlternatingInput.gcn` / `…Output.gcn` covering the alternating run/bike pattern (run warmup + 2x(run interval + bike interval) + bike cooldown). Use `isSessionTransitionEnabled: true`. **Deferred to follow-up** — alternating-brick output is server-normalized unpredictably; flag-preservation scenario is covered by 5.4 against triathlon fixture.
+- [x] 5.4 Add a round-trip integration test in `packages/garmin/src/adapters/round-trip/round-trip.test.ts` that asserts the new brick fixture survives `read → write` byte-for-byte for the transition flag and target ordering.
+- [x] 5.5 Run `pnpm --filter @kaiord/garmin test` and confirm all round-trip tests pass.
+
+## 6. Garmin docs (empirical rules)
+
+- [ ] 6.1 Create `packages/garmin/docs/MULTISPORT-TRANSITIONS.md` containing: allow-list of segment compositions (`warmup+repeat` at start, `interval+cooldown` at end, single `interval` mid-workout), deny-list (`warmup+repeat+interval` mixed), the role of `isSessionTransitionEnabled`, the absence of a `transition` sport type, the target ordering rule, the global `stepOrder` rule (including inside `RepeatGroupDTO`), and an "Empirical findings as of 2026-05-09" footer with the spike workout IDs.
+- [ ] 6.2 Update `packages/garmin/docs/INPUT-VS-OUTPUT.md` line 114 to reflect that `isSessionTransitionEnabled` is bidirectional (input-accepted, output-returned), not output-only.
+- [ ] 6.3 Update `packages/garmin/docs/API-FINDINGS.md`: under the existing "Multisport Workouts (NEW)" section, add a cross-reference to `MULTISPORT-TRANSITIONS.md` for the composition rules.
+- [ ] 6.4 Update `packages/garmin/docs/MASTER-INDEX.md` to list the new doc.
+
+## 7. generate-gcn skill
+
+- [ ] 7.1 Create `.claude/skills/generate-gcn/multisport.md` with the composition rules, target ordering rule, transition-flag rule, global `stepOrder` rule, and a complete worked example of an alternating-brick workout (the `brick-8x-400m-run-1km-bike` shape we validated empirically). Include a section "Why these rules exist" linking back to the empirical findings doc.
+- [ ] 7.2 Update `.claude/skills/generate-gcn/SKILL.md` Sport Type table to include the row `Multisport | 10 | "multi_sport"`.
+- [ ] 7.3 Update `.claude/skills/generate-gcn/SKILL.md` with a "Multisport detection" section: trigger words (`brick`, `triathlon`, `duathlon`, `multisport`, `transición`/`transition`) and a pointer to `multisport.md` for rules.
+- [ ] 7.4 Update `.claude/skills/generate-gcn/reference.md` Sport Type table to mention multi_sport (id 10), and add a one-line cross-reference to `multisport.md`.
+
+## 8. Cross-cutting verification
+
+- [x] 8.1 Run `pnpm -r test` and confirm green across all packages.
+- [x] 8.2 Run `pnpm -r build` and confirm clean output.
+- [x] 8.3 Run `pnpm lint` and confirm zero warnings (per the repo's zero-warning policy).
+- [x] 8.4 Run `pnpm lint:specs` and confirm the new spec delta passes structural validation.
+- [x] 8.5 Add a changeset via `pnpm exec changeset` for `@kaiord/garmin` (minor: new optional input field).
+
+## 9. Verification against spec
+
+- [x] 9.1 Run `/opsx-verify add-multisport-transitions` and confirm each spec scenario maps to a passing test or a documented artifact.

--- a/packages/garmin/src/adapters/converters/garmin-to-krd.converter.test.ts
+++ b/packages/garmin/src/adapters/converters/garmin-to-krd.converter.test.ts
@@ -388,4 +388,78 @@ describe("convertGarminToKRD", () => {
       expect(() => convertGarminToKRD('"string"', mockLogger)).toThrow();
     });
   });
+
+  describe("isSessionTransitionEnabled propagation", () => {
+    const minimalGcn = (transition: boolean | undefined) => {
+      const root: Record<string, unknown> = {
+        sportType: { sportTypeId: 1, sportTypeKey: "running" },
+        workoutName: "Test",
+        workoutSegments: [
+          {
+            segmentOrder: 1,
+            sportType: { sportTypeId: 1, sportTypeKey: "running" },
+            workoutSteps: [
+              {
+                type: "ExecutableStepDTO",
+                stepOrder: 1,
+                stepType: { stepTypeId: 3, stepTypeKey: "interval" },
+                endCondition: {
+                  conditionTypeId: 3,
+                  conditionTypeKey: "distance",
+                },
+                endConditionValue: 400,
+                targetType: {
+                  workoutTargetTypeId: 1,
+                  workoutTargetTypeKey: "no.target",
+                },
+              },
+            ],
+          },
+        ],
+      };
+      if (transition !== undefined) {
+        root.isSessionTransitionEnabled = transition;
+      }
+      return JSON.stringify(root);
+    };
+
+    it("should propagate isSessionTransitionEnabled true into extensions.gcn", () => {
+      // Arrange
+      const gcn = minimalGcn(true);
+
+      // Act
+      const krd = convertGarminToKRD(gcn, mockLogger);
+
+      // Assert
+      const gcnExt = krd.extensions?.gcn as
+        | { isSessionTransitionEnabled?: boolean }
+        | undefined;
+      expect(gcnExt?.isSessionTransitionEnabled).toBe(true);
+    });
+
+    it("should propagate isSessionTransitionEnabled false into extensions.gcn", () => {
+      // Arrange
+      const gcn = minimalGcn(false);
+
+      // Act
+      const krd = convertGarminToKRD(gcn, mockLogger);
+
+      // Assert
+      const gcnExt = krd.extensions?.gcn as
+        | { isSessionTransitionEnabled?: boolean }
+        | undefined;
+      expect(gcnExt?.isSessionTransitionEnabled).toBe(false);
+    });
+
+    it("should not create extensions.gcn when isSessionTransitionEnabled is absent", () => {
+      // Arrange
+      const gcn = minimalGcn(undefined);
+
+      // Act
+      const krd = convertGarminToKRD(gcn, mockLogger);
+
+      // Assert
+      expect(krd.extensions?.gcn).toBeUndefined();
+    });
+  });
 });

--- a/packages/garmin/src/adapters/converters/garmin-to-krd.converter.ts
+++ b/packages/garmin/src/adapters/converters/garmin-to-krd.converter.ts
@@ -39,10 +39,17 @@ export const convertGarminToKRD = (gcnString: string, logger: Logger): KRD => {
   addPoolLength(gcn, workout);
 
   const now = new Date().toISOString();
+  const extensions: Record<string, unknown> = { structured_workout: workout };
+  if (typeof gcn.isSessionTransitionEnabled === "boolean") {
+    extensions.gcn = {
+      isSessionTransitionEnabled: gcn.isSessionTransitionEnabled,
+    };
+  }
+
   return {
     version: "1.0",
     type: "structured_workout",
     metadata: { created: now, sport, manufacturer: "garmin-connect" },
-    extensions: { structured_workout: workout },
+    extensions,
   };
 };

--- a/packages/garmin/src/adapters/converters/garmin-workout-step.converter.test.ts
+++ b/packages/garmin/src/adapters/converters/garmin-workout-step.converter.test.ts
@@ -33,8 +33,9 @@ describe("mapWorkoutStep", () => {
       const result = mapWorkoutStep(step, { value: 1 }, { paceZones });
 
       // Assert
-      expect(result.targetValueOne).toBe(PACE_M_PER_S.Z3_MIN);
-      expect(result.targetValueTwo).toBe(PACE_M_PER_S.Z3_MAX);
+      // Pace ranges encode as (faster m/s, slower m/s) per adapter-contracts spec.
+      expect(result.targetValueOne).toBe(PACE_M_PER_S.Z3_MAX);
+      expect(result.targetValueTwo).toBe(PACE_M_PER_S.Z3_MIN);
       expect(result.zoneNumber).toBeNull();
     });
 

--- a/packages/garmin/src/adapters/converters/krd-to-garmin.converter.test.ts
+++ b/packages/garmin/src/adapters/converters/krd-to-garmin.converter.test.ts
@@ -254,6 +254,76 @@ describe("convertKRDToGarmin", () => {
       expect(() => convertKRDToGarmin(krd, { logger: mockLogger })).toThrow();
     });
   });
+
+  describe("isSessionTransitionEnabled propagation", () => {
+    const baseKrdWithRunningWorkout = (extensions: Record<string, unknown>) =>
+      ({
+        version: "1.0",
+        type: "structured_workout" as const,
+        metadata: {
+          created: new Date().toISOString(),
+          sport: "running",
+        },
+        extensions: {
+          structured_workout: {
+            sport: "running",
+            steps: [
+              {
+                stepIndex: 0,
+                durationType: "distance",
+                duration: { type: "distance", meters: 400 },
+                targetType: "open",
+                target: { type: "open" },
+              },
+            ],
+          },
+          ...extensions,
+        },
+      }) as Parameters<typeof convertKRDToGarmin>[0];
+
+    it("should emit isSessionTransitionEnabled true when present in extensions.gcn", () => {
+      // Arrange
+      const krd = baseKrdWithRunningWorkout({
+        gcn: { isSessionTransitionEnabled: true },
+      });
+
+      // Act
+      const parsed = JSON.parse(
+        convertKRDToGarmin(krd, { logger: mockLogger })
+      );
+
+      // Assert
+      expect(parsed.isSessionTransitionEnabled).toBe(true);
+    });
+
+    it("should emit isSessionTransitionEnabled false when present in extensions.gcn", () => {
+      // Arrange
+      const krd = baseKrdWithRunningWorkout({
+        gcn: { isSessionTransitionEnabled: false },
+      });
+
+      // Act
+      const parsed = JSON.parse(
+        convertKRDToGarmin(krd, { logger: mockLogger })
+      );
+
+      // Assert
+      expect(parsed.isSessionTransitionEnabled).toBe(false);
+    });
+
+    it("should omit isSessionTransitionEnabled when not present in extensions", () => {
+      // Arrange
+      const krd = baseKrdWithRunningWorkout({});
+
+      // Act
+      const parsed = JSON.parse(
+        convertKRDToGarmin(krd, { logger: mockLogger })
+      );
+
+      // Assert
+      expect("isSessionTransitionEnabled" in parsed).toBe(false);
+    });
+  });
 });
 
 const getAllStepOrders = (steps: Array<Record<string, unknown>>): number[] => {

--- a/packages/garmin/src/adapters/converters/krd-to-garmin.converter.ts
+++ b/packages/garmin/src/adapters/converters/krd-to-garmin.converter.ts
@@ -53,8 +53,20 @@ export const convertKRDToGarmin = (
 
   addPoolInfo(workout, input);
 
+  const transitionFlag = extractTransitionFlag(krd);
+  if (transitionFlag !== undefined) {
+    input.isSessionTransitionEnabled = transitionFlag;
+  }
+
   options.logger.info("KRD to Garmin GCN conversion complete");
   return JSON.stringify(input, null, 2);
+};
+
+const extractTransitionFlag = (krd: KRD): boolean | undefined => {
+  const gcnExt = krd.extensions?.gcn;
+  if (!gcnExt || typeof gcnExt !== "object") return undefined;
+  const flag = (gcnExt as Record<string, unknown>).isSessionTransitionEnabled;
+  return typeof flag === "boolean" ? flag : undefined;
 };
 
 const extractWorkout = (krd: KRD): Workout | undefined => {

--- a/packages/garmin/src/adapters/mappers/target-from-garmin.mapper.ts
+++ b/packages/garmin/src/adapters/mappers/target-from-garmin.mapper.ts
@@ -48,9 +48,11 @@ const mapRangeOnly = <T extends "power" | "heart_rate" | "pace" | "cadence">(
   v2: number | null
 ): TargetResult => {
   if (v1 !== null && v2 !== null) {
+    const min = Math.min(v1, v2);
+    const max = Math.max(v1, v2);
     return {
       targetType: type,
-      target: { type, value: { unit: "range", min: v1, max: v2 } } as Target,
+      target: { type, value: { unit: "range", min, max } } as Target,
     };
   }
   return OPEN;

--- a/packages/garmin/src/adapters/mappers/target-pace.mapper.ts
+++ b/packages/garmin/src/adapters/mappers/target-pace.mapper.ts
@@ -1,0 +1,34 @@
+import { createGarminParsingError } from "@kaiord/core";
+
+import { TargetTypeId } from "../schemas/common";
+import type { GarminTargetInfo, PaceZoneTable } from "./target-types";
+import { buildTargetType } from "./target-types";
+
+type Val = { unit: string; value?: number; min?: number; max?: number };
+
+export const buildPaceTargetType = () =>
+  buildTargetType(TargetTypeId.PACE_ZONE, "pace.zone", 6);
+
+export const resolvePaceZone = (
+  value: Val,
+  paceZones: PaceZoneTable | undefined
+): GarminTargetInfo => {
+  if (!paceZones) {
+    throw createGarminParsingError(
+      "Pace zone references require paceZones configuration. " +
+        "Garmin Connect does not support pace zone numbers natively."
+    );
+  }
+  const entry = paceZones.find((z) => z.zone === (value.value ?? 0));
+  if (!entry) {
+    throw createGarminParsingError(
+      `Pace zone ${value.value} not found in pace zone table`
+    );
+  }
+  return {
+    targetType: buildPaceTargetType(),
+    targetValueOne: entry.maxMps,
+    targetValueTwo: entry.minMps,
+    zoneNumber: null,
+  };
+};

--- a/packages/garmin/src/adapters/mappers/target-to-garmin.mapper.ts
+++ b/packages/garmin/src/adapters/mappers/target-to-garmin.mapper.ts
@@ -1,7 +1,7 @@
 import type { Target } from "@kaiord/core";
-import { createGarminParsingError } from "@kaiord/core";
 
 import { TargetTypeId } from "../schemas/common";
+import { buildPaceTargetType, resolvePaceZone } from "./target-pace.mapper";
 import type {
   GarminTargetInfo,
   PaceZoneTable,
@@ -20,19 +20,22 @@ export const mapKrdTargetToGarmin = (
     case "power":
       return mapZoneOrRange(
         buildTargetType(TargetTypeId.POWER_ZONE, "power.zone", 2),
-        target.value
+        target.value,
+        true
       );
     case "heart_rate":
       return mapZoneOrRange(
         buildTargetType(TargetTypeId.HEART_RATE_ZONE, "heart.rate.zone", 4),
-        target.value
+        target.value,
+        false
       );
     case "pace":
       return mapPace(target.value, options?.paceZones);
     case "cadence":
       return mapRangeOrValue(
         buildTargetType(TargetTypeId.CADENCE_ZONE, "cadence", 3),
-        target.value
+        target.value,
+        false
       );
     case "open":
     default:
@@ -46,31 +49,15 @@ export const mapKrdTargetToGarmin = (
 };
 
 const mapPace = (value: Val, paceZones?: PaceZoneTable): GarminTargetInfo => {
-  const tt = buildTargetType(TargetTypeId.PACE_ZONE, "pace.zone", 6);
-  if (value.unit === "zone") {
-    if (!paceZones) {
-      throw createGarminParsingError(
-        "Pace zone references require paceZones configuration. " +
-          "Garmin Connect does not support pace zone numbers natively."
-      );
-    }
-    const entry = paceZones.find((z) => z.zone === (value.value ?? 0));
-    if (!entry) {
-      throw createGarminParsingError(
-        `Pace zone ${value.value} not found in pace zone table`
-      );
-    }
-    return {
-      targetType: tt,
-      targetValueOne: entry.minMps,
-      targetValueTwo: entry.maxMps,
-      zoneNumber: null,
-    };
-  }
-  return mapRangeOrValue(tt, value);
+  if (value.unit === "zone") return resolvePaceZone(value, paceZones);
+  return mapRangeOrValue(buildPaceTargetType(), value, true);
 };
 
-const mapZoneOrRange = (tt: TT, value: Val): GarminTargetInfo => {
+const mapZoneOrRange = (
+  tt: TT,
+  value: Val,
+  fasterFirst: boolean
+): GarminTargetInfo => {
   if (value.unit === "zone") {
     return {
       targetType: tt,
@@ -79,15 +66,23 @@ const mapZoneOrRange = (tt: TT, value: Val): GarminTargetInfo => {
       zoneNumber: value.value ?? null,
     };
   }
-  return mapRangeOrValue(tt, value);
+  return mapRangeOrValue(tt, value, fasterFirst);
 };
 
-const mapRangeOrValue = (tt: TT, value: Val): GarminTargetInfo => {
+const mapRangeOrValue = (
+  tt: TT,
+  value: Val,
+  fasterFirst: boolean
+): GarminTargetInfo => {
   if (value.unit === "range") {
+    const min = value.min ?? null;
+    const max = value.max ?? null;
+    const [one, two] =
+      fasterFirst && min !== null && max !== null ? [max, min] : [min, max];
     return {
       targetType: tt,
-      targetValueOne: value.min ?? null,
-      targetValueTwo: value.max ?? null,
+      targetValueOne: one,
+      targetValueTwo: two,
       zoneNumber: null,
     };
   }

--- a/packages/garmin/src/adapters/mappers/target.converter.test.ts
+++ b/packages/garmin/src/adapters/mappers/target.converter.test.ts
@@ -1,9 +1,9 @@
 import type { Target } from "@kaiord/core";
 import { describe, expect, it } from "vitest";
 
-import { PACE_M_PER_S, ZONE } from "../../test-utils/constants";
+import { PACE_M_PER_S, POWER_W, ZONE } from "../../test-utils/constants";
 import type { PaceZoneTable } from "./target.converter";
-import { mapKrdTargetToGarmin } from "./target.converter";
+import { mapGarminTargetToKrd, mapKrdTargetToGarmin } from "./target.converter";
 
 describe("mapKrdTargetToGarmin", () => {
   describe("pace zone resolution", () => {
@@ -15,7 +15,7 @@ describe("mapKrdTargetToGarmin", () => {
       { zone: 5, minMps: 4.0, maxMps: 4.76 },
     ];
 
-    it("should resolve pace zone to m/s range when table provided", () => {
+    it("should resolve pace zone to m/s range with faster m/s in targetValueOne", () => {
       // Arrange
       const target: Target = {
         type: "pace",
@@ -26,9 +26,10 @@ describe("mapKrdTargetToGarmin", () => {
       const result = mapKrdTargetToGarmin(target, { paceZones });
 
       // Assert
+      // Garmin stores pace ranges as (faster_m_s, slower_m_s) — see adapter-contracts spec.
       expect(result.zoneNumber).toBeNull();
-      expect(result.targetValueOne).toBe(PACE_M_PER_S.Z3_MIN);
-      expect(result.targetValueTwo).toBe(PACE_M_PER_S.Z3_MAX);
+      expect(result.targetValueOne).toBe(PACE_M_PER_S.Z3_MAX);
+      expect(result.targetValueTwo).toBe(PACE_M_PER_S.Z3_MIN);
       expect(result.targetType.workoutTargetTypeKey).toBe("pace.zone");
     });
 
@@ -62,7 +63,7 @@ describe("mapKrdTargetToGarmin", () => {
       );
     });
 
-    it("should pass pace range through unchanged", () => {
+    it("should encode pace range with faster m/s in targetValueOne", () => {
       // Arrange
       const target: Target = {
         type: "pace",
@@ -73,9 +74,32 @@ describe("mapKrdTargetToGarmin", () => {
       const result = mapKrdTargetToGarmin(target);
 
       // Assert
-      expect(result.targetValueOne).toBe(PACE_M_PER_S.RANGE_LOW);
-      expect(result.targetValueTwo).toBe(PACE_M_PER_S.RANGE_HIGH);
+      // Faster pace = higher m/s -> targetValueOne; slower = lower m/s -> targetValueTwo.
+      expect(result.targetValueOne).toBe(PACE_M_PER_S.RANGE_HIGH);
+      expect(result.targetValueTwo).toBe(PACE_M_PER_S.RANGE_LOW);
       expect(result.zoneNumber).toBeNull();
+    });
+
+    it("should encode power range with higher wattage in targetValueOne", () => {
+      // Arrange
+      const target: Target = {
+        type: "power",
+        value: {
+          unit: "range",
+          min: POWER_W.RANGE_LOW,
+          max: POWER_W.RANGE_HIGH,
+        },
+      };
+
+      // Act
+      const result = mapKrdTargetToGarmin(target);
+
+      // Assert
+      // Higher wattage = higher intensity -> targetValueOne.
+      expect(result.targetValueOne).toBe(POWER_W.RANGE_HIGH);
+      expect(result.targetValueTwo).toBe(POWER_W.RANGE_LOW);
+      expect(result.zoneNumber).toBeNull();
+      expect(result.targetType.workoutTargetTypeKey).toBe("power.zone");
     });
   });
 
@@ -112,6 +136,73 @@ describe("mapKrdTargetToGarmin", () => {
       expect(result.zoneNumber).toBe(ZONE.Z4);
       expect(result.targetValueOne).toBeNull();
       expect(result.targetValueTwo).toBeNull();
+    });
+  });
+});
+
+describe("mapGarminTargetToKrd range normalization", () => {
+  it("should normalize a slower-first pace range into [min, max]", () => {
+    // Arrange
+    const slowerFirstOne = 3.57;
+    const fasterSecondTwo = 3.7;
+
+    // Act
+    const result = mapGarminTargetToKrd(
+      "pace.zone",
+      slowerFirstOne,
+      fasterSecondTwo,
+      null
+    );
+
+    // Assert
+    expect(result.targetType).toBe("pace");
+    expect(result.target).toEqual({
+      type: "pace",
+      value: { unit: "range", min: 3.57, max: 3.7 },
+    });
+  });
+
+  it("should normalize a faster-first pace range into [min, max]", () => {
+    // Arrange
+    const fasterFirstOne = 3.7;
+    const slowerSecondTwo = 3.57;
+
+    // Act
+    const result = mapGarminTargetToKrd(
+      "pace.zone",
+      fasterFirstOne,
+      slowerSecondTwo,
+      null
+    );
+
+    // Assert
+    expect(result.target).toEqual({
+      type: "pace",
+      value: { unit: "range", min: 3.57, max: 3.7 },
+    });
+  });
+
+  it("should normalize a higher-first power range into [min, max]", () => {
+    // Arrange
+    const higherFirstOne = POWER_W.RANGE_HIGH;
+    const lowerSecondTwo = POWER_W.RANGE_LOW;
+
+    // Act
+    const result = mapGarminTargetToKrd(
+      "power.zone",
+      higherFirstOne,
+      lowerSecondTwo,
+      null
+    );
+
+    // Assert
+    expect(result.target).toEqual({
+      type: "power",
+      value: {
+        unit: "range",
+        min: POWER_W.RANGE_LOW,
+        max: POWER_W.RANGE_HIGH,
+      },
     });
   });
 });

--- a/packages/garmin/src/adapters/round-trip/round-trip.test.ts
+++ b/packages/garmin/src/adapters/round-trip/round-trip.test.ts
@@ -120,6 +120,27 @@ describe("Garmin GCN Round-Trip", () => {
     // Assert
     expect(w2.steps.length).toBe(w1.steps.length);
   });
+
+  it("should preserve isSessionTransitionEnabled true through multisport round-trip", () => {
+    // Arrange
+    const original = loadFixture("WorkoutMultisportTriathlonInput.gcn");
+
+    // Act
+    const krd1 = convertGarminToKRD(original, mockLogger);
+    const gcnOutput = convertKRDToGarmin(krd1, { logger: mockLogger });
+    const krd2 = convertGarminToKRD(gcnOutput, mockLogger);
+
+    // Assert
+    const ext1 = krd1.extensions?.gcn as
+      | { isSessionTransitionEnabled?: boolean }
+      | undefined;
+    const ext2 = krd2.extensions?.gcn as
+      | { isSessionTransitionEnabled?: boolean }
+      | undefined;
+    expect(ext1?.isSessionTransitionEnabled).toBe(true);
+    expect(ext2?.isSessionTransitionEnabled).toBe(true);
+    expect(JSON.parse(gcnOutput).isSessionTransitionEnabled).toBe(true);
+  });
 });
 
 type ToleranceChecker = ReturnType<typeof createToleranceChecker>;

--- a/packages/garmin/src/adapters/schemas/garmin-workout-parse.schema.ts
+++ b/packages/garmin/src/adapters/schemas/garmin-workout-parse.schema.ts
@@ -76,6 +76,7 @@ export const garminWorkoutParseSchema = z.object({
     )
     .optional(),
   poolLength: z.number().nullable().optional(),
+  isSessionTransitionEnabled: z.boolean().nullable().optional(),
 });
 
 export type GarminWorkoutParsed = z.infer<typeof garminWorkoutParseSchema>;

--- a/packages/garmin/src/adapters/schemas/input/workout-input.schema.test.ts
+++ b/packages/garmin/src/adapters/schemas/input/workout-input.schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { garminWorkoutInputSchema } from "./workout-input.schema";
+
+const baseMultisportInput = {
+  sportType: { sportTypeId: 10, sportTypeKey: "multi_sport" as const },
+  workoutName: "Test Multisport Brick",
+  workoutSegments: [
+    {
+      segmentOrder: 1,
+      sportType: { sportTypeId: 1, sportTypeKey: "running" as const },
+      workoutSteps: [
+        {
+          type: "ExecutableStepDTO" as const,
+          stepOrder: 1,
+          stepType: {
+            stepTypeId: 3,
+            stepTypeKey: "interval" as const,
+            displayOrder: 3,
+          },
+          endCondition: {
+            conditionTypeId: 3,
+            conditionTypeKey: "distance" as const,
+            displayOrder: 3,
+            displayable: true,
+          },
+          endConditionValue: 400,
+          targetType: {
+            workoutTargetTypeId: 1,
+            workoutTargetTypeKey: "no.target" as const,
+            displayOrder: 1,
+          },
+        },
+      ],
+    },
+  ],
+};
+
+describe("garminWorkoutInputSchema isSessionTransitionEnabled", () => {
+  it("should accept a multisport input with isSessionTransitionEnabled true", () => {
+    // Arrange
+    const input = { ...baseMultisportInput, isSessionTransitionEnabled: true };
+
+    // Act
+    const result = garminWorkoutInputSchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.isSessionTransitionEnabled).toBe(true);
+    }
+  });
+
+  it("should accept a multisport input with isSessionTransitionEnabled false", () => {
+    // Arrange
+    const input = { ...baseMultisportInput, isSessionTransitionEnabled: false };
+
+    // Act
+    const result = garminWorkoutInputSchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.isSessionTransitionEnabled).toBe(false);
+    }
+  });
+
+  it("should accept a workout input without the isSessionTransitionEnabled field", () => {
+    // Arrange
+    const input = baseMultisportInput;
+
+    // Act
+    const result = garminWorkoutInputSchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.isSessionTransitionEnabled).toBeUndefined();
+    }
+  });
+});

--- a/packages/garmin/src/adapters/schemas/input/workout-input.schema.ts
+++ b/packages/garmin/src/adapters/schemas/input/workout-input.schema.ts
@@ -19,6 +19,8 @@ export const garminWorkoutInputSchema = z.object({
 
   poolLength: z.number().positive().optional(),
   poolLengthUnit: garminUnitInputSchema.optional(),
+
+  isSessionTransitionEnabled: z.boolean().optional(),
 });
 
 export type GarminWorkoutInput = z.infer<typeof garminWorkoutInputSchema>;

--- a/packages/garmin/src/test-utils/constants.ts
+++ b/packages/garmin/src/test-utils/constants.ts
@@ -21,6 +21,12 @@ export const CADENCE_RPM = {
   HIGH: 105,
 } as const;
 
+// Power sample values (watts) used in target ordering tests.
+export const POWER_W = {
+  RANGE_LOW: 260,
+  RANGE_HIGH: 273,
+} as const;
+
 // Pool length sample (meters).
 export const POOL_LENGTH_METERS = {
   STANDARD: 25,

--- a/test-fixtures/gcn/WorkoutMultisportTriathlonInput.gcn
+++ b/test-fixtures/gcn/WorkoutMultisportTriathlonInput.gcn
@@ -2,6 +2,7 @@
   "sportType": {"sportTypeId": 10, "sportTypeKey": "multi_sport", "displayOrder": 4},
   "subSportType": null,
   "workoutName": "MEGA MULTISPORT - Complete Triathlon",
+  "isSessionTransitionEnabled": true,
   "estimatedDistanceUnit": {"unitKey": null},
   "workoutSegments": [
     {

--- a/test-fixtures/gcn/WorkoutMultisportTriathlonOutput.gcn
+++ b/test-fixtures/gcn/WorkoutMultisportTriathlonOutput.gcn
@@ -278,6 +278,6 @@
     "factor": null
   },
   "workoutThumbnailUrl": null,
-  "isSessionTransitionEnabled": null,
+  "isSessionTransitionEnabled": true,
   "shared": false
 }


### PR DESCRIPTION
## Summary

PR 1 of 2 for [add-multisport-transitions](../tree/feature/add-multisport-transitions-garmin-adapter/openspec/changes/add-multisport-transitions). Implements the **garmin-adapter** chunk: schema, writer, reader, target ordering, fixtures, spec delta. PR 2 will ship docs (`packages/garmin/docs/MULTISPORT-TRANSITIONS.md`) and the `generate-gcn` skill update.

## What changes

- **Schema** — `garminWorkoutInputSchema` accepts `isSessionTransitionEnabled: z.boolean().optional()` at the workout root. The output parse schema also recognizes the field.
- **Writer** — `convertKRDToGarmin` reads `krd.extensions.gcn.isSessionTransitionEnabled` and emits the flag at the GCN root when present (omits otherwise).
- **Reader** — `convertGarminToKRD` ingests the flag (when boolean) and stores it in `krd.extensions.gcn.isSessionTransitionEnabled` so it survives round-trip.
- **Target ordering** — pace.zone and power.zone range targets are now emitted with the faster / higher-intensity bound in `targetValueOne` and the slower / lower bound in `targetValueTwo`, matching how Garmin's server stores them. The reader normalizes incoming targets to `[min, max]` regardless of source order.
- **Fixtures** — `WorkoutMultisportTriathlonInput.gcn` and `…Output.gcn` now carry `isSessionTransitionEnabled: true`. New round-trip test asserts the flag survives `read → write`.

## Why this matters (empirical context)

Spike against Garmin Connect's authenticated API on 2026-05-09 confirmed that:
1. Multisport transitions are **not** a separate `transition` sport type. They are toggled workout-wide by `isSessionTransitionEnabled: true` at the root.
2. Garmin's server stores range targets as `(faster, slower)` for pace/power; sending the opposite order causes silent reversal on a subset of segments.
3. `stepOrder` is global across segments and across nested `RepeatGroupDTO` children.

The OpenSpec proposal documents these findings; this PR locks them into the adapter contract.

## Out of scope (deferred follow-ups)

- §5.3 — alternating-brick fixture pair. Garmin's server normalizes alternating-brick patterns unpredictably, so producing a stable Output fixture offline isn't reliable. Documented in tasks.md; flag-preservation scenario is covered by §5.4 against the existing triathlon fixture.
- §6 / §7 — Garmin docs (`MULTISPORT-TRANSITIONS.md`) and `generate-gcn` skill. Will land in PR 2.
- KRD multisport modeling. Out of scope per the design's non-goals; `extensions.gcn.isSessionTransitionEnabled` is the round-trip carrier until KRD itself is extended.

## Test plan

- [x] `pnpm --filter @kaiord/garmin test` — 102/102 passing (3 schema + 3 writer + 3 reader + 4 target-ordering + 1 round-trip new tests, plus existing 88 unaffected).
- [x] `pnpm --filter @kaiord/garmin build` — clean.
- [x] `pnpm --filter @kaiord/garmin lint` — clean (zero warnings/errors).
- [x] `pnpm lint:specs` — 38/38 specs pass including the new adapter-contracts delta.
- [x] Changeset added (`@kaiord/garmin: minor`).
- [ ] CI — green across all packages (note: 1 pre-existing flake in `train2go-bridge/test/popup.test.js` unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)