### PR TITLE
fix(ci): capture CWS error body in publishItem 4xx for actionable logs

### DIFF
--- a/scripts/cws-api/error-detail.mjs
+++ b/scripts/cws-api/error-detail.mjs
@@ -1,0 +1,25 @@
+// Shared helper: read an HTTP error response body for inclusion in a
+// CwsStateError message. Strips Bearer/Authorization tokens defensively
+// before truncation. Used by both `publish.mjs` and `state.mjs` so the
+// redaction behaves identically across CWS API helpers.
+//
+// Regex order is load-bearing: the more-specific `Authorization: Bearer`
+// pattern runs FIRST and consumes the full span in one pass, so the
+// bare `Bearer` pattern only fires on tokens outside an Authorization
+// header. No `/i` flag — CWS error responses use canonical HTTP casing
+// and a case-insensitive match would widen the regex beyond intent.
+
+export async function readErrorDetail(res) {
+  try {
+    const text = await res.text();
+    const redacted = text
+      .replace(
+        /Authorization:\s*Bearer\s+[A-Za-z0-9._\-\/=]+/g,
+        "Authorization: [redacted]"
+      )
+      .replace(/\bBearer\s+[A-Za-z0-9._\-\/=]+/g, "Bearer [redacted]");
+    return redacted.replace(/\s+/g, " ").slice(0, 400);
+  } catch {
+    return "(no body)";
+  }
+}

--- a/scripts/cws-api/publish.mjs
+++ b/scripts/cws-api/publish.mjs
@@ -15,6 +15,13 @@
 import { CwsAuthError, CwsStateError } from "./errors.mjs";
 import { mintAccessToken } from "./auth.mjs";
 import { CWS_API_BASE_URL } from "./state.mjs";
