### PR TITLE
docs(garmin): multisport transition rules + generate-gcn skill update

### DIFF
--- a/.claude/skills/generate-gcn/SKILL.md
+++ b/.claude/skills/generate-gcn/SKILL.md
@@ -22,11 +22,16 @@ If the user doesn't specify an output filename, derive one from the workout name
 
 Infer from context. Default to cycling if ambiguous.
 
-| Sport    | sportTypeId | sportTypeKey |
-| -------- | ----------- | ------------ |
-| Running  | 1           | "running"    |
-| Cycling  | 2           | "cycling"    |
-| Swimming | 4           | "swimming"   |
+| Sport      | sportTypeId | sportTypeKey  |
+| ---------- | ----------- | ------------- |
+| Running    | 1           | "running"     |
+| Cycling    | 2           | "cycling"     |
+| Swimming   | 4           | "swimming"    |
+| Multisport | 10          | "multi_sport" |
+
+## Multisport detection
+
+If the user describes any of: `multisport` / `multi-sport`, `brick`, `triathlon` / `triatlón`, `duathlon` / `duatlón`, `aquathlon`, `transitions` / `transiciones`, OR a single workout that alternates between two or more sports — switch to multisport mode and **read [multisport.md](./multisport.md) before generating the JSON**. Multisport has its own segment-composition, target-ordering, and `stepOrder` rules; following the single-sport templates in `reference.md` will produce a workout that Garmin's server silently corrupts.
 
 ## Step Types (Intensity)
 

--- a/.claude/skills/generate-gcn/multisport.md
+++ b/.claude/skills/generate-gcn/multisport.md
@@ -43,9 +43,9 @@ Forbidden:
 
 ## Segment composition rules (CRITICAL)
 
-Garmin's server silently rewrites multisport segments that violate these rules. Following them is the difference between "the workout you intended" and "a corrupted workout with steps in the wrong segments". The full empirical write-up is in [`packages/garmin/docs/MULTISPORT-TRANSITIONS.md`](../../packages/garmin/docs/MULTISPORT-TRANSITIONS.md). The summary:
+Garmin's server silently rewrites multisport segments that violate these rules. Following them is the difference between "the workout you intended" and "a corrupted workout with steps in the wrong segments". The full empirical write-up is in [`packages/garmin/docs/MULTISPORT-TRANSITIONS.md`](../../../packages/garmin/docs/MULTISPORT-TRANSITIONS.md). The summary:
 
-```
+```text
 ALLOWED in one segment:
   • warmup + repeat        (first segment, "warmup with strides")
   • warmup alone           (first segment)
@@ -63,7 +63,7 @@ FORBIDDEN — server splits / reorders if you ship these:
 
 For an 8x (run + bike) brick, use **17 segments**:
 
-```
+```text
 Seg  1  RUNNING  warmup + repeat 4x(progressive + rest)
 Seg  2  RUNNING  run rep 1 (single interval)
 Seg  3  CYCLING  bike rep 1 (single interval)
@@ -110,7 +110,7 @@ In multisport workouts, `stepOrder` is **global across all segments AND across n
 
 Example for the 17-segment brick above:
 
-```
+```text
 Seg 1: warmup       stepOrder 1
        repeat       stepOrder 2
          progressive   stepOrder 3   ← global, NOT 1
