### PR TITLE
fix(train2go-bridge): preserve <li>/<br> line breaks in coaching description

### DIFF
--- a/packages/train2go-bridge/parser.js
+++ b/packages/train2go-bridge/parser.js
@@ -144,12 +144,23 @@ const extractDescription = (block) => {
   let text = descMatch[1];
   // Remove SVGs and nested elements
   text = text.replace(/<svg[\s\S]*?<\/svg>/g, "");
+  // CAUTION: this strips ANY balanced <div>...</div> block — content
+  // and all — which is intentional for the trailing
+  // `activity-hint-ecos` div but would also eat bullets if Train2Go
+  // ever wrapped them in <div> instead of <ul><li>. Bullets currently
+  // arrive as <ul><li>, so we mirror htmlToPlainText's pattern below
+  // (convert closing block-level tags to "\n" BEFORE strip-all) to
+  // preserve the line break that <li> implies.
   text = text.replace(/<div[\s\S]*?<\/div>/g, "");
   // Preserve bold markers
   text = text.replace(/<strong>([^<]*)<\/strong>/g, "**$1**");
-  // Convert breaks and paragraphs to newlines
-  text = text.replace(/<br\s*\/?>/g, "\n");
-  text = text.replace(/<p>/g, "\n");
+  // Convert breaks and block-level tags to newlines BEFORE stripping
+  // remaining HTML. Without `<li>`/`</li>`/`</p>` conversion the live
+  // single-line T2G shape `<p>title</p><ul><li>a</li><li>b</li></ul>`
+  // collapses to `titleab` after strip-all (user-reported regression).
+  text = text.replace(/<br\s*\/?>/gi, "\n");
+  text = text.replace(/<\/(p|h[1-6]|li|ul|ol)>/gi, "\n");
+  text = text.replace(/<(p|li)\b[^>]*>/gi, "\n");
   // Strip remaining HTML
   text = text.replace(/<[^>]+>/g, "");
   text = decodeEntities(text);

--- a/packages/train2go-bridge/test/parser.test.js
+++ b/packages/train2go-bridge/test/parser.test.js
@@ -165,6 +165,45 @@ describe("parser", () => {
       expect(activities[0].description).toContain("3x15' Z3 d/5' Z1");
     });
 
+    it("should preserve <li> bullet line breaks in description (regression: <ul><li> concatenation)", () => {
+      // Arrange
+      // Real-world Train2Go HTML ships single-line (no whitespace
+      // between tags): `<p>title</p><ul><li>a</li><li>b</li></ul>`.
+      // The previous extractDescription only converted `<br>` and the
+      // OPENING `<p>` to "\n" before stripping remaining tags, so
+      // `</li><li>` concatenated and the closing `</p>` did not break
+      // the line ahead of `<ul>`. User-reported symptom:
+      //   "3 progresiones de 1' en Z3 → Z4:1' @ 200–220w1' @ 220–240w..."
+      const html =
+        `<aside><div class="activity activity-medium" data-status="0" data-id="42">` +
+        `<figure class="icon icon-sportscycling"></figure>` +
+        `<span class="measured">1:55 h</span>` +
+        `<div class="workload workload-default" data-value="2"></div>` +
+        `<div class="activity-title"><strong>Progresiones</strong></div>` +
+        `<div class="activity-description">` +
+        `<p>3 progresiones de 1' en Z3 → Z4:</p>` +
+        `<ul><li>1' @ 200–220w</li><li>1' @ 220–240w</li><li>1' @ 240–260w</li></ul>` +
+        `<p>(Recuperación 1' fácil entre cada una)</p>` +
+        `</div></div></aside>`;
+
+      // Act
+      const activities = parseDailyHtml(html);
+
+      // Assert
+      expect(activities).toHaveLength(1);
+      const lines = activities[0].description.split("\n");
+      expect(lines).toContain("3 progresiones de 1' en Z3 → Z4:");
+      expect(lines).toContain("1' @ 200–220w");
+      expect(lines).toContain("1' @ 220–240w");
+      expect(lines).toContain("1' @ 240–260w");
+      expect(lines).toContain("(Recuperación 1' fácil entre cada una)");
+      // No bullet should be concatenated with another bullet or paragraph.
+      expect(activities[0].description).not.toMatch(/220w1'/);
+      expect(activities[0].description).not.toMatch(/240w1'/);
+      expect(activities[0].description).not.toMatch(/260w\(Recup/);
+      expect(activities[0].description).not.toMatch(/Z4:1'/);
+    });
+
     it('should not leak the opening tag of the next sibling block into the description (regression: <div class=" trailing fragment)', () => {
       // Arrange
       // The live T2G response has the activity-description block followed

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts
@@ -128,6 +128,33 @@ describe("formatCoachingDescription", () => {
     ]);
   });
 
+  it("should render bullet-list output from train2go-bridge as one paragraph per line", () => {
+    // Arrange
+    // End-to-end shape: the train2go-bridge parser converts
+    // `<p>title</p><ul><li>a</li><li>b</li><li>c</li></ul><p>tail</p>`
+    // into the 5-line "\n"-separated text below. The SPA renderer
+    // MUST split each line into its own paragraph so bullets don't
+    // collapse onto a single line (user-reported regression).
+    const text =
+      "3 progresiones de 1' en Z3 → Z4:\n1' @ 200–220w\n1' @ 220–240w\n1' @ 240–260w\n(Recuperación 1' fácil entre cada una)";
+
+    // Act
+    const result = formatCoachingDescription(text);
+
+    // Assert
+    // eslint-disable-next-line no-magic-numbers -- expected paragraph count from 5-line bullet shape
+    expect(result).toHaveLength(5);
+    expect(result[0]?.inlines[0]?.value).toBe(
+      "3 progresiones de 1' en Z3 → Z4:"
+    );
+    expect(result[1]?.inlines[0]?.value).toBe("1' @ 200–220w");
+    expect(result[2]?.inlines[0]?.value).toBe("1' @ 220–240w");
+    expect(result[3]?.inlines[0]?.value).toBe("1' @ 240–260w");
+    expect(result[4]?.inlines[0]?.value).toBe(
+      "(Recuperación 1' fácil entre cada una)"
+    );
+  });
+
   it("should decode common HTML entities", () => {
     // Arrange
     const html = "<p>Pace &lt; threshold &amp; effort &gt; Z3</p>";


### PR DESCRIPTION
## Summary

Fixes a parser regression that collapses Train2Go bullet lists onto a single line when rendered in the Kaiord calendar coaching description.

### User-reported symptom

**Train2Go (source, what the user sees on Train2Go):**

```
3 progresiones de 1' en Z3 → Z4:
1' @ 200–220w
1' @ 220–240w
1' @ 240–260w
(Recuperación 1' fácil entre cada una)
```

**Kaiord (current bug):**

```
3 progresiones de 1' en Z3 → Z4:1' @ 200–220w1' @ 220–240w1' @ 240–260w (Recuperación 1' fácil entre cada una)
```

The bullet items ARE present in the text — they were just concatenated without separators.

### Root cause

Train2Go ships activity descriptions as **single-line HTML** (no whitespace between tags):

```html
<p>3 progresiones de 1' en Z3 → Z4:</p><ul><li>1' @ 200–220w</li>…</ul><p>(Recup…)</p>
```

`extractDescription` in `packages/train2go-bridge/parser.js` only converted `<br>` and the **opening `<p>`** to `\n` before stripping remaining tags, so:

- `</li><li>` concatenated (no break between bullets).
- `</p><ul>` did not break (no break between the title line and the first bullet).
- The closing `</p>` before the tail paragraph was silently swallowed.

### Fix

Mirror the canonical `htmlToPlainText` pattern (already in the same file): convert `<br>`, opening `<p>`/`<li>`, and closing `</p>` / `</h{1-6}>` / `</li>` / `</ul>` / `</ol>` to `\n` BEFORE the strip-all pass. The existing trim/filter/join then collapses the result. Bullets now arrive at the SPA as `\n`-separated lines and the existing `formatCoachingDescription` splitter renders them as one paragraph each.

A comment was also added documenting the existing `<div[\s\S]*?</div>` content-strip risk if Train2Go ever migrates bullets to `<div>` (out of scope to refactor; flagged for the next contributor).

### Tests added

- **`packages/train2go-bridge/test/parser.test.js`** — Regression test using the **single-line** T2G fixture shape that reproduces the bug (the earlier whitespace-formatted fixture passed by accident because newlines between tags survived the strip).
- **`packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.test.ts`** — SPA-side end-to-end test confirming a 5-line `\n`-separated input renders as 5 paragraphs.

## Test plan

- [x] `pnpm -F @kaiord/train2go-bridge test` — 128/128 passed
- [x] `pnpm -F @kaiord/workout-spa-editor test` — 3870/3870 passed
- [x] `pnpm -F @kaiord/workout-spa-editor lint` — clean (tsc + eslint + prettier)
- [x] `pnpm test:scripts` — 419/419 passed
- [x] Regression test added and verified to **fail before fix** (reproduces bug) and **pass after fix**

## Out of scope

- SPA dialog UI changes (PR #599)
- Schema changes
- Refactoring `htmlToPlainText`
- Changing the `<div>` content-strip behavior (documented in a code comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression where activity descriptions containing bullet lists were collapsing into a single line, breaking proper text formatting and readability.

* **Tests**
  * Added regression test to ensure bullet-list items maintain individual line breaks in activity descriptions.
  * Added test validation for correct multi-line description rendering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/600)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->