### PR TITLE
chore(ci): workflow_dispatch to regenerate visual baselines (#554)

### DIFF
--- a/.changeset/ux-redesign-foundations.md
+++ b/.changeset/ux-redesign-foundations.md
@@ -1,0 +1,16 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+UX redesign foundations (Phase 0+1 structural slice): introduce a UX
+glossary (`packages/workout-spa-editor/docs/ux-glossary.md`) defining
+canonical verbs and nouns for the spa editor; add a `Card` atom and
+migrate three duplicated inline `rounded-lg border …` surfaces
+(`ManualCreateSection`, `GettingStartedTips`, `LibraryPageCard`) to it;
+add a visible `EditorPageHeader` to replace the previous `sr-only` h1
+so the editor matches the header pattern used by `LibraryPageHeader`.
+`EmptyWeekState` is migrated from raw HTML buttons (inline
+`bg-primary-600 px-4 py-2 …`) to the `Button` atom (`primary` /
+`secondary`, `sm`) without copy changes. No behavioural change. See
+`.omc/specs/deep-dive-ui-flow-map-ux-redesign.md` for the full phased
+roadmap; verb-pass and AI/journey items ship in subsequent PRs.

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -1,0 +1,60 @@
+name: Update Visual Baselines
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to update baselines on (must already exist on origin)"
+        required: true
+        type: string
+      spec:
+        description: "Visual spec glob (relative to packages/workout-spa-editor)"
+        required: false
+        type: string
+        default: "e2e/**/*.visual.spec.ts"
+
+permissions:
+  contents: write
+
+jobs:
+  update-baselines:
+    name: Regenerate Playwright snapshots
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout target branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.branch }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
+
+      - name: Install Playwright browsers
+        run: pnpm --filter @kaiord/workout-spa-editor test:e2e:install
+
+      - name: Build workspace dependencies
+        run: pnpm -r build
+
+      - name: Regenerate snapshots
+        run: |
+          pnpm --filter @kaiord/workout-spa-editor exec playwright test \
+            --project=chromium \
+            --update-snapshots \
+            ${{ inputs.spec }}
+        env:
+          CI: true
+
+      - name: Commit and push snapshots
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [[ -z "$(git status --porcelain packages/workout-spa-editor)" ]]; then
+            echo "No snapshot changes — branch already has up-to-date baselines."
+            exit 0
+          fi
+          git add packages/workout-spa-editor
+          git commit -m "chore(spa-editor): regenerate visual baselines via update-visual-baselines workflow"
+          git push origin HEAD:${{ inputs.branch }}

--- a/packages/workout-spa-editor/docs/ux-glossary.md
+++ b/packages/workout-spa-editor/docs/ux-glossary.md
@@ -1,0 +1,57 @@
+# UX Glossary
+
+> Canonical user-facing terms for `@kaiord/workout-spa-editor`.
+> Owned by the design system. Pull requests that introduce new
+> verbs or rename existing ones must update this glossary first.
+
+The trace and reflection that motivate this glossary live in
+`.omc/specs/deep-dive-trace-ui-flow-map-ux-redesign.md` and
+`.omc/specs/deep-dive-ui-flow-map-ux-redesign-reflection.md`.
+
+## Verbs (one per goal)
+
+| Verb                 | Use when…                                                                 | Avoid               |
+| -------------------- | ------------------------------------------------------------------------- | ------------------- |
+| **Create**           | The user starts a brand-new workout from scratch (manual / AI / template) | "Add", "New"        |
+| **Schedule**         | The user places an existing workout/template on a specific calendar day   | "Plan", "Set"       |
+| **Send**             | The user pushes a workout to a connected device (Garmin)                  | "Push", "Upload"    |
+| **Save**             | The user persists changes to a workout in storage                         | "Store", "Commit"   |
+| **Save as template** | The user persists a workout as a reusable template in the library         | "Save to Library"   |
+| **Load**             | The user opens an existing workout/template into the editor               | "Open"              |
+| **Polish with AI**   | The user transforms a manually-edited workout via AI                      | "Improve", "Refine" |
+| **Match**            | The user pairs a coaching prescription with an existing workout           | "Link", "Connect"   |
+| **Connect**          | The user pairs an external account/device (Garmin, Train2Go)              | "Link", "Pair"      |
+| **Switch**           | The user changes the active profile                                       | "Change"            |
+
+## Nouns
+
+| Noun                 | Means                                                          |
+| -------------------- | -------------------------------------------------------------- |
+| **Workout**          | A single training session, structured or imported              |
+| **Template**         | A reusable workout saved in the library                        |
+| **Step**             | A single interval inside a workout                             |
+| **Repetition block** | A grouped sequence of steps that repeats N times               |
+| **Coach**            | The external coaching prescription source (Train2Go etc.)      |
+| **Zone**             | A training intensity band (HR or power), defined per profile   |
+| **Profile**          | The athlete identity (zones · linked accounts · personal data) |
+| **Calendar week**    | The Monday-anchored week shown on `/calendar`                  |
+
+## State labels (visible to user)
+
+| Label         | Means                                                |
+| ------------- | ---------------------------------------------------- |
+| **Connected** | Bridge / device is online and reachable              |
+| **Offline**   | Bridge / device is unreachable                       |
+| **Synced**    | Last data exchange completed without conflict        |
+| **Conflict**  | Last sync surfaced a difference requiring resolution |
+
+## Rationale (kept short, applies across the app)
+
+- One verb per goal so users build a stable vocabulary.
+- Verbs are imperative and concrete (not "Manage", not "Handle").
+- Nouns map 1:1 to a domain concept; never use "session" or "activity"
+  as a synonym for "workout" in user-facing copy.
+- State labels live in a fixed vocabulary so the persistent status
+  header reads consistently across the app.
+- Existing call-sites are not retroactively renamed by this glossary
+  doc; verb migrations ship in their own PRs to keep diffs reviewable.

