### PR TITLE
feat(spa-editor): success toast on coaching match (manual + picker)

### DIFF
--- a/.changeset/ux-redesign-coaching-match-toast.md
+++ b/.changeset/ux-redesign-coaching-match-toast.md
@@ -1,0 +1,14 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+UX redesign Phase 1 leftover: surface a success toast when a coaching
+activity is matched to a workout (manual picker) or converted to a
+new manual workout via the coaching dialog. Both success branches now
+fire `toast.success("Workout matched", activity.title, { duration: 3000 })`.
+The manual handler fires the toast BEFORE `onClose()` to make the
+ordering explicit, even though `AppToastProvider` lives above the
+dialog tree and would survive unmount either way. Static title
+satisfies the R-PIIInterpolation guard; the dynamic activity title
+flows through the description field. Removes another of the
+"asymmetric handoff" dead-ends identified by the deep-dive trace.

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-actions.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-actions.test.tsx
@@ -9,12 +9,25 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockMatch = vi.fn();
 const mockUnmatch = vi.fn();
+const mockShowSuccess = vi.fn();
 
 vi.mock("../../../hooks/use-match-session", () => ({
   useMatchSession: () => mockMatch,
 }));
 vi.mock("../../../hooks/use-unmatch-session", () => ({
   useUnmatchSession: () => mockUnmatch,
+}));
+vi.mock("../../../contexts/ToastContext", () => ({
+  useToastContext: () => ({
+    error: vi.fn(),
+    success: mockShowSuccess,
+    toast: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    toasts: [],
+    dismiss: vi.fn(),
+    dismissAll: vi.fn(),
+  }),
 }));
 
 import type { ActivityMatchState } from "../../../hooks/use-activity-match-state";

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-actions.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-actions.ts
@@ -8,6 +8,7 @@
 
 import { useCallback, useState } from "react";
 
+import { useToastContext } from "../../../contexts/ToastContext";
 import type { ActivityMatchState } from "../../../hooks/use-activity-match-state";
 import { useMatchSession } from "../../../hooks/use-match-session";
 import { useUnmatchSession } from "../../../hooks/use-unmatch-session";
@@ -35,6 +36,7 @@ export const useCoachingDialogActions = (
 
   const matchSession = useMatchSession();
   const unmatchSession = useUnmatchSession();
+  const { success: showSuccess } = useToastContext();
 
   const handleSelectWorkout = useCallback(
     async (workoutId: string) => {
@@ -50,12 +52,15 @@ export const useCoachingDialogActions = (
           workoutId,
           source: "manual",
         });
+        // Static title satisfies R-PIIInterpolation; the dynamic
+        // activity title flows through the description field.
+        showSuccess("Workout matched", activity.title, { duration: 3000 });
         setPickerOpen(false);
       } finally {
         setMatching(false);
       }
     },
