### PR TITLE
feat(spa-editor): success toast on library template load

### DIFF
--- a/.changeset/ux-redesign-library-load-toast.md
+++ b/.changeset/ux-redesign-library-load-toast.md
@@ -1,0 +1,14 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+UX redesign Phase 1 leftover (start): show a success toast when a
+template is loaded into the editor from the library. The library's
+"Load into editor" CTA navigates to `/workout/new`; previously the
+user landed on the welcome screen with no confirmation that the
+template had been loaded. The new toast surfaces a static
+`"Template loaded"` title (PII guard R-PIIInterpolation compliant)
+with the template name as the description and a 3-second auto-dismiss,
+addressing one of the "dead-ends after success" issues identified in
+the deep-dive trace. Auto-dismiss + toast for the batch and coaching
+completion flows ships in subsequent PRs.

--- a/packages/workout-spa-editor/src/components/pages/LibraryPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/LibraryPage.test.tsx
@@ -292,6 +292,34 @@ describe("LibraryPage", () => {
     });
   });
 
+  it("should show a success toast when a template is loaded into the editor", async () => {
+    // Arrange
+
+    const template = makeTemplate({
+      id: "t-toast",
+      name: "Sweet Spot",
+      sport: "cycling",
+    });
+    await db.table("templates").add(template);
+    useWorkoutStore.setState({ currentWorkout: ACTIVE_KRD });
+
+    const user = userEvent.setup();
+
+    // Act
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("card-load-into-editor")).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId("card-load-into-editor"));
+
+    // Assert
+
+    expect(await screen.findByText("Template loaded")).toBeInTheDocument();
+    expect(await screen.findByText("Sweet Spot")).toBeInTheDocument();
+  });
+
   it("should render the page heading with the route-heading attribute", async () => {
     // Arrange
 

--- a/packages/workout-spa-editor/src/components/pages/LibraryPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/LibraryPage.tsx
@@ -35,7 +35,7 @@ import { useScheduleTemplate } from "./use-schedule-template";
 export default function LibraryPage() {
   const templates = useLibraryTemplatesLive();
   const persistence = usePersistence();
-  const { error: showError } = useToastContext();
+  const { error: showError, success: showSuccess } = useToastContext();
   const { scheduling, openScheduler, closeScheduler, confirmSchedule } =
     useScheduleTemplate();
   const currentWorkout = useCurrentWorkout();
@@ -57,6 +57,12 @@ export default function LibraryPage() {
 
   const handleLoad = (template: WorkoutTemplate) => {
     loadWorkout(template.krd);
+    // Toast confirms the load so the user does not land on the
+    // editor's welcome screen wondering whether anything happened.
+    // Title is a static literal (PII guard R-PIIInterpolation);
+    // template.name flows through the description field which the
+    // guard intentionally does not constrain.
+    showSuccess("Template loaded", template.name, { duration: 3000 });
     // SPA navigation (no full reload) so the freshly-loaded workout
     // survives the route transition. Hard reload would drop Zustand.
     navigate("/workout/new");


### PR DESCRIPTION
## Summary

Third slice of the UX redesign roadmap (Phase 1 leftover, partial). Addresses one of the "dead-end flows after success" identified in the deep-dive trace.

### Behaviour change

- Clicking **Load into editor** on a library template now surfaces a `success` toast with a static `"Template loaded"` title (3-second auto-dismiss) and the template name as the description, before navigating to `/workout/new`. Previously the user landed on the welcome screen with no signal that the template had been loaded.

### Why a static title

The PII guard (`R-PIIInterpolation`, enforced by `scripts/check-no-pii-leakage.mjs`) requires the toast's first argument to be a bare string literal or a top-level `SCREAMING_SNAKE_CASE` constant. The template name flows through the `description` field, which the guard intentionally does not constrain.

### Out of scope (follow-up PRs)

- Auto-dismiss + toast on batch completion (Phase 1.5)
- Auto-dismiss + toast on coaching match (Phase 1.5)
- AI success affordance row in the AI overlay (Phase 1.7)

See `.omc/specs/deep-dive-ui-flow-map-ux-redesign.md` for the full phased roadmap.

## Test plan

- [x] `pnpm -F @kaiord/workout-spa-editor exec vitest run src/components/pages/LibraryPage.test.tsx` (10/10 pass, including the new toast test)
- [x] `pnpm -F @kaiord/workout-spa-editor lint`
- [x] `node scripts/check-no-pii-leakage.mjs` (R-PIIInterpolation green)
- [ ] CI required checks: detect-changes, lint, typecheck, test, build, round-trip, Changeset, Link checker
- [ ] CodeRabbit review (may be rate-limited from earlier PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)