--- a/packages/workout-spa-editor/src/components/atoms/Card/Card.test.tsx
+++ b/packages/workout-spa-editor/src/components/atoms/Card/Card.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Card } from "./Card";
+
+describe("Card", () => {
+  describe("rendering", () => {
+    it("should render children content", () => {
+      // Arrange
+
+      // Act
+
+      render(<Card>Content here</Card>);
+
+      // Assert
+
+      expect(screen.getByText("Content here")).toBeInTheDocument();
+    });
+
+    it("should apply default base classes", () => {
+      // Arrange
+
+      render(<Card data-testid="card">Body</Card>);
+
+      // Act
+
+      const card = screen.getByTestId("card");
+
+      // Assert
+
+      expect(card).toHaveClass("rounded-lg");
+      expect(card).toHaveClass("border");
+      expect(card).toHaveClass("bg-white");
+      expect(card).toHaveClass("shadow-sm");
+    });
+
+    it("should apply dark mode classes", () => {
+      // Arrange
+
+      render(<Card data-testid="card">Body</Card>);
+
+      // Act
+
+      const card = screen.getByTestId("card");
+
+      // Assert
+
+      expect(card).toHaveClass("dark:border-gray-700");
+      expect(card).toHaveClass("dark:bg-gray-800");
+    });
+  });
+
+  describe("variants", () => {
+    it("should render default variant without interactive classes", () => {
+      // Arrange
+
+      render(
+        <Card variant="default" data-testid="card">
+          Body
+        </Card>
+      );
+
+      // Act
+
+      const card = screen.getByTestId("card");
+
+      // Assert
+
+      expect(card).not.toHaveClass("hover:shadow-lg");
+    });
+
+    it("should render interactive variant with hover effect", () => {
+      // Arrange
+
+      render(
+        <Card variant="interactive" data-testid="card">
+          Body
+        </Card>
+      );
+
+      // Act
+
+      const card = screen.getByTestId("card");
+
+      // Assert
+
+      expect(card).toHaveClass("hover:shadow-lg");
+      expect(card).toHaveClass("transition-all");
+      expect(card).toHaveClass("group");
+      expect(card).toHaveClass("overflow-hidden");
+    });
+  });
+
+  describe("custom props", () => {
+    it("should accept custom className", () => {
+      // Arrange
+
+      render(
+        <Card className="custom-class" data-testid="card">
+          Body
+        </Card>
+      );
+
+      // Act
+
+      const card = screen.getByTestId("card");
+
+      // Assert
+
+      expect(card).toHaveClass("custom-class");
+    });
+
+    it("should forward ref to underlying div", () => {
+      // Arrange
+
+      const ref = vi.fn();
+
+      // Act
+
+      render(<Card ref={ref}>Body</Card>);
+
+      // Assert
+
+      expect(ref).toHaveBeenCalled();
+    });
+
+    it("should pass through HTML attributes like data-testid", () => {
+      // Arrange
+
+      render(<Card data-testid="library-card">Body</Card>);
+
+      // Act
+
+      const card = screen.getByTestId("library-card");
+
+      // Assert
+
+      expect(card).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/atoms/Card/Card.tsx
+++ b/packages/workout-spa-editor/src/components/atoms/Card/Card.tsx
@@ -1,0 +1,31 @@
+import { forwardRef, type HTMLAttributes } from "react";
+
+export type CardVariant = "default" | "interactive";
+
+export type CardProps = HTMLAttributes<HTMLDivElement> & {
+  variant?: CardVariant;
+};
+
+const baseClasses =
+  "rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800";
+
+const variantClasses: Record<CardVariant, string> = {
+  default: "",
+  interactive: "group relative overflow-hidden transition-all hover:shadow-lg",
+};
+
+export const Card = forwardRef<HTMLDivElement, CardProps>(
+  ({ variant = "default", className = "", children, ...props }, ref) => {
+    const classes = [baseClasses, variantClasses[variant], className]
+      .filter(Boolean)
+      .join(" ");
+
+    return (
+      <div ref={ref} className={classes} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+Card.displayName = "Card";

--- a/packages/workout-spa-editor/src/components/atoms/Card/index.ts
+++ b/packages/workout-spa-editor/src/components/atoms/Card/index.ts
@@ -1,0 +1,2 @@
+export type { CardProps, CardVariant } from "./Card";
+export { Card } from "./Card";

--- a/packages/workout-spa-editor/src/components/molecules/CalendarEmptyStates/EmptyWeekState.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CalendarEmptyStates/EmptyWeekState.tsx
@@ -5,6 +5,8 @@
 import { Calendar, Plus } from "lucide-react";
 import { useLocation } from "wouter";
 
+import { Button } from "../../atoms/Button/Button";
+
 export type EmptyWeekStateProps = {
   onGoToLatest?: () => void;
 };
@@ -20,22 +22,18 @@ export function EmptyWeekState({ onGoToLatest }: EmptyWeekStateProps) {
       <Calendar className="h-10 w-10 text-muted-foreground" />
       <p className="text-muted-foreground">No workouts this week</p>
       <div className="flex gap-3">
-        <button
-          type="button"
+        <Button
+          variant="primary"
+          size="sm"
           onClick={() => navigate("/workout/new")}
-          className="flex items-center gap-1.5 rounded-md bg-primary-600 px-4 py-2 text-sm text-white hover:bg-primary-700"
         >
           <Plus className="h-4 w-4" />
           Add workout
-        </button>
+        </Button>
         {onGoToLatest && (
-          <button
-            type="button"
-            onClick={onGoToLatest}
-            className="rounded-md border px-4 py-2 text-sm hover:bg-gray-50 dark:hover:bg-gray-800"
-          >
+          <Button variant="secondary" size="sm" onClick={onGoToLatest}>
             Go to latest
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/EditorPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/EditorPage.tsx
@@ -17,7 +17,6 @@ import { useSearch } from "wouter";
 import { useActiveProfileLive } from "../../hooks/use-active-profile-live";
 import { useAppHandlers } from "../../hooks/useAppHandlers";
 import { useDeleteCleanup } from "../../hooks/useDeleteCleanup";
-import { ROUTE_HEADING_ATTR } from "../../routing/constants";
 import { useWorkoutStore } from "../../store/workout-store";
 import type { Workout } from "../../types/krd";
 import { useCoachingSidebar } from "../organisms/CoachingSidebar/use-coaching-sidebar";
@@ -25,6 +24,7 @@ import { DateBanner } from "./DateBanner";
 import { EditorBody } from "./EditorBody";
 import { EditorLoading, EditorNoData } from "./EditorLoadingState";
 import { EditorNewWorkout } from "./EditorNewWorkout";
+import { EditorPageHeader } from "./EditorPageHeader";
 import { EditorWorkflowBar } from "./EditorWorkflowBar";
 import { useEditorActions } from "./use-editor-actions";
 import { useWorkoutRecord } from "./use-workout-record";
@@ -58,9 +58,7 @@ export default function EditorPage({ id }: EditorPageProps) {
 
   return (
     <div className="space-y-6">
-      <h1 tabIndex={-1} {...{ [ROUTE_HEADING_ATTR]: "" }} className="sr-only">
-        {id ? "Edit workout" : "New workout"}
-      </h1>
+      <EditorPageHeader mode={id ? "edit" : "new"} />
       {!id && dateParam && <DateBanner date={dateParam} />}
       {record && (
         <EditorWorkflowBar

--- a/packages/workout-spa-editor/src/components/pages/EditorPageHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/EditorPageHeader.tsx
@@ -1,0 +1,38 @@
+import { PenLine } from "lucide-react";
+
+import { ROUTE_HEADING_ATTR } from "../../routing/constants";
+
+export type EditorPageHeaderProps = {
+  mode: "new" | "edit";
+};
+
+const COPY = {
+  new: {
+    title: "New workout",
+    description: "Create from scratch, generate with AI, or import a file.",
+  },
+  edit: {
+    title: "Edit workout",
+    description: "Refine steps, intervals, and targets.",
+  },
+} as const;
+
+export function EditorPageHeader({ mode }: EditorPageHeaderProps) {
+  const { title, description } = COPY[mode];
+
+  return (
+    <div className="mb-2">
+      <div className="flex items-center gap-2 mb-1">
+        <PenLine className="h-5 w-5 text-primary" />
+        <h1
+          tabIndex={-1}
+          {...{ [ROUTE_HEADING_ATTR]: "" }}
+          className="text-xl font-semibold text-gray-900 dark:text-white"
+        >
+          {title}
+        </h1>
+      </div>
+      <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/GettingStartedTips.tsx
+++ b/packages/workout-spa-editor/src/components/pages/GettingStartedTips.tsx
@@ -1,6 +1,8 @@
+import { Card } from "../atoms/Card/Card";
+
 export function GettingStartedTips() {
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+    <Card className="p-6">
       <h3 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
         Getting Started
       </h3>
@@ -9,6 +11,6 @@ export function GettingStartedTips() {
         <li>• Load an existing workout file</li>
         <li>• Add, edit, and organize workout steps</li>
       </ul>
-    </div>
+    </Card>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/LibraryPageCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/LibraryPageCard.tsx
@@ -13,6 +13,7 @@ import { Play } from "lucide-react";
 
 import type { WorkoutTemplate } from "../../types/workout-library";
 import { Button } from "../atoms/Button/Button";
+import { Card } from "../atoms/Card/Card";
 import { CardBadges } from "../organisms/WorkoutLibrary/components/CardBadges";
 import { CardHeader } from "../organisms/WorkoutLibrary/components/CardHeader";
 import { CardScheduleAction } from "../organisms/WorkoutLibrary/components/CardScheduleAction";
@@ -35,10 +36,7 @@ export function LibraryPageCard({
   onLoad,
 }: LibraryPageCardProps) {
   return (
-    <div
-      className="group relative overflow-hidden rounded-lg border border-gray-200 bg-white transition-all hover:shadow-lg dark:border-gray-700 dark:bg-gray-800"
-      data-testid="library-card"
-    >
+    <Card variant="interactive" data-testid="library-card">
       <CardThumbnail
         thumbnailData={template.thumbnailData}
         workoutName={template.name}
@@ -69,6 +67,6 @@ export function LibraryPageCard({
           Created {new Date(template.createdAt).toLocaleDateString()}
         </p>
       </div>
-    </div>
+    </Card>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/ManualCreateSection.tsx
+++ b/packages/workout-spa-editor/src/components/pages/ManualCreateSection.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useAnalytics } from "../../contexts";
 import type { KRD, ValidationError } from "../../types/krd";
 import { Button } from "../atoms/Button/Button";
+import { Card } from "../atoms/Card/Card";
 import { FileUpload } from "../molecules/FileUpload/FileUpload";
 
 type ManualCreateSectionProps = {
@@ -28,7 +29,7 @@ export function ManualCreateSection({
   };
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800">
+    <Card>
       <button
         type="button"
         onClick={() => setExpanded(!expanded)}
@@ -62,6 +63,6 @@ export function ManualCreateSection({
           />
         </div>
       )}
-    </div>
+    </Card>
   );
 }


### PR DESCRIPTION
## Summary

Adds a manually-triggered GitHub Actions workflow that regenerates Playwright visual-regression snapshots inside CI (ubuntu-latest / chromium) and commits them back to a target branch as \`github-actions[bot]\`. Closes the platform-mismatch problem that's blocking PR #605: \`toHaveScreenshot()\` requires PNGs rendered on the same OS as CI, so baselines generated on macOS would always diverge by font-rendering pixels.

## How it'll be used

After this lands on main:

1. **Actions → Update Visual Baselines → Run workflow**
2. Inputs:
   - \`branch\`: \`feat/issue-554-coaching-sidebar-visual-snapshots\`
   - \`spec\`: default (\`e2e/**/*.visual.spec.ts\`) is fine
3. Workflow regenerates the PNGs and pushes a commit to that branch as \`github-actions[bot]\`.
4. PR #605's CI re-runs with the new baselines, goes green, and can be merged → closes #554.

## Design

- \`workflow_dispatch\` only; never auto-triggered, no side effects on normal CI.
- \`permissions: contents: write\` is the minimum required to push back.
- Idempotent: exits cleanly if no snapshot changes are produced.
- Reusable for any future \`*.visual.spec.ts\`; spec glob is a parameter, not hardcoded.

## Test plan

- [ ] Merge this PR.
- [ ] Trigger the workflow against \`feat/issue-554-coaching-sidebar-visual-snapshots\`.
- [ ] Verify the workflow pushes a commit with PNGs under \`packages/workout-spa-editor/e2e/coaching-sidebar.visual.spec.ts-snapshots/\`.
- [ ] PR #605 CI goes green; merge it; #554 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)