### PR TITLE
test: raise branch coverage 80.32% → 83.53% (+3.21pp) across 3 OMC self-improve rounds

### DIFF
--- a/packages/workout-spa-editor/src/adapters/train2go/use-zones-sync-orchestrator.test.ts
+++ b/packages/workout-spa-editor/src/adapters/train2go/use-zones-sync-orchestrator.test.ts
@@ -1,0 +1,240 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CoachingTransport } from "../../application/coaching/coaching-transport-port";
+import {
+  TOAST_ZONES_FETCH_FAILED,
+  TOAST_ZONES_SHAPE_MISMATCH,
+  TOAST_ZONES_UNSUPPORTED,
+} from "../../application/coaching/sync-zones";
+import type { useToast } from "../../hooks/useToast";
+import type { PersistencePort } from "../../ports/persistence-port";
+import type {
+  ConflictItem,
+  SyncZonesResult,
+  ZonesPayload,
+} from "../../types/coaching-zones";
+
+const mockSyncZones = vi.fn<(...args: unknown[]) => Promise<SyncZonesResult>>();
+const mockCommit = vi.fn<(...args: unknown[]) => Promise<void>>();
+
+vi.mock("../../application/coaching/sync-zones", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    syncZones: (...args: unknown[]) => mockSyncZones(...args),
+  };
+});
+
+vi.mock("../../application/coaching/commit-conflict-resolution", () => ({
+  commitConflictResolution: (...args: unknown[]) => mockCommit(...args),
+}));
+
+import { useZonesSyncOrchestrator } from "./use-zones-sync-orchestrator";
+
+type ToastSpy = ReturnType<typeof useToast>;
+
+const buildToasts = (): ToastSpy =>
+  ({
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    toast: vi.fn(),
+    dismiss: vi.fn(),
+    dismissAll: vi.fn(),
+    toasts: [],
+  }) as unknown as ToastSpy;
+
+const persistence = { profiles: {} as object } as unknown as PersistencePort;
+const transport = {} as CoachingTransport;
+
+const sampleConflict: ConflictItem = {
+  field: "cycling.ftp",
+  current: 200,
+  incoming: 210,
+};
+const samplePayload = { cycling: { ftp: 210 } } as unknown as ZonesPayload;
+
+describe("useZonesSyncOrchestrator", () => {
+  beforeEach(() => {
+    mockSyncZones.mockReset();
+    mockCommit.mockReset();
+    mockCommit.mockResolvedValue(undefined);
+  });
+
+  it("should call toasts.error with TOAST_ZONES_FETCH_FAILED when syncZones returns transport-error", async () => {
+    // Arrange
+    mockSyncZones.mockResolvedValue({ ok: false, reason: "transport-error" });
+    const toasts = buildToasts();
+
+    // Act
+    const { result } = renderHook(() =>
+      useZonesSyncOrchestrator(persistence, transport, toasts)
+    );
+    await act(async () => {
+      await result.current.runSync("p1");
+    });
+
+    // Assert
+    expect(toasts.error).toHaveBeenCalledWith(TOAST_ZONES_FETCH_FAILED);
+    expect(result.current.pending).toBeNull();
+  });
+
+  it("should call toasts.warning with TOAST_ZONES_SHAPE_MISMATCH when reason is shape-mismatch", async () => {
+    // Arrange
+    mockSyncZones.mockResolvedValue({ ok: false, reason: "shape-mismatch" });
+    const toasts = buildToasts();
+
+    // Act
+    const { result } = renderHook(() =>
+      useZonesSyncOrchestrator(persistence, transport, toasts)
+    );
+    await act(async () => {
+      await result.current.runSync("p1");
+    });
+
+    // Assert
+    expect(toasts.warning).toHaveBeenCalledWith(TOAST_ZONES_SHAPE_MISMATCH);
+    expect(result.current.pending).toBeNull();
+  });
+
+  it("should call toasts.info with TOAST_ZONES_UNSUPPORTED when reason is unsupported", async () => {
+    // Arrange
+    mockSyncZones.mockResolvedValue({ ok: false, reason: "unsupported" });
+    const toasts = buildToasts();
+
+    // Act
+    const { result } = renderHook(() =>
+      useZonesSyncOrchestrator(persistence, transport, toasts)
+    );
+    await act(async () => {
+      await result.current.runSync("p1");
+    });
+
+    // Assert
+    expect(toasts.info).toHaveBeenCalledWith(TOAST_ZONES_UNSUPPORTED);
+    expect(result.current.pending).toBeNull();
+  });
+
+  it("should set pending state when syncZones succeeds with conflicts", async () => {
+    // Arrange
+    mockSyncZones.mockResolvedValue({
+      ok: true,
+      applied: [],
+      conflicts: [sampleConflict],
+      payload: samplePayload,
+    });
+    const toasts = buildToasts();
+
+    // Act
+    const { result } = renderHook(() =>
+      useZonesSyncOrchestrator(persistence, transport, toasts)
+    );
+    await act(async () => {
+      await result.current.runSync("p1");
+    });
+
+    // Assert
+    expect(result.current.pending).toEqual({
+      profileId: "p1",
+      conflicts: [sampleConflict],
+      payload: samplePayload,
+    });
+  });
+
+  it("should NOT set pending when syncZones succeeds with empty conflicts", async () => {
+    // Arrange
+    mockSyncZones.mockResolvedValue({
+      ok: true,
+      applied: [],
+      conflicts: [],
+      payload: samplePayload,
+    });
+    const toasts = buildToasts();
+
+    // Act
+    const { result } = renderHook(() =>
+      useZonesSyncOrchestrator(persistence, transport, toasts)
+    );
+    await act(async () => {
+      await result.current.runSync("p1");
+    });
+
+    // Assert
+    expect(result.current.pending).toBeNull();
+  });
+
+  it("should call commitConflictResolution and clear pending when confirmDecisions runs with pending state", async () => {
+    // Arrange
+    mockSyncZones.mockResolvedValue({
+      ok: true,
+      applied: [],
+      conflicts: [sampleConflict],
+      payload: samplePayload,
+    });
+    const toasts = buildToasts();
+    const { result } = renderHook(() =>
+      useZonesSyncOrchestrator(persistence, transport, toasts)
+    );
+    await act(async () => {
+      await result.current.runSync("p1");
+    });
+
+    // Act
+    await act(async () => {
+      await result.current.confirmDecisions({ "cycling.ftp": "accept" });
+    });
+
+    // Assert
+    expect(mockCommit).toHaveBeenCalledWith(
+      "p1",
+      { "cycling.ftp": "accept" },
+      persistence.profiles,
+      samplePayload
+    );
+    expect(result.current.pending).toBeNull();
+  });
+
+  it("should be a no-op when confirmDecisions runs without pending state", async () => {
+    // Arrange
+    const toasts = buildToasts();
+
+    // Act
+    const { result } = renderHook(() =>
+      useZonesSyncOrchestrator(persistence, transport, toasts)
+    );
+    await act(async () => {
+      await result.current.confirmDecisions({ "cycling.ftp": "accept" });
+    });
+
+    // Assert
+    expect(mockCommit).not.toHaveBeenCalled();
+    expect(result.current.pending).toBeNull();
+  });
+
+  it("should clear pending state when cancel is called", async () => {
+    // Arrange
+    mockSyncZones.mockResolvedValue({
+      ok: true,
+      applied: [],
+      conflicts: [sampleConflict],
+      payload: samplePayload,
+    });
+    const toasts = buildToasts();
+    const { result } = renderHook(() =>
+      useZonesSyncOrchestrator(persistence, transport, toasts)
+    );
+    await act(async () => {
+      await result.current.runSync("p1");
+    });
+
+    // Act
+    act(() => {
+      result.current.cancel();
+    });
+
+    // Assert
+    expect(result.current.pending).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/components/atoms/Tooltip/compute-position.test.ts
+++ b/packages/workout-spa-editor/src/components/atoms/Tooltip/compute-position.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import type { Align, Side } from "./compute-position";
+import { computeTooltipPosition } from "./compute-position";
+
+// Fixture: triggerRect at (200,100), size 80x30 -> right=280, bottom=130.
+// Tooltip size 60x20. SIDE_OFFSET=5. jsdom default window.scrollX=scrollY=0.
+const triggerRect = {
+  top: 100,
+  bottom: 130,
+  left: 200,
+  right: 280,
+  width: 80,
+  height: 30,
+  x: 200,
+  y: 100,
+  toJSON: () => ({}),
+} as DOMRect;
+
+const tooltipRect = {
+  top: 0,
+  bottom: 0,
+  left: 0,
+  right: 0,
+  width: 60,
+  height: 20,
+  x: 0,
+  y: 0,
+  toJSON: () => ({}),
+} as DOMRect;
+
+describe("computeTooltipPosition", () => {
+  it.each<{ side: Side; align: Align; top: number; left: number }>([
+    // top + align: top = 100 - 20 - 5 = 75
+    { side: "top", align: "start", top: 75, left: 200 },
+    { side: "top", align: "center", top: 75, left: 210 },
+    { side: "top", align: "end", top: 75, left: 220 },
+    // bottom + align: top = 130 + 5 = 135
+    { side: "bottom", align: "start", top: 135, left: 200 },
+    { side: "bottom", align: "center", top: 135, left: 210 },
+    { side: "bottom", align: "end", top: 135, left: 220 },
+    // left + align: left = 200 - 60 - 5 = 135
+    { side: "left", align: "start", top: 100, left: 135 },
+    { side: "left", align: "center", top: 105, left: 135 },
+    { side: "left", align: "end", top: 110, left: 135 },
+    // right + align: left = 280 + 5 = 285
+    { side: "right", align: "start", top: 100, left: 285 },
+    { side: "right", align: "center", top: 105, left: 285 },
+    { side: "right", align: "end", top: 110, left: 285 },
+  ])(
+    "should compute position for side=$side align=$align",
+    ({ side, align, top, left }) => {
+      // Arrange
+
+      // Act
+      const result = computeTooltipPosition(
+        triggerRect,
+        tooltipRect,
+        side,
+        align
+      );
+
+      // Assert
+      expect(result).toEqual({ top, left });
+    }
+  );
+});

--- a/packages/workout-spa-editor/src/components/molecules/DurationPicker/advanced/duration-helpers.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/DurationPicker/advanced/duration-helpers.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest";
+
+import type { Duration } from "../../../../types/krd";
+import {
+  getDurationTypeFromValue,
+  getRepeatFromValue,
+  getValueFromDuration,
+  getValueLabel,
+  isRepeatType,
+} from "./duration-helpers";
+import {
+  type AdvancedDurationType,
+  DURATION_TYPE_OPTIONS,
+} from "./duration-type-options";
+
+const DURATION_FIXTURES: Record<AdvancedDurationType, Duration> = {
+  calories: { type: "calories", calories: 120 },
+  power_less_than: { type: "power_less_than", watts: 250 },
+  power_greater_than: { type: "power_greater_than", watts: 250 },
+  heart_rate_less_than: { type: "heart_rate_less_than", bpm: 150 },
+  repeat_until_time: {
+    type: "repeat_until_time",
+    seconds: 600,
+    repeatFrom: 1,
+  },
+  repeat_until_distance: {
+    type: "repeat_until_distance",
+    meters: 5000,
+    repeatFrom: 2,
+  },
+  repeat_until_calories: {
+    type: "repeat_until_calories",
+    calories: 120,
+    repeatFrom: 3,
+  },
+  repeat_until_heart_rate_greater_than: {
+    type: "repeat_until_heart_rate_greater_than",
+    bpm: 150,
+    repeatFrom: 4,
+  },
+  repeat_until_heart_rate_less_than: {
+    type: "repeat_until_heart_rate_less_than",
+    bpm: 150,
+    repeatFrom: 5,
+  },
+  repeat_until_power_less_than: {
+    type: "repeat_until_power_less_than",
+    watts: 250,
+    repeatFrom: 6,
+  },
+  repeat_until_power_greater_than: {
+    type: "repeat_until_power_greater_than",
+    watts: 250,
+    repeatFrom: 7,
+  },
+};
+
+const ALL_TYPES: Array<AdvancedDurationType> = DURATION_TYPE_OPTIONS.map(
+  (o) => o.value
+);
+
+const VALUE_FROM_DURATION_EXPECTED: Record<AdvancedDurationType, string> = {
+  calories: "120",
+  power_less_than: "250",
+  power_greater_than: "250",
+  heart_rate_less_than: "150",
+  repeat_until_time: "600",
+  repeat_until_distance: "5000",
+  repeat_until_calories: "120",
+  repeat_until_heart_rate_greater_than: "150",
+  repeat_until_heart_rate_less_than: "150",
+  repeat_until_power_less_than: "250",
+  repeat_until_power_greater_than: "250",
+};
+
+const REPEAT_FROM_EXPECTED: Record<AdvancedDurationType, string> = {
+  calories: "0",
+  power_less_than: "0",
+  power_greater_than: "0",
+  heart_rate_less_than: "0",
+  repeat_until_time: "1",
+  repeat_until_distance: "2",
+  repeat_until_calories: "3",
+  repeat_until_heart_rate_greater_than: "4",
+  repeat_until_heart_rate_less_than: "5",
+  repeat_until_power_less_than: "6",
+  repeat_until_power_greater_than: "7",
+};
+
+const VALUE_LABEL_EXPECTED: Record<AdvancedDurationType, string> = {
+  calories: "Calories",
+  power_less_than: "Power (watts)",
+  power_greater_than: "Power (watts)",
+  heart_rate_less_than: "Heart Rate (bpm)",
+  repeat_until_time: "Time (seconds)",
+  repeat_until_distance: "Distance (meters)",
+  repeat_until_calories: "Calories",
+  repeat_until_heart_rate_greater_than: "Heart Rate (bpm)",
+  repeat_until_heart_rate_less_than: "Heart Rate (bpm)",
+  repeat_until_power_less_than: "Power (watts)",
+  repeat_until_power_greater_than: "Power (watts)",
+};
+
+const REPEAT_TYPES: Array<AdvancedDurationType> = [
+  "repeat_until_time",
+  "repeat_until_distance",
+  "repeat_until_calories",
+  "repeat_until_heart_rate_greater_than",
+  "repeat_until_heart_rate_less_than",
+  "repeat_until_power_less_than",
+  "repeat_until_power_greater_than",
+];
+
+const NON_REPEAT_TYPES: Array<AdvancedDurationType> = [
+  "calories",
+  "power_less_than",
+  "power_greater_than",
+  "heart_rate_less_than",
+];
+
+describe("getDurationTypeFromValue", () => {
+  it("should return calories when value is null", () => {
+    // Arrange
+    const value = null;
+
+    // Act
+    const actual = getDurationTypeFromValue(value);
+
+    // Assert
+    expect(actual).toBe("calories");
+  });
+
+  it("should return calories for unrecognised duration type", () => {
+    // Arrange
+    const value = { type: "open" } as unknown as Duration;
+
+    // Act
+    const actual = getDurationTypeFromValue(value);
+
+    // Assert
+    expect(actual).toBe("calories");
+  });
+
+  it.each(ALL_TYPES.map((t) => [t] as const))(
+    "should return %s when duration.type matches the advanced enum",
+    (durationType) => {
+      // Arrange
+      const value = DURATION_FIXTURES[durationType];
+
+      // Act
+      const actual = getDurationTypeFromValue(value);
+
+      // Assert
+      expect(actual).toBe(durationType);
+    }
+  );
+});
+
+describe("getValueFromDuration", () => {
+  it("should return empty string when value is null", () => {
+    // Arrange
+    const value = null;
+
+    // Act
+    const actual = getValueFromDuration(value);
+
+    // Assert
+    expect(actual).toBe("");
+  });
+
+  it("should return empty string for unrecognised duration type", () => {
+    // Arrange
+    const value = { type: "open" } as unknown as Duration;
+
+    // Act
+    const actual = getValueFromDuration(value);
+
+    // Assert
+    expect(actual).toBe("");
+  });
+
+  it.each(ALL_TYPES.map((t) => [t] as const))(
+    "should return numeric string for %s",
+    (durationType) => {
+      // Arrange
+      const value = DURATION_FIXTURES[durationType];
+      const expected = VALUE_FROM_DURATION_EXPECTED[durationType];
+
+      // Act
+      const actual = getValueFromDuration(value);
+
+      // Assert
+      expect(actual).toBe(expected);
+    }
+  );
+});
+
+describe("getRepeatFromValue", () => {
+  it("should return 0 when value is null", () => {
+    // Arrange
+    const value = null;
+
+    // Act
+    const actual = getRepeatFromValue(value);
+
+    // Assert
+    expect(actual).toBe("0");
+  });
+
+  it("should return 0 for unrecognised duration type", () => {
+    // Arrange
+    const value = { type: "open" } as unknown as Duration;
+
+    // Act
+    const actual = getRepeatFromValue(value);
+
+    // Assert
+    expect(actual).toBe("0");
+  });
+
+  it.each(ALL_TYPES.map((t) => [t] as const))(
+    "should return repeatFrom string for %s",
+    (durationType) => {
+      // Arrange
+      const value = DURATION_FIXTURES[durationType];
+      const expected = REPEAT_FROM_EXPECTED[durationType];
+
+      // Act
+      const actual = getRepeatFromValue(value);
+
+      // Assert
+      expect(actual).toBe(expected);
+    }
+  );
+});
+
+describe("getValueLabel", () => {
+  it("should return empty string for an unrecognised duration type cast", () => {
+    // Arrange
+    const durationType = "__unknown__" as AdvancedDurationType;
+
+    // Act
+    const actual = getValueLabel(durationType);
+
+    // Assert
+    expect(actual).toBe("");
+  });
+
+  it.each(ALL_TYPES.map((t) => [t] as const))(
+    "should return literal label for %s",
+    (durationType) => {
+      // Arrange
+      const expected = VALUE_LABEL_EXPECTED[durationType];
+
+      // Act
+      const actual = getValueLabel(durationType);
+
+      // Assert
+      expect(actual).toBe(expected);
+    }
+  );
+});
+
+describe("isRepeatType", () => {
+  it.each(REPEAT_TYPES.map((t) => [t] as const))(
+    "should return true for %s",
+    (durationType) => {
+      // Arrange
+
+      // Act
+      const actual = isRepeatType(durationType);
+
+      // Assert
+      expect(actual).toBe(true);
+    }
+  );
+
+  it.each(NON_REPEAT_TYPES.map((t) => [t] as const))(
+    "should return false for %s",
+    (durationType) => {
+      // Arrange
+
+      // Act
+      const actual = isRepeatType(durationType);
+
+      // Assert
+      expect(actual).toBe(false);
+    }
+  );
+});

--- a/packages/workout-spa-editor/src/components/molecules/FileUpload/file-parser-error-fallbacks.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/FileUpload/file-parser-error-fallbacks.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createFileParsingErrorState,
+  createGenericErrorState,
+  createSyntaxErrorState,
+  createUnrecoverableErrorState,
+} from "./file-parser-error-fallbacks";
+
+describe("createFileParsingErrorState", () => {
+  it.each([
+    {
+      label: "plain-message-no-position",
+      error: { message: "bad" },
+      expected: {
+        title: "Invalid File Format",
+        message: "Failed to parse JSON: bad",
+      },
+    },
+    {
+      label: "position-only",
+      error: { message: "oops at position 42" },
+      expected: {
+        title: "Invalid File Format",
+        message: "Failed to parse JSON at position 42",
+      },
+    },
+    {
+      label: "line-and-position",
+      error: { message: "oops at position 42", line: 7 },
+      expected: {
+        title: "Invalid File Format",
+        message: "Failed to parse JSON at position 42 (line 7)",
+      },
+    },
+    {
+      label: "line-column-and-position",
+      error: { message: "oops at position 42", line: 7, column: 3 },
+      expected: {
+        title: "Invalid File Format",
+        message: "Failed to parse JSON at position 42 (line 7, column 3)",
+      },
+    },
+    {
+      label: "line-column-no-position",
+      error: { message: "oops", line: 7, column: 3 },
+      expected: {
+        title: "Invalid File Format",
+        message: "Failed to parse JSON (line 7, column 3)",
+      },
+    },
+    {
+      label: "line-only-no-position",
+      error: { message: "oops", line: 7 },
+      expected: {
+        title: "Invalid File Format",
+        message: "Failed to parse JSON (line 7)",
+      },
+    },
+  ])("should build $label error state", ({ error, expected }) => {
+    // Arrange
+
+    // Act
+    const result = createFileParsingErrorState(error);
+
+    // Assert
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("createSyntaxErrorState", () => {
+  it.each([
+    {
+      label: "with-position-suffix",
+      error: new SyntaxError("Unexpected token at position 5"),
+      expected: {
+        title: "Invalid File Format",
+        message:
+          "Failed to parse JSON: Unexpected token at position 5. Please check your file and try again.",
+      },
+    },
+    {
+      label: "without-position",
+      error: new SyntaxError("plain error"),
+      expected: {
+        title: "Invalid File Format",
+        message: "Failed to parse JSON: plain error",
+      },
+    },
+  ])("should build $label syntax error state", ({ error, expected }) => {
+    // Arrange
+
+    // Act
+    const result = createSyntaxErrorState(error);
+
+    // Assert
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("createUnrecoverableErrorState", () => {
+  it.each([
+    {
+      label: "not-a-fit-file",
+      error: new Error("not a FIT file"),
+      expected: {
+        title: "Import Failed",
+        message: "not a FIT file. Please check your file and try again.",
+      },
+    },
+  ])("should build $label unrecoverable error state", ({ error, expected }) => {
+    // Arrange
+
+    // Act
+    const result = createUnrecoverableErrorState(error);
+
+    // Assert
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("createGenericErrorState", () => {
+  it.each([
+    {
+      label: "real-error",
+      error: new Error("disk full"),
+      expected: {
+        title: "File Read Error",
+        message:
+          "Failed to read file: disk full. Please check your file and try again.",
+      },
+    },
+    {
+      label: "plain-string",
+      error: "string error" as unknown,
+      expected: {
+        title: "File Read Error",
+        message:
+          "Failed to read file: Unknown error. Please check your file and try again.",
+      },
+    },
+    {
+      label: "null",
+      error: null as unknown,
+      expected: {
+        title: "File Read Error",
+        message:
+          "Failed to read file: Unknown error. Please check your file and try again.",
+      },
+    },
+    {
+      label: "plain-object",
+      error: { custom: "object" } as unknown,
+      expected: {
+        title: "File Read Error",
+        message:
+          "Failed to read file: Unknown error. Please check your file and try again.",
+      },
+    },
+  ])("should build $label generic error state", ({ error, expected }) => {
+    // Arrange
+
+    // Act
+    const result = createGenericErrorState(error);
+
+    // Assert
+    expect(result).toEqual(expected);
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/FileUpload/file-parser.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/FileUpload/file-parser.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import { ImportError } from "../../../utils/import-workout";
+import { createParseError } from "./file-parser";
+
+describe("createParseError", () => {
+  it("should pass through inputs that already have a title", () => {
+    // Arrange
+    const input = { title: "Already Set", message: "ok" };
+
+    // Act
+    const result = createParseError(input);
+
+    // Assert
+    expect(result).toEqual(input);
+  });
+
+  it("should delegate to createImportErrorState for ImportError instances", () => {
+    // Arrange
+    const cause = new Error("inner");
+    const err = new ImportError("Failed to import foo", "fit", cause);
+
+    // Act
+    const result = createParseError(err);
+
+    // Assert
+    expect(result.title).toBe("Import Failed");
+    expect(result.message).toBe("Failed to import foo");
+  });
+
+  it("should delegate to createFileParsingErrorState for FileParsingError-shaped objects", () => {
+    // Arrange
+    const err = {
+      name: "FileParsingError",
+      message: "oops",
+      line: 7,
+      column: 3,
+    };
+
+    // Act
+    const result = createParseError(err);
+
+    // Assert
+    expect(result.title).toBe("Invalid File Format");
+    expect(result.message).toBe("Failed to parse JSON (line 7, column 3)");
+  });
+
+  it("should delegate to createSyntaxErrorState for SyntaxError instances", () => {
+    // Arrange
+    const err = new SyntaxError("Unexpected token at position 5");
+
+    // Act
+    const result = createParseError(err);
+
+    // Assert
+    expect(result.title).toBe("Invalid File Format");
+    expect(result.message).toBe(
+      "Failed to parse JSON: Unexpected token at position 5. Please check your file and try again."
+    );
+  });
+
+  it.each([
+    {
+      label: "input-is-not-a-FIT-file",
+      message: "input is not a FIT file: corrupted bytes",
+    },
+    { label: "not-a-FIT-file", message: "not a FIT file" },
+    { label: "corrupted", message: "corrupted" },
+  ])(
+    "should delegate to createUnrecoverableErrorState for $label",
+    ({ message }) => {
+      // Arrange
+      const err = new Error(message);
+
+      // Act
+      const result = createParseError(err);
+
+      // Assert
+      expect(result.title).toBe("Import Failed");
+      expect(result.message).toBe(
+        `${message}. Please check your file and try again.`
+      );
+    }
+  );
+
+  it("should delegate to createGenericErrorState for non-matching Error", () => {
+    // Arrange
+    const err = new Error("something else");
+
+    // Act
+    const result = createParseError(err);
+
+    // Assert
+    expect(result.title).toBe("File Read Error");
+    expect(result.message).toBe(
+      "Failed to read file: something else. Please check your file and try again."
+    );
+  });
+
+  it("should delegate to createGenericErrorState for plain strings", () => {
+    // Arrange
+    const err = "plain string";
+
+    // Act
+    const result = createParseError(err);
+
+    // Assert
+    expect(result.title).toBe("File Read Error");
+    expect(result.message).toBe(
+      "Failed to read file: Unknown error. Please check your file and try again."
+    );
+  });
+
+  it("should delegate to createGenericErrorState for null", () => {
+    // Arrange
+    const err = null;
+
+    // Act
+    const result = createParseError(err);
+
+    // Assert
+    expect(result.title).toBe("File Read Error");
+    expect(result.message).toBe(
+      "Failed to read file: Unknown error. Please check your file and try again."
+    );
+  });
+
+  it("should delegate to createGenericErrorState for objects without a title key", () => {
+    // Arrange
+    const err = { message: "noname", name: "NotMatchingName" };
+
+    // Act
+    const result = createParseError(err);
+
+    // Assert
+    expect(result.title).toBe("File Read Error");
+    expect(result.message).toBe(
+      "Failed to read file: Unknown error. Please check your file and try again."
+    );
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/calculate-duration.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/calculate-duration.test.ts
@@ -1,0 +1,327 @@
+/* eslint-disable no-magic-numbers -- test fixtures use literal duration values for clarity */
+import { describe, expect, it } from "vitest";
+
+import type { KRD } from "../../../types/krd";
+import { calculateWorkoutDuration } from "./calculate-duration";
+
+const wrap = (steps: unknown): KRD =>
+  ({ extensions: { structured_workout: { steps } } }) as unknown as KRD;
+
+describe("calculateWorkoutDuration", () => {
+  it("should return undefined when workout has no extensions", () => {
+    // Arrange
+    const workout = {} as unknown as KRD;
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when extensions.structured_workout is missing", () => {
+    // Arrange
+    const workout = { extensions: {} } as unknown as KRD;
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when structured_workout is not an object (string)", () => {
+    // Arrange
+    const workout = {
+      extensions: { structured_workout: "invalid" },
+    } as unknown as KRD;
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when structured_workout has no steps key", () => {
+    // Arrange
+    const workout = {
+      extensions: { structured_workout: { other: 1 } },
+    } as unknown as KRD;
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when structured_workout.steps is not an array", () => {
+    // Arrange
+    const workout = {
+      extensions: { structured_workout: { steps: "nope" } },
+    } as unknown as KRD;
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should return undefined when steps array is empty", () => {
+    // Arrange
+    const workout = wrap([]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should sum a single time-step with seconds=120 to 120", () => {
+    // Arrange
+    const workout = wrap([{ duration: { type: "time", seconds: 120 } }]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBe(120);
+  });
+
+  it("should sum two leaf time-steps (60 + 90) to 150", () => {
+    // Arrange
+    const workout = wrap([
+      { duration: { type: "time", seconds: 60 } },
+      { duration: { type: "time", seconds: 90 } },
+    ]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBe(150);
+  });
+
+  it("should ignore leaf step whose duration is null", () => {
+    // Arrange
+    const workout = wrap([{ duration: null }]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should ignore leaf step whose duration.type is 'distance'", () => {
+    // Arrange
+    const workout = wrap([{ duration: { type: "distance", meters: 1000 } }]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should ignore leaf step whose duration is missing seconds key", () => {
+    // Arrange
+    const workout = wrap([{ duration: { type: "time" } }]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should ignore leaf step where seconds is not a number (string)", () => {
+    // Arrange
+    const workout = wrap([{ duration: { type: "time", seconds: "60" } }]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should expand a repeat block { repeatCount: 3, steps: [60s] } to 180", () => {
+    // Arrange
+    const workout = wrap([
+      {
+        repeatCount: 3,
+        steps: [{ duration: { type: "time", seconds: 60 } }],
+      },
+    ]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBe(180);
+  });
+
+  it("should treat repeat block with repeatCount=0 as 0 contribution", () => {
+    // Arrange
+    const workout = wrap([
+      {
+        repeatCount: 0,
+        steps: [{ duration: { type: "time", seconds: 60 } }],
+      },
+    ]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should treat repeat block with repeatCount=1 the same as a single iteration", () => {
+    // Arrange
+    const workout = wrap([
+      {
+        repeatCount: 1,
+        steps: [{ duration: { type: "time", seconds: 120 } }],
+      },
+    ]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBe(120);
+  });
+
+  it("should ignore non-time inner step inside a repeat block (distance)", () => {
+    // Arrange
+    const workout = wrap([
+      {
+        repeatCount: 2,
+        steps: [{ duration: { type: "distance", meters: 500 } }],
+      },
+    ]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should ignore inner step whose duration is null inside a repeat block", () => {
+    // Arrange
+    const workout = wrap([{ repeatCount: 2, steps: [{ duration: null }] }]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should ignore inner step missing 'seconds' key inside a repeat block", () => {
+    // Arrange
+    const workout = wrap([
+      { repeatCount: 2, steps: [{ duration: { type: "time" } }] },
+    ]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should ignore inner step whose seconds is not a number inside a repeat block", () => {
+    // Arrange
+    const workout = wrap([
+      {
+        repeatCount: 2,
+        steps: [{ duration: { type: "time", seconds: "x" } }],
+      },
+    ]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should ignore inner step that is not an object (number) inside a repeat block", () => {
+    // Arrange
+    const workout = wrap([{ repeatCount: 2, steps: [42] }]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should sum a leaf step (60) plus a repeat block (3x40=120) to 180", () => {
+    // Arrange
+    const workout = wrap([
+      { duration: { type: "time", seconds: 60 } },
+      {
+        repeatCount: 3,
+        steps: [{ duration: { type: "time", seconds: 40 } }],
+      },
+    ]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBe(180);
+  });
+
+  it("should ignore step that is null at top level", () => {
+    // Arrange
+    const workout = wrap([null]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should ignore step that is a primitive (string) at top level", () => {
+    // Arrange
+    const workout = wrap(["nope"]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should ignore repeat-block-shaped step whose inner steps is not an array", () => {
+    // Arrange
+    const workout = wrap([{ repeatCount: 2, steps: "nope" }]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+
+  it("should ignore step that has 'repeatCount' but no 'steps' key", () => {
+    // Arrange
+    const workout = wrap([{ repeatCount: 2 }]);
+
+    // Act
+    const result = calculateWorkoutDuration(workout);
+
+    // Assert
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/format-cadence-pace.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/format-cadence-pace.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCadenceTarget, formatPaceTarget } from "./format-cadence-pace";
+
+const NUMERIC_NON_OBJECT_INPUT = 42;
+
+describe("formatCadenceTarget", () => {
+  it.each<[string, unknown, string]>([
+    ["null input", null, "Cadence"],
+    ["undefined input", undefined, "Cadence"],
+    ["string input", "rpm", "Cadence"],
+    ["number input", NUMERIC_NON_OBJECT_INPUT, "Cadence"],
+    ["empty object", {}, "Cadence"],
+    ["object missing unit key", { value: 90 }, "Cadence"],
+    ["rpm with numeric value", { unit: "rpm", value: 90 }, "90 rpm"],
+    [
+      "rpm with string value (rejected)",
+      { unit: "rpm", value: "90" },
+      "Cadence",
+    ],
+    ["rpm without value field", { unit: "rpm" }, "Cadence"],
+    [
+      "range with numeric min/max",
+      { unit: "range", min: 80, max: 100 },
+      "80-100 rpm",
+    ],
+    [
+      "range with NaN min",
+      { unit: "range", min: Number.NaN, max: 100 },
+      "Cadence",
+    ],
+    ["range missing max", { unit: "range", min: 80 }, "Cadence"],
+    ["range missing min", { unit: "range", max: 100 }, "Cadence"],
+    ["unrecognised unit", { unit: "watts", value: 90 }, "Cadence"],
+  ])("should format %s as expected", (_label, input, expected) => {
+    // Arrange
+    const value = input;
+
+    // Act
+    const actual = formatCadenceTarget(value);
+
+    // Assert
+    expect(actual).toBe(expected);
+  });
+});
+
+describe("formatPaceTarget", () => {
+  it.each<[string, unknown, string]>([
+    ["null input", null, "Pace"],
+    ["undefined input", undefined, "Pace"],
+    ["string input", "mps", "Pace"],
+    ["number input", NUMERIC_NON_OBJECT_INPUT, "Pace"],
+    ["empty object", {}, "Pace"],
+    ["object missing unit key", { value: 3.5 }, "Pace"],
+    // mps -> min/km. 1000/(3.5*60) = 4.7619... -> minutes=4 seconds=Math.round(45.71)=46
+    ["mps numeric value", { unit: "mps", value: 3.5 }, "4:46 min/km"],
+    ["mps zero (invalid)", { unit: "mps", value: 0 }, "--:-- min/km"],
+    ["mps negative (invalid)", { unit: "mps", value: -1 }, "--:-- min/km"],
+    [
+      "mps Infinity (rejected by isValidNumber)",
+      { unit: "mps", value: Number.POSITIVE_INFINITY },
+      "Pace",
+    ],
+    ["mps with string value (rejected)", { unit: "mps", value: "3.5" }, "Pace"],
+    // Edge case: seconds rounds to 60 -> minutes+1, "5:00"
+    // 1000/(3.3334*60) = 4.99990... -> minutes=4 fractional=0.9999 seconds=Math.round(59.994)=60
+    [
+      "mps where seconds rounds to 60",
+      { unit: "mps", value: 3.3334 },
+      "5:00 min/km",
+    ],
+    ["zone numeric", { unit: "zone", value: 3 }, "Zone 3"],
+    ["zone string (rejected)", { unit: "zone", value: "3" }, "Pace"],
+    // range: max becomes the faster (smaller min/km), min becomes the slower
+    // max=4.0 -> 1000/240 = 4.1666 -> "4:10"; min=3.0 -> 1000/180 = 5.5555 -> "5:33"
+    [
+      "range numeric min/max (formatted faster-slower)",
+      { unit: "range", min: 3.0, max: 4.0 },
+      "4:10-5:33 min/km",
+    ],
+    [
+      "range with NaN min",
+      { unit: "range", min: Number.NaN, max: 4.0 },
+      "Pace",
+    ],
+    ["range missing max", { unit: "range", min: 3.0 }, "Pace"],
+    ["unrecognised unit", { unit: "rpm", value: 90 }, "Pace"],
+  ])("should format pace target for %s", (_label, input, expected) => {
+    // Arrange
+    const value = input;
+
+    // Act
+    const actual = formatPaceTarget(value);
+
+    // Assert
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/format-duration.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/format-duration.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkoutStep } from "../../../types/krd";
+import { formatDuration } from "./format-duration";
+
+const step = (durationType: string, duration: unknown): WorkoutStep =>
+  ({ durationType, duration }) as unknown as WorkoutStep;
+
+describe("formatDuration", () => {
+  it("should format a 5-minute time step (300s) as '5 min' (no padding when seconds=0)", () => {
+    // Arrange
+    const input = step("time", { seconds: 300 });
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("5 min");
+  });
+
+  it("should format a 4:10 time step (250s) as '4:10'", () => {
+    // Arrange
+    const input = step("time", { seconds: 250 });
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("4:10");
+  });
+
+  it("should format a 0:05 time step (5s) as '0:05' (padStart adds leading zero)", () => {
+    // Arrange
+    const input = step("time", { seconds: 5 });
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("0:05");
+  });
+
+  it("should format a 0-second time step as '0 min'", () => {
+    // Arrange
+    const input = step("time", { seconds: 0 });
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("0 min");
+  });
+
+  it("should fall back to 'Time' when durationType='time' but duration is missing seconds key", () => {
+    // Arrange
+    const input = step("time", {});
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("Time");
+  });
+
+  it("should format a 1500m distance step as '1.50 km'", () => {
+    // Arrange
+    const input = step("distance", { meters: 1500 });
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("1.50 km");
+  });
+
+  it("should format a 1000m distance step as '1.00 km' (boundary km=1)", () => {
+    // Arrange
+    const input = step("distance", { meters: 1000 });
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("1.00 km");
+  });
+
+  it("should format a 500m distance step as '500 m' (km < 1 fallback)", () => {
+    // Arrange
+    const input = step("distance", { meters: 500 });
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("500 m");
+  });
+
+  it("should fall back to 'Distance' when durationType='distance' but duration has no meters key", () => {
+    // Arrange
+    const input = step("distance", {});
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("Distance");
+  });
+
+  it("should format a calories step as '250 cal'", () => {
+    // Arrange
+    const input = step("calories", { calories: 250 });
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("250 cal");
+  });
+
+  it("should fall back to 'Calories' when durationType='calories' but duration has no calories key", () => {
+    // Arrange
+    const input = step("calories", {});
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("Calories");
+  });
+
+  it("should return 'Open' for an open step", () => {
+    // Arrange
+    const input = step("open", {});
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("Open");
+  });
+
+  it("should default-format an unknown durationType by replacing underscores with spaces", () => {
+    // Arrange
+    const input = step("lap_button_press", {});
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("lap button press");
+  });
+
+  it("should default-format a snake_case durationType with multiple underscores", () => {
+    // Arrange
+    const input = step("heart_rate_zone_high", {});
+
+    // Act
+    const result = formatDuration(input);
+
+    // Assert
+    expect(result).toBe("heart rate zone high");
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/format-power-hr.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/format-power-hr.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { formatHeartRateTarget, formatPowerTarget } from "./format-power-hr";
+
+const NUMERIC_NON_OBJECT_INPUT = 7;
+
+describe("formatPowerTarget", () => {
+  it.each<[string, unknown, string]>([
+    ["null input", null, "Power"],
+    ["undefined input", undefined, "Power"],
+    ["string input", "x", "Power"],
+    ["number input", NUMERIC_NON_OBJECT_INPUT, "Power"],
+    ["empty object", {}, "Power"],
+    ["object missing unit key", { value: 250 }, "Power"],
+    ["watts numeric", { unit: "watts", value: 250 }, "250W"],
+    ["watts string (rejected)", { unit: "watts", value: "250" }, "Power"],
+    ["percent_ftp numeric", { unit: "percent_ftp", value: 85 }, "85% FTP"],
+    [
+      "percent_ftp string (rejected)",
+      { unit: "percent_ftp", value: "85" },
+      "Power",
+    ],
+    ["zone numeric", { unit: "zone", value: 3 }, "Zone 3"],
+    ["zone string (rejected)", { unit: "zone", value: "3" }, "Power"],
+    [
+      "range numeric min/max",
+      { unit: "range", min: 200, max: 260 },
+      "200-260W",
+    ],
+    [
+      "range with NaN min",
+      { unit: "range", min: Number.NaN, max: 260 },
+      "Power",
+    ],
+    ["range missing max", { unit: "range", min: 200 }, "Power"],
+    ["range missing min", { unit: "range", max: 260 }, "Power"],
+    ["unrecognised unit", { unit: "bpm", value: 150 }, "Power"],
+  ])("should format power target for %s", (_label, input, expected) => {
+    // Arrange
+    const value = input;
+
+    // Act
+    const actual = formatPowerTarget(value);
+
+    // Assert
+    expect(actual).toBe(expected);
+  });
+});
+
+describe("formatHeartRateTarget", () => {
+  it.each<[string, unknown, string]>([
+    ["null input", null, "Heart Rate"],
+    ["undefined input", undefined, "Heart Rate"],
+    ["string input", "x", "Heart Rate"],
+    ["number input", NUMERIC_NON_OBJECT_INPUT, "Heart Rate"],
+    ["empty object", {}, "Heart Rate"],
+    ["object missing unit key", { value: 150 }, "Heart Rate"],
+    ["bpm numeric", { unit: "bpm", value: 150 }, "150 bpm"],
+    ["bpm string (rejected)", { unit: "bpm", value: "150" }, "Heart Rate"],
+    ["percent_max numeric", { unit: "percent_max", value: 85 }, "85% max"],
+    [
+      "percent_max string (rejected)",
+      { unit: "percent_max", value: "85" },
+      "Heart Rate",
+    ],
+    ["zone numeric", { unit: "zone", value: 4 }, "Zone 4"],
+    ["zone string (rejected)", { unit: "zone", value: "4" }, "Heart Rate"],
+    [
+      "range numeric min/max",
+      { unit: "range", min: 140, max: 160 },
+      "140-160 bpm",
+    ],
+    [
+      "range with NaN max",
+      { unit: "range", min: 140, max: Number.NaN },
+      "Heart Rate",
+    ],
+    ["range missing max", { unit: "range", min: 140 }, "Heart Rate"],
+    ["range missing min", { unit: "range", max: 160 }, "Heart Rate"],
+    ["unrecognised unit", { unit: "watts", value: 250 }, "Heart Rate"],
+  ])("should format heart rate target for %s", (_label, input, expected) => {
+    // Arrange
+    const value = input;
+
+    // Act
+    const actual = formatHeartRateTarget(value);
+
+    // Assert
+    expect(actual).toBe(expected);
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/TargetPicker/helpers-labels.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/TargetPicker/helpers-labels.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { getValueLabel, getValuePlaceholder } from "./helpers-labels";
+
+type TargetType = "power" | "heart_rate" | "pace" | "cadence" | "open";
+
+describe("getValueLabel", () => {
+  it.each<[TargetType, string, string]>([
+    // unit === "range" early return takes priority over targetType
+    ["power", "range", "Range"],
+    ["heart_rate", "range", "Range"],
+    ["pace", "range", "Range"],
+    ["cadence", "range", "Range"],
+    ["open", "range", "Range"],
+    // power switch arms
+    ["power", "watts", "Power (watts)"],
+    ["power", "percent_ftp", "Power (% FTP)"],
+    ["power", "zone", "Power Zone (1-7)"],
+    ["power", "__unknown__", "Power Value"],
+    // heart_rate switch arms
+    ["heart_rate", "bpm", "Heart Rate (BPM)"],
+    ["heart_rate", "zone", "HR Zone (1-5)"],
+    ["heart_rate", "percent_max", "Heart Rate (% Max)"],
+    ["heart_rate", "__unknown__", "Heart Rate Value"],
+    // pace switch arms
+    ["pace", "mps", "Pace (m/s)"],
+    ["pace", "zone", "Pace Zone (1-5)"],
+    ["pace", "__unknown__", "Pace Value"],
+    // cadence switch arms
+    ["cadence", "rpm", "Cadence (RPM)"],
+    ["cadence", "__unknown__", "Cadence Value"],
+    // open is the default switch arm
+    ["open", "watts", "Value"],
+    ["open", "rpm", "Value"],
+    ["open", "__unknown__", "Value"],
+  ])(
+    "should return %s for targetType=%s unit=%s",
+    (targetType, unit, expected) => {
+      // Arrange
+      const tt = targetType;
+      const u = unit;
+
+      // Act
+      const actual = getValueLabel(tt, u);
+
+      // Assert
+      expect(actual).toBe(expected);
+    }
+  );
+});
+
+describe("getValuePlaceholder", () => {
+  it.each<[TargetType, string, string]>([
+    // unit === "range" early return
+    ["power", "range", ""],
+    ["heart_rate", "range", ""],
+    ["pace", "range", ""],
+    ["cadence", "range", ""],
+    ["open", "range", ""],
+    // power
+    ["power", "watts", "e.g., 250"],
+    ["power", "percent_ftp", "e.g., 85"],
+    ["power", "zone", "1-7"],
+    ["power", "__unknown__", "Enter value"],
+    // heart_rate
+    ["heart_rate", "bpm", "e.g., 150"],
+    ["heart_rate", "zone", "1-5"],
+    ["heart_rate", "percent_max", "e.g., 85"],
+    ["heart_rate", "__unknown__", "Enter value"],
+    // pace
+    ["pace", "mps", "e.g., 3.5"],
+    ["pace", "zone", "1-5"],
+    ["pace", "__unknown__", "Enter value"],
+    // cadence
+    ["cadence", "rpm", "e.g., 90"],
+    ["cadence", "__unknown__", "Enter value"],
+    // default arm (open)
+    ["open", "watts", "Enter value"],
+    ["open", "rpm", "Enter value"],
+    ["open", "__unknown__", "Enter value"],
+  ])(
+    "should return placeholder %s for targetType=%s unit=%s",
+    (targetType, unit, expected) => {
+      // Arrange
+      const tt = targetType;
+      const u = unit;
+
+      // Act
+      const actual = getValuePlaceholder(tt, u);
+
+      // Assert
+      expect(actual).toBe(expected);
+    }
+  );
+});

--- a/packages/workout-spa-editor/src/components/molecules/TargetPicker/validation-pace-cadence.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/TargetPicker/validation-pace-cadence.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  validateCadenceRange,
+  validateCadenceTarget,
+  validatePaceRange,
+  validatePaceTarget,
+} from "./validation-pace-cadence";
+import type { ValidationResult } from "./validation-types";
+
+describe("validatePaceTarget", () => {
+  it.each([
+    {
+      label: "zone-too-low",
+      unit: "zone",
+      value: 0,
+      expected: {
+        isValid: false,
+        error: "Pace zone must be between 1 and 5",
+      } as ValidationResult,
+    },
+    {
+      label: "zone-too-high",
+      unit: "zone",
+      value: 6,
+      expected: {
+        isValid: false,
+        error: "Pace zone must be between 1 and 5",
+      } as ValidationResult,
+    },
+    {
+      label: "zone-non-integer",
+      unit: "zone",
+      value: 2.5,
+      expected: {
+        isValid: false,
+        error: "Pace zone must be between 1 and 5",
+      } as ValidationResult,
+    },
+    {
+      label: "zone-lower-boundary",
+      unit: "zone",
+      value: 1,
+      expected: {
+        isValid: true,
+        target: {
+          type: "pace",
+          value: { unit: "zone", value: 1 },
+        },
+      } as ValidationResult,
+    },
+    {
+      label: "zone-middle",
+      unit: "zone",
+      value: 3,
+      expected: {
+        isValid: true,
+        target: {
+          type: "pace",
+          value: { unit: "zone", value: 3 },
+        },
+      } as ValidationResult,
+    },
+    {
+      label: "zone-upper-boundary",
+      unit: "zone",
+      value: 5,
+      expected: {
+        isValid: true,
+        target: {
+          type: "pace",
+          value: { unit: "zone", value: 5 },
+        },
+      } as ValidationResult,
+    },
+    {
+      label: "mps-too-high",
+      unit: "mps",
+      value: 21,
+      expected: {
+        isValid: false,
+        error: "Pace cannot exceed 20 m/s",
+      } as ValidationResult,
+    },
+    {
+      label: "mps-upper-boundary",
+      unit: "mps",
+      value: 20,
+      expected: {
+        isValid: true,
+        target: {
+          type: "pace",
+          value: { unit: "mps", value: 20 },
+        },
+      } as ValidationResult,
+    },
+    {
+      label: "mps-typical",
+      unit: "mps",
+      value: 3.5,
+      expected: {
+        isValid: true,
+        target: {
+          type: "pace",
+          value: { unit: "mps", value: 3.5 },
+        },
+      } as ValidationResult,
+    },
+    {
+      label: "fall-through-unit",
+      unit: "other",
+      value: 99,
+      expected: {
+        isValid: true,
+        target: {
+          type: "pace",
+          value: { unit: "other" as "mps" | "zone", value: 99 },
+        },
+      } as ValidationResult,
+    },
+  ])(
+    "should return $label result for unit=$unit value=$value",
+    ({ unit, value, expected }) => {
+      // Arrange
+
+      // Act
+      const result = validatePaceTarget(unit, value);
+
+      // Assert
+      expect(result).toEqual(expected);
+    }
+  );
+});
+
+describe("validatePaceRange", () => {
+  it.each([
+    {
+      min: 3,
+      max: 5,
+      expected: {
+        isValid: true,
+        target: {
+          type: "pace",
+          value: { unit: "range", min: 3, max: 5 },
+        },
+      } as ValidationResult,
+    },
+    {
+      min: 0,
+      max: 0,
+      expected: {
+        isValid: true,
+        target: {
+          type: "pace",
+          value: { unit: "range", min: 0, max: 0 },
+        },
+      } as ValidationResult,
+    },
+  ])(
+    "should build a pace-range target for min=$min max=$max",
+    ({ min, max, expected }) => {
+      // Arrange
+
+      // Act
+      const result = validatePaceRange(min, max);
+
+      // Assert
+      expect(result).toEqual(expected);
+    }
+  );
+});
+
+describe("validateCadenceTarget", () => {
+  it.each([
+    {
+      label: "rpm-too-high",
+      unit: "rpm",
+      value: 301,
+      expected: {
+        isValid: false,
+        error: "Cadence cannot exceed 300 RPM",
+      } as ValidationResult,
+    },
+    {
+      label: "rpm-upper-boundary",
+      unit: "rpm",
+      value: 300,
+      expected: {
+        isValid: true,
+        target: {
+          type: "cadence",
+          value: { unit: "rpm", value: 300 },
+        },
+      } as ValidationResult,
+    },
+    {
+      label: "rpm-typical",
+      unit: "rpm",
+      value: 90,
+      expected: {
+        isValid: true,
+        target: {
+          type: "cadence",
+          value: { unit: "rpm", value: 90 },
+        },
+      } as ValidationResult,
+    },
+    {
+      label: "fall-through-unit",
+      unit: "other",
+      value: 99,
+      expected: {
+        isValid: true,
+        target: {
+          type: "cadence",
+          value: { unit: "rpm", value: 99 },
+        },
+      } as ValidationResult,
+    },
+  ])(
+    "should return $label result for unit=$unit value=$value",
+    ({ unit, value, expected }) => {
+      // Arrange
+
+      // Act
+      const result = validateCadenceTarget(unit, value);
+
+      // Assert
+      expect(result).toEqual(expected);
+    }
+  );
+});
+
+describe("validateCadenceRange", () => {
+  it.each([
+    {
+      min: 70,
+      max: 110,
+      expected: {
+        isValid: true,
+        target: {
+          type: "cadence",
+          value: { unit: "range", min: 70, max: 110 },
+        },
+      } as ValidationResult,
+    },
+  ])(
+    "should build a cadence-range target for min=$min max=$max",
+    ({ min, max, expected }) => {
+      // Arrange
+
+      // Act
+      const result = validateCadenceRange(min, max);
+
+      // Assert
+      expect(result).toEqual(expected);
+    }
+  );
+});

--- a/packages/workout-spa-editor/src/components/molecules/TargetPicker/zone-info-helpers.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/TargetPicker/zone-info-helpers.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { HeartRateZone, PowerZone, Profile } from "../../../types/profile";
+
+vi.mock("./helpers", () => ({
+  getPowerZoneName: vi.fn(),
+  calculatePowerFromZone: vi.fn(),
+  getHeartRateZoneName: vi.fn(),
+  calculateHeartRateFromZone: vi.fn(),
+}));
+
+import {
+  calculateHeartRateFromZone,
+  calculatePowerFromZone,
+  getHeartRateZoneName,
+  getPowerZoneName,
+} from "./helpers";
+import { getZoneInfo } from "./zone-info-helpers";
+
+const getPowerZoneNameMock = vi.mocked(getPowerZoneName);
+const calculatePowerFromZoneMock = vi.mocked(calculatePowerFromZone);
+const getHeartRateZoneNameMock = vi.mocked(getHeartRateZoneName);
+const calculateHeartRateFromZoneMock = vi.mocked(calculateHeartRateFromZone);
+
+const POWER_ZONES: Array<PowerZone> = [
+  { zone: 2, name: "Endurance", minPercent: 56, maxPercent: 75 },
+];
+
+const HEART_RATE_ZONES: Array<HeartRateZone> = [
+  { zone: 3, name: "Aerobic", minBpm: 140, maxBpm: 160 },
+];
+
+type ProfileOverrides = {
+  withCycling?: boolean;
+  ftp?: number;
+  powerZones?: Array<PowerZone>;
+  heartRateZones?: Array<HeartRateZone>;
+};
+
+const makeProfile = ({
+  withCycling = true,
+  ftp = 250,
+  powerZones = POWER_ZONES,
+  heartRateZones = HEART_RATE_ZONES,
+}: ProfileOverrides = {}): Profile => {
+  const cyclingZones = {
+    thresholds: { ftp },
+    powerZones: { mode: "ftp" as const, zones: powerZones },
+    heartRateZones: { mode: "max_hr" as const, zones: heartRateZones },
+  };
+  const profile = {
+    id: "00000000-0000-0000-0000-000000000000",
+    name: "Test",
+    sportZones: withCycling ? { cycling: cyclingZones } : {},
+    linkedAccounts: [],
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  };
+  return profile as unknown as Profile;
+};
+
+describe("getZoneInfo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should return null when unit is not zone", () => {
+    // Arrange
+    const profile = makeProfile();
+
+    // Act
+    const actual = getZoneInfo("power", "watts", "2", profile);
+
+    // Assert
+    expect(actual).toBeNull();
+  });
+
+  it("should return null when value is empty string", () => {
+    // Arrange
+    const profile = makeProfile();
+
+    // Act
+    const actual = getZoneInfo("power", "zone", "", profile);
+
+    // Assert
+    expect(actual).toBeNull();
+  });
+
+  it("should return null when activeProfile is null", () => {
+    // Arrange
+    const profile = null;
+
+    // Act
+    const actual = getZoneInfo("power", "zone", "2", profile);
+
+    // Assert
+    expect(actual).toBeNull();
+  });
+
+  it("should return null when activeProfile is undefined", () => {
+    // Arrange
+
+    // Act
+    const actual = getZoneInfo("power", "zone", "2");
+
+    // Assert
+    expect(actual).toBeNull();
+  });
+
+  it("should return null when sportZones.cycling is missing", () => {
+    // Arrange
+    const profile = makeProfile({ withCycling: false });
+
+    // Act
+    const actual = getZoneInfo("power", "zone", "2", profile);
+
+    // Assert
+    expect(actual).toBeNull();
+  });
+
+  it("should return formatted power zone string when name and range are present", () => {
+    // Arrange
+    const profile = makeProfile();
+    getPowerZoneNameMock.mockReturnValue("Endurance");
+    calculatePowerFromZoneMock.mockReturnValue({ min: 175, max: 210 });
+
+    // Act
+    const actual = getZoneInfo("power", "zone", "2", profile);
+
+    // Assert
+    expect(actual).toBe("Endurance (175-210W)");
+  });
+
+  it("should return power zone name only when range is null", () => {
+    // Arrange
+    const profile = makeProfile();
+    getPowerZoneNameMock.mockReturnValue("Endurance");
+    calculatePowerFromZoneMock.mockReturnValue(null);
+
+    // Act
+    const actual = getZoneInfo("power", "zone", "2", profile);
+
+    // Assert
+    expect(actual).toBe("Endurance");
+  });
+
+  it("should return null when power zone name is null and range is null", () => {
+    // Arrange
+    const profile = makeProfile();
+    getPowerZoneNameMock.mockReturnValue(null);
+    calculatePowerFromZoneMock.mockReturnValue(null);
+
+    // Act
+    const actual = getZoneInfo("power", "zone", "99", profile);
+
+    // Assert
+    expect(actual).toBeNull();
+  });
+
+  it("should default to empty zones when powerZones is undefined", () => {
+    // Arrange
+    const profile = makeProfile();
+    // Strip powerZones to exercise the `?? []` fallback branch
+    const stripped = profile as unknown as {
+      sportZones: { cycling: { powerZones?: unknown } };
+    };
+    stripped.sportZones.cycling.powerZones = undefined;
+    getPowerZoneNameMock.mockReturnValue(null);
+    calculatePowerFromZoneMock.mockReturnValue(null);
+
+    // Act
+    const actual = getZoneInfo("power", "zone", "2", profile);
+
+    // Assert
+    expect(actual).toBeNull();
+  });
+
+  it("should return formatted heart rate zone string when name and range are present", () => {
+    // Arrange
+    const profile = makeProfile();
+    getHeartRateZoneNameMock.mockReturnValue("Aerobic");
+    calculateHeartRateFromZoneMock.mockReturnValue({ min: 140, max: 160 });
+
+    // Act
+    const actual = getZoneInfo("heart_rate", "zone", "3", profile);
+
+    // Assert
+    expect(actual).toBe("Aerobic (140-160 BPM)");
+  });
+
+  it("should return heart rate zone name only when range is null", () => {
+    // Arrange
+    const profile = makeProfile();
+    getHeartRateZoneNameMock.mockReturnValue("Aerobic");
+    calculateHeartRateFromZoneMock.mockReturnValue(null);
+
+    // Act
+    const actual = getZoneInfo("heart_rate", "zone", "3", profile);
+
+    // Assert
+    expect(actual).toBe("Aerobic");
+  });
+
+  it("should return null heart rate zone name when not found", () => {
+    // Arrange
+    const profile = makeProfile();
+    getHeartRateZoneNameMock.mockReturnValue(null);
+    calculateHeartRateFromZoneMock.mockReturnValue(null);
+
+    // Act
+    const actual = getZoneInfo("heart_rate", "zone", "99", profile);
+
+    // Assert
+    expect(actual).toBeNull();
+  });
+
+  it.each<["pace" | "cadence" | "open"]>([["pace"], ["cadence"], ["open"]])(
+    "should return null for non-power non-heart_rate targetType=%s",
+    (targetType) => {
+      // Arrange
+      const profile = makeProfile();
+
+      // Act
+      const actual = getZoneInfo(targetType, "zone", "2", profile);
+
+      // Assert
+      expect(actual).toBeNull();
+    }
+  );
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/hooks/filters/sort-utils.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/hooks/filters/sort-utils.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkoutTemplate } from "../../../../../types/workout-library";
+import { sortTemplates } from "./sort-utils";
+
+const tpl = (overrides: Partial<WorkoutTemplate>): WorkoutTemplate =>
+  ({
+    id: "00000000-0000-0000-0000-000000000000",
+    name: "Default",
+    sport: "running",
+    krd: {},
+    tags: [],
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    ...overrides,
+  }) as unknown as WorkoutTemplate;
+
+describe("sortTemplates", () => {
+  it("should sort templates by name ascending using localeCompare", () => {
+    // Arrange
+    const templates = [
+      tpl({ name: "Charlie" }),
+      tpl({ name: "Alpha" }),
+      tpl({ name: "Bravo" }),
+    ];
+
+    // Act
+    const result = sortTemplates(templates, "name", "asc");
+
+    // Assert
+    expect(result.map((t) => t.name)).toEqual(["Alpha", "Bravo", "Charlie"]);
+  });
+
+  it("should sort templates by name descending (negate comparison)", () => {
+    // Arrange
+    const templates = [
+      tpl({ name: "Charlie" }),
+      tpl({ name: "Alpha" }),
+      tpl({ name: "Bravo" }),
+    ];
+
+    // Act
+    const result = sortTemplates(templates, "name", "desc");
+
+    // Assert
+    expect(result.map((t) => t.name)).toEqual(["Charlie", "Bravo", "Alpha"]);
+  });
+
+  it("should sort templates by date ascending using createdAt", () => {
+    // Arrange
+    const templates = [
+      tpl({ name: "A", createdAt: "2024-01-01T00:00:00.000Z" }),
+      tpl({ name: "C", createdAt: "2024-03-01T00:00:00.000Z" }),
+      tpl({ name: "B", createdAt: "2024-02-01T00:00:00.000Z" }),
+    ];
+
+    // Act
+    const result = sortTemplates(templates, "date", "asc");
+
+    // Assert
+    expect(result.map((t) => t.name)).toEqual(["A", "B", "C"]);
+  });
+
+  it("should sort templates by date descending using createdAt", () => {
+    // Arrange
+    const templates = [
+      tpl({ name: "A", createdAt: "2024-01-01T00:00:00.000Z" }),
+      tpl({ name: "C", createdAt: "2024-03-01T00:00:00.000Z" }),
+      tpl({ name: "B", createdAt: "2024-02-01T00:00:00.000Z" }),
+    ];
+
+    // Act
+    const result = sortTemplates(templates, "date", "desc");
+
+    // Assert
+    expect(result.map((t) => t.name)).toEqual(["C", "B", "A"]);
+  });
+
+  it("should sort templates by difficulty ascending (easy=1 < medium=2 < hard=3)", () => {
+    // Arrange
+    const templates = [
+      tpl({ name: "H", difficulty: "hard" as WorkoutTemplate["difficulty"] }),
+      tpl({ name: "E", difficulty: "easy" as WorkoutTemplate["difficulty"] }),
+      tpl({
+        name: "M",
+        difficulty: "medium" as unknown as WorkoutTemplate["difficulty"],
+      }),
+    ];
+
+    // Act
+    const result = sortTemplates(templates, "difficulty", "asc");
+
+    // Assert
+    expect(result.map((t) => t.name)).toEqual(["E", "M", "H"]);
+  });
+
+  it("should sort templates by difficulty descending", () => {
+    // Arrange
+    const templates = [
+      tpl({ name: "H", difficulty: "hard" as WorkoutTemplate["difficulty"] }),
+      tpl({ name: "E", difficulty: "easy" as WorkoutTemplate["difficulty"] }),
+      tpl({
+        name: "M",
+        difficulty: "medium" as unknown as WorkoutTemplate["difficulty"],
+      }),
+    ];
+
+    // Act
+    const result = sortTemplates(templates, "difficulty", "desc");
+
+    // Assert
+    expect(result.map((t) => t.name)).toEqual(["H", "M", "E"]);
+  });
+
+  it("should treat schema 'moderate' difficulty as 0 via the || fallback (sorts before easy)", () => {
+    // Arrange
+    const templates = [
+      tpl({ name: "E", difficulty: "easy" as WorkoutTemplate["difficulty"] }),
+      tpl({
+        name: "Mod",
+        difficulty: "moderate" as WorkoutTemplate["difficulty"],
+      }),
+    ];
+
+    // Act
+    const result = sortTemplates(templates, "difficulty", "asc");
+
+    // Assert
+    expect(result.map((t) => t.name)).toEqual(["Mod", "E"]);
+  });
+
+  it("should produce a new array (not mutate the input)", () => {
+    // Arrange
+    const templates = [
+      tpl({ name: "Charlie" }),
+      tpl({ name: "Alpha" }),
+      tpl({ name: "Bravo" }),
+    ];
+    const original = templates.map((t) => t.name);
+
+    // Act
+    sortTemplates(templates, "name", "asc");
+
+    // Assert
+    expect(templates.map((t) => t.name)).toEqual(original);
+  });
+
+  it("should preserve length when input has duplicates", () => {
+    // Arrange
+    const templates = [tpl({ name: "Same" }), tpl({ name: "Same" })];
+
+    // Act
+    const result = sortTemplates(templates, "name", "asc");
+
+    // Assert
+    expect(result).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Raises monorepo-wide branch coverage from **80.32% → 83.53% (+3.21pp)** by adding 13 new co-located unit/boundary test files for previously-untested SPA pure helpers. Generated via 3 rounds of the `/oh-my-claudecode:self-improve` loop (researcher → planners → critics → executors → tournament selection → no-regression re-benchmark).

No production code modified. Zero new dependencies. All 13 new files are `*.test.ts` siblings of their source.

### Per-round breakdown

| Round | Family | Files | Tests | Δ branch % |
|---|---|---|---|---|
| 1 | `add_unit_tests` | 5 (TargetPicker + StepCard + DurationPicker helpers) | 185 | +1.68pp |
| 2 | `add_unit_tests` | 5 (0%-coverage modules: validation-pace-cadence, file-parser-error-fallbacks, compute-position, file-parser, use-zones-sync-orchestrator) | ~71 | +0.93pp |
| 3 | `add_unit_tests` | 3 (calculate-duration, format-duration, sort-utils) | 48 | +0.60pp |
| **Total** | — | **13 files** | **~304 tests** | **+3.21pp** |

### Package coverage delta

| Package | Before | After |
|---|---|---|
| workout-spa-editor | 78.68% | 83.20% (+4.52pp) |
| all other packages | unchanged | unchanged |

### Test conventions enforced

All new files comply with the repo's mechanical guards:
- `R-ItTitleShould` — every `it()` title starts with `should ` (lowercase + space)
- `R-ItBodyAAA` — every `it()` body has Pascal-case `// Arrange`, `// Act`, `// Assert` markers in order
- Specific assertions only (`toBe(literal)`, `toEqual({...})`) — no `toBeDefined`/`toBeTruthy` tautologies
- Co-located next to source (sibling `.test.ts` files)
- TypeScript strict mode

### Tournament losers (not included)

Across 3 rounds, 6 alternative plans were generated and benchmarked but archived as lower-scoring (kept as `archive/round_N_executor_X` tags for reference):
- Round 1 plan B (`boundary_tests` on SaveToLibrary calculate-duration): +0.68pp
- Round 1 plan C (`fixture_expansion` on train2go-bridge parser.js): −0.02pp (regression — new fixtures added more branches than tests covered)
- Round 2 plan B (`add_error_path_tests` on CLI logger + 4 pretty-formatters + file-handler): cli jumped 72.93→94.32 internal but only +0.71pp global
- Round 2 plan C (`boundary_tests` on 4 ZWO encoders): zwo jumped 81.99→88.17 internal but only +0.27pp global
- Round 3 plan A (`boundary_tests` on TargetPicker validators): +0.64pp
- Round 3 plan B (`add_error_path_tests` on 3 SPA classifiers, required 6 constructor-signature fixes from critic): +0.39pp

Lesson captured across rounds: package-level coverage gains weighted by branches-per-package. `workout-spa-editor` (5507-branch denominator) dominates the global metric, so all 3 winners targeted it.

### Test plan

- [x] `pnpm lint` — clean (zero warnings/errors)
- [x] `pnpm test:scripts` — 411/411 mechanical guards pass (no-zustand-writethrough, no-PII, no-library-dual-mount, test title `should `, AAA)
- [x] `pnpm -r build` — all 12 packages build
- [x] Full SPA test suite — 3799+ tests passing across 425 files
- [x] No-regression re-benchmark on merged improve/test_coverage at each round

### Files added (13)

```
packages/workout-spa-editor/src/components/molecules/TargetPicker/
  ├── helpers-labels.test.ts                   (R1)
  ├── zone-info-helpers.test.ts                (R1)
  └── validation-pace-cadence.test.ts          (R2)

packages/workout-spa-editor/src/components/molecules/StepCard/
  ├── format-cadence-pace.test.ts              (R1)
  ├── format-power-hr.test.ts                  (R1)
  └── format-duration.test.ts                  (R3)

packages/workout-spa-editor/src/components/molecules/DurationPicker/advanced/
  └── duration-helpers.test.ts                 (R1)

packages/workout-spa-editor/src/components/molecules/FileUpload/
  ├── file-parser-error-fallbacks.test.ts      (R2)
  └── file-parser.test.ts                      (R2)

packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/
  └── calculate-duration.test.ts               (R3)

packages/workout-spa-editor/src/components/atoms/Tooltip/
  └── compute-position.test.ts                 (R2)

packages/workout-spa-editor/src/adapters/train2go/
  └── use-zones-sync-orchestrator.test.ts      (R2)

packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/hooks/filters/
  └── sort-utils.test.ts                       (R3)
```

No changeset required — tests only, no published-package behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via 3 rounds of `/oh-my-claudecode:self-improve`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit tests covering sync orchestration, tooltip positioning, advanced duration helpers, file parsing and error fallbacks, duration calculation, formatting for cadence/pace/power/HR/duration, target picker helpers and validation, zone info, and template sorting to boost reliability and catch regressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/580)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->