### PR TITLE
fix(docs): replace defineConfig() helper with satisfies UserConfig (TS6 crash workaround)

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -1,7 +1,6 @@
-import { defineConfig } from "vitepress";
 import { transformerTwoslash } from "@shikijs/vitepress-twoslash";
 import llmstxt from "vitepress-plugin-llms";
-import type { HeadConfig } from "vitepress";
+import type { HeadConfig, UserConfig } from "vitepress";
 
 import { buildStaticHead } from "./head-config.mjs";
 
@@ -83,7 +82,7 @@ function buildJsonLd(
   return results;
 }
 
-export default defineConfig({
+const config = {
   lang: "en",
   title: "Kaiord",
   description:
@@ -254,4 +253,6 @@ export default defineConfig({
 
     return head;
   },
-});
+} satisfies UserConfig;
+
+export default config;


### PR DESCRIPTION
Vite 8.0.12 (in dependabot #591) triggers a TypeScript 6.0.3 internal Debug Failure when type-checking VitePress's `defineConfig({...})` return type, crashing tsc.

Workaround: use `satisfies UserConfig` instead of the `defineConfig()` helper. Same runtime behavior, no inference change for the consumer (UserConfig still constrains the shape), but bypasses the deep signature comparison that crashes TS 6.0.3.

Verified locally with `pnpm exec tsc --noEmit` (vite 8.0.9 / vite 8.0.12 both pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal refactoring of configuration structure with no user-facing changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/592)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->