### PR TITLE
chore(spa-editor): add ux2026.unifiedSettings feature flag

### DIFF
--- a/.changeset/ux2026-unified-settings-flag.md
+++ b/.changeset/ux2026-unified-settings-flag.md
@@ -1,0 +1,11 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Add `ux2026.unifiedSettings` feature flag (default `false`) to the
+`FEATURE_FLAGS` const in `packages/workout-spa-editor/src/lib/feature-flags.ts`.
+Prerequisite for PR E of the UX redesign roadmap
+(`.omc/plans/ralplan-ux-redesign-phase1-leftovers-and-phase2.md`),
+which will gate the unified `/settings` route behind this flag. No
+behavioural change — the flag is not yet read anywhere. Existing
+namespace + default-false tests cover the new entry automatically.

--- a/packages/workout-spa-editor/src/lib/feature-flags.ts
+++ b/packages/workout-spa-editor/src/lib/feature-flags.ts
@@ -26,6 +26,8 @@ export const FEATURE_FLAGS = {
   "ux2026.commandPalette": false,
   /** Phase 2: read-only zone peek shortcut. */
   "ux2026.zonePeek": false,
+  /** Phase 2: unified /settings route with deep-linkable tabs. */
+  "ux2026.unifiedSettings": false,
 } as const;
 
 export type FeatureFlagName = keyof typeof FEATURE_FLAGS;


### PR DESCRIPTION
## Summary

PR 0 from the UX redesign Phase 1+2 roadmap. Pure infrastructure: extends `FEATURE_FLAGS` with `ux2026.unifiedSettings`, defaulting to `false`. No behavioral change — the flag is not yet read anywhere; PR E will gate the unified `/settings` route behind it.

### Files

- `packages/workout-spa-editor/src/lib/feature-flags.ts` — one new entry
- `.changeset/ux2026-unified-settings-flag.md` — patch on `@kaiord/workout-spa-editor`

### Why a dedicated PR

Plan §"PR 0" (`.omc/plans/ralplan-ux-redesign-phase1-leftovers-and-phase2.md`) explicitly carved out the flag introduction as a prerequisite so PR E stays focused on UI work and avoids the "first deploy of the flag" coupling.

## Test plan

- [x] `pnpm -F @kaiord/workout-spa-editor exec vitest run src/lib/feature-flags.test.ts` — 5/5 pass (existing namespace + default-false tests cover the new flag automatically)
- [x] `pnpm -F @kaiord/workout-spa-editor lint` — green
- [ ] CI required checks
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added feature flag infrastructure in preparation for upcoming unified settings experience improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/627?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->