### PR TITLE
fix(docs): spread llmstxt() tuple for stricter Vite PluginOption type

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -216,7 +216,7 @@ export default defineConfig({
 
   vite: {
     build: { target: "esnext" },
-    plugins: [llmstxt()],
+    plugins: [...llmstxt()],
   },
 
   transformHead({ pageData }) {


### PR DESCRIPTION
Preparation for dependabot #586 (minor-and-patch group): bumps `vite` 8.0.9 → 8.0.12, which tightens `PluginOption` so a single `[Plugin, Plugin]` tuple at `plugins: [llmstxt()]` no longer flattens implicitly. Spread it explicitly so the array contains plain Plugin entries. Verified locally: `pnpm exec tsc --noEmit` + `vitepress build` both green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build configuration to optimize plugin handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/590)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->