### PR TITLE
feat(spa-editor): success toast on batch completion

### DIFF
--- a/.changeset/ux-redesign-batch-toast.md
+++ b/.changeset/ux-redesign-batch-toast.md
@@ -1,0 +1,15 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+UX redesign Phase 1 leftover: surface a success toast when a batch
+of raw workouts finishes processing. `useBatchRunner` gains an
+optional `onSuccess(count)` callback that fires only when the
+`processBatch` await resolves cleanly — cancellation and errors
+short-circuit through the existing `catch` so no toast appears in
+those paths. `useBatchState` wires `useToastContext().success` to
+the callback with a static `"Batch processed"` title and a
+`"${count} workouts"` description (R-PIIInterpolation compliant —
+the title is a bare literal; the dynamic count flows through the
+description field). Removes the "did anything happen?" dead-end on
+the calendar's batch-process flow identified in the deep-dive trace.

--- a/packages/workout-spa-editor/src/components/pages/use-batch-runner.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-batch-runner.test.ts
@@ -58,6 +58,45 @@ describe("useBatchRunner", () => {
     expect(result.current.isProcessing).toBe(false);
   });
 
+  it("should fire onSuccess with the workout count after a clean batch run", async () => {
+    // Arrange
+
+    processBatchSpy.mockResolvedValueOnce(undefined);
+    const setMessage = vi.fn();
+    const onSuccess = vi.fn();
+
+    // Act
+
+    const { result } = renderHook(() => useBatchRunner(setMessage, onSuccess));
+    await act(async () => {
+      await result.current.run({ provider, workouts: [workout, workout] });
+    });
+
+    // Assert
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledWith(2);
+  });
+
+  it("should NOT fire onSuccess when processBatch throws", async () => {
+    // Arrange
+
+    processBatchSpy.mockRejectedValueOnce(new Error("boom"));
+    const setMessage = vi.fn();
+    const onSuccess = vi.fn();
+
+    // Act
+
+    const { result } = renderHook(() => useBatchRunner(setMessage, onSuccess));
+    await act(async () => {
+      await result.current.run({ provider, workouts: [workout] });
+    });
+
+    // Assert
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
   it("should surface an error message when processBatch throws", async () => {
     // Arrange
 

--- a/packages/workout-spa-editor/src/components/pages/use-batch-runner.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-batch-runner.ts
@@ -6,7 +6,10 @@ import { processBatch } from "../../application/batch-processor";
 import { createProcessOne } from "./batch-process-one";
 import type { BatchPending } from "./use-batch-state";
 
-export function useBatchRunner(setMessage: (msg: string | null) => void) {
+export function useBatchRunner(
+  setMessage: (msg: string | null) => void,
+  onSuccess?: (count: number) => void
+) {
   const [progress, setProgress] = useState<BatchProgress | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -25,13 +28,18 @@ export function useBatchRunner(setMessage: (msg: string | null) => void) {
           setProgress,
           controller.signal
         );
+        // Success branch — fire onSuccess only when the await resolves
+        // cleanly (cancellation throws AbortError → caught below → no
+        // notification). Static-title toast lives in the caller to keep
+        // this hook free of React-context coupling.
+        onSuccess?.(batch.workouts.length);
       } catch {
         setMessage("Batch processing encountered an unexpected error.");
       } finally {
         setIsProcessing(false);
       }
     },
-    [setMessage]
+    [setMessage, onSuccess]
   );
 
   const cancel = useCallback(() => {

--- a/packages/workout-spa-editor/src/components/pages/use-batch-state.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-batch-state.test.ts
@@ -28,12 +28,37 @@ vi.mock("./batch-prepare", () => ({
   prepareBatch: async () => mockPrep,
 }));
 
+const runnerSuccessSpy = vi.fn<(count: number) => void>();
+
 vi.mock("./use-batch-runner", () => ({
-  useBatchRunner: () => ({
-    progress: null,
-    isProcessing: false,
-    run: runSpy,
-    cancel: vi.fn(),
+  useBatchRunner: (
+    _setMessage: (msg: string | null) => void,
+    onSuccess?: (count: number) => void
+  ) => {
+    if (onSuccess) {
+      runnerSuccessSpy.mockImplementation(onSuccess);
+    }
+    return {
+      progress: null,
+      isProcessing: false,
+      run: runSpy,
+      cancel: vi.fn(),
+    };
+  },
+}));
+
+const mockShowSuccess = vi.fn();
+
+vi.mock("../../contexts/ToastContext", () => ({
+  useToastContext: () => ({
+    error: vi.fn(),
+    success: mockShowSuccess,
+    toast: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    toasts: [],
+    dismiss: vi.fn(),
+    dismissAll: vi.fn(),
   }),
 }));
 

--- a/packages/workout-spa-editor/src/components/pages/use-batch-state.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-batch-state.ts
@@ -11,6 +11,7 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { useCallback, useState } from "react";
 
 import { db } from "../../adapters/dexie/dexie-database";
+import { useToastContext } from "../../contexts/ToastContext";
 import type { LlmProviderConfig } from "../../store/ai-store-types";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import { prepareBatch } from "./batch-prepare";
@@ -24,7 +25,12 @@ export type BatchPending = {
 export function useBatchState(weekStart: string, weekEnd: string) {
   const [message, setMessage] = useState<string | null>(null);
   const [pending, setPending] = useState<BatchPending | null>(null);
-  const runner = useBatchRunner(setMessage);
+  const { success: showSuccess } = useToastContext();
+  // Static title satisfies the R-PIIInterpolation guard; the dynamic
+  // count flows through the description field.
+  const runner = useBatchRunner(setMessage, (count) =>
+    showSuccess("Batch processed", `${count} workouts`, { duration: 3000 })
+  );
 
   const providerCount = useLiveQuery(() => db.table("aiProviders").count(), []);
 

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-page.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-page.test.tsx
@@ -19,6 +19,7 @@ import { Route, Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 
 import { db } from "../../adapters/dexie/dexie-database";
+import { AppToastProvider } from "../../components/providers/AppToastProvider";
 import { GarminBridgeProvider } from "../../contexts";
 import { CoachingRegistryProvider } from "../../contexts/coaching-registry-context";
 import { PersistenceProvider } from "../../contexts/persistence-context";
@@ -107,9 +108,11 @@ const wrap = (children: ReactNode) => {
     <PersistenceProvider persistence={createInMemoryPersistence()}>
       <GarminBridgeProvider>
         <CoachingRegistryProvider factories={[]}>
-          <Router hook={hook}>
-            <Route path="/calendar/:weekId?">{children}</Route>
-          </Router>
+          <AppToastProvider>
+            <Router hook={hook}>
+              <Route path="/calendar/:weekId?">{children}</Route>
+            </Router>
+          </AppToastProvider>
         </CoachingRegistryProvider>
       </GarminBridgeProvider>
     </PersistenceProvider>


### PR DESCRIPTION
## Summary

PR A from the UX redesign roadmap (Phase 1 leftover). Closes one of the four "dead-end after success" flows identified in the deep-dive trace: batch processing on the calendar now surfaces a confirmation toast when it finishes cleanly.

### Behaviour change

When the user processes a batch of raw workouts from the calendar and `processBatch` resolves successfully, the app now surfaces a `success` toast with a static `"Batch processed"` title (3-second auto-dismiss) and the workout count as the description. Cancellation (AbortError) and processing errors short-circuit through the existing `catch` block, so no toast appears in those paths.

### Implementation

- `use-batch-runner.ts` — accepts an optional `onSuccess(count)` callback, fired inside the `try` block immediately after `await processBatch(...)` resolves. Hook stays pure (no React-context coupling).
- `use-batch-state.ts` — wires `useToastContext().success` to the callback with `"Batch processed"` as the static title and `${count} workouts` as the description. Static title satisfies `R-PIIInterpolation`; the dynamic count flows through the description field (unconstrained by the guard).
- Tests: two new unit tests in `use-batch-runner.test.ts` covering the success and error branches of the `onSuccess` contract; existing `use-batch-state.test.ts` extended with a mock for `useToastContext`.

### Plan reference

See `.omc/plans/ralplan-ux-redesign-phase1-leftovers-and-phase2.md` §"PR A".

## Test plan

- [x] `pnpm -F @kaiord/workout-spa-editor exec vitest run src/components/pages/use-batch-runner.test.ts src/components/pages/use-batch-state.test.ts` — 10/10 pass
- [x] `pnpm -F @kaiord/workout-spa-editor lint` — green
- [x] `node scripts/check-no-pii-leakage.mjs` — R-PIIInterpolation green
- [ ] CI required checks
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)