### PR TITLE
fix(ci): split cws-publish into decide/act + typed live-version resolver

### DIFF
--- a/.github/workflows/cws-publish.yml
+++ b/.github/workflows/cws-publish.yml
@@ -95,7 +95,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          # Full history needed; fetch-tags is explicit because some
+          # checkout-action versions ship history without tag refs.
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Resolve current version
         id: version
@@ -124,7 +127,8 @@ jobs:
         run: |
           LIVE_JSON=$(node scripts/cws-api.mjs live-version \
             ${{ secrets[matrix.extension.extension_id_secret] }} \
-            --package ${{ matrix.extension.name }})
+            --package ${{ matrix.extension.name }} \
+            --local ${{ steps.version.outputs.current }})
           # Persist the entire JSON payload as a single output for downstream
           # decision branching; individual fields are also surfaced for
           # readability in step logs.
@@ -338,7 +342,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          # Full history needed; fetch-tags is explicit because some
+          # checkout-action versions ship history without tag refs.
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Resolve current version
         id: version

--- a/.github/workflows/cws-publish.yml
+++ b/.github/workflows/cws-publish.yml
@@ -16,6 +16,11 @@ on:
         type: boolean
         required: false
         default: false
+      dry_run:
+        description: "Run decide/summary only; do not upload or publish (workflow_dispatch only)"
+        type: boolean
+        required: false
+        default: false
 
 # Top-level concurrency: prevents two workflow runs (push vs dispatch)
 # from racing on the same ref. Job-level cws-issue-writer concurrency
@@ -58,13 +63,22 @@ jobs:
           node scripts/cws-notify-issue.mjs cws-auth-broken "" \
             "Pre-flight failed at $(date -u +%FT%TZ). See workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-  publish:
-    name: Publish ${{ matrix.extension.name }}
+      - name: Write summary header
+        if: always()
+        run: |
+          {
+            echo "## CWS Publish Status"
+            echo ""
+            echo "| Extension | Local | Draft | Git tag | API PUBLISHED | Status | Warnings |"
+            echo "|---|---|---|---|---|---|---|"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  decide:
+    name: Decide ${{ matrix.extension.name }}
     runs-on: ubuntu-latest
-    # n=14 across both matrix entries (<20 successful runs) → fall back to
-    # test-family ceiling 30. wait-uploaded (60s) + wait-published (120s) +
-    # CWS API jitter all comfortably fit under this.
-    timeout-minutes: 30
+    # Read-only path: tag lookup + two CWS getItem calls + a few jq invocations.
+    # Comfortably under lint-family ceiling 10.
+    timeout-minutes: 10
     needs: pre-flight
     concurrency:
       group: cws-issue-writer
@@ -90,18 +104,12 @@ jobs:
           CURRENT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('packages/$EXT/package.json','utf8')).version)")
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
 
-      - name: Setup pnpm
-        uses: ./.github/actions/setup-pnpm
-
-      - name: Sync manifest versions
-        run: node scripts/sync-extension-version.mjs ${{ matrix.extension.name }}
-
-      - name: Package extension
-        run: bash scripts/package-extension.sh ${{ matrix.extension.name }}
-
-      - name: Query CWS state (skipped on force_upload)
+      # The decide job replaces the legacy "DRAFT response carries crxVersion of
+      # the live item" heuristic. The live-version subcommand combines git tag
+      # (canonical, per Principle #1) with projection=PUBLISHED verification;
+      # the DRAFT projection's crxVersion is no longer treated as authoritative.
+      - name: Query CWS DRAFT state
         id: state
-        if: ${{ inputs.force_upload != true }}
         env:
           CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
         run: |
@@ -109,31 +117,301 @@ jobs:
           echo "draft_version=$(echo "$STATE" | jq -r '.crxVersion // ""')" >> "$GITHUB_OUTPUT"
           echo "draft_upload_state=$(echo "$STATE" | jq -r '.uploadState // ""')" >> "$GITHUB_OUTPUT"
 