-    [activity, targetProfileId, matching, matchSession]
+    [activity, targetProfileId, matching, matchSession, showSuccess]
   );
 
   const handleSplit = useCallback(async () => {

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.test.tsx
@@ -15,9 +15,23 @@ import type { CoachingActivityRecord } from "../../../types/coaching-activity-re
 import { useCoachingManual } from "./use-coaching-manual-handler";
 
 const navigateMock = vi.fn();
+const mockShowSuccess = vi.fn();
 
 vi.mock("wouter", () => ({
   useLocation: () => ["/calendar", navigateMock],
+}));
+
+vi.mock("../../../contexts/ToastContext", () => ({
+  useToastContext: () => ({
+    error: vi.fn(),
+    success: mockShowSuccess,
+    toast: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    toasts: [],
+    dismiss: vi.fn(),
+    dismissAll: vi.fn(),
+  }),
 }));
 
 const activity: CoachingActivity = {
@@ -71,6 +85,7 @@ describe("useCoachingManual", () => {
   it("should persist a workout and navigate to the editor on success", async () => {
     // Arrange
     navigateMock.mockClear();
+    mockShowSuccess.mockClear();
     const persistence = createInMemoryPersistence();
     await seedActivity(persistence);
     const onClose = vi.fn();
@@ -89,6 +104,37 @@ describe("useCoachingManual", () => {
     expect(navigateMock).toHaveBeenCalledWith(
       expect.stringMatching(/^\/workout\//)
     );
+  });
+
+  it("should fire a success toast with static title before closing the dialog", async () => {
+    // Arrange
+    navigateMock.mockClear();
+    mockShowSuccess.mockClear();
+    const persistence = createInMemoryPersistence();
+    await seedActivity(persistence);
+    const onClose = vi.fn();
+    const { result } = renderHook(
+      () => useCoachingManual(activity, "profile-1", onClose),
+      { wrapper: wrap(persistence) }
+    );
+
+    // Act
+    await act(async () => {
+      await result.current.startManual();
+    });
+
+    // Assert
+    await waitFor(() => expect(mockShowSuccess).toHaveBeenCalledTimes(1));
+    expect(mockShowSuccess).toHaveBeenCalledWith(
+      "Workout matched",
+      activity.title,
+      { duration: 3000 }
+    );
+    // Toast fires BEFORE onClose so the success signal is committed
+    // even though AppToastProvider lives above the dialog tree.
+    const successOrder = mockShowSuccess.mock.invocationCallOrder[0];
+    const onCloseOrder = onClose.mock.invocationCallOrder[0];
+    expect(successOrder).toBeLessThan(onCloseOrder);
   });
 
   it("should no-op when activity or profileId is missing", async () => {

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.ts
@@ -13,6 +13,7 @@ import { useLocation } from "wouter";
 import { convertCoachingActivityManual } from "../../../application/coaching/convert-coaching-activity-manual";
 import { useAnalytics } from "../../../contexts/analytics-context";
 import { usePersistence } from "../../../contexts/persistence-context";
+import { useToastContext } from "../../../contexts/ToastContext";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 
 export type UseCoachingManual = {
@@ -29,6 +30,7 @@ export const useCoachingManual = (
 ): UseCoachingManual => {
   const persistence = usePersistence();
   const analytics = useAnalytics();
+  const { success: showSuccess } = useToastContext();
   const [, navigate] = useLocation();
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -56,6 +58,9 @@ export const useCoachingManual = (
           clock: () => new Date().toISOString(),
         }
       );
+      // Fire toast BEFORE onClose() to keep the success signal visible
+      // even though the AppToastProvider lives above the dialog tree.
+      showSuccess("Workout matched", activity.title, { duration: 3000 });
       onClose();
       navigate(`/workout/${result.workoutId}`);
     } catch (err) {
@@ -64,7 +69,15 @@ export const useCoachingManual = (
       setCreating(false);
       inFlight.current = false;
     }
-  }, [activity, profileId, persistence, analytics, navigate, onClose]);
+  }, [
+    activity,
+    profileId,
+    persistence,
+    analytics,
+    navigate,
+    onClose,
+    showSuccess,
+  ]);
 
   return {
     creating,


### PR DESCRIPTION
## Summary

PR B from the UX redesign roadmap (Phase 1 leftover). Closes another of the "asymmetric handoff after success" flows identified in the deep-dive trace: matching a workout to a coaching activity now surfaces a confirmation toast.

### Behaviour change

Both coaching-dialog success branches now fire `toast.success("Workout matched", activity.title, { duration: 3000 })`:

- **Picker → match** (`useCoachingDialogActions.handleSelectWorkout`): after `await matchSession(...)` resolves, before `setPickerOpen(false)`.
- **Manual create → match** (`useCoachingManual.startManual`): after `await convertCoachingActivityManual(...)` resolves, **before** `onClose()` so the toast survives dialog unmount (even though `AppToastProvider` lives above the dialog tree, the ordering is now explicit).

### R-PIIInterpolation compliance

Static title `"Workout matched"`; the dynamic activity title flows through the description field (unconstrained by the guard).

### Tests

- New `should fire a success toast with static title before closing the dialog` in `use-coaching-manual-handler.test.tsx`, asserting both the call AND the invocation order vs `onClose`.
- `use-coaching-dialog-actions.test.tsx` gains a `ToastContext` mock so the new hook dependency resolves (9 tests that previously crashed now pass).

### Plan reference

See `.omc/plans/ralplan-ux-redesign-phase1-leftovers-and-phase2.md` §"PR B".

## Test plan

- [x] `pnpm -F @kaiord/workout-spa-editor exec vitest run src/components/molecules/CoachingCard/` — 91/91 pass
- [x] `pnpm -F @kaiord/workout-spa-editor lint` — green
- [x] `node scripts/check-no-pii-leakage.mjs` — R-PIIInterpolation green
- [ ] CI required checks
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)