### PR TITLE
feat(spa-editor): make workouts profile-scoped (Dexie v13) with cascade-delete on profile remove

### DIFF
--- a/packages/workout-spa-editor/e2e/helpers/dexie-factories.ts
+++ b/packages/workout-spa-editor/e2e/helpers/dexie-factories.ts
@@ -5,22 +5,22 @@
  * compatible with the Dexie schema.
  */
 
-const makeStep = () => ({
+import { E2E_DEFAULT_PROFILE_ID } from "./e2e-defaults";
+
+const STEP = {
   stepIndex: 0,
   durationType: "time",
   duration: { type: "time", seconds: 600 },
   targetType: "power",
   target: { type: "power", value: { unit: "watts", value: 200 } },
   intensity: "active",
-});
+};
 
 const makeKrd = (name: string, sport: string) => ({
   version: "1.0",
   type: "structured_workout",
   metadata: { created: new Date().toISOString(), sport },
-  extensions: {
-    structured_workout: { name, sport, steps: [makeStep()] },
-  },
+  extensions: { structured_workout: { name, sport, steps: [STEP] } },
 });
 
 /** Factory for a minimal WorkoutRecord. */
@@ -28,6 +28,7 @@ export function makeWorkout(overrides: Record<string, unknown> = {}) {
   const now = new Date().toISOString();
   return {
     id: crypto.randomUUID(),
+    profileId: E2E_DEFAULT_PROFILE_ID,
     date: now.slice(0, 10),
     sport: "running",
     source: "kaiord",

--- a/packages/workout-spa-editor/e2e/helpers/e2e-defaults.ts
+++ b/packages/workout-spa-editor/e2e/helpers/e2e-defaults.ts
@@ -1,0 +1,6 @@
+/**
+ * Shared e2e defaults. The profile id every e2e test scaffolds via
+ * `seedDefaultProfile`. Lives on its own so seed and factory modules
+ * stay under the 80-line cap.
+ */
+export const E2E_DEFAULT_PROFILE_ID = "e2e-default-profile";

--- a/packages/workout-spa-editor/e2e/helpers/seed-dexie.ts
+++ b/packages/workout-spa-editor/e2e/helpers/seed-dexie.ts
@@ -8,6 +8,10 @@
 import type { Page } from "@playwright/test";
 
 export { makeRawWorkout, makeTemplate, makeWorkout } from "./dexie-factories";
+export { E2E_DEFAULT_PROFILE_ID } from "./e2e-defaults";
+export { seedDefaultProfile } from "./seed-profile";
+
+import { seedDefaultProfile } from "./seed-profile";
 
 type DexieDb = {
   table: (n: string) => {
@@ -44,7 +48,13 @@ export async function seedTemplates(
   }, templates);
 }
 
-/** Clear all Dexie tables. */
+/**
+ * Clear all Dexie tables AND seed the e2e default profile so any
+ * subsequent workout-write goes through the post-Dexie-v13 profileId
+ * filter cleanly. Tests that exercise multi-profile flows seed their
+ * own rows on top — the default seed is just a baseline so the
+ * `meta.activeProfileId` is never null after `clearDexie`.
+ */
 export async function clearDexie(page: Page) {
   await page.evaluate(async () => {
     const db = (window as unknown as Record<string, unknown>).__KAIORD_DB__ as
@@ -62,6 +72,7 @@ export async function clearDexie(page: Page) {
     ];
     await Promise.all(tables.map((t) => db.table(t).clear()));
   });
+  await seedDefaultProfile(page);
 }
 
 /** Get ISO date strings (Mon-Sun) for a week offset from now. */

--- a/packages/workout-spa-editor/e2e/helpers/seed-profile.ts
+++ b/packages/workout-spa-editor/e2e/helpers/seed-profile.ts
@@ -27,6 +27,7 @@ export async function seedDefaultProfile(page: Page): Promise<string> {
       {
         id: profileId,
         name: "E2E Default Profile",
+        linkedAccounts: [],
         createdAt: now,
         updatedAt: now,
       },

--- a/packages/workout-spa-editor/e2e/helpers/seed-profile.ts
+++ b/packages/workout-spa-editor/e2e/helpers/seed-profile.ts
@@ -1,0 +1,37 @@
+/**
+ * Seed the e2e default profile and write its id to
+ * `meta.activeProfileId`. Used by `clearDexie` so every test that
+ * resets Dexie starts with a valid active profile (post-Dexie v13
+ * workouts require profileId).
+ */
+
+import type { Page } from "@playwright/test";
+
+import { E2E_DEFAULT_PROFILE_ID } from "./e2e-defaults";
+
+type DexieDb = {
+  table: (n: string) => {
+    bulkPut: (r: unknown[]) => Promise<void>;
+    put: (r: unknown) => Promise<void>;
+  };
+};
+
+export async function seedDefaultProfile(page: Page): Promise<string> {
+  await page.evaluate(async (profileId) => {
+    const db = (window as unknown as Record<string, unknown>).__KAIORD_DB__ as
+      | DexieDb
+      | undefined;
+    if (!db) throw new Error("__KAIORD_DB__ not available");
+    const now = new Date().toISOString();
+    await db.table("profiles").bulkPut([
+      {
+        id: profileId,
+        name: "E2E Default Profile",
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    await db.table("meta").put({ key: "activeProfileId", value: profileId });
+  }, E2E_DEFAULT_PROFILE_ID);
+  return E2E_DEFAULT_PROFILE_ID;
+}

--- a/packages/workout-spa-editor/e2e/library-calendar.spec.ts
+++ b/packages/workout-spa-editor/e2e/library-calendar.spec.ts
@@ -12,6 +12,7 @@ import {
   getWeekId,
   makeTemplate,
   makeWorkout,
+  seedDefaultProfile,
   seedTemplates,
   seedWorkouts,
 } from "./helpers/seed-dexie";
@@ -20,6 +21,7 @@ test.describe("Library-Calendar Integration", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/calendar");
     await clearDexie(page);
+    await seedDefaultProfile(page);
   });
 
   test("/library route shows library page", async ({ page }) => {

--- a/packages/workout-spa-editor/e2e/library-flows.spec.ts
+++ b/packages/workout-spa-editor/e2e/library-flows.spec.ts
@@ -22,6 +22,7 @@ import {
   getWeekId,
   makeTemplate,
   makeWorkout,
+  seedDefaultProfile,
   seedTemplates,
   seedWorkouts,
 } from "./helpers/seed-dexie";
@@ -30,6 +31,7 @@ test.describe("Library flows", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/calendar");
     await clearDexie(page);
+    await seedDefaultProfile(page);
   });
 
   test("Test A: header Library navigates to /library and focuses the page heading", async ({

--- a/packages/workout-spa-editor/e2e/workout-lifecycle.spec.ts
+++ b/packages/workout-spa-editor/e2e/workout-lifecycle.spec.ts
@@ -11,6 +11,7 @@ import {
   getWeekId,
   makeRawWorkout,
   makeWorkout,
+  seedDefaultProfile,
   seedWorkouts,
 } from "./helpers/seed-dexie";
 
@@ -18,6 +19,7 @@ test.describe("Workout Lifecycle", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/calendar");
     await clearDexie(page);
+    await seedDefaultProfile(page);
   });
 
   test("RAW workout -> open dialog -> Skip -> card shows skipped state", async ({

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-persistence-adapter.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-persistence-adapter.test.ts
@@ -35,6 +35,7 @@ function makeKrd(): KRD {
 function makeWorkout(overrides: Partial<WorkoutRecord> = {}): WorkoutRecord {
   return {
     id: "w-1",
+    profileId: PROFILE_UUID_1,
     date: "2026-04-07",
     sport: "cycling",
     source: "kaiord",

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-schemas.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-schemas.ts
@@ -39,6 +39,15 @@ const CORE_V5 = {
 // v8 — AI provider insertion-order index. `createdAt` becomes a Dexie
 // index so the repository's getAll can `orderBy("createdAt")` cheaply.
 const CORE_V8 = { ...CORE_V5, aiProviders: "id, createdAt" };
+// v13 — workouts gain `profileId` so each workout is profile-scoped 1–1.
+// Adds `profileId` and `[profileId+date]` indexes so the calendar's
+// per-profile + date-range query hits an index, and the cascade auto-
+// discovery (`isPerProfileTable`) picks the table up at delete time.
+const CORE_V13 = {
+  ...CORE_V8,
+  workouts:
+    "id, profileId, [profileId+date], date, [date+state], [source+sourceId], sport, *tags",
+};
 
 export const SCHEMAS = {
   v1: CORE_V1,
@@ -46,6 +55,7 @@ export const SCHEMAS = {
   v4: CORE_V4,
   v5: CORE_V5,
   v8: CORE_V8,
+  v13: CORE_V13,
 } as const;
 
 /** Backfills `linkedAccounts: []` on profile rows missing the field. */

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v13-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v13-migration.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Forward migration v12 → v13 — workouts gain `profileId`.
+ *
+ * Backfills every legacy row from `meta.activeProfileId`. Throws when
+ * workouts exist but no active profile is set. Idempotent on re-run.
+ * Empty workouts table is a no-op.
+ */
+import "fake-indexeddb/auto";
+
+import type { Transaction } from "dexie";
+import Dexie from "dexie";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { applyV13Upgrade } from "./dexie-v13-migration";
+
+const dbName = (suffix: string) =>
+  `kaiord-test-v13-${suffix}-${Date.now()}-${Math.random()}`;
+
+const NOW = "2026-05-08T10:00:00.000Z";
+const SCHEMA_V12 = 12;
+const SCHEMA_V13 = 13;
+const ACTIVE_PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const STORES_V12 = {
+  workouts: "id, date, [date+state], [source+sourceId], sport, *tags",
+  meta: "key",
+} as const;
+
+const STORES_V13 = {
+  workouts:
+    "id, profileId, [profileId+date], date, [date+state], [source+sourceId], sport, *tags",
+  meta: "key",
+} as const;
+
+const seedRow = (overrides: Record<string, unknown> = {}) => ({
+  id: "w-1",
+  date: "2026-04-13",
+  sport: "cycling",
+  source: "kaiord",
+  sourceId: null,
+  planId: null,
+  state: "raw",
+  raw: null,
+  krd: null,
+  lastProcessingError: null,
+  feedback: null,
+  aiMeta: null,
+  garminPushId: null,
+  tags: [],
+  previousState: null,
+  createdAt: NOW,
+  modifiedAt: null,
+  updatedAt: NOW,
+  ...overrides,
+});
+
+const seedV12 = async (
+  name: string,
+  workouts: ReadonlyArray<Record<string, unknown>>,
+  meta: ReadonlyArray<Record<string, unknown>>
+): Promise<void> => {
+  const v12 = new Dexie(name);
+  v12.version(SCHEMA_V12).stores(STORES_V12);
+  await v12.open();
+  if (workouts.length > 0) await v12.table("workouts").bulkAdd([...workouts]);
+  if (meta.length > 0) await v12.table("meta").bulkAdd([...meta]);
+  v12.close();
+};
+
+const openWithV13Migration = async (name: string): Promise<Dexie> => {
+  const db = new Dexie(name);
+  db.version(SCHEMA_V13).stores(STORES_V13).upgrade(applyV13Upgrade);
+  await db.open();
+  return db;
+};
+
+type Row = { id: string; profileId?: string };
+
+describe("Dexie v12 → v13 migration (workouts profileId backfill)", () => {
+  let name: string;
+
+  beforeEach(() => {
+    name = dbName("apply");
+  });
+
+  afterEach(async () => {
+    await Dexie.delete(name);
+  });
+
+  it("should backfill profileId from meta.activeProfileId on every legacy row", async () => {
+    // Arrange
+    await seedV12(
+      name,
+      [seedRow({ id: "w-1" }), seedRow({ id: "w-2", date: "2026-04-14" })],
+      [{ key: "activeProfileId", value: ACTIVE_PROFILE_ID }]
+    );
+
+    // Act
+    const db = await openWithV13Migration(name);
+
+    // Assert
+    const rows = (await db.table("workouts").toArray()) as Row[];
+    expect(rows).toHaveLength(2);
+    for (const row of rows) {
+      expect(row.profileId).toBe(ACTIVE_PROFILE_ID);
+    }
+    db.close();
+  });
+
+  it("should preserve an existing profileId verbatim", async () => {
+    // Arrange
+    const otherProfileId = "22222222-2222-4222-8222-222222222222";
+    await seedV12(
+      name,
+      [seedRow({ id: "w-1", profileId: otherProfileId })],
+      [{ key: "activeProfileId", value: ACTIVE_PROFILE_ID }]
+    );
+
+    // Act
+    const db = await openWithV13Migration(name);
+
+    // Assert
+    const rows = (await db.table("workouts").toArray()) as Row[];
+    expect(rows[0]?.profileId).toBe(otherProfileId);
+    db.close();
+  });
+
+  it("should be idempotent on a re-run", async () => {
+    // Arrange
+    await seedV12(
+      name,
+      [seedRow({ id: "w-1" })],
+      [{ key: "activeProfileId", value: ACTIVE_PROFILE_ID }]
+    );
+    const first = await openWithV13Migration(name);
+    first.close();
+
+    // Act
+    const second = new Dexie(name);
+    second.version(SCHEMA_V13).stores(STORES_V13);
+    await second.open();
+    await second.transaction("rw", ["workouts", "meta"], async (tx) =>
+      applyV13Upgrade(tx as unknown as Transaction)
+    );
+
+    // Assert
+    const rows = (await second.table("workouts").toArray()) as Row[];
+    expect(rows[0]?.profileId).toBe(ACTIVE_PROFILE_ID);
+    second.close();
+  });
+
+  it("should be a no-op on an empty workouts table even without an active profile", async () => {
+    // Arrange
+    await seedV12(name, [], []);
+
+    // Act
+    const db = await openWithV13Migration(name);
+
+    // Assert
+    expect(await db.table("workouts").toArray()).toHaveLength(0);
+    db.close();
+  });
+
+  it("should throw a descriptive error when workouts exist but meta.activeProfileId is missing", async () => {
+    // Arrange
+    await seedV12(name, [seedRow({ id: "w-1" })], []);
+
+    // Act
+    const open = openWithV13Migration(name);
+
+    // Assert
+    await expect(open).rejects.toThrow(/activeProfileId is missing/i);
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v13-migration.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v13-migration.ts
@@ -1,0 +1,46 @@
+/**
+ * v12 → v13 migration — workouts become profile-scoped 1–1.
+ *
+ * Reads `meta.activeProfileId` once and assigns it to every legacy
+ * `workouts` row that lacks `profileId`. Rows that already have the
+ * field are skipped (idempotent on re-run).
+ *
+ * Failure mode: if `meta.activeProfileId` is missing or not a string
+ * (degenerate state — the app always sets one at first profile creation)
+ * AND the database has at least one workout, the upgrade throws with a
+ * descriptive error. No silent fallback chain. Empty databases are a
+ * no-op.
+ */
+import type { Transaction } from "dexie";
+
+type MetaRow = { key: string; value: unknown };
+type WorkoutRow = { id: string; profileId?: string };
+
+const ACTIVE_PROFILE_KEY = "activeProfileId";
+
+const readActiveProfileId = async (tx: Transaction): Promise<string | null> => {
+  const row = (await tx.table("meta").get(ACTIVE_PROFILE_KEY)) as
+    | MetaRow
+    | undefined;
+  return typeof row?.value === "string" ? row.value : null;
+};
+
+export const applyV13Upgrade = async (tx: Transaction): Promise<void> => {
+  const workoutCount = await tx.table("workouts").count();
+  if (workoutCount === 0) return;
+  const activeProfileId = await readActiveProfileId(tx);
+  if (!activeProfileId) {
+    throw new Error(
+      "Dexie v13 upgrade aborted: meta.activeProfileId is missing but " +
+        "workouts exist. Set an active profile before re-opening the app."
+    );
+  }
+  await tx
+    .table("workouts")
+    .toCollection()
+    .modify((row: WorkoutRow) => {
+      if (typeof row.profileId !== "string" || row.profileId.length === 0) {
+        row.profileId = activeProfileId;
+      }
+    });
+};

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v5-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v5-migration.test.ts
@@ -61,6 +61,9 @@ async function seedV4(name: string, data: Fixture): Promise<void> {
   await v4.table("workouts").bulkPut(data.workouts);
   await v4.table("coachingActivities").bulkPut(data.coachingActivities);
   await v4.table("coachingSyncState").bulkPut(data.coachingSyncState);
+  // v13 expects meta.activeProfileId to be set when workouts exist.
+  // Seed it so the workout-profileId backfill resolves cleanly.
+  await v4.table("meta").put({ key: "activeProfileId", value: "p1" });
   v4.close();
 }
 
@@ -77,7 +80,12 @@ describe("Dexie v5 migration round-trip", () => {
     const activities = await db.table("coachingActivities").toArray();
     const sync = await db.table("coachingSyncState").toArray();
     expect(profiles).toEqual(fixture.profiles);
-    expect(workouts).toEqual(fixture.workouts);
+    // v13 backfills profileId on every legacy workout row; the rest of
+    // the fixture is preserved byte-identically. We assert the per-row
+    // shape rather than reusing the v4 fixture directly.
+    expect(workouts).toEqual(
+      fixture.workouts.map((w) => ({ ...w, profileId: "p1" }))
+    );
     expect(activities).toEqual(fixture.coachingActivities);
     expect(sync).toEqual(fixture.coachingSyncState);
     const sessionMatches = createDexieSessionMatchRepository(db);

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-workout-repository.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-workout-repository.ts
@@ -47,5 +47,9 @@ export function createDexieWorkoutRepository(
     delete: async (id) => {
       await table().delete(id);
     },
+
+    deleteByProfile: async (profileId) => {
+      await table().where("profileId").equals(profileId).delete();
+    },
   };
 }

--- a/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions.ts
@@ -19,6 +19,7 @@ import { backfillLinkedAccounts, SCHEMAS } from "./dexie-schemas";
 import { applyV10Upgrade } from "./dexie-v10-migration";
 import { applyV11Upgrade } from "./dexie-v11-migration";
 import { applyV12Upgrade } from "./dexie-v12-migration";
+import { applyV13Upgrade } from "./dexie-v13-migration";
 
 // Narrowed handle: only `version()` is needed and Dexie's full surface
 // causes "Type instantiation is excessively deep" when passed as a
@@ -91,9 +92,19 @@ const registerV10ToV12 = (db: DexieVersionHost): void => {
   db.version(12).stores(SCHEMAS.v8).upgrade(applyV12Upgrade);
 };
 
+const registerV13 = (db: DexieVersionHost): void => {
+  // v13 — workouts become profile-scoped 1–1. Adds `profileId` +
+  // `[profileId+date]` indexes on the `workouts` store and backfills
+  // every legacy row from `meta.activeProfileId`. The upgrade throws
+  // when workouts exist but no active profile is set — degenerate
+  // state, not a silently-tolerated condition.
+  db.version(13).stores(SCHEMAS.v13).upgrade(applyV13Upgrade);
+};
+
 export const registerKaiordVersions = (db: DexieVersionHost): void => {
   registerV1ToV3(db);
   registerV4ToV6(db);
   registerV7ToV9(db);
   registerV10ToV12(db);
+  registerV13(db);
 };

--- a/packages/workout-spa-editor/src/application/coaching/coaching-workout-builder.ts
+++ b/packages/workout-spa-editor/src/application/coaching/coaching-workout-builder.ts
@@ -36,6 +36,7 @@ export const buildStructuredCoachingWorkout = (
   input: StructuredCoachingWorkoutInput
 ): WorkoutRecord => ({
   id: input.id,
+  profileId: input.activity.profileId,
   date: input.activity.date,
   sport: input.activity.sport,
   source: input.activity.source,

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai.test-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai.test-helpers.ts
@@ -1,12 +1,7 @@
 import type { Analytics } from "@kaiord/core";
 import { vi } from "vitest";
 
-import type {
-  CoachingRepository,
-  WorkoutRepository,
-} from "../../ports/persistence-port";
 import type { AiMeta } from "../../types/calendar-fragments";
-import type { WorkoutRecord } from "../../types/calendar-record";
 import {
   buildCoachingActivityId,
   type CoachingActivityRecord,
@@ -14,17 +9,23 @@ import {
 import type { KRD } from "../../types/schemas";
 import { buildCoachingTemplateKrd } from "./coaching-template";
 
+export {
+  buildStubCoachingRepo,
+  buildStubWorkoutRepo,
+  type StubWorkoutRepo,
+} from "./convert-coaching-activity-with-ai.test-stubs";
+
 export const stubActivity = (
   overrides: Partial<CoachingActivityRecord> = {}
 ): CoachingActivityRecord => {
-  const profileId = overrides.profileId ?? "p1";
-  const source = overrides.source ?? "train2go";
-  const sourceId = overrides.sourceId ?? "12345";
+  const p = overrides.profileId ?? "p1";
+  const s = overrides.source ?? "train2go";
+  const sid = overrides.sourceId ?? "12345";
   return {
-    id: buildCoachingActivityId(profileId, source, sourceId),
-    profileId,
-    source,
-    sourceId,
+    id: buildCoachingActivityId(p, s, sid),
+    profileId: p,
+    source: s,
+    sourceId: sid,
     date: "2026-04-29",
     sport: "cycling",
     title: "FTP test",
@@ -32,43 +33,6 @@ export const stubActivity = (
     status: "pending",
     fetchedAt: "2026-04-28T10:00:00.000Z",
     ...overrides,
-  };
-};
-
-export const buildStubCoachingRepo = (
-  rows: CoachingActivityRecord[]
-): CoachingRepository => {
-  const map = new Map(rows.map((r) => [r.id, r]));
-  return {
-    getById: async (id) => map.get(id),
-    getByProfileAndDateRange: async () => [...map.values()],
-    getByProfileAndSourceId: async () => undefined,
-    upsertMany: async () => undefined,
-    put: async () => undefined,
-    delete: async () => undefined,
-    deleteByProfile: async () => undefined,
-  };
-};
-
-export type StubWorkoutRepo = WorkoutRepository & {
-  setSourceLookup: (w: WorkoutRecord | undefined) => void;
-};
-
-export const buildStubWorkoutRepo = (
-  rows: WorkoutRecord[] = []
-): StubWorkoutRepo => {
-  const store = new Map(rows.map((r) => [r.id, r]));
-  let next: WorkoutRecord | undefined;
-  return {
-    getById: async (id) => store.get(id),
-    getByDateRange: async () => [...store.values()],
-    getByState: async () => [],
-    getBySourceId: async () => next,
-    put: async (w) => void store.set(w.id, w),
-    delete: async (id) => void store.delete(id),
-    setSourceLookup: (w) => {
-      next = w;
-    },
   };
 };
 

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai.test-stubs.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai.test-stubs.ts
@@ -1,0 +1,56 @@
+/**
+ * Stub repository builders used by `convertCoachingActivityWithAi`
+ * tests. Split from the main test-helpers file to keep both under the
+ * per-file line cap.
+ */
+import type {
+  CoachingRepository,
+  WorkoutRepository,
+} from "../../ports/persistence-port";
+import type { WorkoutRecord } from "../../types/calendar-record";
+import type { CoachingActivityRecord } from "../../types/coaching-activity-record";
+
+export const buildStubCoachingRepo = (
+  rows: CoachingActivityRecord[]
+): CoachingRepository => {
+  const map = new Map(rows.map((r) => [r.id, r]));
+  return {
+    getById: async (id) => map.get(id),
+    getByProfileAndDateRange: async () => [...map.values()],
+    getByProfileAndSourceId: async () => undefined,
+    upsertMany: async () => undefined,
+    put: async () => undefined,
+    delete: async () => undefined,
+    deleteByProfile: async () => undefined,
+  };
+};
+
+export type StubWorkoutRepo = WorkoutRepository & {
+  setSourceLookup: (w: WorkoutRecord | undefined) => void;
+};
+
+const deleteFromStore = (
+  store: Map<string, WorkoutRecord>,
+  pid: string
+): void => {
+  for (const [k, w] of store) if (w.profileId === pid) store.delete(k);
+};
+
+export const buildStubWorkoutRepo = (
+  rows: WorkoutRecord[] = []
+): StubWorkoutRepo => {
+  const store = new Map(rows.map((r) => [r.id, r]));
+  let next: WorkoutRecord | undefined;
+  return {
+    getById: async (id) => store.get(id),
+    getByDateRange: async () => [...store.values()],
+    getByState: async () => [],
+    getBySourceId: async () => next,
+    put: async (w) => void store.set(w.id, w),
+    delete: async (id) => void store.delete(id),
+    deleteByProfile: async (pid) => deleteFromStore(store, pid),
+    setSourceLookup: (w) => {
+      next = w;
+    },
+  };
+};

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity.ts
@@ -45,6 +45,7 @@ const buildRawWorkout = (
   now: string
 ): WorkoutRecord => ({
   id,
+  profileId: activity.profileId,
   date: activity.date,
   sport: activity.sport,
   source: activity.source,

--- a/packages/workout-spa-editor/src/application/library/schedule-template.test.ts
+++ b/packages/workout-spa-editor/src/application/library/schedule-template.test.ts
@@ -5,6 +5,8 @@ import { addTemplate } from "./add-template";
 import { scheduleTemplate } from "./schedule-template";
 import { makeKrd } from "./test-fixtures";
 
+const PROFILE_ID = "00000000-0000-4000-8000-0000000000aa";
+
 describe("scheduleTemplate", () => {
   it("should create a workout record from the template on the given date", async () => {
     // Arrange
@@ -21,6 +23,7 @@ describe("scheduleTemplate", () => {
     const record = await scheduleTemplate(persistence, {
       templateId: template.id,
       date: "2026-05-04",
+      profileId: PROFILE_ID,
     });
 
     // Assert
@@ -30,6 +33,7 @@ describe("scheduleTemplate", () => {
     expect(record.state).toBe("structured");
     expect(record.krd).toEqual(template.krd);
     expect(record.tags).toEqual(["tempo", "z3"]);
+    expect(record.profileId).toBe(PROFILE_ID);
   });
 
   it("should persist the workout via PersistencePort.workouts.put", async () => {
@@ -44,6 +48,7 @@ describe("scheduleTemplate", () => {
     const record = await scheduleTemplate(persistence, {
       templateId: template.id,
       date: "2026-05-05",
+      profileId: PROFILE_ID,
     });
 
     // Act
@@ -51,6 +56,7 @@ describe("scheduleTemplate", () => {
 
     // Assert
     expect(stored).toEqual(record);
+    expect(stored?.profileId).toBe(PROFILE_ID);
   });
 
   it("should throw when the template id is unknown", async () => {
@@ -64,6 +70,7 @@ describe("scheduleTemplate", () => {
       scheduleTemplate(persistence, {
         templateId: "missing",
         date: "2026-05-04",
+        profileId: PROFILE_ID,
       })
     ).rejects.toThrow(/Template not found/);
   });
@@ -81,6 +88,7 @@ describe("scheduleTemplate", () => {
       scheduleTemplate(persistence, {
         templateId: template.id,
         date: "2026-05-04",
+        profileId: PROFILE_ID,
       })
     ).rejects.toThrow("simulated");
   });

--- a/packages/workout-spa-editor/src/application/library/schedule-template.ts
+++ b/packages/workout-spa-editor/src/application/library/schedule-template.ts
@@ -15,28 +15,31 @@ import type { WorkoutTemplate } from "../../types/workout-library";
 export type ScheduleTemplateInput = {
   templateId: string;
   date: string;
+  profileId: string;
 };
 
 export const scheduleTemplate = async (
   persistence: PersistencePort,
-  { templateId, date }: ScheduleTemplateInput
+  { templateId, date, profileId }: ScheduleTemplateInput
 ): Promise<WorkoutRecord> => {
   const template = await persistence.templates.getById(templateId);
   if (!template) {
     throw new Error(`Template not found: ${templateId}`);
   }
-  const record = createWorkoutFromTemplate(template, date);
+  const record = createWorkoutFromTemplate(template, date, profileId);
   await persistence.workouts.put(record);
   return record;
 };
 
 function createWorkoutFromTemplate(
   template: WorkoutTemplate,
-  date: string
+  date: string,
+  profileId: string
 ): WorkoutRecord {
   const now = new Date().toISOString();
   return {
     id: crypto.randomUUID(),
+    profileId,
     date,
     sport: template.sport,
     source: "kaiord",

--- a/packages/workout-spa-editor/src/application/profile/delete-profile-with-cascade.test.ts
+++ b/packages/workout-spa-editor/src/application/profile/delete-profile-with-cascade.test.ts
@@ -20,8 +20,9 @@ import { deleteProfileWithCascade } from "./delete-profile-with-cascade";
 
 const NOW = "2026-04-28T10:00:00.000Z";
 
-const makeWorkout = (id: string): WorkoutRecord => ({
+const makeWorkout = (id: string, profileId: string = "p1"): WorkoutRecord => ({
   id,
+  profileId,
   date: "2026-04-13",
   sport: "cycling",
   source: "train2go",
@@ -59,6 +60,7 @@ const makeRecord = (
 const makeDeps = (
   overrides: Partial<DeleteProfileWithCascadeDeps> = {}
 ): DeleteProfileWithCascadeDeps => ({
+  workouts: overrides.workouts ?? createInMemoryWorkoutRepository(),
   coaching: overrides.coaching ?? createInMemoryCoachingRepository(),
   coachingSyncState:
     overrides.coachingSyncState ?? createInMemoryCoachingSyncStateRepository(),
@@ -127,17 +129,18 @@ describe("deleteProfileWithCascade", () => {
     ).toBeDefined();
   });
 
-  it("should do NOT cascade to converted WorkoutRecord rows (workouts survive)", async () => {
+  it("should cascade delete the deleted profile's workouts and preserve other profiles' workouts", async () => {
     // Arrange
     const coaching = createInMemoryCoachingRepository();
     const coachingSyncState = createInMemoryCoachingSyncStateRepository();
     const workouts = createInMemoryWorkoutRepository();
-    await workouts.put(makeWorkout("w1"));
+    await workouts.put(makeWorkout("w1", "p1"));
+    await workouts.put(makeWorkout("w2", "p2"));
     await coaching.upsertMany([makeRecord("p1", "1")]);
 
     // Act
     await deleteProfileWithCascade(
-      makeDeps({ coaching, coachingSyncState }),
+      makeDeps({ coaching, coachingSyncState, workouts }),
       "p1"
     );
 
@@ -145,7 +148,8 @@ describe("deleteProfileWithCascade", () => {
     expect(
       await coaching.getByProfileAndDateRange("p1", "2026-01-01", "2026-12-31")
     ).toHaveLength(0);
-    expect(await workouts.getById("w1")).toBeDefined();
+    expect(await workouts.getById("w1")).toBeUndefined();
+    expect(await workouts.getById("w2")).toBeDefined();
   });
 
   it("should use the supplied id (NOT getActiveId)", async () => {

--- a/packages/workout-spa-editor/src/application/profile/delete-profile-with-cascade.ts
+++ b/packages/workout-spa-editor/src/application/profile/delete-profile-with-cascade.ts
@@ -6,15 +6,17 @@
  * argument's `deletedProfileId` — NEVER `getActiveId()` (would race when
  * deleting a non-active profile or right after a switch).
  *
- * The cascade covers every per-profile repository: coaching activities,
- * coaching sync state, session matches, auto-match dismissals, and user
- * preferences. Each repository's deletion method is called once with the
- * deleted profile id.
+ * The cascade covers every per-profile repository: workouts, coaching
+ * activities, coaching sync state, session matches, auto-match
+ * dismissals, and user preferences. Each repository's deletion method
+ * is called once with the deleted profile id. As of Dexie v13 workouts
+ * are profile-scoped 1–1 (see `dexie-v13-migration.ts`), so they are
+ * included in the cascade — `isPerProfileTable` also auto-discovers
+ * them at delete time.
  *
- * Profile-agnostic data (workouts, templates, AI providers, usage, sync
- * state, meta) is NOT cascaded — those rows are user-owned across profile
- * boundaries by design (per spec "Profile delete preserves converted
- * workouts" and "AI providers are profile-agnostic").
+ * Profile-agnostic data (templates, AI providers, usage, sync state,
+ * meta) is NOT cascaded — those rows are user-owned across profile
+ * boundaries by design ("AI providers are profile-agnostic", etc.).
  *
  * Atomicity: this use case does NOT open its own transaction. The caller
  * MUST wrap both this call and the subsequent `deleteProfile` invocation
@@ -27,11 +29,13 @@ import type { AutoMatchDismissalRepository } from "../../ports/auto-match-dismis
 import type {
   CoachingRepository,
   CoachingSyncStateRepository,
+  WorkoutRepository,
 } from "../../ports/persistence-port";
 import type { SessionMatchRepository } from "../../ports/session-match-repository";
 import type { UserPreferencesRepository } from "../../ports/user-preferences-repository";
 
 export type DeleteProfileWithCascadeDeps = {
+  workouts: WorkoutRepository;
   coaching: CoachingRepository;
   coachingSyncState: CoachingSyncStateRepository;
   sessionMatch: SessionMatchRepository;
@@ -44,6 +48,7 @@ export const deleteProfileWithCascade = async (
   deletedProfileId: string
 ): Promise<void> => {
   await Promise.all([
+    deps.workouts.deleteByProfile(deletedProfileId),
     deps.coaching.deleteByProfile(deletedProfileId),
     deps.coachingSyncState.deleteByProfile(deletedProfileId),
     deps.sessionMatch.deleteByProfile(deletedProfileId),

--- a/packages/workout-spa-editor/src/application/profile/delete-profile.cascade.integration.test.ts
+++ b/packages/workout-spa-editor/src/application/profile/delete-profile.cascade.integration.test.ts
@@ -99,6 +99,28 @@ const makeSeedRow = (
           },
         ],
       };
+    case "workouts":
+      return {
+        id,
+        profileId,
+        date: WEEK_START,
+        sport: "cycling",
+        source: "kaiord",
+        sourceId: null,
+        planId: null,
+        state: "raw",
+        raw: null,
+        krd: null,
+        lastProcessingError: null,
+        feedback: null,
+        aiMeta: null,
+        garminPushId: null,
+        tags: [],
+        previousState: null,
+        createdAt: NOW,
+        modifiedAt: null,
+        updatedAt: NOW,
+      };
     default:
       // Catch-all keeps the test honest: a new per-profile table without a
       // seed entry produces an obviously-broken row that the put will reject,
@@ -117,6 +139,7 @@ const performCascadeOrchestration = async (
   await persistence.transaction(async () => {
     await deleteProfileWithCascade(
       {
+        workouts: persistence.workouts,
         coaching: persistence.coaching,
         coachingSyncState: persistence.coachingSyncState,
         sessionMatch: persistence.sessionMatch,
@@ -164,6 +187,7 @@ describe("deleteProfile cascade fan-out (integration)", () => {
         "coachingSyncState",
         "sessionMatches",
         "userPreferences",
+        "workouts",
       ])
     );
     const A = "00000000-0000-4000-8000-0000000000a1";

--- a/packages/workout-spa-editor/src/application/test-helpers.ts
+++ b/packages/workout-spa-editor/src/application/test-helpers.ts
@@ -12,6 +12,7 @@ export function makeWorkoutRecord(
 ): WorkoutRecord {
   return {
     id: "550e8400-e29b-41d4-a716-446655440000",
+    profileId: "550e8400-e29b-41d4-a716-446655440001",
     date: "2025-01-15",
     sport: "running",
     source: "train2go",

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-state.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-state.test.tsx
@@ -39,6 +39,7 @@ const activity: CoachingActivity = {
 const makeWorkout = (id: string): WorkoutRecord =>
   ({
     id,
+    profileId: PROFILE_ID,
     date: "2026-04-13",
     sport: "cycling",
     source: "train2go",

--- a/packages/workout-spa-editor/src/components/molecules/EmptyDayDialog/EmptyDayDialog.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/EmptyDayDialog/EmptyDayDialog.test.tsx
@@ -27,10 +27,23 @@ function renderWithRouter(ui: React.ReactNode, path = "/calendar") {
   };
 }
 
+const PROFILE_ID = "00000000-0000-4000-8000-0000000000e1";
+
 describe("EmptyDayDialog", () => {
   beforeEach(async () => {
     await db.table("templates").clear();
     await db.table("workouts").clear();
+    await db.table("profiles").clear();
+    await db.table("meta").clear();
+    await db.table("profiles").put({
+      id: PROFILE_ID,
+      name: "Tester",
+      sportZones: {},
+      linkedAccounts: [],
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    });
+    await db.table("meta").put({ key: "activeProfileId", value: PROFILE_ID });
   });
 
   it("should render dialog when date is provided (open)", () => {

--- a/packages/workout-spa-editor/src/components/molecules/EmptyDayDialog/EmptyDayDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/EmptyDayDialog/EmptyDayDialog.tsx
@@ -18,6 +18,7 @@ import { useLocation } from "wouter";
 import { scheduleTemplate } from "../../../application/library/schedule-template";
 import { usePersistence } from "../../../contexts/persistence-context";
 import { useToastContext } from "../../../contexts/ToastContext";
+import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import { TemplatePickerDialog } from "../TemplatePickerDialog";
 import { EmptyDayChoices } from "./EmptyDayChoices";
 
@@ -35,6 +36,7 @@ export function EmptyDayDialog({ date, onClose }: EmptyDayDialogProps) {
   const [, navigate] = useLocation();
   const persistence = usePersistence();
   const toast = useToastContext();
+  const profileId = useActiveProfileLive()?.id ?? null;
   const [pickerOpen, setPickerOpen] = useState(false);
   const isOpen = date !== null;
 
@@ -44,8 +46,8 @@ export function EmptyDayDialog({ date, onClose }: EmptyDayDialogProps) {
   };
 
   const handlePick = (templateId: string) => {
-    if (!date) return;
-    void scheduleTemplate(persistence, { templateId, date })
+    if (!date || !profileId) return;
+    void scheduleTemplate(persistence, { templateId, date, profileId })
       .then(() => {
         toast.success(TOAST_SCHEDULE_OK_TITLE, TOAST_SCHEDULE_OK_DESC);
         setPickerOpen(false);

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileDelete.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileDelete.ts
@@ -2,9 +2,10 @@
  * useProfileDelete Hook
  *
  * Profile deletion with full cascade fan-out. The cascade clears all
- * profile-scoped persistence (coaching activities, coaching sync state,
- * session matches, auto-match dismissals, user preferences) BEFORE the
- * profile row itself is removed via `deleteProfile`. The whole flow runs
+ * profile-scoped persistence (workouts, coaching activities, coaching
+ * sync state, session matches, auto-match dismissals, user preferences)
+ * BEFORE the profile row itself is removed via `deleteProfile`. The
+ * whole flow runs
  * inside `persistence.transaction(...)` so a mid-cascade crash leaves the
  * database in the pre-delete state. `deletedProfileId` is captured at
  * confirm time — NEVER `getActiveId()` (would race when deleting a
@@ -44,6 +45,7 @@ export function useProfileDelete(params: UseProfileDeleteParams) {
         await persistence.transaction(async () => {
           await deleteProfileWithCascade(
             {
+              workouts: persistence.workouts,
               coaching: persistence.coaching,
               coachingSyncState: persistence.coachingSyncState,
               sessionMatch: persistence.sessionMatch,

--- a/packages/workout-spa-editor/src/components/pages/CalendarPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPage.test.tsx
@@ -12,9 +12,12 @@ import type { WorkoutRecord } from "../../types/calendar-record";
 import { AppToastProvider } from "../providers/AppToastProvider";
 import CalendarPage from "./CalendarPage";
 
+const PROFILE_ID = "00000000-0000-4000-8000-0000000000c1";
+
 function makeWorkout(overrides: Partial<WorkoutRecord> = {}): WorkoutRecord {
   return {
     id: crypto.randomUUID(),
+    profileId: PROFILE_ID,
     date: "2026-04-06",
     sport: "running",
     source: "kaiord",
@@ -68,6 +71,17 @@ function renderCalendar(path = "/calendar/2026-W15") {
 describe("CalendarPage", () => {
   beforeEach(async () => {
     await db.table("workouts").clear();
+    await db.table("profiles").clear();
+    await db.table("meta").clear();
+    await db.table("profiles").put({
+      id: PROFILE_ID,
+      name: "Tester",
+      sportZones: {},
+      linkedAccounts: [],
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    });
+    await db.table("meta").put({ key: "activeProfileId", value: PROFILE_ID });
   });
 
   it("should show first-visit state when no workouts exist", async () => {

--- a/packages/workout-spa-editor/src/components/pages/LibraryPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/LibraryPage.test.tsx
@@ -60,11 +60,24 @@ const ACTIVE_KRD: KRD = {
   },
 };
 
+const PROFILE_ID = "00000000-0000-4000-8000-0000000000d1";
+
 describe("LibraryPage", () => {
   beforeEach(async () => {
     useWorkoutStore.setState({ currentWorkout: null });
     await db.table("templates").clear();
     await db.table("workouts").clear();
+    await db.table("profiles").clear();
+    await db.table("meta").clear();
+    await db.table("profiles").put({
+      id: PROFILE_ID,
+      name: "Tester",
+      sportZones: {},
+      linkedAccounts: [],
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    });
+    await db.table("meta").put({ key: "activeProfileId", value: PROFILE_ID });
   });
 
   afterEach(() => {
@@ -205,6 +218,7 @@ describe("LibraryPage", () => {
       expect(workouts[0].source).toBe("kaiord");
       expect(workouts[0].state).toBe("structured");
       expect(workouts[0].krd).not.toBeNull();
+      expect(workouts[0].profileId).toBe(PROFILE_ID);
     });
   });
 

--- a/packages/workout-spa-editor/src/components/pages/calendar-hooks.ts
+++ b/packages/workout-spa-editor/src/components/pages/calendar-hooks.ts
@@ -35,7 +35,7 @@ export type CalendarData = {
   rawCount: number;
 };
 
-export function useCalendarData(): CalendarData {
+export function useCalendarData(profileId: string | null): CalendarData {
   const params = useParams<{ weekId?: string }>();
   const [hydration, setHydration] = useState<HydrationStatus>("pending");
 
@@ -50,12 +50,15 @@ export function useCalendarData(): CalendarData {
   const range = useMemo(() => parseWeekId(weekId), [weekId]);
 
   const workouts = useLiveQuery(async (): Promise<WorkoutRecord[]> => {
-    if (!range) return [];
+    if (!range || !profileId) {
+      setHydration("complete");
+      return [];
+    }
     try {
       const result = await db
         .table<WorkoutRecord>("workouts")
-        .where("date")
-        .between(range.start, range.end, true, true)
+        .where("[profileId+date]")
+        .between([profileId, range.start], [profileId, range.end], true, true)
         .toArray();
       setHydration("complete");
       return result;
@@ -63,11 +66,14 @@ export function useCalendarData(): CalendarData {
       setHydration("failed");
       return [];
     }
-  }, [range?.start, range?.end]);
+  }, [profileId, range?.start, range?.end]);
 
   const totalWorkoutCount = useLiveQuery(
-    () => db.table("workouts").count(),
-    []
+    async () =>
+      profileId
+        ? db.table("workouts").where("profileId").equals(profileId).count()
+        : 0,
+    [profileId]
   );
 
   const workoutsByDay = useMemo(

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-page.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-page.test.tsx
@@ -58,10 +58,12 @@ const seedActivity = (date: string): CoachingActivityRecord => ({
 const seedWorkout = (
   date: string,
   durationSeconds: number = ONE_HOUR_SECONDS,
-  id = "w-1"
+  id = "w-1",
+  profileId: string = PROFILE_ID
 ): WorkoutRecord =>
   ({
     id,
+    profileId,
     date,
     sport: "cycling",
     source: "manual",
@@ -165,7 +167,7 @@ describe("useCalendarPage", () => {
     expect(result.current.suggestions[0]!.workoutId).toBe("w-1");
   });
 
-  it("should fall back to a ready state with no suggestions when no profile is active", async () => {
+  it("should fall back to a ready state with no suggestions and an empty calendar when no profile is active", async () => {
     // Arrange
     await setActiveProfile(null);
     await db
@@ -184,6 +186,34 @@ describe("useCalendarPage", () => {
     if (result.current.state !== "ready") throw new Error("not ready");
     expect(result.current.suggestions).toEqual([]);
     expect(result.current.density).toBeUndefined();
-    expect(result.current.buckets.soloActualsByDay[MONDAY]).toHaveLength(1);
+    // No active profile → calendar query is empty (profile-scoped read).
+    expect(result.current.buckets.soloActualsByDay[MONDAY] ?? []).toHaveLength(
+      0
+    );
+  });
+
+  it("should isolate workouts to the active profile (cross-profile leak regression)", async () => {
+    // Arrange
+    const OTHER = "00000000-0000-4000-8000-0000000000b2";
+    await setActiveProfile(makeProfile());
+    await db
+      .table("workouts")
+      .put(seedWorkout(MONDAY, ONE_HOUR_SECONDS, "w-mine", PROFILE_ID));
+    await db
+      .table("workouts")
+      .put(seedWorkout(MONDAY, ONE_HOUR_SECONDS, "w-other", OTHER));
+
+    // Act
+    const { result } = renderHook(() => useCalendarPage(), {
+      wrapper: ({ children }) => wrap(children),
+    });
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.state).toBe("ready");
+    });
+    if (result.current.state !== "ready") throw new Error("not ready");
+    const mondayCards = result.current.buckets.soloActualsByDay[MONDAY] ?? [];
+    expect(mondayCards.map((w) => w.id)).toEqual(["w-mine"]);
   });
 });

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-state.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-state.ts
@@ -8,13 +8,27 @@ import { useLocation } from "wouter";
 
 import { db } from "../../adapters/dexie/dexie-database";
 import { useGarminBridge } from "../../contexts";
+import { useActiveProfileLive } from "../../hooks/use-active-profile-live";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import { getWeekIdForDate } from "../../utils/week-utils";
 import { useCalendarData } from "./calendar-hooks";
 import { useBatchState } from "./use-batch-state";
 
+const fetchLatestWorkout = async (
+  profileId: string | null
+): Promise<WorkoutRecord | undefined> => {
+  if (!profileId) return undefined;
+  const rows = await db
+    .table<WorkoutRecord>("workouts")
+    .where("profileId")
+    .equals(profileId)
+    .sortBy("date");
+  return rows.at(-1);
+};
+
 export function useCalendarState() {
-  const data = useCalendarData();
+  const profileId = useActiveProfileLive()?.id ?? null;
+  const data = useCalendarData(profileId);
   const [, navigate] = useLocation();
   const { extensionInstalled } = useGarminBridge();
   const [selectedWorkout, setSelectedWorkout] = useState<WorkoutRecord | null>(
@@ -24,8 +38,8 @@ export function useCalendarState() {
   const batch = useBatchState(data.weekStart, data.weekEnd);
 
   const latestWorkout = useLiveQuery(
-    () => db.table<WorkoutRecord>("workouts").orderBy("date").last(),
-    []
+    () => fetchLatestWorkout(profileId),
+    [profileId]
   );
 
   const aiProviderCount = useLiveQuery(

--- a/packages/workout-spa-editor/src/components/pages/use-schedule-template.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-schedule-template.ts
@@ -7,16 +7,19 @@
 import { useCallback, useState } from "react";
 
 import { db } from "../../adapters/dexie/dexie-database";
+import { useActiveProfileLive } from "../../hooks/use-active-profile-live";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { WorkoutTemplate } from "../../types/workout-library";
 
 function createWorkoutFromTemplate(
   template: WorkoutTemplate,
-  date: string
+  date: string,
+  profileId: string
 ): WorkoutRecord {
   const now = new Date().toISOString();
   return {
     id: crypto.randomUUID(),
+    profileId,
     date,
     sport: template.sport,
     source: "kaiord",
@@ -39,6 +42,7 @@ function createWorkoutFromTemplate(
 
 export function useScheduleTemplate() {
   const [scheduling, setScheduling] = useState<WorkoutTemplate | null>(null);
+  const profileId = useActiveProfileLive()?.id ?? null;
 
   const openScheduler = useCallback((template: WorkoutTemplate) => {
     setScheduling(template);
@@ -50,12 +54,12 @@ export function useScheduleTemplate() {
 
   const confirmSchedule = useCallback(
     async (date: string) => {
-      if (!scheduling) return;
-      const record = createWorkoutFromTemplate(scheduling, date);
+      if (!scheduling || !profileId) return;
+      const record = createWorkoutFromTemplate(scheduling, date, profileId);
       await db.table("workouts").put(record);
       setScheduling(null);
     },
-    [scheduling]
+    [scheduling, profileId]
   );
 
   return { scheduling, openScheduler, closeScheduler, confirmSchedule };

--- a/packages/workout-spa-editor/src/hooks/use-auto-match-suggestions.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/use-auto-match-suggestions.test.tsx
@@ -30,6 +30,7 @@ const seedActivity = (
 const seedWorkout = (date: string, duration = 3600): WorkoutRecord =>
   ({
     id: "w-1",
+    profileId: "p1",
     date,
     sport: "cycling",
     source: "manual",

--- a/packages/workout-spa-editor/src/ports/persistence-port.ts
+++ b/packages/workout-spa-editor/src/ports/persistence-port.ts
@@ -7,8 +7,6 @@
 
 import type { LlmProviderConfig } from "../store/ai-store-types";
 import type { SyncState } from "../types/bridge-schemas";
-import type { WorkoutState } from "../types/calendar-enums";
-import type { WorkoutRecord } from "../types/calendar-schemas";
 import type { Profile } from "../types/profile";
 import type { UsageRecord } from "../types/usage-schemas";
 import type { WorkoutTemplate } from "../types/workout-library";
@@ -19,6 +17,7 @@ import type {
 } from "./coaching-repositories";
 import type { SessionMatchRepository } from "./session-match-repository";
 import type { UserPreferencesRepository } from "./user-preferences-repository";
+import type { WorkoutRepository } from "./workout-repository";
 
 export type { AutoMatchDismissalRepository } from "./auto-match-dismissal-repository";
 export type {
@@ -27,18 +26,7 @@ export type {
 } from "./coaching-repositories";
 export type { SessionMatchRepository } from "./session-match-repository";
 export type { UserPreferencesRepository } from "./user-preferences-repository";
-
-export type WorkoutRepository = {
-  getById: (id: string) => Promise<WorkoutRecord | undefined>;
-  getByDateRange: (start: string, end: string) => Promise<WorkoutRecord[]>;
-  getByState: (state: WorkoutState) => Promise<WorkoutRecord[]>;
-  getBySourceId: (
-    source: string,
-    sourceId: string
-  ) => Promise<WorkoutRecord | undefined>;
-  put: (workout: WorkoutRecord) => Promise<void>;
-  delete: (id: string) => Promise<void>;
-};
+export type { WorkoutRepository } from "./workout-repository";
 
 export type TemplateRepository = {
   getAll: () => Promise<WorkoutTemplate[]>;

--- a/packages/workout-spa-editor/src/ports/workout-repository.ts
+++ b/packages/workout-spa-editor/src/ports/workout-repository.ts
@@ -1,0 +1,22 @@
+/**
+ * Workout Repository Port
+ *
+ * Hexagonal port for workout persistence. As of Dexie v13 workouts are
+ * profile-scoped 1–1; `deleteByProfile` is the cascade entry point.
+ */
+
+import type { WorkoutState } from "../types/calendar-enums";
+import type { WorkoutRecord } from "../types/calendar-schemas";
+
+export type WorkoutRepository = {
+  getById: (id: string) => Promise<WorkoutRecord | undefined>;
+  getByDateRange: (start: string, end: string) => Promise<WorkoutRecord[]>;
+  getByState: (state: WorkoutState) => Promise<WorkoutRecord[]>;
+  getBySourceId: (
+    source: string,
+    sourceId: string
+  ) => Promise<WorkoutRecord | undefined>;
+  put: (workout: WorkoutRecord) => Promise<void>;
+  delete: (id: string) => Promise<void>;
+  deleteByProfile: (profileId: string) => Promise<void>;
+};

--- a/packages/workout-spa-editor/src/test-utils/in-memory-persistence.test.ts
+++ b/packages/workout-spa-editor/src/test-utils/in-memory-persistence.test.ts
@@ -30,6 +30,7 @@ function makeKrd(): KRD {
 function makeWorkout(overrides: Partial<WorkoutRecord> = {}): WorkoutRecord {
   return {
     id: "w-1",
+    profileId: PROFILE_UUID_1,
     date: "2026-04-07",
     sport: "cycling",
     source: "kaiord",

--- a/packages/workout-spa-editor/src/test-utils/in-memory-workout-repository.ts
+++ b/packages/workout-spa-editor/src/test-utils/in-memory-workout-repository.ts
@@ -33,5 +33,11 @@ export function createInMemoryWorkoutRepository(
     delete: async (id) => {
       store.delete(id);
     },
+
+    deleteByProfile: async (profileId) => {
+      for (const [id, w] of store) {
+        if (w.profileId === profileId) store.delete(id);
+      }
+    },
   };
 }

--- a/packages/workout-spa-editor/src/types/calendar-record.ts
+++ b/packages/workout-spa-editor/src/types/calendar-record.ts
@@ -16,6 +16,10 @@ import { krdSchema } from "./schemas";
 
 export const workoutRecordSchema = z.object({
   id: z.uuid(),
+  // profileId scopes each workout to exactly one user profile. Added in
+  // Dexie v13; backfilled from `meta.activeProfileId` for legacy rows.
+  // Every writer MUST set this from the active profile at write time.
+  profileId: z.string().min(1),
   date: z.iso.date(),
   sport: z.string(),
   source: z.string(),

--- a/packages/workout-spa-editor/src/types/calendar-schemas.test.ts
+++ b/packages/workout-spa-editor/src/types/calendar-schemas.test.ts
@@ -300,6 +300,7 @@ describe("aiMetaSchema", () => {
 describe("workoutRecordSchema", () => {
   const validRecord = {
     id: "550e8400-e29b-41d4-a716-446655440000",
+    profileId: "550e8400-e29b-41d4-a716-446655440001",
     date: "2025-01-15",
     sport: "running",
     source: "train2go",
@@ -358,6 +359,28 @@ describe("workoutRecordSchema", () => {
     // Assert
     expect(() =>
       workoutRecordSchema.parse({ ...validRecord, state: "archived" })
+    ).toThrow();
+  });
+
+  it("should reject a missing profileId", () => {
+    // Arrange
+    const { profileId: _omit, ...without } = validRecord;
+    void _omit;
+
+    // Act
+
+    // Assert
+    expect(() => workoutRecordSchema.parse(without)).toThrow();
+  });
+
+  it("should reject an empty profileId", () => {
+    // Arrange
+
+    // Act
+
+    // Assert
+    expect(() =>
+      workoutRecordSchema.parse({ ...validRecord, profileId: "" })
     ).toThrow();
   });
 


### PR DESCRIPTION
## Summary

Makes `WorkoutRecord` profile-scoped 1–1 to stop two symptoms:

1. Profile deletion leaves orphaned structured workouts in the calendar.
2. Switching active profile shows leaked workouts from other profiles.

Implemented from the crystallized spec (`.omc/specs/deep-dive-profile-delete-leaks-and-cross-mix.md`) — backed by the 3-lane causal trace (`.omc/specs/deep-dive-trace-profile-delete-leaks-and-cross-mix.md`).

## Locked decisions (honored)

- `WorkoutRecord` gains non-null `profileId: string` (Zod `min(1)`).
- Dexie v12 → v13 backfills every legacy row from `meta.activeProfileId`; **throws a descriptive error if the active profile id is missing while workouts exist** (no silent fallback chain).
- `deleteProfileWithCascade` now calls `workouts.deleteByProfile(profileId)` inside the existing transaction; the cascade integration test auto-discovers the workouts table via `isPerProfileTable` because the new `profileId` index satisfies the predicate.

## Changes

Three atomic commits:

1. **Dexie v13 schema + migration + port + adapter** — `profileId` + `[profileId+date]` indexes; `applyV13Upgrade`; `WorkoutRepository.deleteByProfile`; type extracted to `ports/workout-repository.ts`.
2. **Write path** — every workout writer now sets `profileId` at create time (coaching converts reuse `activity.profileId`; `scheduleTemplate` takes `profileId` as input; `EmptyDayDialog` + `useScheduleTemplate` read from `useActiveProfileLive`).
3. **Read path + cascade** — `useCalendarData` filters by `[profileId+date]`; `useCalendarState` threads the active profileId; `deleteProfileWithCascade` cascades to workouts; cross-profile-leak regression test added to `useCalendarPage`.

## Acceptance criteria

- [x] **A1** — `workoutRecordSchema` requires `profileId: z.string().min(1)`. Dexie v13 indexes `profileId` and `[profileId+date]`.
- [x] **A2** — v13 migration backfills `profileId = meta.activeProfileId`. Idempotent. Throws when activeProfileId missing and workouts exist.
- [x] **A3** — Every writer (`convertCoachingActivity`, `convertCoachingActivityWithAi`, `convertCoachingActivityManual`, `scheduleTemplate`) sets `profileId`. Adapter tests assert this via `schedule-template.test.ts` and `LibraryPage.test.tsx`.
- [x] **A4** — `useCalendarData(profileId)` uses `where("[profileId+date]").between(...)`; bucket logic unchanged.
- [x] **A5** — `deleteProfileWithCascade` includes `workouts.deleteByProfile`. `delete-profile.cascade.integration.test.ts` auto-validates the workouts table.
- [x] **A6** — Cross-profile isolation regression test: `useCalendarPage` only surfaces workouts for the active profile when two profiles have workouts on the same day.
- [x] **A7** — All 3884 existing tests pass after fixture updates.
- [x] **A8** — `pnpm lint` clean. `pnpm test:scripts` clean (419/419). `pnpm -F @kaiord/workout-spa-editor exec tsc --noEmit` clean. `pnpm -F @kaiord/workout-spa-editor exec vitest run` → 433/433 files, 3884/3884 tests.

## Test plan

- [x] `pnpm -F @kaiord/workout-spa-editor test` — 3884 pass
- [x] `pnpm lint` — clean
- [x] `pnpm test:scripts` — 419 pass
- [x] `pnpm -F @kaiord/workout-spa-editor exec tsc --noEmit` — clean
- [x] `pnpm -F @kaiord/workout-spa-editor build` — clean
- [ ] Manual smoke: open SPA on a DB with workouts but no active profile (degenerate) — confirm the v13 upgrade aborts with the descriptive error rather than wiping data silently.
- [ ] Manual smoke: create two profiles, schedule workouts under each, switch active profile — confirm the calendar shows only the active profile's workouts.
- [ ] Manual smoke: delete a profile with workouts — confirm the workouts are removed from IndexedDB and the calendar.

## Out of scope (per spec)

- Workout sharing / move-to-profile UI.
- Templates, AI providers, sync state (remain user-owned across profiles).
- Per-profile usage counters.
- Telemetry on cross-profile leakage.
- Backwards-compat shims for the legacy "profile-agnostic" workout path.

## References

- Spec: `.omc/specs/deep-dive-profile-delete-leaks-and-cross-mix.md`
- Trace: `.omc/specs/deep-dive-trace-profile-delete-leaks-and-cross-mix.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workouts are now profile-scoped; repositories support deleting workouts by profile.

* **Improvements**
  * Calendar, scheduling, coaching, and related UI flows operate per active profile.
  * Profile deletion now cascades to remove associated workouts.

* **Chores**
  * Local DB upgraded to schema v13 with a migration that backfills missing workout profile IDs.

* **Tests**
  * Unit, integration, and e2e tests updated to seed and validate profile-scoped workouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/601)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->