+import { readErrorDetail } from "./error-detail.mjs";
+
+// Runbook for operators when this helper throws CwsStateError on a 4xx/5xx:
+// docs/runbooks/cws-service-account.md (sections "Emergency re-publish"
+// and "Reviewer rejections"). The thrown message includes the redacted
+// CWS response body so the runbook step can be picked directly.
+const RUNBOOK = "see docs/runbooks/cws-service-account.md";
 
 export async function publishItem(
   serviceAccount,
@@ -45,7 +52,9 @@ export async function publishItem(
   }
   if (!res.ok) {
     const detail = await readErrorDetail(res);
-    throw new CwsStateError(`publishItem returned ${res.status}: ${detail}`);
+    throw new CwsStateError(
+      `publishItem returned ${res.status}: ${detail} — ${RUNBOOK}`
+    );
   }
   const body = await parseJsonOrThrow(res);
   return {
@@ -53,21 +62,6 @@ export async function publishItem(
     statusDetail: Array.isArray(body.statusDetail) ? body.statusDetail : [],
     rawResponse: body,
   };
-}
-
-async function readErrorDetail(res) {
-  try {
-    const text = await res.text();
-    // Order matters: Authorization header consumed first so the Bearer regex
-    // doesn't double-redact the same span. No /i flag — error responses use
-    // canonical HTTP header casing.
-    const redacted = text
-      .replace(/Authorization:\s*Bearer\s+[A-Za-z0-9._\-\/=]+/g, "Authorization: [redacted]")
-      .replace(/\bBearer\s+[A-Za-z0-9._\-\/=]+/g, "Bearer [redacted]");
-    return redacted.replace(/\s+/g, " ").slice(0, 400);
-  } catch {
-    return "(no body)";
-  }
 }
 
 async function parseJsonOrThrow(res) {

--- a/scripts/cws-api/publish.mjs
+++ b/scripts/cws-api/publish.mjs
@@ -44,7 +44,8 @@ export async function publishItem(
     throw new CwsStateError("publishItem returned 429 (rate limited)");
   }
   if (!res.ok) {
-    throw new CwsStateError(`publishItem returned ${res.status}`);
+    const detail = await readErrorDetail(res);
+    throw new CwsStateError(`publishItem returned ${res.status}: ${detail}`);
   }
   const body = await parseJsonOrThrow(res);
   return {
@@ -52,6 +53,21 @@ export async function publishItem(
     statusDetail: Array.isArray(body.statusDetail) ? body.statusDetail : [],
     rawResponse: body,
   };
+}
+
+async function readErrorDetail(res) {
+  try {
+    const text = await res.text();
+    // Order matters: Authorization header consumed first so the Bearer regex
+    // doesn't double-redact the same span. No /i flag — error responses use
+    // canonical HTTP header casing.
+    const redacted = text
+      .replace(/Authorization:\s*Bearer\s+[A-Za-z0-9._\-\/=]+/g, "Authorization: [redacted]")
+      .replace(/\bBearer\s+[A-Za-z0-9._\-\/=]+/g, "Bearer [redacted]");
+    return redacted.replace(/\s+/g, " ").slice(0, 400);
+  } catch {
+    return "(no body)";
+  }
 }
 
 async function parseJsonOrThrow(res) {

--- a/scripts/cws-api/publish.test.mjs
+++ b/scripts/cws-api/publish.test.mjs
@@ -140,7 +140,9 @@ describe("publishItem 4xx body capture", () => {
     // Assert
     assert.ok(caught instanceof CwsStateError);
     // Message = "[CwsStateError] publishItem returned 400: " + up to 400 chars body
-    assert.ok(caught.message.length <= 450);
+    // + " — see docs/runbooks/cws-service-account.md"
+    assert.ok(caught.message.length <= 500);
+    assert.match(caught.message, /docs\/runbooks\/cws-service-account\.md/);
   });
 
   it("should redact Bearer tokens leaked back in the error body", async () => {

--- a/scripts/cws-api/publish.test.mjs
+++ b/scripts/cws-api/publish.test.mjs
@@ -1,0 +1,222 @@
+// Tests for scripts/cws-api/publish.mjs using node:test.
+//
+// Covers: 4xx body capture, redaction, auth-branch isolation, 429 message lock.
+// Fetch is stubbed via globalThis.fetch to short-circuit OAuth and CWS I/O.
+
+import { strict as assert } from "node:assert";
+import { generateKeyPairSync } from "node:crypto";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { _resetCache } from "./auth.mjs";
+import { CwsAuthError, CwsStateError } from "./errors.mjs";
+import { publishItem } from "./publish.mjs";
+
+let originalFetch;
+
+function makeServiceAccount() {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const pem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  return {
+    client_email: "test@example.iam.gserviceaccount.com",
+    private_key: pem,
+    token_uri: "https://oauth2.googleapis.com/token",
+  };
+}
+
+function stubFetch(statusAndBody) {
+  globalThis.fetch = async (url, _init) => {
+    if (String(url).includes("oauth2.googleapis.com/token")) {
+      return new Response(
+        JSON.stringify({ access_token: "stub-token", expires_in: 3600 }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    return new Response(statusAndBody.raw, {
+      status: statusAndBody.status,
+      headers: { "content-type": "application/json" },
+    });
+  };
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+  _resetCache();
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  _resetCache();
+});
+
+describe("publishItem 4xx body capture", () => {
+  it("should include CWS error message on 400 with Google standard envelope", async () => {
+    // Arrange
+    const sa = makeServiceAccount();
+    const body = JSON.stringify({
+      error: {
+        code: 400,
+        status: "INVALID_ARGUMENT",
+        message: "Item must be in DRAFT state to publish; current state: IN_REVIEW",
+        details: [],
+      },
+    });
+    stubFetch({ status: 400, raw: body });
+
+    // Act
+    let caught;
+    try {
+      await publishItem(sa, "abc");
+    } catch (e) {
+      caught = e;
+    }
+
+    // Assert
+    assert.ok(caught instanceof CwsStateError);
+    assert.match(caught.message, /400/);
+    assert.match(caught.message, /INVALID_ARGUMENT/);
+    assert.match(caught.message, /Item must be in DRAFT state/);
+  });
+
+  it("should include CWS error message on 400 with itemError array shape", async () => {
+    // Arrange
+    const sa = makeServiceAccount();
+    const body = JSON.stringify({
+      itemError: [
+        {
+          error_code: "ITEM_NOT_READY_FOR_PUBLISH",
+          error_detail: "Item is in review",
+        },
+      ],
+    });
+    stubFetch({ status: 400, raw: body });
+
+    // Act
+    let caught;
+    try {
+      await publishItem(sa, "abc");
+    } catch (e) {
+      caught = e;
+    }
+
+    // Assert
+    assert.ok(caught instanceof CwsStateError);
+    assert.match(caught.message, /400/);
+    assert.match(caught.message, /ITEM_NOT_READY_FOR_PUBLISH/);
+    assert.match(caught.message, /Item is in review/);
+  });
+
+  it("should fall back to raw body on 400 with non-JSON response", async () => {
+    // Arrange
+    const sa = makeServiceAccount();
+    stubFetch({ status: 400, raw: "plain text error from CWS" });
+
+    // Act
+    let caught;
+    try {
+      await publishItem(sa, "abc");
+    } catch (e) {
+      caught = e;
+    }
+
+    // Assert
+    assert.ok(caught instanceof CwsStateError);
+    assert.match(caught.message, /400/);
+    assert.match(caught.message, /plain text error from CWS/);
+  });
+
+  it("should slice oversized error bodies to 400 chars", async () => {
+    // Arrange
+    const sa = makeServiceAccount();
+    stubFetch({ status: 400, raw: "X".repeat(2000) });
+
+    // Act
+    let caught;
+    try {
+      await publishItem(sa, "abc");
+    } catch (e) {
+      caught = e;
+    }
+
+    // Assert
+    assert.ok(caught instanceof CwsStateError);
+    // Message = "[CwsStateError] publishItem returned 400: " + up to 400 chars body
+    assert.ok(caught.message.length <= 450);
+  });
+
+  it("should redact Bearer tokens leaked back in the error body", async () => {
+    // Arrange
+    const sa = makeServiceAccount();
+    stubFetch({ status: 400, raw: "rejected: Bearer ya29.aaaaaaaaaaaaaaaaaaaa" });
+
+    // Act
+    let caught;
+    try {
+      await publishItem(sa, "abc");
+    } catch (e) {
+      caught = e;
+    }
+
+    // Assert
+    assert.ok(caught instanceof CwsStateError);
+    assert.match(caught.message, /400/);
+    assert.match(caught.message, /\[redacted\]/);
+    assert.ok(!caught.message.includes("ya29.aaaaaaaaaaaaaaaaaaaa"));
+  });
+
+  it("should redact Authorization header without double-replacing the Bearer span", async () => {
+    // Arrange
+    const sa = makeServiceAccount();
+    stubFetch({ status: 400, raw: "Authorization: Bearer abc123" });
+
+    // Act
+    let caught;
+    try {
+      await publishItem(sa, "abc");
+    } catch (e) {
+      caught = e;
+    }
+
+    // Assert
+    assert.ok(caught instanceof CwsStateError);
+    assert.match(caught.message, /Authorization: \[redacted\]/);
+    assert.ok(!caught.message.includes("Authorization: [redacted] [redacted]"));
+  });
+
+  it("should throw CwsAuthError on 401 without exposing response body", async () => {
+    // Arrange
+    const sa = makeServiceAccount();
+    stubFetch({ status: 401, raw: "Bearer leaked-token-body" });
+
+    // Act
+    let caught;
+    try {
+      await publishItem(sa, "abc");
+    } catch (e) {
+      caught = e;
+    }
+
+    // Assert
+    assert.ok(caught instanceof CwsAuthError);
+    assert.ok(!caught.message.includes("leaked-token-body"));
+  });
+
+  it("should keep the explicit rate-limited message on 429", async () => {
+    // Arrange
+    const sa = makeServiceAccount();
+    stubFetch({ status: 429, raw: "Quota exceeded — long detail..." });
+
+    // Act
+    let caught;
+    try {
+      await publishItem(sa, "abc");
+    } catch (e) {
+      caught = e;
+    }
+
+    // Assert
+    assert.strictEqual(
+      caught.message,
+      "[CwsStateError] publishItem returned 429 (rate limited)"
+    );
+  });
+});

--- a/scripts/cws-api/state.mjs
+++ b/scripts/cws-api/state.mjs
@@ -4,9 +4,16 @@
 
 import { CwsAuthError, CwsStateError } from "./errors.mjs";
 import { mintAccessToken } from "./auth.mjs";
+import { readErrorDetail } from "./error-detail.mjs";
 
 export const CWS_API_BASE_URL =
   "https://www.googleapis.com/chromewebstore/v1.1";
+
+// Runbook for operators when getItem throws CwsStateError on a non-OK
+// response: docs/runbooks/cws-service-account.md. The thrown message
+// embeds the redacted CWS response body so the runbook step can be
+// picked directly.
+const RUNBOOK = "see docs/runbooks/cws-service-account.md";
 
 async function safeJson(res) {
   const text = await res.text();
@@ -35,26 +42,11 @@ export async function getItem(serviceAccount, id, projection = "DRAFT") {
   if (!res.ok) {
     const detail = await readErrorDetail(res);
     throw new CwsStateError(
-      `getItem(${projection}) returned ${res.status}: ${detail}`
+      `getItem(${projection}) returned ${res.status}: ${detail} — ${RUNBOOK}`
     );
   }
   const body = await safeJson(res);
   return normalizeItem(body);
-}
-
-async function readErrorDetail(res) {
-  try {
-    const text = await res.text();
-    // Order matters: Authorization header consumed first so the Bearer regex
-    // doesn't double-redact the same span. No /i flag — error responses use
-    // canonical HTTP header casing.
-    const redacted = text
-      .replace(/Authorization:\s*Bearer\s+[A-Za-z0-9._\-\/=]+/g, "Authorization: [redacted]")
-      .replace(/\bBearer\s+[A-Za-z0-9._\-\/=]+/g, "Bearer [redacted]");
-    return redacted.replace(/\s+/g, " ").slice(0, 400);
-  } catch {
-    return "(no body)";
-  }
 }
 
 function normalizeItem(body) {

--- a/scripts/cws-api/state.mjs
+++ b/scripts/cws-api/state.mjs
@@ -45,7 +45,13 @@ export async function getItem(serviceAccount, id, projection = "DRAFT") {
 async function readErrorDetail(res) {
   try {
     const text = await res.text();
-    return text.replace(/\s+/g, " ").slice(0, 400);
+    // Order matters: Authorization header consumed first so the Bearer regex
+    // doesn't double-redact the same span. No /i flag — error responses use
+    // canonical HTTP header casing.
+    const redacted = text
+      .replace(/Authorization:\s*Bearer\s+[A-Za-z0-9._\-\/=]+/g, "Authorization: [redacted]")
+      .replace(/\bBearer\s+[A-Za-z0-9._\-\/=]+/g, "Bearer [redacted]");
+    return redacted.replace(/\s+/g, " ").slice(0, 400);
   } catch {
     return "(no body)";
   }

--- a/scripts/cws-api/state.test.mjs
+++ b/scripts/cws-api/state.test.mjs
@@ -120,3 +120,24 @@ test("getItem URL-encodes the extension id", async () => {
   );
   assert.match(apiUrl, /weird%2Fid%20with%20spaces/);
 });
+
+test("should redact Bearer tokens leaked back in getItem error body", async () => {
+  // Arrange
+  const sa = makeServiceAccount();
+  mockResponses.set("default", () =>
+    new Response("rejected: Bearer ya29.aaaaaaaaaaaaaaaaaaaa", { status: 400 })
+  );
+
+  // Act
+  let caught;
+  try {
+    await getItem(sa, "abc", "DRAFT");
+  } catch (e) {
+    caught = e;
+  }
+
+  // Assert
+  assert.ok(caught instanceof (await import("./errors.mjs")).CwsStateError);
+  assert.match(caught.message, /\[redacted\]/);
+  assert.ok(!caught.message.includes("ya29.aaaaaaaaaaaaaaaaaaaa"));
+});


### PR DESCRIPTION
## Summary

During PR 610's Phase 7.5 canary, `publishItem returned 400` for both bridges (`garmin-bridge@7.2.0`, `train2go-bridge@7.2.1`). The error gave no actionable signal — diagnosing required visiting the partner dashboard. This PR captures the CWS response body (whitespace-collapsed, sliced to 400 chars, Bearer-redacted) into the thrown `CwsStateError`, surfacing the reason inline.

## Changes

- `scripts/cws-api/publish.mjs` (66 → 82 lines): new `readErrorDetail` helper; generic 4xx/5xx now embed the body in the error message.
- `scripts/cws-api/state.mjs` (63 → 69 lines): backport same redaction regex pair to the existing `readErrorDetail` for symmetry (per Architect-flagged drift smell).
- `scripts/cws-api/publish.test.mjs` (NEW, 8 cases): Google standard envelope, CWS `itemError` shape, non-JSON, 400-char slice, Bearer redaction, **regex-ordering regression lock** (Test 6), 401 auth isolation, 429 message verbatim.
- `scripts/cws-api/state.test.mjs` (+1 case): redaction-symmetry test for `getItem` body capture.

## Why

The original cws-publish-hardening spec (`/Users/pablo/development/kaiord/.omc/specs/deep-dive-train2go-bridge-not-updating.md`) explicitly deferred this as a follow-up. PR 610's canary demonstrated the gap is real.

## Verification

- `pnpm test:scripts` — **474 pass, 0 fail** (was 465; +9 new tests).
- `pnpm lint` — zero new warnings.
- Reviewed via ralplan consensus loop: Planner → Architect (ITERATE, 3 edits folded) → Critic (ITERATE on regex defect + stale-state false alarms — defect fixed, false alarms resolved by `origin/main` pull) → re-Critic APPROVE.
- Phase 4 autopilot validation: Architect APPROVE, Security-reviewer APPROVE (LOW risk; redaction order correct, 401/403 path safe), Code-reviewer APPROVE (1 LOW vacuous-assertion fix landed in this PR).

## Test plan

- [ ] CI green.
- [ ] Trigger `gh workflow run cws-publish.yml --ref feat/publish-error-body-capture -f dry_run=true` to confirm summary table still renders (no behavior change in non-error paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages when publishing to Chrome Web Store by including response details for better diagnostics.
  * Automatically redacts sensitive authentication tokens from error messages to prevent credential exposure.

* **Tests**
  * Added tests for error handling and token redaction to ensure security and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/613)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->