### PR TITLE
feat(spa-editor): show executed activities in matched coaching dialog

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialog.tsx
@@ -11,22 +11,26 @@ import { useCallback, useMemo } from "react";
 import { useLocation } from "wouter";
 
 import { usePickableWorkouts } from "../../../hooks/use-pickable-workouts";
+import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 import { buildCoachingDialogCloseHandler } from "./build-coaching-dialog-close-handler";
 import { CoachingDialogShell } from "./coaching-dialog-shell";
 import { CoachingActivityDialogContent } from "./CoachingActivityDialogContent";
 import { useCoachingDialog } from "./use-coaching-dialog";
+import { useOpenExecutedHandler } from "./use-open-executed-handler";
 
 export type CoachingActivityDialogProps = {
   activity: CoachingActivity | null;
   onClose: () => void;
   expandActivity: (activity: CoachingActivity) => void;
+  onOpenExecuted?: (workout: WorkoutRecord) => void;
 };
 
 export function CoachingActivityDialog({
   activity,
   onClose,
   expandActivity,
+  onOpenExecuted,
 }: CoachingActivityDialogProps) {
   const dialog = useCoachingDialog(activity, onClose, expandActivity);
   const pickable = usePickableWorkouts(
@@ -50,6 +54,7 @@ export function CoachingActivityDialog({
     () => buildCoachingDialogCloseHandler(cancelAi, onClose),
     [cancelAi, onClose]
   );
+  const handleOpenExecuted = useOpenExecutedHandler(onClose, onOpenExecuted);
 
   if (!activity) return null;
 
@@ -73,9 +78,8 @@ export function CoachingActivityDialog({
         onClosePicker={dialog.closePicker}
         onSelectWorkout={dialog.handleSelectWorkout}
         onOpenEditor={onOpenEditor}
-        onPushToGarmin={
-          onOpenEditor /* disabled in MatchedActions until dialog grows a real push handler */
-        }
+        onOpenExecuted={handleOpenExecuted}
+        onPushToGarmin={onOpenEditor}
         onSplit={dialog.handleSplit}
       />
     </CoachingDialogShell>

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialogContent.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialogContent.tsx
@@ -43,7 +43,7 @@ export function CoachingActivityDialogContent(
       </div>
       <DialogDescription activity={activity} />
       {matched
-        ? renderMatchedBody(props, matched.workout)
+        ? renderMatchedBody(props, matched.workout, matched.executed)
         : renderNoWorkoutBody(props)}
     </div>
   );

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/ExecutedWorkoutsSection.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/ExecutedWorkoutsSection.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * ExecutedWorkoutsSection — matched-state dialog body for the executed
+ * (e.g., Garmin/FIT) recordings auto-linked to a coaching activity.
+ * Asserts: rows render per executed workout, click fires
+ * `onOpenExecuted` with the matching record, empty list renders nothing.
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import { ExecutedWorkoutsSection } from "./ExecutedWorkoutsSection";
+
+const ONE_HOUR_SECONDS = 3600;
+
+const makeWorkout = (overrides: Partial<WorkoutRecord> = {}): WorkoutRecord =>
+  ({
+    id: "w-1",
+    date: "2026-04-13",
+    sport: "cycling",
+    state: "raw",
+    raw: {
+      title: "Recorded cycling ride",
+      description: "From Garmin",
+      duration: { value: ONE_HOUR_SECONDS, unit: "s" },
+    },
+    ...overrides,
+  }) as unknown as WorkoutRecord;
+
+describe("ExecutedWorkoutsSection", () => {
+  it("should render one row per executed workout", () => {
+    // Arrange
+    const executed = [
+      makeWorkout({ id: "exec-1" }),
+      makeWorkout({
+        id: "exec-2",
+        raw: {
+          title: "Second activity",
+          duration: { value: 1800, unit: "s" },
+        } as WorkoutRecord["raw"],
+      }),
+    ];
+
+    // Act
+    render(
+      <ExecutedWorkoutsSection executed={executed} onOpenExecuted={vi.fn()} />
+    );
+
+    // Assert
+    expect(screen.getByTestId("executed-workouts-section")).toBeInTheDocument();
+    expect(screen.getByTestId("executed-workout-exec-1")).toBeInTheDocument();
+    expect(screen.getByTestId("executed-workout-exec-2")).toBeInTheDocument();
+    expect(screen.getByText("Recorded cycling ride")).toBeInTheDocument();
+    expect(screen.getByText("Second activity")).toBeInTheDocument();
+  });
+
+  it("should fire onOpenExecuted with the clicked workout", async () => {
+    // Arrange
+    const onOpenExecuted = vi.fn();
+    const clicked = makeWorkout({ id: "exec-1" });
+
+    // Act
+    render(
+      <ExecutedWorkoutsSection
+        executed={[clicked]}
+        onOpenExecuted={onOpenExecuted}
+      />
+    );
+    await userEvent.click(screen.getByTestId("executed-workout-exec-1"));
+
+    // Assert
+    expect(onOpenExecuted).toHaveBeenCalledTimes(1);
+    expect(onOpenExecuted).toHaveBeenCalledWith(clicked);
+  });
+
+  it("should render nothing when executed is empty", () => {
+    // Arrange
+
+    // Act
+    const { container } = render(
+      <ExecutedWorkoutsSection executed={[]} onOpenExecuted={vi.fn()} />
+    );
+
+    // Assert
+    expect(container.firstChild).toBeNull();
+    expect(
+      screen.queryByTestId("executed-workouts-section")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/ExecutedWorkoutsSection.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/ExecutedWorkoutsSection.tsx
@@ -1,0 +1,58 @@
+/**
+ * ExecutedWorkoutsSection — matched-state dialog row(s) listing the
+ * executed activities (e.g., Garmin/FIT recordings) auto-linked to the
+ * same `(profileId, date, canonical sport)` slot as the structured
+ * workout. Mirrors the calendar-card `matched-session-executed-row`
+ * layout but uses a slate border to distinguish it from the emerald
+ * "Linked workout" section. Each row is a button that invokes
+ * `onOpenExecuted` so the user can open the recorded workout the same
+ * way clicking a solo `WorkoutCard` does.
+ */
+
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import {
+  formatDurationMinutes,
+  sportLabel,
+  workoutTitle,
+} from "./linked-workout-utils";
+
+export type ExecutedWorkoutsSectionProps = {
+  executed: readonly WorkoutRecord[];
+  onOpenExecuted: (workout: WorkoutRecord) => void;
+};
+
+export function ExecutedWorkoutsSection({
+  executed,
+  onOpenExecuted,
+}: ExecutedWorkoutsSectionProps) {
+  if (executed.length === 0) return null;
+  return (
+    <div
+      data-testid="executed-workouts-section"
+      className="space-y-2 rounded border border-slate-200 bg-slate-50/40 p-3 text-sm dark:border-slate-700 dark:bg-slate-900/30"
+    >
+      <div className="text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">
+        Completed activities
+      </div>
+      <ul className="space-y-1">
+        {executed.map((w) => (
+          <li key={w.id}>
+            <button
+              type="button"
+              data-testid={`executed-workout-${w.id}`}
+              onClick={() => onOpenExecuted(w)}
+              className="flex w-full flex-col items-start rounded px-2 py-1 text-left hover:bg-slate-100 dark:hover:bg-slate-800"
+            >
+              <span className="font-medium">{workoutTitle(w)}</span>
+              <span className="text-xs text-slate-600 dark:text-slate-400">
+                {sportLabel(w.sport)}
+                {formatDurationMinutes(w.raw?.duration?.value) &&
+                  ` · ${formatDurationMinutes(w.raw?.duration?.value)}`}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/LinkedWorkoutSection.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/LinkedWorkoutSection.tsx
@@ -6,6 +6,11 @@
  */
 
 import type { WorkoutRecord } from "../../../types/calendar-record";
+import {
+  formatDurationMinutes,
+  sportLabel,
+  workoutTitle,
+} from "./linked-workout-utils";
 
 export type LinkedWorkoutSectionProps = {
   workout: WorkoutRecord;
@@ -13,35 +18,12 @@ export type LinkedWorkoutSectionProps = {
   onSplit: () => void;
 };
 
-const SPORT_LABELS: Record<string, string> = {
-  cycling: "Cycling",
-  running: "Running",
-  swimming: "Swimming",
-  strength: "Strength",
-};
-
-const formatDuration = (seconds: number | undefined): string => {
-  if (!seconds) return "";
-  const min = Math.round(seconds / 60);
-  return `${min}min`;
-};
-
-const sportLabel = (sport: string | null | undefined): string => {
-  if (!sport) return "Workout";
-  return SPORT_LABELS[sport] ?? sport;
-};
-
-const workoutTitle = (workout: WorkoutRecord): string => {
-  const raw = workout.raw as { title?: string; description?: string } | null;
-  return raw?.title || raw?.description?.slice(0, 60) || "Untitled workout";
-};
-
 export function LinkedWorkoutSection({
   workout,
   splitting,
   onSplit,
 }: LinkedWorkoutSectionProps) {
-  const duration = formatDuration(workout.raw?.duration?.value);
+  const duration = formatDurationMinutes(workout.raw?.duration?.value);
   return (
     <div
       data-testid="linked-workout-section"

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-body-props.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-body-props.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared prop bundle for the matched / no-workout body renderers of
+ * `CoachingActivityDialog`. Lives in its own file so both
+ * `coaching-dialog-body.tsx` (no-workout) and
+ * `coaching-dialog-matched-body.tsx` (matched) can stay under the
+ * per-file line cap.
+ */
+
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import type { AiFailureState } from "./use-coaching-ai-handler";
+
+export type CoachingDialogBodyProps = {
+  activity: CoachingActivity;
+  pickerOpen: boolean;
+  pickerWorkouts: WorkoutRecord[];
+  matching: boolean;
+  splitting: boolean;
+  aiProcessing: boolean;
+  aiFailure: AiFailureState | null;
+  manualCreating: boolean;
+  onClose: () => void;
+  onAiProcess: () => void;
+  onAiCancel: () => void;
+  onEditManually: () => void;
+  onOpenPicker: () => void;
+  onClosePicker: () => void;
+  onSelectWorkout: (workoutId: string) => void;
+  onOpenEditor: () => void;
+  onOpenExecuted: (workout: WorkoutRecord) => void;
+  onPushToGarmin: () => void;
+  onSplit: () => void;
+};

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-body.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-body.tsx
@@ -1,36 +1,16 @@
 /**
- * Body renderers for `CoachingActivityDialog`. Split out from the
- * dispatcher so it stays under the per-file line cap.
+ * No-workout body renderer for `CoachingActivityDialog`. The matched-
+ * state body lives in `coaching-dialog-matched-body.tsx`; both reside
+ * in their own files so the dispatcher and each renderer stay under
+ * the per-file line cap.
  */
-import type { WorkoutRecord } from "../../../types/calendar-record";
-import type { CoachingActivity } from "../../../types/coaching-activity";
 import { AiErrorState } from "./AiErrorState";
 import { AiProcessingOverlay } from "./AiProcessingOverlay";
-import { LinkedWorkoutSection } from "./LinkedWorkoutSection";
-import { MatchedActions } from "./MatchedActions";
+import type { CoachingDialogBodyProps } from "./coaching-dialog-body-props";
 import { NoWorkoutActions } from "./NoWorkoutActions";
-import type { AiFailureState } from "./use-coaching-ai-handler";
 
-export type CoachingDialogBodyProps = {
-  activity: CoachingActivity;
-  pickerOpen: boolean;
-  pickerWorkouts: WorkoutRecord[];
-  matching: boolean;
-  splitting: boolean;
-  aiProcessing: boolean;
-  aiFailure: AiFailureState | null;
-  manualCreating: boolean;
-  onClose: () => void;
-  onAiProcess: () => void;
-  onAiCancel: () => void;
-  onEditManually: () => void;
-  onOpenPicker: () => void;
-  onClosePicker: () => void;
-  onSelectWorkout: (workoutId: string) => void;
-  onOpenEditor: () => void;
-  onPushToGarmin: () => void;
-  onSplit: () => void;
-};
+export type { CoachingDialogBodyProps };
+export { renderMatchedBody } from "./coaching-dialog-matched-body";
 
 export const renderNoWorkoutBody = (props: CoachingDialogBodyProps) => {
   if (props.aiProcessing)
@@ -62,25 +42,3 @@ export const renderNoWorkoutBody = (props: CoachingDialogBodyProps) => {
     />
   );
 };
-
-export const renderMatchedBody = (
-  props: CoachingDialogBodyProps,
-  workout: WorkoutRecord
-) => (
-  <>
-    <LinkedWorkoutSection
-      workout={workout}
-      splitting={false}
-      onSplit={() => undefined}
-    />
-    <MatchedActions
-      workout={workout}
-      splitting={props.splitting}
-      onClose={props.onClose}
-      onOpenEditor={props.onOpenEditor}
-      onAiProcess={props.onAiProcess}
-      onPushToGarmin={props.onPushToGarmin}
-      onSplit={props.onSplit}
-    />
-  </>
-);

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-matched-body.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-matched-body.tsx
@@ -1,0 +1,40 @@
+/**
+ * Matched-state body renderer for `CoachingActivityDialog`. Split out
+ * from `coaching-dialog-body.tsx` so the shared body file stays under
+ * the per-file line cap with both `LinkedWorkoutSection` and the new
+ * `ExecutedWorkoutsSection` slots wired up.
+ */
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingDialogBodyProps } from "./coaching-dialog-body-props";
+import { ExecutedWorkoutsSection } from "./ExecutedWorkoutsSection";
+import { LinkedWorkoutSection } from "./LinkedWorkoutSection";
+import { MatchedActions } from "./MatchedActions";
+
+export const renderMatchedBody = (
+  props: CoachingDialogBodyProps,
+  workout: WorkoutRecord,
+  executed: WorkoutRecord[]
+) => (
+  <>
+    <LinkedWorkoutSection
+      workout={workout}
+      splitting={false}
+      onSplit={() => undefined}
+    />
+    {executed.length > 0 ? (
+      <ExecutedWorkoutsSection
+        executed={executed}
+        onOpenExecuted={props.onOpenExecuted}
+      />
+    ) : null}
+    <MatchedActions
+      workout={workout}
+      splitting={props.splitting}
+      onClose={props.onClose}
+      onOpenEditor={props.onOpenEditor}
+      onAiProcess={props.onAiProcess}
+      onPushToGarmin={props.onPushToGarmin}
+      onSplit={props.onSplit}
+    />
+  </>
+);

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/linked-workout-utils.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/linked-workout-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared display helpers for matched-state dialog sections
+ * (`LinkedWorkoutSection`, `ExecutedWorkoutsSection`). Extracted so both
+ * the structured and executed slots share the same title/sport/duration
+ * formatting and the per-file line caps stay satisfied.
+ */
+
+import type { WorkoutRecord } from "../../../types/calendar-record";
+
+const SPORT_LABELS: Record<string, string> = {
+  cycling: "Cycling",
+  running: "Running",
+  swimming: "Swimming",
+  strength: "Strength",
+};
+
+export const formatDurationMinutes = (seconds: number | undefined): string => {
+  if (!seconds) return "";
+  const min = Math.round(seconds / 60);
+  return `${min}min`;
+};
+
+export const sportLabel = (sport: string | null | undefined): string => {
+  if (!sport) return "Workout";
+  return SPORT_LABELS[sport] ?? sport;
+};
+
+export const workoutTitle = (workout: WorkoutRecord): string => {
+  const raw = workout.raw as { title?: string; description?: string } | null;
+  return raw?.title || raw?.description?.slice(0, 60) || "Untitled workout";
+};

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-state.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-state.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * useCoachingDialogState — matched-state must populate `executed` from
+ * `match.executedWorkoutIds`. Seeds the shared Dexie database (fake
+ * IndexedDB) with a SessionMatch + 1 structured workout + 2 executed
+ * workouts, then asserts `kind === "matched"` carries both the
+ * structured workout and the two executed records.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { db } from "../../../adapters/dexie/dexie-database";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import { toPersistedCoachingActivityId } from "../../../types/coaching-activity-record";
+import type { SessionMatch } from "../../../types/session-match";
+import { useCoachingDialogState } from "./use-coaching-dialog-state";
+
+const PROFILE_ID = "p1";
+const ACTIVITY_ID = "train2go:abc";
+const PERSISTED_ACTIVITY_ID = toPersistedCoachingActivityId(
+  PROFILE_ID,
+  ACTIVITY_ID
+);
+
+const activity: CoachingActivity = {
+  id: ACTIVITY_ID,
+  source: "train2go",
+  sourceBadge: "T2G",
+  date: "2026-04-13",
+  sport: { label: "Cycling", icon: "🚴" },
+  title: "Sweet spot intervals",
+  duration: "01:00:00",
+  effort: 4,
+  status: "pending",
+  description: "Body",
+};
+
+const makeWorkout = (id: string): WorkoutRecord =>
+  ({
+    id,
+    date: "2026-04-13",
+    sport: "cycling",
+    source: "train2go",
+    sourceId: id,
+    state: "structured",
+    raw: { title: id, duration: { value: 3600, unit: "s" } },
+  }) as unknown as WorkoutRecord;
+
+const makeMatch = (
+  workoutId: string,
+  executedWorkoutIds: string[]
+): SessionMatch => ({
+  id: "M-1",
+  profileId: PROFILE_ID,
+  coachingActivityId: PERSISTED_ACTIVITY_ID,
+  workoutId,
+  date: "2026-04-13",
+  createdAt: "2026-05-01T12:00:00.000Z",
+  source: "auto-coaching",
+  executedWorkoutIds,
+});
+
+afterEach(async () => {
+  await db.table("sessionMatches").clear();
+  await db.table("workouts").clear();
+});
+
+describe("useCoachingDialogState — matched executed", () => {
+  it("should populate executed from match.executedWorkoutIds", async () => {
+    // Arrange
+    const structured = makeWorkout("w-structured");
+    const exec1 = makeWorkout("w-exec-1");
+    const exec2 = makeWorkout("w-exec-2");
+    await db.table("workouts").bulkPut([structured, exec1, exec2]);
+    await db
+      .table("sessionMatches")
+      .put(makeMatch(structured.id, [exec1.id, exec2.id]));
+
+    // Act
+    const { result } = renderHook(() =>
+      useCoachingDialogState(PROFILE_ID, activity)
+    );
+
+    // Assert
+    await waitFor(() => expect(result.current?.kind).toBe("matched"));
+    const state = result.current;
+    if (state?.kind !== "matched") throw new Error("expected matched");
+    expect(state.workout.id).toBe(structured.id);
+    expect(state.executed.map((w) => w.id)).toEqual([exec1.id, exec2.id]);
+  });
+
+  it("should return empty executed array when no executedWorkoutIds are set", async () => {
+    // Arrange
+    const structured = makeWorkout("w-structured");
+    await db.table("workouts").bulkPut([structured]);
+    await db.table("sessionMatches").put(makeMatch(structured.id, []));
+
+    // Act
+    const { result } = renderHook(() =>
+      useCoachingDialogState(PROFILE_ID, activity)
+    );
+
+    // Assert
+    await waitFor(() => expect(result.current?.kind).toBe("matched"));
+    const state = result.current;
+    if (state?.kind !== "matched") throw new Error("expected matched");
+    expect(state.executed).toEqual([]);
+  });
+
+  it("should drop dangling executed ids that point to deleted workouts", async () => {
+    // Arrange
+    const structured = makeWorkout("w-structured");
+    const exec1 = makeWorkout("w-exec-1");
+    await db.table("workouts").bulkPut([structured, exec1]);
+    await db
+      .table("sessionMatches")
+      .put(makeMatch(structured.id, [exec1.id, "w-missing"]));
+
+    // Act
+    const { result } = renderHook(() =>
+      useCoachingDialogState(PROFILE_ID, activity)
+    );
+
+    // Assert
+    await waitFor(() => expect(result.current?.kind).toBe("matched"));
+    const state = result.current;
+    if (state?.kind !== "matched") throw new Error("expected matched");
+    expect(state.executed.map((w) => w.id)).toEqual([exec1.id]);
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-state.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-state.ts
@@ -28,7 +28,22 @@ import type { SessionMatch } from "../../../types/session-match";
 export type CoachingDialogState =
   | { kind: "no-workout" }
   | { kind: "converted"; workout: WorkoutRecord }
-  | { kind: "matched"; matchId: string; workout: WorkoutRecord };
+  | {
+      kind: "matched";
+      matchId: string;
+      workout: WorkoutRecord;
+      executed: WorkoutRecord[];
+    };
+
+const resolveExecuted = async (
+  ids: readonly string[]
+): Promise<WorkoutRecord[]> => {
+  if (ids.length === 0) return [];
+  const rows = await db.table<WorkoutRecord>("workouts").bulkGet([...ids]);
+  // `bulkGet` returns `undefined` for missing ids; drop dangling refs so
+  // the dialog never renders a row for a deleted recording.
+  return rows.filter((r): r is WorkoutRecord => Boolean(r));
+};
 
 const resolveState = async (
   profileId: string,
@@ -49,7 +64,8 @@ const resolveState = async (
     // to the no-workout branch so the dialog re-offers AI/Manual/Match.
     // Stale-match cleanup belongs to the cascade hooks, not the dialog.
     if (!workout) return { kind: "no-workout" };
-    return { kind: "matched", matchId: match.id, workout };
+    const executed = await resolveExecuted(match.executedWorkoutIds ?? []);
+    return { kind: "matched", matchId: match.id, workout, executed };
   }
 
   const prefix = `${activity.source}:`;

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-open-executed-handler.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-open-executed-handler.ts
@@ -1,0 +1,24 @@
+/**
+ * Bridges the dialog's `onOpenExecuted` callback to the parent so a
+ * click on an executed-row in `ExecutedWorkoutsSection` closes the
+ * coaching dialog first, then opens the recorded workout the same way
+ * a solo `WorkoutCard` click would. Returns a stable no-op when the
+ * parent does not wire `onOpenExecuted`, keeping the section harmless.
+ */
+
+import { useCallback } from "react";
+
+import type { WorkoutRecord } from "../../../types/calendar-record";
+
+export const useOpenExecutedHandler = (
+  onClose: () => void,
+  onOpenExecuted: ((workout: WorkoutRecord) => void) | undefined
+): ((workout: WorkoutRecord) => void) =>
+  useCallback(
+    (workout: WorkoutRecord) => {
+      if (!onOpenExecuted) return;
+      onClose();
+      onOpenExecuted(workout);
+    },
+    [onClose, onOpenExecuted]
+  );

--- a/packages/workout-spa-editor/src/components/pages/CalendarDialogs.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarDialogs.tsx
@@ -19,6 +19,7 @@ export type CalendarDialogsProps = {
   onCloseDay: () => void;
   onCloseCoaching?: () => void;
   expandActivity: (activity: CoachingActivity) => void;
+  onOpenExecuted?: (workout: WorkoutRecord) => void;
 };
 
 export function CalendarDialogs({
@@ -29,6 +30,7 @@ export function CalendarDialogs({
   onCloseDay,
   onCloseCoaching = () => {},
   expandActivity,
+  onOpenExecuted,
 }: CalendarDialogsProps) {
   const { handleProcess, handleSkip, handleUnskip, isSubmitting } =
     useDialogHandlers(selectedWorkout, onCloseWorkout);
@@ -48,6 +50,7 @@ export function CalendarDialogs({
         activity={selectedCoachingActivity}
         onClose={onCloseCoaching}
         expandActivity={expandActivity}
+        onOpenExecuted={onOpenExecuted}
       />
     </>
   );

--- a/packages/workout-spa-editor/src/components/pages/CalendarPageView.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPageView.tsx
@@ -59,6 +59,7 @@ export function CalendarPageView({
         onCloseDay={() => s.setEmptyDayDate(null)}
         onCloseCoaching={() => setSelectedActivity(null)}
         expandActivity={coaching.expandActivity}
+        onOpenExecuted={s.handleWorkoutClick}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Follow-up to #597. The calendar `MatchedSessionCard` already collapses prescribed + structured + executed[1..N] into one card, but opening the matched coaching dialog (click the card) only surfaced the structured workout via `LinkedWorkoutSection`. Executed activities — Garmin/FIT recordings auto-linked through `match.executedWorkoutIds` — had no entry point inside the dialog, leaving the user with no way to open the recorded activity.

This change adds an `ExecutedWorkoutsSection` inside the matched dialog body that lists each executed workout (title + sport + duration) and routes a click through the calendar page's existing `handleWorkoutClick`. Opening a recorded activity from the dialog now matches opening one from a solo `WorkoutCard`.

## The gap PR #597 left

- #597 added the 3rd "executed" slot to the calendar card (visual surfacing).
- #597 did NOT add any executed UI inside the dialog opened from that card.
- Result: with 1..N Garmin/FIT recordings auto-linked, the user could see they exist on the calendar card but could not navigate to them.

## Changes

- `useCoachingDialogState` (`use-coaching-dialog-state.ts`): the `"matched"` variant now resolves `executed: WorkoutRecord[]` via `db.workouts.bulkGet(match.executedWorkoutIds)`, with dangling-ref tolerance (deleted workouts are dropped, mirroring the structured-workout branch).
- New `ExecutedWorkoutsSection.tsx`: list of clickable rows, one per executed workout. Slate border to differentiate from the emerald `LinkedWorkoutSection`. Heading "Completed activities". Hidden entirely when `executed.length === 0`.
- New `linked-workout-utils.ts`: shared title / sport label / duration helpers used by both the linked and executed sections.
- `coaching-dialog-body.tsx` split: matched-body renderer extracted to `coaching-dialog-matched-body.tsx`; shared props moved to `coaching-dialog-body-props.ts`. Keeps every file under the per-file line cap.
- `CoachingActivityDialog` accepts `onOpenExecuted?: (workout) => void`; wires it through `CalendarDialogs` → `CalendarPageView`, where it maps to `s.handleWorkoutClick` (same handler used by solo `WorkoutCard` clicks). Closing the dialog before opening the recorded workout mirrors the existing `onOpenEditor` flow.

## Acceptance criteria

- [x] Matched dialog shows `<ExecutedWorkoutsSection>` when 1..N executed workouts are linked.
- [x] Section hidden entirely when no executed workouts are linked (no empty state).
- [x] `data-testid="executed-workouts-section"` on the wrapper.
- [x] `data-testid="executed-workout-${w.id}"` on each row.
- [x] Click on a row closes the dialog and navigates to that workout the same way a solo `WorkoutCard` click does.
- [x] Section heading: "Completed activities".
- [x] Slate border (different from emerald `LinkedWorkoutSection`) for visual differentiation.
- [x] Dangling-ref tolerance: deleted executed workouts are silently dropped, not rendered.
- [x] No schema changes — `executedWorkoutIds` already exists from #597.
- [x] No use-case changes — UI wiring only.

## Tests

- New `ExecutedWorkoutsSection.test.tsx` (3 cases): renders one row per executed workout, fires `onOpenExecuted` with the clicked workout, renders nothing when empty.
- New `use-coaching-dialog-state.test.tsx` (3 cases): populates `executed` from `match.executedWorkoutIds`, empty array when none configured, drops dangling executed ids that point to deleted workouts.

## Test plan

- [x] `pnpm -F @kaiord/workout-spa-editor exec tsc --noEmit` clean
- [x] `pnpm -F @kaiord/workout-spa-editor exec eslint .` clean (0 errors / 0 warnings)
- [x] `pnpm -F @kaiord/workout-spa-editor exec prettier --check src e2e` clean
- [x] `pnpm -F @kaiord/workout-spa-editor test` 3875/3875 passed
- [x] `pnpm test:scripts` 419/419 passed
- [ ] Manual: open a matched coaching dialog with 1 executed workout, confirm row appears and click navigates to the recorded workout.
- [ ] Manual: open a matched coaching dialog with 2+ executed workouts, confirm all rows render.
- [ ] Manual: open a matched coaching dialog with 0 executed workouts, confirm the section is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Completed activities" section that displays previously executed workouts in the coaching dialog.
  * Users can now click on completed activities to open and view their details.
  * Improved workout information display with support for activity titles, duration, and sport classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/599)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->