### PR TITLE
fix(ci): auto-close cws-untrusted-state issues when run logs SYNCED (#621)

### DIFF
--- a/.github/workflows/cws-publish.yml
+++ b/.github/workflows/cws-publish.yml
@@ -219,6 +219,21 @@ jobs:
             echo "cws-untrusted-state issue already open for $EXT (#$EXISTING); skipping create"
           fi
 
+      - name: Auto-close reconciled untrusted-state issues
+        if: steps.live.outputs.status == 'SYNCED' && steps.decide.outputs.reason == 'in-sync'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXT: ${{ matrix.extension.name }}
+        run: |
+          gh issue list --state open \
+            --search "in:title \"CWS untrusted state: ${EXT}\"" \
+            --json number --jq '.[].number' | \
+          while read n; do
+            [ -z "$n" ] && continue
+            gh issue close "$n" --comment \
+              "Reconciled by run ${{ github.run_id }} (STATUS=SYNCED, reason=in-sync)."
+          done
+
       - name: Build summary row
         id: row
         if: always()

--- a/.github/workflows/cws-publish.yml
+++ b/.github/workflows/cws-publish.yml
@@ -225,14 +225,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EXT: ${{ matrix.extension.name }}
         run: |
-          gh issue list --state open \
-            --search "in:title \"CWS untrusted state: ${EXT}\"" \
-            --json number --jq '.[].number' | \
-          while read n; do
-            [ -z "$n" ] && continue
-            gh issue close "$n" --comment \
-              "Reconciled by run ${{ github.run_id }} (STATUS=SYNCED, reason=in-sync)."
-          done
+          TITLE="CWS untrusted state: $EXT"
+          gh issue list --state open --search "$TITLE in:title" \
+            --json number,title --limit 20 \
+            | jq -r --arg t "$TITLE" '.[] | select(.title == $t) | .number' \
+            | while read n; do
+                [ -z "$n" ] && continue
+                gh issue close "$n" --comment \
+                  "Reconciled by run ${{ github.run_id }} (STATUS=SYNCED, reason=in-sync)."
+              done
 
       - name: Build summary row
         id: row


### PR DESCRIPTION
## Summary

Adds a step in \`cws-publish.yml\` that auto-closes any open \`cws-untrusted-state\` issue for an extension when a later run reconciles its state (\`STATUS=SYNCED && reason=in-sync\`). Uses the same \`steps.decide.outputs\` source as the existing issue-creating step, so STUCK_DRAFT and other non-reconciled states are never matched.

Closes #621.

## Test plan

Pre-merge dry-run is impractical (\`decide\` derives \`STATUS\` from live CWS API state, not from \`workflow_dispatch\` inputs). Verification path:

- [ ] Post-merge: on the next natural SYNCED+in-sync run for an extension that has an open \`cws-untrusted-state\` issue, confirm the issue auto-closes with a comment linking the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automation to automatically close CWS "untrusted state" issues when live status reports a successful sync. The automation will close matching open issues and add an inline comment referencing the workflow run and the reconciliation condition (STATUS=SYNCED, reason=in-sync).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->