@@ -440,4 +440,4 @@ Below is a known-good 2-rep brick (warmup + 4×100m progressive + 2× (run 400m 
 
 ## Why these rules exist
 
-Every rule above was discovered empirically by spiking against Garmin Connect's authenticated API. The full transcript with workout IDs, before/after server responses, and the corruption modes that motivated each rule lives in [`packages/garmin/docs/MULTISPORT-TRANSITIONS.md`](../../packages/garmin/docs/MULTISPORT-TRANSITIONS.md). When you encounter a multisport edge case this skill doesn't cover, that doc is the source of truth.
+Every rule above was discovered empirically by spiking against Garmin Connect's authenticated API. The full transcript with workout IDs, before/after server responses, and the corruption modes that motivated each rule lives in [`packages/garmin/docs/MULTISPORT-TRANSITIONS.md`](../../../packages/garmin/docs/MULTISPORT-TRANSITIONS.md). When you encounter a multisport edge case this skill doesn't cover, that doc is the source of truth.

--- a/.claude/skills/generate-gcn/multisport.md
+++ b/.claude/skills/generate-gcn/multisport.md
@@ -1,0 +1,443 @@
+# Multisport / Brick / Triathlon Workouts
+
+When the user describes a workout that alternates between sports (running and cycling, for example, or a full triathlon), you are generating a **multisport** GCN. Multisport rules differ from single-sport ones; read this file end-to-end before producing the JSON.
+
+## When to use multisport
+
+Trigger words / phrases (any language):
+
+- `multisport`, `multi-sport`, `multi sport`
+- `brick`, `triatlón`, `triathlon`, `duatlón`, `duathlon`, `aquathlon`
+- `transición`, `transition`, `transiciones`
+- Two or more sports alternating in the same session ("8x 400m run + 1km bike")
+
+If the workout involves more than one sport AND the user wants the device to prompt them at sport boundaries, it is multisport.
+
+## Root-level shape
+
+```json
+{
+  "sportType": {
+    "sportTypeId": 10,
+    "sportTypeKey": "multi_sport",
+    "displayOrder": 4
+  },
+  "subSportType": null,
+  "workoutName": "<= 255 chars",
+  "description": "<= 2000 chars",
+  "isSessionTransitionEnabled": true,
+  "workoutSegments": [
+    /* one segment per sport leg */
+  ]
+}
+```
+
+Mandatory:
+
+- `sportType.sportTypeId: 10`, `sportType.sportTypeKey: "multi_sport"`.
+- `isSessionTransitionEnabled: true` to enable lap-button transitions between segments. Without this, the device flows through all segments without prompting.
+
+Forbidden:
+
+- Do **not** create segments with `sportTypeKey: "transition"` or `sportTypeId: 8`. There is no transition sport in Garmin's data model. Transitions are an implicit consequence of `isSessionTransitionEnabled: true` plus segments of different sports.
+
+## Segment composition rules (CRITICAL)
+
+Garmin's server silently rewrites multisport segments that violate these rules. Following them is the difference between "the workout you intended" and "a corrupted workout with steps in the wrong segments". The full empirical write-up is in [`packages/garmin/docs/MULTISPORT-TRANSITIONS.md`](../../packages/garmin/docs/MULTISPORT-TRANSITIONS.md). The summary:
+
+```
+ALLOWED in one segment:
+  • warmup + repeat        (first segment, "warmup with strides")
+  • warmup alone           (first segment)
+  • single interval        (any position)
+  • interval + cooldown    (last segment)
+  • cooldown alone         (last segment)
+
+FORBIDDEN — server splits / reorders if you ship these:
+  • warmup + repeat + interval        ← biggest gotcha
+  • two or more top-level intervals
+  • warmup + interval (no repeat)
+```
+
+### Practical brick layout
+
+For an 8x (run + bike) brick, use **17 segments**:
+
+```
+Seg  1  RUNNING  warmup + repeat 4x(progressive + rest)
+Seg  2  RUNNING  run rep 1 (single interval)
+Seg  3  CYCLING  bike rep 1 (single interval)
+Seg  4  RUNNING  run rep 2
+Seg  5  CYCLING  bike rep 2
+...
+Seg 16  RUNNING  run rep 8
+Seg 17  CYCLING  bike rep 8 + cooldown
+```
+
+If you tried to keep the warmup, repeat, and first run interval in the same segment-1, the server would split them and shift sport labels for every subsequent segment. Don't.
+
+## Range targets — faster first
+
+For `pace.zone`, `power.zone`, and `speed.zone` ranges, place the **faster / higher-intensity** value in `targetValueOne` and the **slower / lower-intensity** value in `targetValueTwo`:
+
+| Target type  | `targetValueOne`    | `targetValueTwo`   |
+| ------------ | ------------------- | ------------------ |
+| `pace.zone`  | higher m/s (faster) | lower m/s (slower) |
+| `power.zone` | higher watts        | lower watts        |
+| `speed.zone` | higher m/s          | lower m/s          |
+
+Sending values in the opposite order causes Garmin to silently reverse them on a subset of segments, producing inconsistent display. `heart.rate.zone` and `cadence` are unaffected.
+
+Example for "Z4 pace 4:40-4:30/km":
+
+```json
+"targetType": { "workoutTargetTypeId": 6, "workoutTargetTypeKey": "pace.zone", "displayOrder": 6 },
+"targetValueOne": 3.7,   // faster (4:30/km)
+"targetValueTwo": 3.57   // slower (4:40/km)
+```
+
+Example for "Z3 power 260-273W":
+
+```json
+"targetType": { "workoutTargetTypeId": 2, "workoutTargetTypeKey": "power.zone", "displayOrder": 2 },
+"targetValueOne": 273,
+"targetValueTwo": 260
+```
+
+## Global `stepOrder`
+
+In multisport workouts, `stepOrder` is **global across all segments AND across nested `RepeatGroupDTO` children**. This differs from single-sport workouts where `stepOrder` resets inside a repeat block.
+
+Example for the 17-segment brick above:
+
+```
+Seg 1: warmup       stepOrder 1
+       repeat       stepOrder 2
+         progressive   stepOrder 3   ← global, NOT 1
+         rest          stepOrder 4   ← global, NOT 2
+Seg 2: run rep 1    stepOrder 5
+Seg 3: bike rep 1   stepOrder 6
+...
+```
+
+`stepId` values may be simple incrementing integers; Garmin reassigns them server-side.
+
+## Worked example — alternating brick
+
+Below is a known-good 2-rep brick (warmup + 4×100m progressive + 2× (run 400m Z4 + bike 1km Z3) + cooldown). Empirically verified to round-trip correctly through Garmin Connect.
+
+```json
+{
+  "sportType": {
+    "sportTypeId": 10,
+    "sportTypeKey": "multi_sport",
+    "displayOrder": 4
+  },
+  "subSportType": null,
+  "workoutName": "Brick 2x 400m Run Z4 + 1km Bike Z3",
+  "description": "Multisport brick. Warmup + 4x100m progresivos. 2x(400m run Z4 + 1km bike Z3 100-105% FTP). Cooldown 10' easy bike.",
+  "isSessionTransitionEnabled": true,
+  "workoutSegments": [
+    {
+      "segmentOrder": 1,
+      "sportType": {
+        "sportTypeId": 1,
+        "sportTypeKey": "running",
+        "displayOrder": 1
+      },
+      "estimatedDurationInSecs": 954,
+      "estimatedDistanceInMeters": 2020.0,
+      "estimatedDistanceUnit": { "unitKey": "kilometer" },
+      "estimateType": "TIME_ESTIMATED",
+      "avgTrainingSpeed": 2.12,
+      "workoutSteps": [
+        {
+          "type": "ExecutableStepDTO",
+          "stepId": 1,
+          "stepOrder": 1,
+          "stepType": {
+            "stepTypeId": 1,
+            "stepTypeKey": "warmup",
+            "displayOrder": 1
+          },
+          "endCondition": {
+            "conditionTypeId": 2,
+            "conditionTypeKey": "time",
+            "displayOrder": 2,
+            "displayable": true
+          },
+          "endConditionValue": 600,
+          "targetType": {
+            "workoutTargetTypeId": 6,
+            "workoutTargetTypeKey": "pace.zone",
+            "displayOrder": 6
+          },
+          "targetValueOne": 2.86,
+          "targetValueTwo": 2.54,
+          "description": "10' calentamiento Z1"
+        },
+        {
+          "type": "RepeatGroupDTO",
+          "stepId": 2,
+          "stepOrder": 2,
+          "stepType": {
+            "stepTypeId": 6,
+            "stepTypeKey": "repeat",
+            "displayOrder": 6
+          },
+          "numberOfIterations": 4,
+          "smartRepeat": false,
+          "endCondition": {
+            "conditionTypeId": 7,
+            "conditionTypeKey": "iterations",
+            "displayOrder": 7,
+            "displayable": false
+          },
+          "endConditionValue": 4,
+          "workoutSteps": [
+            {
+              "type": "ExecutableStepDTO",
+              "stepId": 3,
+              "stepOrder": 3,
+              "stepType": {
+                "stepTypeId": 3,
+                "stepTypeKey": "interval",
+                "displayOrder": 3
+              },
+              "endCondition": {
+                "conditionTypeId": 3,
+                "conditionTypeKey": "distance",
+                "displayOrder": 3,
+                "displayable": true
+              },
+              "endConditionValue": 100,
+              "targetType": {
+                "workoutTargetTypeId": 6,
+                "workoutTargetTypeKey": "pace.zone",
+                "displayOrder": 6
+              },
+              "targetValueOne": 4.0,
+              "targetValueTwo": 3.08,
+              "description": "100m progresivo"
+            },
+            {
+              "type": "ExecutableStepDTO",
+              "stepId": 4,
+              "stepOrder": 4,
+              "stepType": {
+                "stepTypeId": 5,
+                "stepTypeKey": "rest",
+                "displayOrder": 5
+              },
+              "endCondition": {
+                "conditionTypeId": 2,
+                "conditionTypeKey": "time",
+                "displayOrder": 2,
+                "displayable": true
+              },
+              "endConditionValue": 60,
+              "targetType": {
+                "workoutTargetTypeId": 6,
+                "workoutTargetTypeKey": "pace.zone",
+                "displayOrder": 6
+              },
+              "targetValueOne": 2.86,
+              "targetValueTwo": 2.54,
+              "description": "1' parado"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "segmentOrder": 2,
+      "sportType": {
+        "sportTypeId": 1,
+        "sportTypeKey": "running",
+        "displayOrder": 1
+      },
+      "estimatedDurationInSecs": 111,
+      "estimatedDistanceInMeters": 400.0,
+      "estimatedDistanceUnit": { "unitKey": "kilometer" },
+      "estimateType": "TIME_ESTIMATED",
+      "avgTrainingSpeed": 3.6,
+      "workoutSteps": [
+        {
+          "type": "ExecutableStepDTO",
+          "stepId": 5,
+          "stepOrder": 5,
+          "stepType": {
+            "stepTypeId": 3,
+            "stepTypeKey": "interval",
+            "displayOrder": 3
+          },
+          "endCondition": {
+            "conditionTypeId": 3,
+            "conditionTypeKey": "distance",
+            "displayOrder": 3,
+            "displayable": true
+          },
+          "endConditionValue": 400,
+          "targetType": {
+            "workoutTargetTypeId": 6,
+            "workoutTargetTypeKey": "pace.zone",
+            "displayOrder": 6
+          },
+          "targetValueOne": 3.7,
+          "targetValueTwo": 3.57,
+          "description": "Run 400m Z4 (4:40-4:30/km) - rep 1"
+        }
+      ]
+    },
+    {
+      "segmentOrder": 3,
+      "sportType": {
+        "sportTypeId": 2,
+        "sportTypeKey": "cycling",
+        "displayOrder": 2
+      },
+      "estimatedDurationInSecs": 100,
+      "estimatedDistanceInMeters": 1000.0,
+      "estimatedDistanceUnit": { "unitKey": "kilometer" },
+      "estimateType": "DISTANCE_ESTIMATED",
+      "avgTrainingSpeed": 10.0,
+      "workoutSteps": [
+        {
+          "type": "ExecutableStepDTO",
+          "stepId": 6,
+          "stepOrder": 6,
+          "stepType": {
+            "stepTypeId": 3,
+            "stepTypeKey": "interval",
+            "displayOrder": 3
+          },
+          "endCondition": {
+            "conditionTypeId": 2,
+            "conditionTypeKey": "time",
+            "displayOrder": 2,
+            "displayable": true
+          },
+          "endConditionValue": 100,
+          "targetType": {
+            "workoutTargetTypeId": 2,
+            "workoutTargetTypeKey": "power.zone",
+            "displayOrder": 2
+          },
+          "targetValueOne": 273,
+          "targetValueTwo": 260,
+          "description": "Bike 1km @ 100-105% FTP (~1:40) - rep 1"
+        }
+      ]
+    },
+    {
+      "segmentOrder": 4,
+      "sportType": {
+        "sportTypeId": 1,
+        "sportTypeKey": "running",
+        "displayOrder": 1
+      },
+      "estimatedDurationInSecs": 111,
+      "estimatedDistanceInMeters": 400.0,
+      "estimatedDistanceUnit": { "unitKey": "kilometer" },
+      "estimateType": "TIME_ESTIMATED",
+      "avgTrainingSpeed": 3.6,
+      "workoutSteps": [
+        {
+          "type": "ExecutableStepDTO",
+          "stepId": 7,
+          "stepOrder": 7,
+          "stepType": {
+            "stepTypeId": 3,
+            "stepTypeKey": "interval",
+            "displayOrder": 3
+          },
+          "endCondition": {
+            "conditionTypeId": 3,
+            "conditionTypeKey": "distance",
+            "displayOrder": 3,
+            "displayable": true
+          },
+          "endConditionValue": 400,
+          "targetType": {
+            "workoutTargetTypeId": 6,
+            "workoutTargetTypeKey": "pace.zone",
+            "displayOrder": 6
+          },
+          "targetValueOne": 3.7,
+          "targetValueTwo": 3.57,
+          "description": "Run 400m Z4 (4:40-4:30/km) - rep 2"
+        }
+      ]
+    },
+    {
+      "segmentOrder": 5,
+      "sportType": {
+        "sportTypeId": 2,
+        "sportTypeKey": "cycling",
+        "displayOrder": 2
+      },
+      "estimatedDurationInSecs": 700,
+      "estimatedDistanceInMeters": 2800.0,
+      "estimatedDistanceUnit": { "unitKey": "kilometer" },
+      "estimateType": "DISTANCE_ESTIMATED",
+      "avgTrainingSpeed": 4.0,
+      "workoutSteps": [
+        {
+          "type": "ExecutableStepDTO",
+          "stepId": 8,
+          "stepOrder": 8,
+          "stepType": {
+            "stepTypeId": 3,
+            "stepTypeKey": "interval",
+            "displayOrder": 3
+          },
+          "endCondition": {
+            "conditionTypeId": 2,
+            "conditionTypeKey": "time",
+            "displayOrder": 2,
+            "displayable": true
+          },
+          "endConditionValue": 100,
+          "targetType": {
+            "workoutTargetTypeId": 2,
+            "workoutTargetTypeKey": "power.zone",
+            "displayOrder": 2
+          },
+          "targetValueOne": 273,
+          "targetValueTwo": 260,
+          "description": "Bike 1km @ 100-105% FTP (~1:40) - rep 2"
+        },
+        {
+          "type": "ExecutableStepDTO",
+          "stepId": 9,
+          "stepOrder": 9,
+          "stepType": {
+            "stepTypeId": 2,
+            "stepTypeKey": "cooldown",
+            "displayOrder": 2
+          },
+          "endCondition": {
+            "conditionTypeId": 2,
+            "conditionTypeKey": "time",
+            "displayOrder": 2,
+            "displayable": true
+          },
+          "endConditionValue": 600,
+          "targetType": {
+            "workoutTargetTypeId": 2,
+            "workoutTargetTypeKey": "power.zone",
+            "displayOrder": 2
+          },
+          "targetValueOne": 143,
+          "targetValueTwo": 111,
+          "description": "10' bici suave Z1"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Why these rules exist
+
+Every rule above was discovered empirically by spiking against Garmin Connect's authenticated API. The full transcript with workout IDs, before/after server responses, and the corruption modes that motivated each rule lives in [`packages/garmin/docs/MULTISPORT-TRANSITIONS.md`](../../packages/garmin/docs/MULTISPORT-TRANSITIONS.md). When you encounter a multisport edge case this skill doesn't cover, that doc is the source of truth.

--- a/.claude/skills/generate-gcn/reference.md
+++ b/.claude/skills/generate-gcn/reference.md
@@ -344,3 +344,7 @@ Formula: m/s = 1000 / (minutes \* 60 + seconds)
 **Endurance (cycling):** Z2 power, 60-180min continuous
 **Tempo run:** Z3-Z4 HR, 20-40min continuous
 **Track intervals (running):** 400m-1600m repeats at pace target
+
+## Multisport (brick / triathlon / duathlon)
+
+Multisport workouts use a different sport type and have additional segment composition rules. Sport: `sportTypeId: 10`, `sportTypeKey: "multi_sport"`. See **[multisport.md](./multisport.md)** for the full rules (segment composition allow-list / deny-list, `isSessionTransitionEnabled` root flag, faster-first range-target ordering, global `stepOrder`, worked example) — read it before producing multisport JSON; the single-sport templates above will not survive Garmin's server normalization.

--- a/openspec/changes/add-multisport-transitions/tasks.md
+++ b/openspec/changes/add-multisport-transitions/tasks.md
@@ -46,17 +46,17 @@ PR 2 (docs-and-skill): §6, §7
 
 ## 6. Garmin docs (empirical rules)
 
-- [ ] 6.1 Create `packages/garmin/docs/MULTISPORT-TRANSITIONS.md` containing: allow-list of segment compositions (`warmup+repeat` at start, `interval+cooldown` at end, single `interval` mid-workout), deny-list (`warmup+repeat+interval` mixed), the role of `isSessionTransitionEnabled`, the absence of a `transition` sport type, the target ordering rule, the global `stepOrder` rule (including inside `RepeatGroupDTO`), and an "Empirical findings as of 2026-05-09" footer with the spike workout IDs.
-- [ ] 6.2 Update `packages/garmin/docs/INPUT-VS-OUTPUT.md` line 114 to reflect that `isSessionTransitionEnabled` is bidirectional (input-accepted, output-returned), not output-only.
-- [ ] 6.3 Update `packages/garmin/docs/API-FINDINGS.md`: under the existing "Multisport Workouts (NEW)" section, add a cross-reference to `MULTISPORT-TRANSITIONS.md` for the composition rules.
-- [ ] 6.4 Update `packages/garmin/docs/MASTER-INDEX.md` to list the new doc.
+- [x] 6.1 Create `packages/garmin/docs/MULTISPORT-TRANSITIONS.md` containing: allow-list of segment compositions (`warmup+repeat` at start, `interval+cooldown` at end, single `interval` mid-workout), deny-list (`warmup+repeat+interval` mixed), the role of `isSessionTransitionEnabled`, the absence of a `transition` sport type, the target ordering rule, the global `stepOrder` rule (including inside `RepeatGroupDTO`), and an "Empirical findings as of 2026-05-09" footer with the spike workout IDs.
+- [x] 6.2 Update `packages/garmin/docs/INPUT-VS-OUTPUT.md` line 114 to reflect that `isSessionTransitionEnabled` is bidirectional (input-accepted, output-returned), not output-only.
+- [x] 6.3 Update `packages/garmin/docs/API-FINDINGS.md`: under the existing "Multisport Workouts (NEW)" section, add a cross-reference to `MULTISPORT-TRANSITIONS.md` for the composition rules.
+- [x] 6.4 Update `packages/garmin/docs/MASTER-INDEX.md` to list the new doc.
 
 ## 7. generate-gcn skill
 
-- [ ] 7.1 Create `.claude/skills/generate-gcn/multisport.md` with the composition rules, target ordering rule, transition-flag rule, global `stepOrder` rule, and a complete worked example of an alternating-brick workout (the `brick-8x-400m-run-1km-bike` shape we validated empirically). Include a section "Why these rules exist" linking back to the empirical findings doc.
-- [ ] 7.2 Update `.claude/skills/generate-gcn/SKILL.md` Sport Type table to include the row `Multisport | 10 | "multi_sport"`.
-- [ ] 7.3 Update `.claude/skills/generate-gcn/SKILL.md` with a "Multisport detection" section: trigger words (`brick`, `triathlon`, `duathlon`, `multisport`, `transición`/`transition`) and a pointer to `multisport.md` for rules.
-- [ ] 7.4 Update `.claude/skills/generate-gcn/reference.md` Sport Type table to mention multi_sport (id 10), and add a one-line cross-reference to `multisport.md`.
+- [x] 7.1 Create `.claude/skills/generate-gcn/multisport.md` with the composition rules, target ordering rule, transition-flag rule, global `stepOrder` rule, and a complete worked example of an alternating-brick workout (the `brick-8x-400m-run-1km-bike` shape we validated empirically). Include a section "Why these rules exist" linking back to the empirical findings doc.
+- [x] 7.2 Update `.claude/skills/generate-gcn/SKILL.md` Sport Type table to include the row `Multisport | 10 | "multi_sport"`.
+- [x] 7.3 Update `.claude/skills/generate-gcn/SKILL.md` with a "Multisport detection" section: trigger words (`brick`, `triathlon`, `duathlon`, `multisport`, `transición`/`transition`) and a pointer to `multisport.md` for rules.
+- [x] 7.4 Update `.claude/skills/generate-gcn/reference.md` Sport Type table to mention multi_sport (id 10), and add a one-line cross-reference to `multisport.md`.
 
 ## 8. Cross-cutting verification
 

--- a/packages/garmin/docs/API-FINDINGS.md
+++ b/packages/garmin/docs/API-FINDINGS.md
@@ -39,6 +39,13 @@ Through systematic testing with 6 comprehensive workouts, we have **completely v
 
 ## Multisport Workouts (NEW)
 
+> **See also** — [MULTISPORT-TRANSITIONS.md](./MULTISPORT-TRANSITIONS.md) for
+> the full empirical rules on segment composition, the `isSessionTransitionEnabled`
+> root flag, the faster-first ordering for `pace.zone` / `power.zone` /
+> `speed.zone` range targets, and the global `stepOrder` rule. The findings
+> below describe the basic multisport shape; the dedicated doc captures the
+> compose / round-trip constraints required to avoid silent server rewrites.
+
 ### Structure
 
 Multisport workouts use `sportTypeId: 10, sportTypeKey: "multi_sport"` and contain multiple `workoutSegments`:

--- a/packages/garmin/docs/INPUT-VS-OUTPUT.md
+++ b/packages/garmin/docs/INPUT-VS-OUTPUT.md
@@ -111,11 +111,18 @@ Fields that appear ONLY in output, never in input:
   workoutNameI18nKey: string | null
   descriptionI18nKey: string | null
   workoutThumbnailUrl: string | null
-  isSessionTransitionEnabled: boolean | null
   shared: boolean
   locale: string | null
 }
 ```
+
+> **Note** — `isSessionTransitionEnabled: boolean | null` was previously listed
+> as output-only. As of 2026-05-09 (see [MULTISPORT-TRANSITIONS.md](./MULTISPORT-TRANSITIONS.md))
+> the field is **bidirectional**: Garmin's API accepts it on input for multisport
+> workouts and echoes it on output. The `@kaiord/garmin` input schema declares
+> it as `z.boolean().optional()` — set it to `true` on multisport (`sportTypeKey:
+"multi_sport"`) workouts to enable lap-button transitions between segments of
+> different sports.
 
 ### Step-Level Fields
 

--- a/packages/garmin/docs/MASTER-INDEX.md
+++ b/packages/garmin/docs/MASTER-INDEX.md
@@ -19,6 +19,13 @@
    - Implementation guidelines
    - **USE THIS for implementation**
 
+2. **[Multisport Transitions](./MULTISPORT-TRANSITIONS.md)** - Empirical rules
+   - `isSessionTransitionEnabled` root flag (no transition sport type exists)
+   - Segment composition allow-list / deny-list
+   - Faster-first ordering for `pace.zone` / `power.zone` / `speed.zone`
+   - Global `stepOrder` (including inside `RepeatGroupDTO`)
+   - **Read before generating multisport GCN by hand**
+
 ### 📚 Research Phase Documents
 
 2. **[Research Document](./garmin-connect-research.md)** - Initial research

--- a/packages/garmin/docs/MULTISPORT-TRANSITIONS.md
+++ b/packages/garmin/docs/MULTISPORT-TRANSITIONS.md
@@ -1,0 +1,141 @@
+# Multisport Transitions — Empirical Rules
+
+Garmin Connect supports multisport workouts (triathlon, brick, duathlon) where a single workout contains multiple `workoutSegments`, each with its own `sportType`. This document captures the empirical rules that govern how Garmin's server stores and renders these workouts. Following them is necessary for the `@kaiord/garmin` adapter to produce JSON that round-trips cleanly through the Garmin Connect API.
+
+> **Empirical findings as of 2026-05-09.** Derived from spike sessions against Garmin Connect's authenticated API using workouts `1562019589` (reference triathlon) and `1562037033` (alternating-brick spike). If Garmin changes the underlying behavior, update this document with a new dated footer rather than silently rewriting it.
+
+---
+
+## TL;DR
+
+```
+SHALL    sportType.sportTypeId = 10 / sportTypeKey = "multi_sport" at the root.
+SHALL    isSessionTransitionEnabled: true at the root to enable transitions.
+SHALL    Each workoutSegment has its own sportType (running, cycling, swimming, ...).
+SHALL    targetValueOne >= targetValueTwo for pace.zone, power.zone, speed.zone.
+SHALL    stepOrder is global across all segments and inside RepeatGroupDTO children.
+
+SHALL NOT  invent a "transition" sportTypeKey — Garmin has no such sport.
+SHALL NOT  put warmup + repeat + interval together in one segment — server splits it.
+SHALL NOT  rely on stepOrder resetting inside a repeat in multisport — it does not.
+```
+
+---
+
+## 1. Transitions are a flag, not a sport type
+
+Garmin's data model does **not** include a `transition` sport. Transitions between segments of different sports are activated workout-wide by the boolean flag `isSessionTransitionEnabled` at the workout root:
+
+```json
+{
+  "sportType": { "sportTypeId": 10, "sportTypeKey": "multi_sport", "displayOrder": 4 },
+  "isSessionTransitionEnabled": true,
+  "workoutSegments": [
+    { "segmentOrder": 1, "sportType": { "sportTypeKey": "running", ... }, ... },
+    { "segmentOrder": 2, "sportType": { "sportTypeKey": "cycling", ... }, ... }
+  ]
+}
+```
+
+When the flag is `true`, the device prompts the user to advance via the lap button at every sport boundary. When it is `false` or omitted, the workout flows seamlessly from one segment to the next without a transition prompt.
+
+**Do not** insert pseudo-segments with a fictitious `sportTypeId: 8` or `sportTypeKey: "transition"`. That sport type does not exist; Garmin's parse schema rejects it (or, worse, silently corrupts the workout).
+
+---
+
+## 2. Segment composition rules
+
+Garmin's server applies an internal segment-rewrite pass when it stores a multisport workout. Composing segments outside the rules below causes the server to silently split, reorder, or strip steps. The rules:
+
+### Allow-list — combinations the server accepts as-is
+
+| Position in the workout | Combination             | Notes                                         |
+| ----------------------- | ----------------------- | --------------------------------------------- |
+| First segment           | `warmup` + `repeat`     | The canonical "warmup with strides" shape.    |
+| First segment           | `warmup` only           | Plain time-based warmup.                      |
+| Any segment             | single `interval`       | The simplest case; one work step per segment. |
+| Last segment            | `interval` + `cooldown` | The interval can be distance- or time-based.  |
+| Last segment            | `cooldown` only         |                                               |
+
+### Deny-list — combinations the server rewrites
+
+| Combination                            | What the server does                           |
+| -------------------------------------- | ---------------------------------------------- |
+| `warmup` + `repeat` + `interval`       | Splits into two segments and reassigns sport.  |
+| Two or more top-level `interval` steps | Splits each into its own segment.              |
+| `warmup` + `interval` (no repeat)      | Splits; the interval ends up in a new segment. |
+
+### Practical advice
+
+- For an alternating brick (run / bike / run / bike / ...), put **each interval in its own segment**. Combine the warmup with its repeat block in the first segment and combine the last interval with the cooldown in the final segment.
+- If you must include multiple work intervals of the same sport in a single segment, wrap them in a `RepeatGroupDTO`. Garmin treats a repeat container as one top-level step, so `warmup + repeat` (where the repeat contains the intervals) is allowed.
+
+---
+
+## 3. Range-target ordering — faster first
+
+Range-based targets (`pace.zone`, `power.zone`, `speed.zone`) MUST be emitted with the faster / higher-intensity bound in `targetValueOne` and the slower / lower-intensity bound in `targetValueTwo`:
+
+| Target type  | `targetValueOne` (faster) | `targetValueTwo` (slower) |
+| ------------ | ------------------------- | ------------------------- |
+| `pace.zone`  | higher m/s                | lower m/s                 |
+| `power.zone` | higher watts              | lower watts               |
+| `speed.zone` | higher m/s                | lower m/s                 |
+
+Sending the values in the opposite order causes Garmin's server to reverse them silently — but only on a subset of segments — producing inconsistent display in the workout editor. The `@kaiord/garmin` writer enforces faster-first encoding; the reader normalizes any incoming order to `[min, max]` so range semantics survive even if a third-party producer sent them slower-first.
+
+`heart.rate.zone` and `cadence` are not affected by this rule (Garmin tolerates either order).
+
+---
+
+## 4. Global `stepOrder`
+
+In multisport workouts, `stepOrder` is **global across all segments and across nested `RepeatGroupDTO` children**. This differs from single-sport workouts, where `stepOrder` resets inside a repeat block.
+
+Example for a multisport with a repeat in segment 1:
+
+```
+seg 1:
+  warmup     stepOrder: 1
+  repeat     stepOrder: 2
+    progressive  stepOrder: 3   ← global, NOT 1
+    rest         stepOrder: 4   ← global, NOT 2
+seg 2:
+  interval   stepOrder: 5
+seg 3:
+  interval   stepOrder: 6
+```
+
+`stepId` values may be simple incrementing integers on input; Garmin's server reassigns them to its own large numeric IDs (e.g., `13306053372`) on storage.
+
+---
+
+## 5. Round-trip carrier in KRD
+
+KRD does not natively model multisport (single sport per workout). To preserve the transition flag across `GCN → KRD → GCN` round-trips, the `@kaiord/garmin` adapter stores it under the `gcn` namespace of `KRD.extensions`:
+
+```json
+{
+  "version": "1.0",
+  "type": "structured_workout",
+  "extensions": {
+    "structured_workout": { ... },
+    "gcn": { "isSessionTransitionEnabled": true }
+  }
+}
+```
+
+The writer reads from `extensions.gcn.isSessionTransitionEnabled`; the reader writes there when the source GCN has the flag. The flag is the only multisport-related field carried in `extensions.gcn` today; future multisport-aware fields would join it under the same namespace.
+
+Multi-segment structure is **not** preserved in the round-trip — the writer always emits a single `workoutSegment` because KRD's domain model has no concept of a multi-sport session. Modeling that natively in KRD is a separate, larger change (currently out of scope).
+
+---
+
+## 6. References
+
+- Source spike workouts (Garmin Connect, account `pablo-albaladejo`):
+  - `1562019589` — reference triathlon multisport (3 segments: cycling / running / swimming).
+  - `1562037033` — alternating-brick spike (revealed segment-rewrite behavior).
+- Adapter contracts: [`openspec/specs/adapter-contracts/spec.md`](../../../openspec/specs/adapter-contracts/spec.md) — search for "Multisport Transition Flag" and "Faster-First Ordering".
+- API findings overview: [`API-FINDINGS.md`](./API-FINDINGS.md) (multisport section).
+- Input/output field map: [`INPUT-VS-OUTPUT.md`](./INPUT-VS-OUTPUT.md).

--- a/packages/garmin/docs/MULTISPORT-TRANSITIONS.md
+++ b/packages/garmin/docs/MULTISPORT-TRANSITIONS.md
@@ -8,7 +8,7 @@ Garmin Connect supports multisport workouts (triathlon, brick, duathlon) where a
 
 ## TL;DR
 
-```
+```text
 SHALL    sportType.sportTypeId = 10 / sportTypeKey = "multi_sport" at the root.
 SHALL    isSessionTransitionEnabled: true at the root to enable transitions.
 SHALL    Each workoutSegment has its own sportType (running, cycling, swimming, ...).
@@ -94,7 +94,7 @@ In multisport workouts, `stepOrder` is **global across all segments and across n
 
 Example for a multisport with a repeat in segment 1:
 
-```
+```text
 seg 1:
   warmup     stepOrder: 1
   repeat     stepOrder: 2


### PR DESCRIPTION
## Summary

PR 2 of 2 for [add-multisport-transitions](../tree/feature/add-multisport-transitions-docs-and-skill/openspec/changes/add-multisport-transitions). Pure documentation + skill content; no code changes. Builds on PR #576 (the adapter implementation).

Captures the empirical multisport rules we discovered while spiking the Garmin Connect API (workout IDs 1562019589, 1562037033) so that future GCN producers — both the `@kaiord/garmin` adapter and the `generate-gcn` skill — produce JSON that survives Garmin's server normalization.

## What changes

**New files**
- `packages/garmin/docs/MULTISPORT-TRANSITIONS.md` — empirical rules: segment composition allow-list/deny-list, `isSessionTransitionEnabled` root flag, faster-first ordering for `pace.zone`/`power.zone`/`speed.zone`, global `stepOrder` (incl. inside `RepeatGroupDTO`), KRD round-trip carrier under `extensions.gcn`. Includes a dated empirical-findings footer with source workout IDs.
- `.claude/skills/generate-gcn/multisport.md` — skill-side rules with multisport detection trigger words, compose/target/stepOrder rules, and a verified 2-rep brick worked example.

**Updated files**
- `packages/garmin/docs/INPUT-VS-OUTPUT.md` — `isSessionTransitionEnabled` is now correctly listed as bidirectional, not output-only.
- `packages/garmin/docs/API-FINDINGS.md` — multisport section cross-links to the new MULTISPORT-TRANSITIONS doc.
- `packages/garmin/docs/MASTER-INDEX.md` — lists the new doc under "Start Here".
- `.claude/skills/generate-gcn/SKILL.md` — Sport Type table includes Multisport (id 10); new "Multisport detection" section points to multisport.md.
- `.claude/skills/generate-gcn/reference.md` — final section cross-references multisport.md.

## Why

Without these docs, the empirical rules would only live in conversation history. The next time someone (human or AI) generates a multisport GCN by hand, they would re-discover the same corruption modes. This PR makes the rules persistent and discoverable from both the package docs and the skill.

## Out of scope (deferred to follow-up issue)

§5.3 — alternating-brick fixture pair (`WorkoutMultisportBrickAlternating{Input,Output}.gcn`). Deferred because Garmin's server normalizes alternating-brick patterns unpredictably, so producing a stable Output fixture offline isn't reliable. Will be filed as a follow-up issue at archive time per the opsx-ship workflow.

## Test plan

- [x] `pnpm lint:specs` — 38/38 pass.
- [x] All scripts tests pass (411/411 via husky pre-commit).
- [x] No code changes; no new test coverage required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive multisport workout support documentation (triathlon, duathlon, brick, and aquathlon workouts)
  * Introduced detailed specifications for multisport segment composition, transitions, and zone ordering requirements
  * Enhanced generate-gcn skill with automatic multisport detection and generation guidance
  * Updated reference materials with multisport examples and empirical rules

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/577)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->