### PR TITLE
fix(spa-editor): show coaching description line breaks for train2go imports

### DIFF
--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
@@ -87,6 +87,33 @@ describe("formatCoachingDescription", () => {
     expect(parte).toBeDefined();
   });
 
+  it("should split on single newlines from train2go-bridge parser output", () => {
+    // Arrange
+    // The train2go-bridge parser flattens <p> and <br> to single "\n"
+    // (see packages/train2go-bridge/parser.js extractDescription), so
+    // descriptions arrive with single newlines, not double. Each line
+    // must render as its own paragraph.
+    const text =
+      "Calentamiento – 15 minutos\n10' rodaje en Z2 baja (130-150w / 120-140 bpm)\n3 progresiones de 1' en Z3 -> Z4:\nBloque principal – 3x4 minutos a ritmo de competición";
+
+    // Act
+    const result = formatCoachingDescription(text);
+
+    // Assert
+    // eslint-disable-next-line no-magic-numbers -- expected paragraph count from 4-line input
+    expect(result).toHaveLength(4);
+    expect(result[0]?.inlines[0]?.value).toBe("Calentamiento – 15 minutos");
+    expect(result[1]?.inlines[0]?.value).toBe(
+      "10' rodaje en Z2 baja (130-150w / 120-140 bpm)"
+    );
+    expect(result[2]?.inlines[0]?.value).toBe(
+      "3 progresiones de 1' en Z3 -> Z4:"
+    );
+    expect(result[3]?.inlines[0]?.value).toBe(
+      "Bloque principal – 3x4 minutos a ritmo de competición"
+    );
+  });
+
   it("should preserve <strong> with attributes", () => {
     // Arrange
     const html = '<p>Effort <strong class="zone-4">Z4</strong></p>';

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts
@@ -70,9 +70,15 @@ export const formatCoachingDescription = (
   raw: string
 ): DescriptionParagraph[] => {
   const paragraphMatches = raw.match(/<p[^>]*>([\s\S]*?)<\/p>/gi);
+  // For plain text input we split on any run of newlines: the
+  // train2go-bridge parser flattens both `<p>` and `<br>` to single
+  // `\n` (see packages/train2go-bridge/parser.js), so splitting only
+  // on `\n{2,}` previously left the entire description as one paragraph.
+  // Empty paragraphs are dropped by the `inlines.length > 0` filter
+  // below, so this also tolerates `\n\n` AI/markdown shapes.
   const paragraphs = paragraphMatches
     ? paragraphMatches.map((p) => p.replace(/^<p[^>]*>|<\/p>$/gi, ""))
-    : raw.split(/\n{2,}/);
+    : raw.split(/\n+/);
   return paragraphs
     .map((p) => ({ inlines: splitInlines(p) }))
     .filter((p) => p.inlines.length > 0);


### PR DESCRIPTION
## Summary

When opening a Train2Go-imported activity in the calendar, the coaching description rendered as a single wall of text without line breaks, even though Train2Go shows them. Reported by user.

## Root cause

\`formatCoachingDescription\` in \`packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts:75\` splits plain-text descriptions on \`\\n{2,}\` (two or more consecutive newlines).

But \`packages/train2go-bridge/parser.js\` \`extractDescription\` collapses both \`<p>\` and \`<br>\` to single \`\\n\` (lines 151-152, 158-161). So Train2Go descriptions arrive at the SPA with single newlines and the formatter never recognised any paragraph boundary.

## Fix

Split on \`\\n+\` instead of \`\\n{2,}\`. The existing \`inlines.length > 0\` filter still drops empty paragraphs, so \`\\n\\n\`-shaped markdown / AI input keeps working unchanged.

Regression test added covering the exact Train2Go output shape.

## Test plan
- [x] Unit tests on \`formatCoachingDescription\` (existing + new regression)
- [x] No production runtime change beyond the regex
- [ ] Verify in UI: open a Train2Go activity in the calendar, description shows as paragraphs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved coaching description formatting to correctly split descriptions containing newlines into separate paragraphs, rather than treating the entire description as a single block.

* **Tests**
  * Added test coverage for description parsing behavior with newline-separated content from the training platform.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/594)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->