### PR TITLE
chore(ci): raise SPA E2E job timeout 25 → 35 min

### DIFF
--- a/.github/workflows/workout-spa-editor-e2e.yml
+++ b/.github/workflows/workout-spa-editor-e2e.yml
@@ -44,7 +44,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    timeout-minutes: 25
+    timeout-minutes: 35
     runs-on: ubuntu-latest
     needs: check-ci-status
     if: needs.check-ci-status.outputs.should-run == 'true'
@@ -90,7 +90,7 @@ jobs:
 
   e2e-mobile:
     name: E2E Mobile Tests
-    timeout-minutes: 25
+    timeout-minutes: 35
     runs-on: ubuntu-latest
     needs: check-ci-status
     if: needs.check-ci-status.outputs.should-run == 'true'


### PR DESCRIPTION
## Summary

Firefox E2E job hit the 25-min budget on commit 32cb142a after the full test suite ran (previous CI failures killed runs earlier, masking the budget). 4 of 5 browsers now pass — chromium + webkit + Mobile Chrome + Mobile Safari all green; only firefox needs more headroom.

Bump both E2E jobs (E2E Tests + E2E Mobile Tests) from 25 → 35 min.

## Test plan
- [x] Workflow YAML lints clean
- [ ] firefox E2E completes within 35 min on the next main run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test infrastructure to allow extended execution time for end-to-end testing procedures.

---

**Note:** This release contains no user-facing changes. The update is an internal infrastructure improvement.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/585)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->