### PR TITLE
fix(ci): playwright spec glob must precede --update-snapshots flag

### DIFF
--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Regenerate snapshots
         run: |
           pnpm --filter @kaiord/workout-spa-editor exec playwright test \
+            "${{ inputs.spec }}" \
             --project=chromium \
-            --update-snapshots \
-            ${{ inputs.spec }}
+            --update-snapshots=all
         env:
           CI: true
 


### PR DESCRIPTION
## Summary

Fix the \`update-visual-baselines\` workflow added in #616. The first dispatch ([run 25957825886](https://github.com/pablo-albaladejo/kaiord/actions/runs/25957825886)) failed because \`--update-snapshots e2e/**/*.visual.spec.ts\` made the Playwright CLI parse the glob as the optional flag value:

\`\`\`
error: option '-u, --update-snapshots [mode]' argument 'e2e/**/*.visual.spec.ts' is invalid.
Allowed choices are all, changed, missing, none.
\`\`\`

Put the spec glob before the flag and pass \`--update-snapshots=all\` so the mode is unambiguous.

## Test plan

- [ ] Merge this PR.
- [ ] Re-dispatch \`Update Visual Baselines\` against \`feat/issue-554-coaching-sidebar-visual-snapshots\`.
- [ ] Verify it commits PNG baselines back to the branch and PR #605 goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)