-      - name: Decide upload/publish skip
+      - name: Resolve live version (combined source-of-truth)
+        id: live
+        env:
+          CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
+        run: |
+          LIVE_JSON=$(node scripts/cws-api.mjs live-version \
+            ${{ secrets[matrix.extension.extension_id_secret] }} \
+            --package ${{ matrix.extension.name }})
+          # Persist the entire JSON payload as a single output for downstream
+          # decision branching; individual fields are also surfaced for
+          # readability in step logs.
+          {
+            echo "json<<LIVE_EOF"
+            echo "$LIVE_JSON"
+            echo "LIVE_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "status=$(echo "$LIVE_JSON" | jq -r '.status')" >> "$GITHUB_OUTPUT"
+          echo "version=$(echo "$LIVE_JSON" | jq -r '.version // ""')" >> "$GITHUB_OUTPUT"
+          echo "source=$(echo "$LIVE_JSON" | jq -r '.source // ""')" >> "$GITHUB_OUTPUT"
+          echo "warnings_json=$(echo "$LIVE_JSON" | jq -c '.warnings // []')" >> "$GITHUB_OUTPUT"
+
+      - name: Compute decision branches
         id: decide
         run: |
           FORCE='${{ inputs.force_upload }}'
-          # crxVersion in the DRAFT projection actually exposes the
-          # currently-PUBLISHED version (CWS API quirk: projection=PUBLISHED
-          # is rejected with 400; DRAFT response carries crxVersion of the
-          # live item). If it equals our local version, there is nothing
-          # to upload or publish.
-          PUBLISHED_VER='${{ steps.state.outputs.draft_version }}'
+          STATUS='${{ steps.live.outputs.status }}'
           CURRENT='${{ steps.version.outputs.current }}'
+          DRAFT_VER='${{ steps.state.outputs.draft_version }}'
           if [ "$FORCE" = "true" ]; then
-            echo "skip_all=false" >> "$GITHUB_OUTPUT"
-            echo "Force-upload requested; ignoring CWS state."
-          elif [ "$PUBLISHED_VER" = "$CURRENT" ]; then
-            echo "skip_all=true" >> "$GITHUB_OUTPUT"
-            echo "CWS already at $CURRENT — no-op success."
+            SKIP_ALL=false
+            TIER_KICK=false
+            REASON="force-upload"
+          elif [ "$STATUS" = "SYNCED" ] && [ "$DRAFT_VER" = "$CURRENT" ]; then
+            SKIP_ALL=true
+            TIER_KICK=false
+            REASON="in-sync"
+          elif [ "$STATUS" = "DRAFT_AHEAD" ]; then
+            SKIP_ALL=false
+            TIER_KICK=false
+            REASON="publish-required"
+          elif [ "$STATUS" = "STUCK_DRAFT" ]; then
+            SKIP_ALL=true
+            TIER_KICK=true
+            REASON="stuck-draft (tier-handler)"
+          elif [ "$STATUS" = "UNTRUSTED_STATE" ]; then
+            SKIP_ALL=true
+            TIER_KICK=false
+            REASON="untrusted (force-dispatch required)"
           else
-            echo "skip_all=false" >> "$GITHUB_OUTPUT"
-            echo "CWS at ${PUBLISHED_VER:-<unknown>}; uploading $CURRENT."
+            # SYNCED but draft != current is a publish-required path too:
+            # the API and tag agree on the live version but the local repo is
+            # ahead and the draft has not been bumped yet.
+            SKIP_ALL=false
+            TIER_KICK=false
+            REASON="publish-required"
           fi
+          echo "skip_all=$SKIP_ALL" >> "$GITHUB_OUTPUT"
+          echo "tier_kick=$TIER_KICK" >> "$GITHUB_OUTPUT"
+          echo "reason=$REASON" >> "$GITHUB_OUTPUT"
+
+      - name: Open cws-untrusted-state issue (idempotent)
+        if: steps.live.outputs.status == 'UNTRUSTED_STATE'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXT="${{ matrix.extension.name }}"
+          TITLE="CWS untrusted state: $EXT"
+          EXISTING=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --limit 20 \
+            | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
+            | head -n 1 || true)
+          if [ -z "$EXISTING" ]; then
+            gh issue create \
+              --title "$TITLE" \
+              --label "cws-untrusted-state-$EXT" \
+              --body "git tag and PUBLISHED projection disagree for $EXT. Force-dispatch with force_upload=true required to resolve after human reconciliation. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          else
+            echo "cws-untrusted-state issue already open for $EXT (#$EXISTING); skipping create"
+          fi
+
+      - name: Build summary row
+        id: row
+        if: always()
+        run: |
+          EXT="${{ matrix.extension.name }}"
+          LOCAL='${{ steps.version.outputs.current }}'
+          DRAFT='${{ steps.state.outputs.draft_version }}'
+          LIVE_SOURCE='${{ steps.live.outputs.source }}'
+          LIVE_VER='${{ steps.live.outputs.version }}'
+          STATUS='${{ steps.live.outputs.status }}'
+          WARNINGS_JSON='${{ steps.live.outputs.warnings_json }}'
+          # Compute git-tag and API-PUBLISHED columns from source/version. If
+          # source=git_tag the live version came from a tag; the API column may
+          # be empty (only when the API projection failed and a warning was
+          # emitted) — render "-" for unknowns to keep the table well-formed.
+          if [ "$LIVE_SOURCE" = "git_tag" ]; then
+            GIT_TAG_COL="$LIVE_VER"
+            # If state_mismatch warning fires, PUBLISHED disagrees and lives in
+            # the warning; otherwise PUBLISHED matches the tag (or is unknown).
+            HAS_MISMATCH=$(echo "${WARNINGS_JSON:-[]}" | jq -r '[.[] | select(.code == "state_mismatch")] | length')
+            HAS_400=$(echo "${WARNINGS_JSON:-[]}" | jq -r '[.[] | select(.code == "published_projection_400")] | length')
+            if [ "${HAS_MISMATCH:-0}" != "0" ]; then
+              # The mismatch warning's message embeds the PUBLISHED value;
+              # extract it for the table cell.
+              API_PUB_COL=$(echo "$WARNINGS_JSON" | jq -r '[.[] | select(.code == "state_mismatch") | .message] | first' | sed -E 's/.*PUBLISHED ([^ ]+).*/\1/')
+            elif [ "${HAS_400:-0}" != "0" ]; then
+              API_PUB_COL="-"
+            else
+              API_PUB_COL="$LIVE_VER"
+            fi
+          elif [ "$LIVE_SOURCE" = "api_PUBLISHED" ]; then
+            GIT_TAG_COL="-"
+            API_PUB_COL="$LIVE_VER"
+          else
+            GIT_TAG_COL="-"
+            API_PUB_COL="-"
+          fi
+          case "$STATUS" in
+            SYNCED) STATUS_COL=":white_check_mark: SYNCED" ;;
+            DRAFT_AHEAD) STATUS_COL=":outbox_tray: DRAFT_AHEAD" ;;
+            STUCK_DRAFT) STATUS_COL=":warning: STUCK_DRAFT" ;;
+            UNTRUSTED_STATE) STATUS_COL=":x: UNTRUSTED_STATE (force-dispatch required)" ;;
+            *) STATUS_COL="$STATUS" ;;
+          esac
+          WARN_COL=$(echo "${WARNINGS_JSON:-[]}" | jq -r '[.[] | "\(.severity): \(.code): \(.message)"] | join("<br>")')
+          ROW="| $EXT | ${LOCAL:--} | ${DRAFT:--} | ${GIT_TAG_COL:--} | ${API_PUB_COL:--} | $STATUS_COL | $WARN_COL |"
+          echo "$ROW" >> "$GITHUB_STEP_SUMMARY"
+          # Also persist the row for the summary job to re-render escalation
+          # rows alongside the canonical one if needed.
+          mkdir -p "$RUNNER_TEMP/decision"
+          echo "$ROW" > "$RUNNER_TEMP/decision/row.md"
+
+      - name: Persist decision artifact
+        if: always()
+        run: |
+          mkdir -p "$RUNNER_TEMP/decision"
+          cat > "$RUNNER_TEMP/decision/decision.json" <<EOF
+          {
+            "extension": "${{ matrix.extension.name }}",
+            "skip_all": "${{ steps.decide.outputs.skip_all }}",
+            "tier_kick": "${{ steps.decide.outputs.tier_kick }}",
+            "status": "${{ steps.live.outputs.status }}",
+            "reason": "${{ steps.decide.outputs.reason }}",
+            "local_version": "${{ steps.version.outputs.current }}",
+            "live_version": "${{ steps.live.outputs.version }}",
+            "live_source": "${{ steps.live.outputs.source }}"
+          }
+          EOF
+
+      - name: Upload decision artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cws-decision-${{ matrix.extension.name }}
+          path: ${{ runner.temp }}/decision/
+          retention-days: 7
+
+  aggregate:
+    name: Aggregate decisions
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: decide
+    if: always()
+    outputs:
+      decisions_json: ${{ steps.collect.outputs.decisions_json }}
+    steps:
+      - name: Download all decisions
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cws-decision-*
+          path: decisions
+          merge-multiple: false
+
+      - name: Collect into single JSON map
+        id: collect
+        run: |
+          MAP="{}"
+          for dir in decisions/cws-decision-*; do
+            [ -d "$dir" ] || continue
+            EXT=$(basename "$dir" | sed 's/^cws-decision-//')
+            FILE="$dir/decision.json"
+            if [ -f "$FILE" ]; then
+              MAP=$(echo "$MAP" | jq --arg ext "$EXT" --slurpfile dec "$FILE" '.[$ext] = $dec[0]')
+            fi
+          done
+          # Emit compact single-line JSON suitable for fromJSON() consumers.
+          COMPACT=$(echo "$MAP" | jq -c '.')
+          echo "decisions_json=$COMPACT" >> "$GITHUB_OUTPUT"
+          echo "Aggregated decisions:"
+          echo "$COMPACT"
+
+  act:
+    name: Act ${{ matrix.extension.name }}
+    runs-on: ubuntu-latest
+    # n=14 across both matrix entries (<20 successful runs) → fall back to
+    # test-family ceiling 30. wait-uploaded (60s) + wait-published (120s) +
+    # CWS API jitter all comfortably fit under this.
+    timeout-minutes: 30
+    needs: [pre-flight, decide, aggregate]
+    # Job-level gate: dry_run physically blocks the act job for workflow_dispatch
+    # runs. Push events bypass the dry-run gate entirely. The decision map gates
+    # per-extension execution: skip_all=true short-circuits unless tier_kick is
+    # set, in which case the tier-handler step runs (and never the upload path).
+    if: |
+      (github.event_name == 'push' || inputs.dry_run != true)
+      && (fromJSON(needs.aggregate.outputs.decisions_json)[matrix.extension.name].skip_all != 'true'
+          || fromJSON(needs.aggregate.outputs.decisions_json)[matrix.extension.name].tier_kick == 'true')
+    concurrency:
+      group: cws-issue-writer
+      cancel-in-progress: false
+    strategy:
+      fail-fast: false
+      matrix:
+        extension:
+          - name: garmin-bridge
+            extension_id_secret: CWS_EXTENSION_ID
+          - name: train2go-bridge
+            extension_id_secret: CWS_TRAIN2GO_EXTENSION_ID
+    outputs:
+      escalation_failed: ${{ steps.tier_escalation_signal.outputs.escalation_failed }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve current version
+        id: version
+        run: |
+          EXT="${{ matrix.extension.name }}"
+          CURRENT=$(node -e "console.log(JSON.parse(require('fs').readFileSync('packages/$EXT/package.json','utf8')).version)")
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+
+      - name: Read decision for this extension
+        id: dec
+        run: |
+          DECISIONS='${{ needs.aggregate.outputs.decisions_json }}'
+          EXT='${{ matrix.extension.name }}'
+          TIER_KICK=$(echo "$DECISIONS" | jq -r --arg ext "$EXT" '.[$ext].tier_kick // "false"')
+          SKIP_ALL=$(echo "$DECISIONS" | jq -r --arg ext "$EXT" '.[$ext].skip_all // "false"')
+          STATUS=$(echo "$DECISIONS" | jq -r --arg ext "$EXT" '.[$ext].status // ""')
+          echo "tier_kick=$TIER_KICK" >> "$GITHUB_OUTPUT"
+          echo "skip_all=$SKIP_ALL" >> "$GITHUB_OUTPUT"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+
+      - name: Tier handler (auto-unstick)
+        id: tier
+        if: steps.dec.outputs.tier_kick == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
+        run: |
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          node scripts/cws-stuck-draft-handler.mjs \
+            "${{ matrix.extension.name }}" \
+            "${{ secrets[matrix.extension.extension_id_secret] }}" \
+            "${{ steps.version.outputs.current }}" \
+            "$RUN_URL"
+
+      - name: Tier 3 escalation labels (best-effort)
+        id: tier3_labels
+        if: steps.dec.outputs.tier_kick == 'true' && steps.tier.outputs.tier == '3'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE="cws-publish-stuck-${{ matrix.extension.name }}-${{ steps.version.outputs.current }}"
+          NUMBER=$(gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --limit 20 \
+            | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
+            | head -n 1)
+          if [ -n "$NUMBER" ]; then
+            gh issue edit "$NUMBER" --add-label "needs-human"
+          fi
+
+      - name: Surface escalation label failure
+        id: tier_escalation_signal
+        if: always() && steps.tier3_labels.conclusion == 'failure'
+        run: echo "escalation_failed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm
+        if: steps.dec.outputs.tier_kick != 'true' && steps.dec.outputs.skip_all != 'true'
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Sync manifest versions
+        if: steps.dec.outputs.tier_kick != 'true' && steps.dec.outputs.skip_all != 'true'
+        run: node scripts/sync-extension-version.mjs ${{ matrix.extension.name }}
+
+      - name: Package extension
+        if: steps.dec.outputs.tier_kick != 'true' && steps.dec.outputs.skip_all != 'true'
+        run: bash scripts/package-extension.sh ${{ matrix.extension.name }}
 
       - name: Upload CRX to Chrome Web Store
         id: upload
-        if: ${{ steps.decide.outputs.skip_all != 'true' }}
+        if: steps.dec.outputs.tier_kick != 'true' && steps.dec.outputs.skip_all != 'true'
         env:
           CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
         run: |
@@ -145,7 +423,7 @@ jobs:
 
       - name: Wait for UPLOADED state
         id: wait_uploaded
-        if: ${{ steps.decide.outputs.skip_all != 'true' }}
+        if: steps.dec.outputs.tier_kick != 'true' && steps.dec.outputs.skip_all != 'true'
         env:
           CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
         run: |
@@ -155,7 +433,7 @@ jobs:
 
       - name: Publish
         id: publish
-        if: ${{ steps.decide.outputs.skip_all != 'true' }}
+        if: steps.dec.outputs.tier_kick != 'true' && steps.dec.outputs.skip_all != 'true'
         env:
           CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
         run: |
@@ -164,7 +442,7 @@ jobs:
 
       - name: Wait for terminal state (PUBLISHED / IN_REVIEW / REJECTED / TIMEOUT)
         id: wait_published
-        if: ${{ steps.decide.outputs.skip_all != 'true' }}
+        if: steps.dec.outputs.tier_kick != 'true' && steps.dec.outputs.skip_all != 'true'
         env:
           CWS_SERVICE_ACCOUNT_KEY: ${{ secrets.CWS_SERVICE_ACCOUNT_KEY }}
         run: |
@@ -214,27 +492,50 @@ jobs:
           fi
 
       - name: Create git tag (only on PUBLISHED)
-        if: ${{ steps.decide.outputs.skip_all != 'true' && steps.wait_published.outputs.status == 'PUBLISHED' }}
+        if: ${{ steps.dec.outputs.tier_kick != 'true' && steps.dec.outputs.skip_all != 'true' && steps.wait_published.outputs.status == 'PUBLISHED' }}
         run: |
           EXT="${{ matrix.extension.name }}"
           TAG="@kaiord/$EXT@${{ steps.version.outputs.current }}"
           git tag "$TAG"
           git push origin "$TAG"
 
-      - name: Summary
-        if: always()
+  summary:
+    name: Summary (escalation rows)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [pre-flight, decide, aggregate, act]
+    # Always render so an act-job failure cannot suppress the summary surface.
+    if: always()
+    steps:
+      - name: Append escalation rows for failed act jobs
         run: |
-          EXT="${{ matrix.extension.name }}"
-          STATUS="${{ steps.wait_published.outputs.status }}"
-          SKIP_ALL="${{ steps.decide.outputs.skip_all }}"
-          PUBLISHED_VER="${{ steps.state.outputs.draft_version }}"
-          echo "## CWS Publish: $EXT" >> "$GITHUB_STEP_SUMMARY"
-          echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **Local version**: ${{ steps.version.outputs.current }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- **CWS published**: ${PUBLISHED_VER:-<unknown>}" >> "$GITHUB_STEP_SUMMARY"
-          if [ "$SKIP_ALL" = "true" ]; then
-            echo "- **Status**: SKIPPED (already at target version, no-op)" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "- **Status**: ${STATUS:-unknown}" >> "$GITHUB_STEP_SUMMARY"
+          DECISIONS='${{ needs.aggregate.outputs.decisions_json }}'
+          ACT_RESULT='${{ needs.act.result }}'
+          ESCALATION_FAILED='${{ needs.act.outputs.escalation_failed }}'
+          # The decide job already appended one row per extension. Append a
+          # follow-up "escalation pending" row when the act job's tier-handler
+          # leg reported escalation_failed=true (Phase 5 wires this; the
+          # placeholder always reports false).
+          if [ "$ESCALATION_FAILED" = "true" ]; then
+            {
+              echo ""
+              echo "> :rotating_light: One or more act jobs reported escalation_failed=true (tier-handler could not complete a label/notify mutation). Inspect the act job logs."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi
-          echo "- **Force upload**: ${{ inputs.force_upload }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$ACT_RESULT" = "failure" ]; then
+            {
+              echo ""
+              echo "> :warning: Act job(s) ended in failure. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          if [ "$ACT_RESULT" = "skipped" ]; then
+            {
+              echo ""
+              echo "> :information_source: Act job(s) skipped (dry-run or all extensions decided skip_all=true)."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          # Footer row pinning the workflow run for cross-reference.
+          {
+            echo ""
+            echo "_force_upload=${{ inputs.force_upload }} • dry_run=${{ inputs.dry_run }} • run=${{ github.run_id }}_"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cws-publish.yml
+++ b/.github/workflows/cws-publish.yml
@@ -63,6 +63,19 @@ jobs:
           node scripts/cws-notify-issue.mjs cws-auth-broken "" \
             "Pre-flight failed at $(date -u +%FT%TZ). See workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
+      - name: Ensure issue labels exist
+        # Idempotent: `gh label create --force` updates the description
+        # if the label already exists. Without these, downstream
+        # `gh issue create --label` calls fail with non-zero exit and
+        # block the decide/act jobs even when the rest of the flow is
+        # healthy.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create cws-stuck --color FF9F1C --description "CWS draft uploaded but not live" --force
+          gh label create cws-untrusted-state --color D7263D --description "git tag and PUBLISHED projection disagree; force-dispatch required" --force
+          gh label create needs-human --color 6A0572 --description "Auto-retry exhausted; human action required" --force
+
       - name: Write summary header
         if: always()
         run: |
@@ -99,6 +112,11 @@ jobs:
           # checkout-action versions ship history without tag refs.
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Ensure tags are fetched
+        # actions/checkout's fetch-tags is best-effort; ensure tag refs
+        # are actually present so the live-version resolver can see them.
+        run: git fetch --tags --force origin
 
       - name: Resolve current version
         id: version
@@ -195,7 +213,7 @@ jobs:
           if [ -z "$EXISTING" ]; then
             gh issue create \
               --title "$TITLE" \
-              --label "cws-untrusted-state-$EXT" \
+              --label "cws-untrusted-state" \
               --body "git tag and PUBLISHED projection disagree for $EXT. Force-dispatch with force_upload=true required to resolve after human reconciliation. Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           else
             echo "cws-untrusted-state issue already open for $EXT (#$EXISTING); skipping create"

--- a/.github/workflows/cws-publish.yml
+++ b/.github/workflows/cws-publish.yml
@@ -317,13 +317,10 @@ jobs:
     timeout-minutes: 30
     needs: [pre-flight, decide, aggregate]
     # Job-level gate: dry_run physically blocks the act job for workflow_dispatch
-    # runs. Push events bypass the dry-run gate entirely. The decision map gates
-    # per-extension execution: skip_all=true short-circuits unless tier_kick is
-    # set, in which case the tier-handler step runs (and never the upload path).
-    if: |
-      (github.event_name == 'push' || inputs.dry_run != true)
-      && (fromJSON(needs.aggregate.outputs.decisions_json)[matrix.extension.name].skip_all != 'true'
-          || fromJSON(needs.aggregate.outputs.decisions_json)[matrix.extension.name].tier_kick == 'true')
+    # runs. Push events bypass the dry-run gate entirely. The matrix-row gate
+    # (skip_all/tier_kick) is evaluated at step level below — GitHub Actions
+    # does not expand `matrix` context inside job-level `if:` expressions.
+    if: github.event_name == 'push' || inputs.dry_run != true
     concurrency:
       group: cws-issue-writer
       cancel-in-progress: false

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "lint:links": "bash scripts/lint-links.sh",
     "icons:build": "node scripts/build-extension-icons.mjs",
     "popup:sync": "node scripts/sync-popup-css.mjs",
-    "test:scripts": "node --test scripts/*.test.mjs scripts/eslint-rules/*.test.mjs",
+    "test:scripts": "node --test scripts/*.test.mjs scripts/cws-api/*.test.mjs scripts/eslint-rules/*.test.mjs",
     "archive:index": "node scripts/generate-archive-index.mjs",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/cws-api.mjs
+++ b/scripts/cws-api.mjs
@@ -55,6 +55,7 @@ function printUsage() {
       "  state          print current CWS state JSON",
       "  upload --source <zip-path>",
       "  publish        publish the uploaded draft",
+      "  live-version <extension-id> --package <package-name>",
       "  wait-uploaded --timeout-ms <N>",
       "  wait-published --version <V> --timeout-ms <N>",
       "",

--- a/scripts/cws-api/cli-live-version.mjs
+++ b/scripts/cws-api/cli-live-version.mjs
@@ -18,6 +18,7 @@ export async function runLiveVersion(id, flags, serviceAccount) {
   return resolveLiveVersion({
     extensionId: id,
     packageName: flags.package,
+    localVersion: flags.local ?? null,
     getItem: bound,
     gitTags: readGitTags(flags.package),
   });

--- a/scripts/cws-api/cli-live-version.mjs
+++ b/scripts/cws-api/cli-live-version.mjs
@@ -15,9 +15,15 @@ function readGitTags(packageName) {
 export async function runLiveVersion(id, flags, serviceAccount) {
   const bound = (_sa, itemId, projection) =>
     getItem(serviceAccount, itemId, projection);
+  // The resolver's regex expects packageName to match the tag prefix
+  // (`@kaiord/<name>@<version>`). The CLI receives the bare workspace
+  // name (e.g. `train2go-bridge`) from the workflow matrix, so prepend
+  // the npm-scope here. readGitTags below already hard-codes the same
+  // prefix in its `git tag -l` query.
+  const fullName = `@kaiord/${flags.package}`;
   return resolveLiveVersion({
     extensionId: id,
-    packageName: flags.package,
+    packageName: fullName,
     localVersion: flags.local ?? null,
     getItem: bound,
     gitTags: readGitTags(flags.package),

--- a/scripts/cws-api/cli-live-version.mjs
+++ b/scripts/cws-api/cli-live-version.mjs
@@ -1,0 +1,24 @@
+// live-version subcommand handler — called by cli.mjs dispatch.
+// Reads git tags via execFileSync and delegates to resolveLiveVersion.
+
+import { execFileSync } from "node:child_process";
+import { getItem } from "./state.mjs";
+import { resolveLiveVersion } from "./live-version.mjs";
+
+function readGitTags(packageName) {
+  const out = execFileSync("git", ["tag", "-l", `@kaiord/${packageName}@*`], {
+    encoding: "utf8",
+  });
+  return out.split("\n").filter(Boolean);
+}
+
+export async function runLiveVersion(id, flags, serviceAccount) {
+  const bound = (_sa, itemId, projection) =>
+    getItem(serviceAccount, itemId, projection);
+  return resolveLiveVersion({
+    extensionId: id,
+    packageName: flags.package,
+    getItem: bound,
+    gitTags: readGitTags(flags.package),
+  });
+}

--- a/scripts/cws-api/cli-live-version.mjs
+++ b/scripts/cws-api/cli-live-version.mjs
@@ -12,20 +12,25 @@ function readGitTags(packageName) {
   return out.split("\n").filter(Boolean);
 }
 
+// Pure args builder. Extracted so a unit test can verify the canonical
+// package-name shape (`@kaiord/<name>`) without spawning a child process.
+// The resolver's regex expects packageName to match the tag prefix, so
+// the CLI must prepend the npm-scope even when the workflow matrix
+// passes a bare name like `train2go-bridge`.
+export function buildResolveArgs(id, flags, getItemFn, gitTags) {
+  return {
+    extensionId: id,
+    packageName: `@kaiord/${flags.package}`,
+    localVersion: flags.local ?? null,
+    getItem: getItemFn,
+    gitTags,
+  };
+}
+
 export async function runLiveVersion(id, flags, serviceAccount) {
   const bound = (_sa, itemId, projection) =>
     getItem(serviceAccount, itemId, projection);
-  // The resolver's regex expects packageName to match the tag prefix
-  // (`@kaiord/<name>@<version>`). The CLI receives the bare workspace
-  // name (e.g. `train2go-bridge`) from the workflow matrix, so prepend
-  // the npm-scope here. readGitTags below already hard-codes the same
-  // prefix in its `git tag -l` query.
-  const fullName = `@kaiord/${flags.package}`;
-  return resolveLiveVersion({
-    extensionId: id,
-    packageName: fullName,
-    localVersion: flags.local ?? null,
-    getItem: bound,
-    gitTags: readGitTags(flags.package),
-  });
+  return resolveLiveVersion(
+    buildResolveArgs(id, flags, bound, readGitTags(flags.package))
+  );
 }

--- a/scripts/cws-api/cli-live-version.test.mjs
+++ b/scripts/cws-api/cli-live-version.test.mjs
@@ -1,0 +1,70 @@
+// Tests for scripts/cws-api/cli-live-version.mjs using node:test.
+//
+// The bug under regression: an earlier revision passed the bare workspace
+// name (e.g. `train2go-bridge`) as packageName to the resolver, so the
+// resolver's regex `^train2go-bridge@(.+)$` failed to match tags shaped
+// like `@kaiord/train2go-bridge@0.1.1`. gitTagVersion came back null,
+// PUBLISHED came back empty, and the resolver routed to UNTRUSTED_STATE
+// despite having the data right there.
+//
+// buildResolveArgs is the pure args builder — the test pins the
+// canonical `@kaiord/<name>` shape independent of any child_process or
+// network I/O.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { buildResolveArgs } from "./cli-live-version.mjs";
+
+test("prepends @kaiord/ scope to bare workspace package name", () => {
+  const args = buildResolveArgs(
+    "abcdefghijklmnopabcdefghijklmnop",
+    { package: "train2go-bridge", local: "7.2.1" },
+    () => ({}),
+    ["@kaiord/train2go-bridge@0.1.1"]
+  );
+  assert.equal(args.packageName, "@kaiord/train2go-bridge");
+});
+
+test("passes localVersion through from --local flag", () => {
+  const args = buildResolveArgs(
+    "abcdefghijklmnopabcdefghijklmnop",
+    { package: "garmin-bridge", local: "4.5.0" },
+    () => ({}),
+    []
+  );
+  assert.equal(args.localVersion, "4.5.0");
+});
+
+test("localVersion defaults to null when --local omitted", () => {
+  const args = buildResolveArgs(
+    "abcdefghijklmnopabcdefghijklmnop",
+    { package: "garmin-bridge" },
+    () => ({}),
+    []
+  );
+  assert.equal(args.localVersion, null);
+});
+
+test("forwards the extension id and gitTags unchanged", () => {
+  const tags = ["@kaiord/garmin-bridge@0.2.0", "@kaiord/garmin-bridge@0.1.0"];
+  const args = buildResolveArgs(
+    "extid12345678901234567890123456",
+    { package: "garmin-bridge", local: "0.2.0" },
+    () => ({}),
+    tags
+  );
+  assert.equal(args.extensionId, "extid12345678901234567890123456");
+  assert.deepEqual(args.gitTags, tags);
+});
+
+test("getItem function is passed through (not unwrapped)", () => {
+  const fn = async () => ({ crxVersion: "0.0.1" });
+  const args = buildResolveArgs(
+    "abcdefghijklmnopabcdefghijklmnop",
+    { package: "train2go-bridge", local: "0.0.1" },
+    fn,
+    []
+  );
+  assert.equal(args.getItem, fn);
+});

--- a/scripts/cws-api/cli.mjs
+++ b/scripts/cws-api/cli.mjs
@@ -73,6 +73,7 @@ function parseFlags(args) {
     else if (arg === "--timeout-ms") flags.timeoutMs = Number(args[++i]);
     else if (arg === "--trusted-testers") flags.trustedTesters = true;
     else if (arg === "--package") flags.package = args[++i];
+    else if (arg === "--local") flags.local = args[++i];
   }
   return flags;
 }

--- a/scripts/cws-api/cli.mjs
+++ b/scripts/cws-api/cli.mjs
@@ -8,6 +8,7 @@ import { getItem } from "./state.mjs";
 import { uploadCrx } from "./upload.mjs";
 import { publishItem } from "./publish.mjs";
 import { waitPublished, waitUploaded } from "./poll.mjs";
+import { runLiveVersion } from "./cli-live-version.mjs";
 
 export async function dispatch(argv, serviceAccount) {
   const [subcommand, id, ...rest] = argv;
@@ -48,18 +49,16 @@ async function runSubcommand(subcommand, id, flags, serviceAccount) {
   }
   if (subcommand === "wait-uploaded") {
     if (!id) throw new UsageError("wait-uploaded requires <extension-id>");
-    return await waitUploaded(serviceAccount, id, {
-      timeoutMs: flags.timeoutMs ?? 60000,
-    });
+    return await waitUploaded(serviceAccount, id, { timeoutMs: flags.timeoutMs ?? 60000 });
   }
   if (subcommand === "wait-published") {
-    if (!id || !flags.version) {
-      throw new UsageError("wait-published requires <id> --version <V>");
-    }
-    return await waitPublished(serviceAccount, id, {
-      version: flags.version,
-      timeoutMs: flags.timeoutMs ?? 120000,
-    });
+    if (!id || !flags.version) throw new UsageError("wait-published requires <id> --version <V>");
+    return await waitPublished(serviceAccount, id, { version: flags.version, timeoutMs: flags.timeoutMs ?? 120000 });
+  }
+  if (subcommand === "live-version") {
+    if (!id) throw new UsageError("live-version requires <extension-id>");
+    if (!flags.package) throw new UsageError("live-version requires --package <name>");
+    return await runLiveVersion(id, flags, serviceAccount);
   }
   throw new UsageError(`unknown subcommand: ${subcommand}`);
 }
@@ -73,6 +72,7 @@ function parseFlags(args) {
     else if (arg === "--projection") flags.projection = args[++i];
     else if (arg === "--timeout-ms") flags.timeoutMs = Number(args[++i]);
     else if (arg === "--trusted-testers") flags.trustedTesters = true;
+    else if (arg === "--package") flags.package = args[++i];
   }
   return flags;
 }
@@ -84,11 +84,8 @@ function handleError(err) {
     process.stderr.write(`[CwsStateError] usage: ${err.message}\n`);
     return 2;
   }
-  if (
-    err instanceof CwsAuthError ||
-    err instanceof CwsStateError ||
-    err instanceof CwsTimeoutError
-  ) {
+  const typed = err instanceof CwsAuthError || err instanceof CwsStateError || err instanceof CwsTimeoutError;
+  if (typed) {
     process.stderr.write(err.message + "\n");
     return 1;
   }

--- a/scripts/cws-api/live-version-status.mjs
+++ b/scripts/cws-api/live-version-status.mjs
@@ -1,0 +1,62 @@
+/**
+ * Status-decision matrix for resolveLiveVersion.
+ *
+ * Exposes:
+ *   - latestTagVersion(gitTags, packageName): pick the highest `<pkg>@*` tag
+ *     by lexicographic sort (the resolver does not parse semver — it compares
+ *     whatever strings the caller feeds it). Returns null when no tag matches.
+ *   - decideStatus(ctx): given gitTagVersion, publishedVersion, localVersion,
+ *     and forceStuck, return { source, version, status, warnings }. Pushes a
+ *     `state_mismatch` warning into ctx.warnings when tag and PUBLISHED
+ *     disagree (status forced to UNTRUSTED_STATE).
+ *
+ * Status precedence (highest first):
+ *   UNTRUSTED_STATE > STUCK_DRAFT > DRAFT_AHEAD > SYNCED
+ */
+
+import { stateMismatchWarning } from "./live-version-warnings.mjs";
+
+export function latestTagVersion(gitTags, packageName) {
+  if (!Array.isArray(gitTags) || gitTags.length === 0) return null;
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escaped}@(.+)$`);
+  const versions = [];
+  for (const tag of gitTags) {
+    const m = re.exec(tag);
+    if (m) versions.push(m[1]);
+  }
+  if (versions.length === 0) return null;
+  versions.sort();
+  return versions[versions.length - 1];
+}
+
+export function decideStatus(ctx) {
+  const { gitTagVersion, publishedVersion, localVersion, forceStuck } = ctx;
+  const source =
+    gitTagVersion !== null
+      ? "git_tag"
+      : publishedVersion !== null
+        ? "api_PUBLISHED"
+        : "unknown";
+  const version = gitTagVersion ?? publishedVersion ?? null;
+  if (
+    gitTagVersion !== null &&
+    publishedVersion !== null &&
+    gitTagVersion !== publishedVersion
+  ) {
+    ctx.warnings.push(stateMismatchWarning(gitTagVersion, publishedVersion));
+    return {
+      source,
+      version,
+      status: "UNTRUSTED_STATE",
+      warnings: ctx.warnings,
+    };
+  }
+  if (forceStuck) {
+    return { source, version, status: "STUCK_DRAFT", warnings: ctx.warnings };
+  }
+  if (localVersion !== null && version !== null && localVersion !== version) {
+    return { source, version, status: "DRAFT_AHEAD", warnings: ctx.warnings };
+  }
+  return { source, version, status: "SYNCED", warnings: ctx.warnings };
+}

--- a/scripts/cws-api/live-version-status.mjs
+++ b/scripts/cws-api/live-version-status.mjs
@@ -39,6 +39,18 @@ export function decideStatus(ctx) {
         ? "api_PUBLISHED"
         : "unknown";
   const version = gitTagVersion ?? publishedVersion ?? null;
+  // Both live-version inputs absent: we know nothing about what's actually
+  // live. Never silently fall through to SYNCED — that re-introduces the
+  // class of bug under repair. Surface as UNTRUSTED_STATE so the workflow
+  // opens an issue and waits for human force-dispatch.
+  if (gitTagVersion === null && publishedVersion === null) {
+    return {
+      source,
+      version,
+      status: "UNTRUSTED_STATE",
+      warnings: ctx.warnings,
+    };
+  }
   if (
     gitTagVersion !== null &&
     publishedVersion !== null &&

--- a/scripts/cws-api/live-version-warnings.mjs
+++ b/scripts/cws-api/live-version-warnings.mjs
@@ -1,0 +1,35 @@
+/**
+ * Typed warning builders for resolveLiveVersion.
+ *
+ * Each builder returns a shape: { code, severity, message }.
+ *   - "published_projection_400" (warn): getItem(PUBLISHED) threw CwsStateError.
+ *   - "git_tag_missing"          (warn): no `<packageName>@*` tag was found.
+ *   - "state_mismatch"           (error): git tag and PUBLISHED disagree.
+ *
+ * Codes are fixed (not free-form strings) so downstream renderers can branch
+ * on `code` without parsing message text.
+ */
+
+export function publishedProjection400Warning(err) {
+  return {
+    code: "published_projection_400",
+    severity: "warn",
+    message: `getItem(PUBLISHED) failed: ${err.message}`,
+  };
+}
+
+export function gitTagMissingWarning(packageName) {
+  return {
+    code: "git_tag_missing",
+    severity: "warn",
+    message: `no git tag matching ${packageName}@* was found`,
+  };
+}
+
+export function stateMismatchWarning(gitTagVersion, publishedVersion) {
+  return {
+    code: "state_mismatch",
+    severity: "error",
+    message: `git tag ${gitTagVersion} disagrees with PUBLISHED ${publishedVersion}`,
+  };
+}

--- a/scripts/cws-api/live-version.mjs
+++ b/scripts/cws-api/live-version.mjs
@@ -1,0 +1,86 @@
+/**
+ * resolveLiveVersion — combined source-of-truth resolver.
+ *
+ * Inputs (strings only; the resolver does not parse semver):
+ *   - localVersion        — what the workflow is about to publish.
+ *   - api_PUBLISHED       — from `getItem(_, _, "PUBLISHED")`; may 400.
+ *   - git_tag_latest      — highest `<packageName>@*` entry in `gitTags`.
+ *
+ * Status enum (no free-form strings):
+ *   - SYNCED             — local matches the chosen live version (or no
+ *                          local supplied) AND tag/PUBLISHED do not conflict.
+ *   - DRAFT_AHEAD        — local differs from the live version; a new
+ *                          release is in flight.
+ *   - STUCK_DRAFT        — caller passes `forceStuck: true` (the workflow
+ *                          owns the staleness clock; Phase 3 wiring).
+ *   - UNTRUSTED_STATE    — git tag and api_PUBLISHED both present and
+ *                          disagree; operator must reconcile.
+ *
+ * warnings[] shape: { code, severity: "info" | "warn" | "error", message }.
+ *   - published_projection_400 (warn) — PUBLISHED projection threw
+ *     CwsStateError; falls back to git_tag.
+ *   - git_tag_missing          (warn) — no `<packageName>@*` tag found;
+ *     falls back to api_PUBLISHED if available.
+ *   - state_mismatch          (error) — tag and PUBLISHED disagree;
+ *     forces UNTRUSTED_STATE.
+ *
+ * `source`: "git_tag" | "api_PUBLISHED" | "unknown".
+ * `version`: the resolved live version string, or null if unknown.
+ */
+
+import { CwsStateError } from "./errors.mjs";
+import { decideStatus, latestTagVersion } from "./live-version-status.mjs";
+import {
+  gitTagMissingWarning,
+  publishedProjection400Warning,
+} from "./live-version-warnings.mjs";
+
+export class UsageError extends Error {
+  constructor(message) {
+    super(`[UsageError] ${message}`);
+    this.name = "UsageError";
+  }
+}
+
+async function fetchPublishedVersion(getItem, extensionId, warnings) {
+  try {
+    const item = await getItem(undefined, extensionId, "PUBLISHED");
+    return item?.crxVersion ?? null;
+  } catch (err) {
+    if (!(err instanceof CwsStateError)) throw err;
+    warnings.push(publishedProjection400Warning(err));
+    return null;
+  }
+}
+
+export async function resolveLiveVersion({
+  extensionId,
+  packageName,
+  localVersion = null,
+  getItem,
+  gitTags,
+  forceStuck = false,
+}) {
+  if (!extensionId) throw new UsageError("extensionId is required");
+  if (!packageName) throw new UsageError("packageName is required");
+  if (typeof getItem !== "function") {
+    throw new UsageError("getItem must be a function");
+  }
+  const warnings = [];
+  const gitTagVersion = latestTagVersion(gitTags, packageName);
+  if (gitTagVersion === null) {
+    warnings.push(gitTagMissingWarning(packageName));
+  }
+  const publishedVersion = await fetchPublishedVersion(
+    getItem,
+    extensionId,
+    warnings
+  );
+  return decideStatus({
+    gitTagVersion,
+    publishedVersion,
+    localVersion,
+    forceStuck,
+    warnings,
+  });
+}

--- a/scripts/cws-api/live-version.mjs
+++ b/scripts/cws-api/live-version.mjs
@@ -45,7 +45,11 @@ export class UsageError extends Error {
 async function fetchPublishedVersion(getItem, extensionId, warnings) {
   try {
     const item = await getItem(undefined, extensionId, "PUBLISHED");
-    return item?.crxVersion ?? null;
+    const v = item?.crxVersion ?? null;
+    // CWS returns an empty crxVersion for items that have no public publish
+    // yet (e.g. only trusted-tester releases). Treat as "no info" so the
+    // resolver routes to UNTRUSTED_STATE instead of silently SYNCED.
+    return v === "" ? null : v;
   } catch (err) {
     if (!(err instanceof CwsStateError)) throw err;
     warnings.push(publishedProjection400Warning(err));

--- a/scripts/cws-api/live-version.test.mjs
+++ b/scripts/cws-api/live-version.test.mjs
@@ -1,0 +1,207 @@
+// Tests for scripts/cws-api/live-version.mjs using node:test.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { CwsStateError } from "./errors.mjs";
+import { resolveLiveVersion, UsageError } from "./live-version.mjs";
+
+const EXT_ID = "abcdefghijklmnopabcdefghijklmnop";
+const PKG = "@kaiord/garmin-bridge";
+
+function makeGetItem(impl) {
+  return async (sa, id, projection) => impl({ sa, id, projection });
+}
+
+test("throws UsageError when extensionId is missing", async () => {
+  await assert.rejects(
+    () =>
+      resolveLiveVersion({
+        extensionId: "",
+        packageName: PKG,
+        getItem: makeGetItem(() => ({})),
+        gitTags: [],
+      }),
+    UsageError
+  );
+});
+
+test("throws UsageError when packageName is missing", async () => {
+  await assert.rejects(
+    () =>
+      resolveLiveVersion({
+        extensionId: EXT_ID,
+        packageName: "",
+        getItem: makeGetItem(() => ({})),
+        gitTags: [],
+      }),
+    UsageError
+  );
+});
+
+test("throws UsageError when getItem is not a function", async () => {
+  await assert.rejects(
+    () =>
+      resolveLiveVersion({
+        extensionId: EXT_ID,
+        packageName: PKG,
+        getItem: null,
+        gitTags: [],
+      }),
+    UsageError
+  );
+});
+
+test("SYNCED: local matches tag, PUBLISHED matches tag", async () => {
+  const result = await resolveLiveVersion({
+    extensionId: EXT_ID,
+    packageName: PKG,
+    localVersion: "0.2.0",
+    getItem: makeGetItem(() => ({ crxVersion: "0.2.0" })),
+    gitTags: [`${PKG}@0.1.0`, `${PKG}@0.2.0`],
+  });
+  assert.equal(result.status, "SYNCED");
+  assert.equal(result.source, "git_tag");
+  assert.equal(result.version, "0.2.0");
+  assert.deepEqual(result.warnings, []);
+});
+
+test("SYNCED: local matches tag and PUBLISHED is unavailable (Scenario C)", async () => {
+  const result = await resolveLiveVersion({
+    extensionId: EXT_ID,
+    packageName: PKG,
+    localVersion: "0.2.0",
+    getItem: makeGetItem(() => {
+      throw new CwsStateError("getItem(PUBLISHED) returned 400: blocked");
+    }),
+    gitTags: [`${PKG}@0.2.0`],
+  });
+  assert.equal(result.status, "SYNCED");
+  assert.equal(result.source, "git_tag");
+  assert.equal(result.version, "0.2.0");
+  assert.equal(result.warnings.length, 1);
+  assert.equal(result.warnings[0].code, "published_projection_400");
+  assert.equal(result.warnings[0].severity, "warn");
+});
+
+test("DRAFT_AHEAD: local greater than tag and PUBLISHED", async () => {
+  const result = await resolveLiveVersion({
+    extensionId: EXT_ID,
+    packageName: PKG,
+    localVersion: "0.3.0",
+    getItem: makeGetItem(() => ({ crxVersion: "0.2.0" })),
+    gitTags: [`${PKG}@0.2.0`],
+  });
+  assert.equal(result.status, "DRAFT_AHEAD");
+  assert.equal(result.source, "git_tag");
+  assert.equal(result.version, "0.2.0");
+});
+
+test("STUCK_DRAFT: forceStuck propagates regardless of version match", async () => {
+  const result = await resolveLiveVersion({
+    extensionId: EXT_ID,
+    packageName: PKG,
+    localVersion: "0.2.0",
+    forceStuck: true,
+    getItem: makeGetItem(() => ({ crxVersion: "0.2.0" })),
+    gitTags: [`${PKG}@0.2.0`],
+  });
+  assert.equal(result.status, "STUCK_DRAFT");
+});
+
+test("UNTRUSTED_STATE: tag and PUBLISHED disagree", async () => {
+  const result = await resolveLiveVersion({
+    extensionId: EXT_ID,
+    packageName: PKG,
+    localVersion: "0.2.0",
+    getItem: makeGetItem(() => ({ crxVersion: "0.5.0" })),
+    gitTags: [`${PKG}@0.2.0`],
+  });
+  assert.equal(result.status, "UNTRUSTED_STATE");
+  assert.equal(result.source, "git_tag");
+  assert.ok(
+    result.warnings.some(
+      (w) => w.code === "state_mismatch" && w.severity === "error"
+    )
+  );
+});
+
+test("git_tag_missing: no matching tag, falls back to api_PUBLISHED", async () => {
+  const result = await resolveLiveVersion({
+    extensionId: EXT_ID,
+    packageName: PKG,
+    localVersion: "0.5.0",
+    getItem: makeGetItem(() => ({ crxVersion: "0.5.0" })),
+    gitTags: ["@kaiord/other-pkg@1.0.0"],
+  });
+  assert.equal(result.source, "api_PUBLISHED");
+  assert.equal(result.version, "0.5.0");
+  assert.ok(result.warnings.some((w) => w.code === "git_tag_missing"));
+  assert.equal(result.status, "SYNCED");
+});
+
+test("source = unknown when both tag and PUBLISHED are absent", async () => {
+  const result = await resolveLiveVersion({
+    extensionId: EXT_ID,
+    packageName: PKG,
+    localVersion: null,
+    getItem: makeGetItem(() => {
+      throw new CwsStateError("getItem(PUBLISHED) returned 400: blocked");
+    }),
+    gitTags: [],
+  });
+  assert.equal(result.source, "unknown");
+  assert.equal(result.version, null);
+  assert.equal(result.status, "SYNCED");
+  assert.ok(result.warnings.some((w) => w.code === "git_tag_missing"));
+  assert.ok(result.warnings.some((w) => w.code === "published_projection_400"));
+});
+
+test("getItem is called with projection='PUBLISHED'", async () => {
+  let captured = null;
+  await resolveLiveVersion({
+    extensionId: EXT_ID,
+    packageName: PKG,
+    getItem: makeGetItem(({ projection, id }) => {
+      captured = { projection, id };
+      return { crxVersion: "0.2.0" };
+    }),
+    gitTags: [`${PKG}@0.2.0`],
+  });
+  assert.equal(captured.projection, "PUBLISHED");
+  assert.equal(captured.id, EXT_ID);
+});
+
+test("latestTagVersion picks the highest matching tag", async () => {
+  // String sort suffices for fixed-width semver like 0.0.1 vs 0.0.2 vs 0.1.0;
+  // the resolver does not parse semver — it compares whatever the caller
+  // feeds it. This test documents the simple "max by string sort" rule.
+  const result = await resolveLiveVersion({
+    extensionId: EXT_ID,
+    packageName: PKG,
+    localVersion: "0.2.0",
+    getItem: makeGetItem(() => ({ crxVersion: "0.2.0" })),
+    gitTags: [
+      `${PKG}@0.1.0`,
+      `${PKG}@0.0.9`,
+      `${PKG}@0.2.0`,
+      "@kaiord/other@9.9.9",
+    ],
+  });
+  assert.equal(result.version, "0.2.0");
+});
+
+test("non-CwsStateError from getItem propagates", async () => {
+  await assert.rejects(
+    () =>
+      resolveLiveVersion({
+        extensionId: EXT_ID,
+        packageName: PKG,
+        getItem: makeGetItem(() => {
+          throw new Error("network down");
+        }),
+        gitTags: [`${PKG}@0.2.0`],
+      }),
+    /network down/
+  );
+});

--- a/scripts/cws-api/live-version.test.mjs
+++ b/scripts/cws-api/live-version.test.mjs
@@ -140,7 +140,10 @@ test("git_tag_missing: no matching tag, falls back to api_PUBLISHED", async () =
   assert.equal(result.status, "SYNCED");
 });
 
-test("source = unknown when both tag and PUBLISHED are absent", async () => {
+test("UNTRUSTED_STATE: both tag and PUBLISHED absent (never silently SYNCED)", async () => {
+  // Driver #1 applied: "no info about live" must not collapse to SYNCED.
+  // Surface as UNTRUSTED_STATE so the workflow opens a tracked issue and
+  // requires human force-dispatch.
   const result = await resolveLiveVersion({
     extensionId: EXT_ID,
     packageName: PKG,
@@ -152,9 +155,27 @@ test("source = unknown when both tag and PUBLISHED are absent", async () => {
   });
   assert.equal(result.source, "unknown");
   assert.equal(result.version, null);
-  assert.equal(result.status, "SYNCED");
+  assert.equal(result.status, "UNTRUSTED_STATE");
   assert.ok(result.warnings.some((w) => w.code === "git_tag_missing"));
   assert.ok(result.warnings.some((w) => w.code === "published_projection_400"));
+});
+
+test("UNTRUSTED_STATE: empty-string crxVersion is treated as absent", async () => {
+  // CWS returns crxVersion='' for items with no public publish yet (e.g.
+  // trusted-tester-only). The resolver must not interpret '' as a valid
+  // live version — otherwise it would route to SYNCED with version='',
+  // reproducing the very class of silent no-op this PR was opened to fix.
+  const result = await resolveLiveVersion({
+    extensionId: EXT_ID,
+    packageName: PKG,
+    localVersion: "7.2.1",
+    getItem: makeGetItem(() => ({ crxVersion: "" })),
+    gitTags: [],
+  });
+  assert.equal(result.source, "unknown");
+  assert.equal(result.version, null);
+  assert.equal(result.status, "UNTRUSTED_STATE");
+  assert.ok(result.warnings.some((w) => w.code === "git_tag_missing"));
 });
 
 test("getItem is called with projection='PUBLISHED'", async () => {

--- a/scripts/cws-api/publish.mjs
+++ b/scripts/cws-api/publish.mjs
@@ -1,6 +1,16 @@
 // Publish an uploaded CRX. POST without body to /items/<id>/publish.
 // Returns { status: [string] } per Google docs. 409 → conflict (a
 // concurrent publish is locking the item).
+//
+// Idempotency contract (Assumption A1 — Tier 2 use):
+//   publishItem(id, { trustedTesters: false }) is safe to call multiple
+//   times against an already-uploaded draft. Google returns HTTP 200 and
+//   does NOT re-trigger a new upload or increment the review queue entry.
+//   Callers may therefore retry publish without a preceding upload step
+//   when the workflow detects an in-flight draft (STUCK_DRAFT status).
+//   This contract is Tier 2 (empirically observed, not formally documented
+//   in the CWS REST API reference); treat unexpected 4xx as a signal that
+//   the assumption no longer holds and escalate to a human.
 
 import { CwsAuthError, CwsStateError } from "./errors.mjs";
 import { mintAccessToken } from "./auth.mjs";

--- a/scripts/cws-api/state.test.mjs
+++ b/scripts/cws-api/state.test.mjs
@@ -1,0 +1,122 @@
+// Tests for scripts/cws-api/state.mjs using node:test.
+//
+// Phase 1 spec Acceptance #2: getItem(_, _, "PUBLISHED") and
+// getItem(_, _, "DRAFT") MUST produce the same normalized shape but
+// build distinct request URLs (the projection query string is the only
+// difference). The test stubs `globalThis.fetch` to capture the URL
+// pattern and to short-circuit OAuth.
+
+import { strict as assert } from "node:assert";
+import { generateKeyPairSync } from "node:crypto";
+import { afterEach, beforeEach, test } from "node:test";
+
+import { _resetCache } from "./auth.mjs";
+import { getItem } from "./state.mjs";
+
+let originalFetch;
+let capturedUrls;
+let mockResponses;
+
+function makeServiceAccount() {
+  // Generate a throwaway RSA key so signJwt() does not fail. We never
+  // verify the JWT — the fetch stub returns a canned token response.
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  return {
+    client_email: "test@example.iam.gserviceaccount.com",
+    private_key: pem,
+    token_uri: "https://oauth2.googleapis.com/token",
+  };
+}
+
+function stubFetch() {
+  capturedUrls = [];
+  mockResponses = new Map();
+  globalThis.fetch = async (url, _init) => {
+    capturedUrls.push(String(url));
+    if (String(url).includes("oauth2.googleapis.com/token")) {
+      return new Response(
+        JSON.stringify({ access_token: "stub-token", expires_in: 3600 }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    const responder = mockResponses.get("default") ?? defaultItemResponder;
+    return responder(String(url));
+  };
+}
+
+function defaultItemResponder(url) {
+  const projection = /projection=([A-Z]+)/.exec(url)?.[1] ?? "DRAFT";
+  return new Response(
+    JSON.stringify({
+      id: "abc",
+      uploadState: projection === "PUBLISHED" ? "PUBLISHED" : "SUCCESS",
+      crxVersion: projection === "PUBLISHED" ? "0.2.0" : "0.3.0",
+      itemError: [],
+    }),
+    { status: 200, headers: { "content-type": "application/json" } }
+  );
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  _resetCache();
+  stubFetch();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  _resetCache();
+});
+
+test("getItem(DRAFT) and getItem(PUBLISHED) build distinct URLs", async () => {
+  const sa = makeServiceAccount();
+  await getItem(sa, "abc", "DRAFT");
+  await getItem(sa, "abc", "PUBLISHED");
+  const apiUrls = capturedUrls.filter((u) =>
+    u.includes("chromewebstore/v1.1/items/")
+  );
+  assert.equal(apiUrls.length, 2);
+  assert.match(apiUrls[0], /projection=DRAFT/);
+  assert.match(apiUrls[1], /projection=PUBLISHED/);
+});
+
+test("getItem returns the same normalized shape for both projections", async () => {
+  const sa = makeServiceAccount();
+  const draft = await getItem(sa, "abc", "DRAFT");
+  const published = await getItem(sa, "abc", "PUBLISHED");
+  const expectedKeys = [
+    "id",
+    "uploadState",
+    "crxVersion",
+    "publicKey",
+    "itemError",
+    "rawResponse",
+  ].sort();
+  assert.deepEqual(Object.keys(draft).sort(), expectedKeys);
+  assert.deepEqual(Object.keys(published).sort(), expectedKeys);
+  // Values differ per projection (which is the whole point), but the
+  // structural contract is identical.
+  assert.equal(typeof draft.uploadState, "string");
+  assert.equal(typeof published.uploadState, "string");
+  assert.ok(Array.isArray(draft.itemError));
+  assert.ok(Array.isArray(published.itemError));
+});
+
+test("getItem defaults to projection=DRAFT when not specified", async () => {
+  const sa = makeServiceAccount();
+  await getItem(sa, "abc");
+  const apiUrl = capturedUrls.find((u) =>
+    u.includes("chromewebstore/v1.1/items/")
+  );
+  assert.match(apiUrl, /projection=DRAFT/);
+});
+
+test("getItem URL-encodes the extension id", async () => {
+  const sa = makeServiceAccount();
+  await getItem(sa, "weird/id with spaces", "PUBLISHED");
+  const apiUrl = capturedUrls.find((u) =>
+    u.includes("chromewebstore/v1.1/items/")
+  );
+  assert.match(apiUrl, /weird%2Fid%20with%20spaces/);
+});

--- a/scripts/cws-api/stuck-draft-tier.mjs
+++ b/scripts/cws-api/stuck-draft-tier.mjs
@@ -1,0 +1,54 @@
+/**
+ * Stuck-draft retry tier state machine.
+ *
+ * Issue bodies carry a single marker line:
+ *
+ *     RETRY_COUNT: <integer>
+ *
+ * Contract:
+ *   - parseRetryCount(body) returns the integer value, or null when:
+ *       * the marker is missing entirely (fresh issue, human triager body)
+ *       * the value is malformed (non-integer, empty, NaN)
+ *       * the marker line was rewritten by a human and no longer matches
+ *     parseRetryCount MUST NOT throw on any input.
+ *
+ *   - bumpRetryCount(body) returns a new body string:
+ *       * if marker present with parseable integer n, replaces with n+1
+ *       * if marker missing or unparseable, appends `RETRY_COUNT: 0`
+ *       * sentinel `-1` is preserved (does not bump): an escalated draft
+ *         stays escalated until a human resets it.
+ *
+ * Re-stick after a human close: if a human closes the issue manually and
+ * the draft sticks again later, a NEW issue opens at Tier 1 (the close is
+ * an explicit human signal). Acceptable noise.
+ *
+ * Tolerances: `\r\n` line endings, leading/trailing whitespace on the
+ * marker line, and bot-reformatted bodies (extra blank lines around the
+ * marker) all parse correctly.
+ */
+
+const MARKER_RE = /^[ \t]*RETRY_COUNT[ \t]*:[ \t]*(-?\d+)[ \t]*$/m;
+
+export function parseRetryCount(issueBody) {
+  if (typeof issueBody !== "string" || issueBody.length === 0) return null;
+  const normalized = issueBody.replace(/\r\n/g, "\n");
+  const match = MARKER_RE.exec(normalized);
+  if (!match) return null;
+  const n = Number.parseInt(match[1], 10);
+  if (!Number.isInteger(n)) return null;
+  return n;
+}
+
+export function bumpRetryCount(issueBody) {
+  const base = typeof issueBody === "string" ? issueBody : "";
+  const normalized = base.replace(/\r\n/g, "\n");
+  const current = parseRetryCount(normalized);
+  if (current === -1) return normalized;
+  if (current === null) {
+    const sep = normalized.length === 0 || normalized.endsWith("\n") ? "" : "\n";
+    return `${normalized}${sep}RETRY_COUNT: 0\n`;
+  }
+  const next = current + 1;
+  return normalized.replace(MARKER_RE, `RETRY_COUNT: ${next}`);
+}
+

--- a/scripts/cws-api/stuck-draft-tier.test.mjs
+++ b/scripts/cws-api/stuck-draft-tier.test.mjs
@@ -1,0 +1,84 @@
+// Tests for scripts/cws-api/stuck-draft-tier.mjs using node:test.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { bumpRetryCount, parseRetryCount } from "./stuck-draft-tier.mjs";
+
+test("parseRetryCount returns null when marker missing", () => {
+  assert.equal(parseRetryCount("just a human body, nothing here"), null);
+  assert.equal(parseRetryCount(""), null);
+  assert.equal(parseRetryCount("RETRY: 1"), null);
+});
+
+test("parseRetryCount returns null for non-string and nullish input", () => {
+  assert.equal(parseRetryCount(null), null);
+  assert.equal(parseRetryCount(undefined), null);
+  assert.equal(parseRetryCount(42), null);
+});
+
+test("parseRetryCount parses a valid integer marker", () => {
+  assert.equal(parseRetryCount("RETRY_COUNT: 0"), 0);
+  assert.equal(parseRetryCount("RETRY_COUNT: 2"), 2);
+  assert.equal(parseRetryCount("Body before\nRETRY_COUNT: 7\nBody after"), 7);
+});
+
+test("parseRetryCount tolerates CRLF, leading/trailing whitespace", () => {
+  assert.equal(parseRetryCount("RETRY_COUNT:   3\r\n"), 3);
+  assert.equal(parseRetryCount("   RETRY_COUNT:   4   \r\n"), 4);
+  assert.equal(parseRetryCount("foo\r\nRETRY_COUNT: 5\r\nbar"), 5);
+});
+
+test("parseRetryCount returns null on malformed values", () => {
+  // Non-integer markers (NaN, empty, decimal) all yield null because the
+  // marker regex requires `(-?\d+)` followed by optional whitespace and EOL.
+  assert.equal(parseRetryCount("RETRY_COUNT: NaN"), null);
+  assert.equal(parseRetryCount("RETRY_COUNT: "), null);
+  assert.equal(parseRetryCount("RETRY_COUNT: 1.5"), null);
+});
+
+test("parseRetryCount parses sentinel -1", () => {
+  assert.equal(parseRetryCount("RETRY_COUNT: -1"), -1);
+});
+
+test("parseRetryCount does not throw on weird shapes", () => {
+  // The parser MUST NOT throw on any input.
+  assert.doesNotThrow(() => parseRetryCount(" "));
+  assert.doesNotThrow(() => parseRetryCount("a".repeat(10000)));
+  assert.doesNotThrow(() => parseRetryCount({}));
+  assert.doesNotThrow(() => parseRetryCount([]));
+});
+
+test("bumpRetryCount inserts marker at 0 when missing", () => {
+  const out = bumpRetryCount("# Title\n\nSome body\n");
+  assert.match(out, /RETRY_COUNT: 0/);
+  assert.ok(out.endsWith("RETRY_COUNT: 0\n"));
+});
+
+test("bumpRetryCount inserts marker when body is empty", () => {
+  assert.equal(bumpRetryCount(""), "RETRY_COUNT: 0\n");
+});
+
+test("bumpRetryCount increments existing marker", () => {
+  const body = "Header\nRETRY_COUNT: 2\nFooter";
+  assert.equal(bumpRetryCount(body), "Header\nRETRY_COUNT: 3\nFooter");
+});
+
+test("bumpRetryCount preserves sentinel -1", () => {
+  const body = "Header\nRETRY_COUNT: -1\nFooter";
+  // Sentinel stays sentinel; an escalated draft does not auto-bump.
+  assert.equal(bumpRetryCount(body), "Header\nRETRY_COUNT: -1\nFooter");
+});
+
+test("bumpRetryCount normalizes CRLF on output", () => {
+  const body = "Header\r\nRETRY_COUNT: 1\r\nFooter\r\n";
+  const out = bumpRetryCount(body);
+  assert.ok(!out.includes("\r\n"));
+  assert.match(out, /RETRY_COUNT: 2/);
+});
+
+test("bumpRetryCount inserts marker when previous value was malformed", () => {
+  const body = "RETRY_COUNT: notanumber";
+  const out = bumpRetryCount(body);
+  assert.match(out, /RETRY_COUNT: 0/);
+});

--- a/scripts/cws-stuck-draft-handler.mjs
+++ b/scripts/cws-stuck-draft-handler.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Tiered auto-unstick handler for STUCK_DRAFT extensions.
+// CLI: node scripts/cws-stuck-draft-handler.mjs <ext> <ext-id> <version> <run-url>
+// See tierFor() for the tier map. Functions return {tier, action};
+// the CLI entry translates that to $GITHUB_OUTPUT. Deps (`gh`, `publishItem`)
+// are injected for testability.
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+import { parseServiceAccountJson } from "./cws-api/auth.mjs";
+import { publishItem } from "./cws-api/publish.mjs";
+import { bumpRetryCount, parseRetryCount } from "./cws-api/stuck-draft-tier.mjs";
+
+// Tier mapping: null → 1 (fresh issue); 0/1 → 2 (kick); -1 or >=2 → 3 (escalate).
+function tierFor(count) {
+  if (count == null) return 1;
+  if (count === -1 || count >= 2) return 3;
+  return 2;
+}
+
+const tier1Body = (ext, version, runUrl) =>
+  `**CWS publish stuck:** ${ext} draft is at ${version}, but the live store version is older.\n\n` +
+  "This issue is automatically tracked by `cws-publish.yml`. Do not edit the `RETRY_COUNT:` marker manually unless you understand the parser contract in `scripts/cws-api/stuck-draft-tier.mjs`.\n\n" +
+  `- Local version: ${version}\n- Run: ${runUrl}\n` +
+  "- Partner dashboard: https://chrome.google.com/webstore/devconsole\n\n" +
+  "### Status\n\n- Tier: 1 (notify)\n- Next workflow run will attempt a `publishItem` kick (Tier 2).\n\nRETRY_COUNT: 0\n";
+
+export function findOpenIssue(gh, title) {
+  const out = gh("issue", [
+    "list", "--state", "open", "--search", `${title} in:title`,
+    "--json", "number,title,body", "--limit", "20",
+  ]);
+  const exact = JSON.parse(out || "[]").find((i) => i.title === title);
+  return exact ? { number: exact.number, body: exact.body ?? "" } : null;
+}
+
+const editBody = (gh, number, body) =>
+  gh("issue", ["edit", String(number), "--body", body]);
+
+async function runTier2(gh, publish, issue, extensionId) {
+  const bumped = bumpRetryCount(issue.body);
+  editBody(gh, issue.number, bumped);
+  try {
+    await publish(extensionId);
+    return { tier: 2, action: "publishitem-kicked" };
+  } catch {
+    editBody(gh, issue.number, bumped.replace(/RETRY_COUNT: \d+/, "RETRY_COUNT: -1"));
+    return { tier: "2-failed-to-3", action: "sentinel-applied" };
+  }
+}
+
+export async function handle({ extension, extensionId, version, runUrl, gh, publish }) {
+  const title = `cws-publish-stuck-${extension}-${version}`;
+  const issue = findOpenIssue(gh, title);
+  if (issue === null) {
+    gh("issue", ["create", "--title", title, "--label", "cws-stuck", "--body", tier1Body(extension, version, runUrl)]);
+    return { tier: 1, action: "opened-issue" };
+  }
+  const tier = tierFor(parseRetryCount(issue.body));
+  if (tier === 1) {
+    editBody(gh, issue.number, bumpRetryCount(issue.body));
+    return { tier: 1, action: "reset-counter" };
+  }
+  if (tier === 2) return runTier2(gh, publish, issue, extensionId);
+  return { tier: 3, action: "escalation-required" };
+}
+
+const defaultGh = () => (sub, args) =>
+  execFileSync("gh", [sub, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+
+const defaultPublish = (env) => {
+  const sa = parseServiceAccountJson(env.CWS_SERVICE_ACCOUNT_KEY ?? "");
+  return (extensionId) => publishItem(sa, extensionId);
+};
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const [extension, extensionId, version, runUrl] = process.argv.slice(2);
+  if (!extension || !extensionId || !version || !runUrl) {
+    process.stderr.write("Usage: cws-stuck-draft-handler.mjs <ext> <ext-id> <version> <run-url>\n");
+    process.exit(2);
+  }
+  handle({ extension, extensionId, version, runUrl, gh: defaultGh(), publish: defaultPublish(process.env) }).then(
+    (result) => {
+      if (process.env.GITHUB_OUTPUT) {
+        appendFileSync(process.env.GITHUB_OUTPUT, `tier=${result.tier}\naction=${result.action}\n`);
+      }
+      process.stdout.write(JSON.stringify(result) + "\n");
+      process.exit(0);
+    },
+    (err) => {
+      process.stderr.write(`[CwsStateError] ${err.message}\n`);
+      process.exit(1);
+    },
+  );
+}

--- a/scripts/cws-stuck-draft-handler.test.mjs
+++ b/scripts/cws-stuck-draft-handler.test.mjs
@@ -1,0 +1,124 @@
+// Tests for scripts/cws-stuck-draft-handler.mjs using node:test.
+// All gh + publish calls are injected fakes; no real network or shell access.
+
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { handle } from "./cws-stuck-draft-handler.mjs";
+
+function makeGh(listResponses = ["[]"]) {
+  const calls = [];
+  let listIdx = 0;
+  const gh = (sub, args) => {
+    calls.push({ sub, args });
+    if (sub === "issue" && args[0] === "list") {
+      const idx = Math.min(listIdx, listResponses.length - 1);
+      listIdx += 1;
+      return listResponses[idx];
+    }
+    if (sub === "issue" && args[0] === "create") {
+      return "https://github.com/o/r/issues/42\n";
+    }
+    return "";
+  };
+  return { gh, calls };
+}
+
+const issueListJson = (body) =>
+  JSON.stringify([{ number: 7, title: "cws-publish-stuck-train2go-bridge-7.2.1", body }]);
+
+const baseArgs = {
+  extension: "train2go-bridge",
+  extensionId: "abc123",
+  version: "7.2.1",
+  runUrl: "https://example.com/run/1",
+};
+
+test("Tier 1 — no issue exists -> creates issue with template body", async () => {
+  const { gh, calls } = makeGh(["[]"]);
+  const result = await handle({ ...baseArgs, gh, publish: async () => {} });
+  assert.deepEqual(result, { tier: 1, action: "opened-issue" });
+  const create = calls.find((c) => c.args[0] === "create");
+  assert.ok(create, "issue create call expected");
+  const bodyIdx = create.args.indexOf("--body");
+  assert.match(create.args[bodyIdx + 1], /RETRY_COUNT: 0/);
+  assert.match(create.args[bodyIdx + 1], /train2go-bridge draft is at 7\.2\.1/);
+  const labelIdx = create.args.indexOf("--label");
+  assert.equal(create.args[labelIdx + 1], "cws-stuck");
+});
+
+test("Tier 1 — issue exists but RETRY_COUNT missing -> resets counter", async () => {
+  const { gh, calls } = makeGh([issueListJson("Human edited body, no marker.\n")]);
+  const result = await handle({ ...baseArgs, gh, publish: async () => {} });
+  assert.deepEqual(result, { tier: 1, action: "reset-counter" });
+  const edit = calls.find((c) => c.args[0] === "edit");
+  assert.ok(edit, "issue edit call expected");
+  const bodyIdx = edit.args.indexOf("--body");
+  assert.match(edit.args[bodyIdx + 1], /RETRY_COUNT: 0/);
+  assert.equal(edit.args[1], "7");
+});
+
+test("Tier 2 — RETRY_COUNT: 0 -> bumps to 1 and calls publishItem", async () => {
+  const { gh, calls } = makeGh([issueListJson("Body\nRETRY_COUNT: 0\n")]);
+  const publishCalls = [];
+  const publish = async (id) => {
+    publishCalls.push(id);
+    return { status: ["OK"] };
+  };
+  const result = await handle({ ...baseArgs, gh, publish });
+  assert.deepEqual(result, { tier: 2, action: "publishitem-kicked" });
+  assert.deepEqual(publishCalls, ["abc123"]);
+  const edits = calls.filter((c) => c.args[0] === "edit");
+  assert.equal(edits.length, 1);
+  const bodyIdx = edits[0].args.indexOf("--body");
+  assert.match(edits[0].args[bodyIdx + 1], /RETRY_COUNT: 1/);
+});
+
+test("Tier 2 — RETRY_COUNT: 1 -> bumps to 2 and calls publishItem", async () => {
+  const { gh, calls } = makeGh([issueListJson("Body\nRETRY_COUNT: 1\n")]);
+  const publishCalls = [];
+  const publish = async (id) => {
+    publishCalls.push(id);
+  };
+  const result = await handle({ ...baseArgs, gh, publish });
+  assert.deepEqual(result, { tier: 2, action: "publishitem-kicked" });
+  assert.deepEqual(publishCalls, ["abc123"]);
+  const edits = calls.filter((c) => c.args[0] === "edit");
+  const bodyIdx = edits[0].args.indexOf("--body");
+  assert.match(edits[0].args[bodyIdx + 1], /RETRY_COUNT: 2/);
+});
+
+test("Tier 2 — publishItem 429 -> sentinel RETRY_COUNT: -1 applied", async () => {
+  const { gh, calls } = makeGh([issueListJson("Body\nRETRY_COUNT: 0\n")]);
+  const publish = async () => {
+    throw new Error("[CwsStateError] publishItem returned 429 (rate limited)");
+  };
+  const result = await handle({ ...baseArgs, gh, publish });
+  assert.deepEqual(result, { tier: "2-failed-to-3", action: "sentinel-applied" });
+  const edits = calls.filter((c) => c.args[0] === "edit");
+  assert.equal(edits.length, 2, "expect two edits: bump then sentinel");
+  const lastBodyIdx = edits[1].args.indexOf("--body");
+  assert.match(edits[1].args[lastBodyIdx + 1], /RETRY_COUNT: -1/);
+});
+
+test("Tier 3 — RETRY_COUNT: 3 -> escalation-required, no publishItem call", async () => {
+  const { gh } = makeGh([issueListJson("Body\nRETRY_COUNT: 3\n")]);
+  let publishCalled = false;
+  const publish = async () => {
+    publishCalled = true;
+  };
+  const result = await handle({ ...baseArgs, gh, publish });
+  assert.deepEqual(result, { tier: 3, action: "escalation-required" });
+  assert.equal(publishCalled, false);
+});
+
+test("Tier 3 — sentinel RETRY_COUNT: -1 -> escalation-required, no publishItem call", async () => {
+  const { gh } = makeGh([issueListJson("Body\nRETRY_COUNT: -1\n")]);
+  let publishCalled = false;
+  const publish = async () => {
+    publishCalled = true;
+  };
+  const result = await handle({ ...baseArgs, gh, publish });
+  assert.deepEqual(result, { tier: 3, action: "escalation-required" });
+  assert.equal(publishCalled, false);
+});


### PR DESCRIPTION
## Summary

The Chrome Web Store listing for `kaiord-train2go-bridge` has been stuck at **7.1.0 (Updated April 26)** for 18 days while the repo is at 7.2.1 and 6+ train2go-touching PRs have merged. Root cause: `cws-publish.yml`'s Decide step compared `local_version` against `DRAFT.crxVersion` and called it the *live* version. When a draft is uploaded but not yet published (PENDING_REVIEW, Trusted-Testers-only, etc.), this returned a false match and every subsequent run silently no-op'd upload+publish. Reproduced in workflow run [`25796823739`](https://github.com/pablo-albaladejo/kaiord/actions/runs/25796823739) (May 13): `PUBLISHED_VER='7.2.1'`, `CURRENT='7.2.1'`, `skip_all=true`, public store still at 7.1.0.

This PR is the output of a `/oh-my-claudecode:deep-dive` → `ralplan --consensus` → `autopilot` pipeline. Spec at `.omc/specs/deep-dive-train2go-bridge-not-updating.md`, plan at `.omc/plans/cws-publish-hardening.md`, Planner/Architect/Critic adjudications in the same folder.

## What changed

### New scripts (≤100 lines each, with co-located node:test)

- `scripts/cws-api/live-version.mjs` — `resolveLiveVersion()` returns a **typed enum status**:
  - `SYNCED` — local matches git tag and PUBLISHED API.
  - `DRAFT_AHEAD` — local > tag, draft uploaded, publish required.
  - `STUCK_DRAFT` — local > tag, draft has been pending too long, tier-kick required.
  - `UNTRUSTED_STATE` — git tag and PUBLISHED API disagree (e.g. transient API flake) → **skip + open `cws-untrusted-state-<ext>` issue + require human force-dispatch**. Never silently republishes.
- `scripts/cws-api/live-version-status.mjs` + `live-version-warnings.mjs` — split to honor the 100-line cap.
- `scripts/cws-api/stuck-draft-tier.mjs` — `parseRetryCount`/`bumpRetryCount` persisting tier state in GitHub issue bodies (survives workflow restarts; tolerates human edits per documented parser contract).
- `scripts/cws-stuck-draft-handler.mjs` — tiered auto-unstick: Tier 1 opens issue, Tier 2 kicks `publishItem` (idempotent, no re-upload), Tier 3 escalates with `continue-on-error` labels.
- `scripts/cws-api/cli-live-version.mjs` — wires `node scripts/cws-api.mjs live-version <id> --package <name>` for the workflow to call.

### Workflow refactor (`.github/workflows/cws-publish.yml`)

Five jobs, detection physically decoupled from action:

```
pre-flight  →  decide (matrix, read-only)  →  aggregate  →  act (matrix, gated)  →  summary (always)
```

- **`decide`** always emits one summary row per extension, even on partial read failures. This is the structural fix — the same defect class as the bug under repair (silent no-op when a downstream step fails) is now impossible.
- **`aggregate`** fan-in via artifacts (GitHub Actions matrix outputs are overwritten by last writer; the artifact pattern is the only fully-decoupled solution).
- **`act`** is gated by `if: github.event_name == 'push' || inputs.dry_run != 'true'`. A `workflow_dispatch` with `dry_run=true` physically skips the act job.
- **`summary`** runs `if: always()` so escalation-label failures (`continue-on-error: true`) surface as "escalation pending" rows.
- New per-extension status table written to `$GITHUB_STEP_SUMMARY` with columns: `Extension | Local | Draft | Git tag | API PUBLISHED | Status | Warnings`.
- Stale comment `# DRAFT response carries crxVersion of the live item` removed (was the bug's textual root cause).

### Slop-warning adjudication

The `UNTRUSTED_STATE` "fallback" path was flagged by a slop-warning hook during planning. Architect §6.2 adjudicated it as **JUSTIFIED degraded-mode contract** — not an ad-hoc shim — because:
- Four typed enum statuses (no free-form strings).
- Typed `warnings[]: Array<{ code, severity, message }>` consumed by the summary builder.
- Mandatory header comments on the new resolver module.
- Disagreement is a first-class, fixture-tested branch.

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm -r build` — all 15 projects build
- `pnpm lint` — zero new warnings
- `pnpm -r test` — all packages pass
- `pnpm test:scripts` — **459 tests, 0 failures** (37 new tests under `scripts/cws-api/` + 7 new in `cws-stuck-draft-handler.test.mjs`)
- Pre-merge smoke (Phase 7): trigger `workflow_dispatch` with `dry_run=true` on this branch and confirm the `act` job is skipped + the summary table renders correctly.

## What's NOT in this PR (deliberate)

- **Phase 8 (live recovery)**: getting train2go-bridge 7.2.1 actually published. The new workflow will detect `STUCK_DRAFT` on the next push; if Google has parked the draft in PENDING_REVIEW (likely due to the new `scripting`/`storage` permissions + `/user/details` endpoint added in 7.2.0), a human must visit https://chrome.google.com/webstore/devconsole, write privacy justifications, and submit for review. The automation can kick `publishItem`; it cannot navigate the partner-dashboard UI.
- **Phase 7.5 post-merge canary**: after merge, manually dispatch with `dry_run=false` once to validate the Tier 2 `publishItem` path that the pre-merge dry-run cannot reach.
- **Changeset**: not needed — only internal `scripts/` and `.github/workflows/**` are touched; no publishable package surface.

## Test plan

- [ ] CI green on this PR (build + lint + test:scripts).
- [ ] `gh workflow run cws-publish.yml --ref feat/cws-publish-hardening -f dry_run=true` produces a summary table; `act` job shown as skipped.
- [ ] After merge: post-merge canary as described in Phase 7.5.
- [ ] After merge: partner-dashboard intervention (Phase 8) to release 7.2.1 to the public store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)