### PR TITLE
feat(spa-editor): AI success affordance row [Regenerate / Edit / Discard / Save]

### DIFF
--- a/.changeset/ux-redesign-ai-affordance-row.md
+++ b/.changeset/ux-redesign-ai-affordance-row.md
@@ -1,0 +1,26 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+UX redesign Phase 1 leftover: surface a 4-button affordance row
+(`Regenerate` / `Edit` / `Discard` / `Save to Library`) inside the AI
+workout panel as soon as generation succeeds. Closes the last
+"dead-end after success" identified in the deep-dive trace — the user
+no longer has to guess what to do with a freshly-generated workout.
+
+New `AiSuccessActions` molecule
+(`packages/workout-spa-editor/src/components/molecules/AiSuccessActions/`)
+with 5 unit tests. Wired into `AiWorkoutForm` so it renders only when
+`generation.status === "success"` and a workout is loaded:
+
+- **Regenerate** re-invokes the existing `generate(text, sport)` with
+  the current prompt — no new code path.
+- **Edit** resets the generation state to `idle` so the affordance
+  row collapses and the user proceeds with the editor below.
+- **Discard** clears the workout via `useClearWorkout` and resets the
+  generation state.
+- **Save to Library** reuses the existing `SaveToLibraryButton`
+  molecule so the save flow stays consistent with the rest of the app.
+
+No behavioural change to the AI generation flow itself; the row is
+purely additive UI.

--- a/packages/workout-spa-editor/src/components/molecules/AiSuccessActions/AiSuccessActions.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/AiSuccessActions/AiSuccessActions.test.tsx
@@ -1,0 +1,113 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders } from "../../../test-utils";
+import type { KRD } from "../../../types/krd";
+import { AiSuccessActions } from "./AiSuccessActions";
+
+const sampleWorkout: KRD = {
+  version: "1.0",
+  type: "structured_workout",
+  metadata: { created: "2026-05-17T08:00:00Z", sport: "cycling" },
+  extensions: {
+    structured_workout: { name: "Generated", sport: "cycling", steps: [] },
+  },
+};
+
+const renderActions = (
+  overrides: Partial<{
+    onRegenerate: () => void;
+    onEdit: () => void;
+    onDiscard: () => void;
+  }> = {}
+) => {
+  const onRegenerate = overrides.onRegenerate ?? vi.fn();
+  const onEdit = overrides.onEdit ?? vi.fn();
+  const onDiscard = overrides.onDiscard ?? vi.fn();
+  renderWithProviders(
+    <AiSuccessActions
+      workout={sampleWorkout}
+      onRegenerate={onRegenerate}
+      onEdit={onEdit}
+      onDiscard={onDiscard}
+    />
+  );
+  return { onRegenerate, onEdit, onDiscard };
+};
+
+describe("AiSuccessActions", () => {
+  it("should render all four action buttons (Regenerate / Edit / Discard / Save)", () => {
+    // Arrange
+
+    // Act
+
+    renderActions();
+
+    // Assert
+
+    expect(screen.getByTestId("ai-action-regenerate")).toBeInTheDocument();
+    expect(screen.getByTestId("ai-action-edit")).toBeInTheDocument();
+    expect(screen.getByTestId("ai-action-discard")).toBeInTheDocument();
+    expect(screen.getByText("Save to Library")).toBeInTheDocument();
+  });
+
+  it("should call onRegenerate when the Regenerate button is clicked", async () => {
+    // Arrange
+
+    const user = userEvent.setup();
+    const { onRegenerate } = renderActions();
+
+    // Act
+
+    await user.click(screen.getByTestId("ai-action-regenerate"));
+
+    // Assert
+
+    expect(onRegenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onEdit when the Edit button is clicked", async () => {
+    // Arrange
+
+    const user = userEvent.setup();
+    const { onEdit } = renderActions();
+
+    // Act
+
+    await user.click(screen.getByTestId("ai-action-edit"));
+
+    // Assert
+
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("should call onDiscard when the Discard button is clicked", async () => {
+    // Arrange
+
+    const user = userEvent.setup();
+    const { onDiscard } = renderActions();
+
+    // Act
+
+    await user.click(screen.getByTestId("ai-action-discard"));
+
+    // Assert
+
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render the Save button labeled with a static title-case 'Save to Library'", () => {
+    // Arrange
+
+    renderActions();
+
+    // Act
+
+    const saveButton = screen.getByRole("button", { name: /Save to Library/i });
+
+    // Assert
+
+    expect(saveButton).toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/AiSuccessActions/AiSuccessActions.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/AiSuccessActions/AiSuccessActions.tsx
@@ -1,0 +1,55 @@
+import { Pencil, RotateCcw, Trash2 } from "lucide-react";
+
+import type { KRD } from "../../../types/krd";
+import { Button } from "../../atoms/Button/Button";
+import { SaveToLibraryButton } from "../SaveToLibraryButton/SaveToLibraryButton";
+
+export type AiSuccessActionsProps = {
+  workout: KRD;
+  onRegenerate: () => void;
+  onEdit: () => void;
+  onDiscard: () => void;
+};
+
+export function AiSuccessActions({
+  workout,
+  onRegenerate,
+  onEdit,
+  onDiscard,
+}: AiSuccessActionsProps) {
+  return (
+    <div
+      className="flex flex-wrap items-center gap-2 rounded-lg border border-blue-200 bg-white/50 p-3 dark:border-blue-700 dark:bg-gray-800/50"
+      data-testid="ai-success-actions"
+    >
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={onRegenerate}
+        data-testid="ai-action-regenerate"
+      >
+        <RotateCcw className="h-4 w-4" />
+        Regenerate
+      </Button>
+      <Button
+        variant="secondary"
+        size="sm"
+        onClick={onEdit}
+        data-testid="ai-action-edit"
+      >
+        <Pencil className="h-4 w-4" />
+        Edit
+      </Button>
+      <Button
+        variant="danger"
+        size="sm"
+        onClick={onDiscard}
+        data-testid="ai-action-discard"
+      >
+        <Trash2 className="h-4 w-4" />
+        Discard
+      </Button>
+      <SaveToLibraryButton workout={workout} />
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/AiSuccessActions/index.ts
+++ b/packages/workout-spa-editor/src/components/molecules/AiSuccessActions/index.ts
@@ -1,0 +1,2 @@
+export type { AiSuccessActionsProps } from "./AiSuccessActions";
+export { AiSuccessActions } from "./AiSuccessActions";

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiSuccessActionsContainer.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiSuccessActionsContainer.test.tsx
@@ -1,0 +1,109 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAiRuntimeStore } from "../../../store/ai-runtime-store";
+import { useWorkoutStore } from "../../../store/workout-store";
+import { renderWithProviders } from "../../../test-utils";
+import type { KRD } from "../../../types/krd";
+import { AiSuccessActionsContainer } from "./AiSuccessActionsContainer";
+
+const sampleWorkout: KRD = {
+  version: "1.0",
+  type: "structured_workout",
+  metadata: { created: "2026-05-17T08:00:00Z", sport: "cycling" },
+  extensions: {
+    structured_workout: { name: "Generated", sport: "cycling", steps: [] },
+  },
+};
+
+describe("AiSuccessActionsContainer", () => {
+  beforeEach(() => {
+    useWorkoutStore.setState({ currentWorkout: null });
+    useAiRuntimeStore.setState({ generation: { status: "idle" } });
+  });
+
+  it("should render nothing when no workout is loaded", () => {
+    // Arrange
+
+    // Act
+
+    const { container } = renderWithProviders(
+      <AiSuccessActionsContainer onRegenerate={vi.fn()} />
+    );
+
+    // Assert
+
+    expect(
+      container.querySelector("[data-testid='ai-success-actions']")
+    ).toBeNull();
+  });
+
+  it("should render the AiSuccessActions row when a workout is loaded", () => {
+    // Arrange
+
+    useWorkoutStore.setState({ currentWorkout: sampleWorkout });
+
+    // Act
+
+    renderWithProviders(<AiSuccessActionsContainer onRegenerate={vi.fn()} />);
+
+    // Assert
+
+    expect(screen.getByTestId("ai-success-actions")).toBeInTheDocument();
+  });
+
+  it("should reset generation state to idle when Edit is clicked", async () => {
+    // Arrange
+
+    useWorkoutStore.setState({ currentWorkout: sampleWorkout });
+    useAiRuntimeStore.setState({ generation: { status: "success" } });
+    const user = userEvent.setup();
+    renderWithProviders(<AiSuccessActionsContainer onRegenerate={vi.fn()} />);
+
+    // Act
+
+    await user.click(screen.getByTestId("ai-action-edit"));
+
+    // Assert
+
+    expect(useAiRuntimeStore.getState().generation.status).toBe("idle");
+  });
+
+  it("should clear the workout and reset generation when Discard is clicked", async () => {
+    // Arrange
+
+    useWorkoutStore.setState({ currentWorkout: sampleWorkout });
+    useAiRuntimeStore.setState({ generation: { status: "success" } });
+    const user = userEvent.setup();
+    renderWithProviders(<AiSuccessActionsContainer onRegenerate={vi.fn()} />);
+
+    // Act
+
+    await user.click(screen.getByTestId("ai-action-discard"));
+
+    // Assert
+
+    expect(useWorkoutStore.getState().currentWorkout).toBeNull();
+    expect(useAiRuntimeStore.getState().generation.status).toBe("idle");
+  });
+
+  it("should call onRegenerate when Regenerate is clicked", async () => {
+    // Arrange
+
+    useWorkoutStore.setState({ currentWorkout: sampleWorkout });
+    const onRegenerate = vi.fn();
+    const user = userEvent.setup();
+    renderWithProviders(
+      <AiSuccessActionsContainer onRegenerate={onRegenerate} />
+    );
+
+    // Act
+
+    await user.click(screen.getByTestId("ai-action-regenerate"));
+
+    // Assert
+
+    expect(onRegenerate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiSuccessActionsContainer.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiSuccessActionsContainer.tsx
@@ -1,0 +1,32 @@
+import { useAiRuntimeStore } from "../../../store/ai-runtime-store";
+import { useClearWorkout, useCurrentWorkout } from "../../../store/selectors";
+import { AiSuccessActions } from "../../molecules/AiSuccessActions/AiSuccessActions";
+
+export type AiSuccessActionsContainerProps = {
+  onRegenerate: () => void;
+};
+
+export function AiSuccessActionsContainer({
+  onRegenerate,
+}: AiSuccessActionsContainerProps) {
+  const setGeneration = useAiRuntimeStore((s) => s.setGeneration);
+  const currentWorkout = useCurrentWorkout();
+  const clearWorkout = useClearWorkout();
+
+  if (!currentWorkout) return null;
+
+  const handleEdit = () => setGeneration({ status: "idle" });
+  const handleDiscard = () => {
+    clearWorkout();
+    setGeneration({ status: "idle" });
+  };
+
+  return (
+    <AiSuccessActions
+      workout={currentWorkout}
+      onRegenerate={onRegenerate}
+      onEdit={handleEdit}
+      onDiscard={handleDiscard}
+    />
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiWorkoutForm.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiWorkoutForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { useAiRuntimeStore } from "../../../store/ai-runtime-store";
 import { Button } from "../../atoms/Button";
+import { AiSuccessActionsContainer } from "./AiSuccessActionsContainer";
 import { ModelSelector } from "./ModelSelector";
 import { SportSelect } from "./SportSelect";
 import { useAiGeneration } from "./useAiGeneration";
@@ -15,6 +16,7 @@ export const AiWorkoutForm: React.FC = () => {
   const generation = useAiRuntimeStore((s) => s.generation);
   const { generate } = useAiGeneration();
   const isLoading = generation.status === "loading";
+  const isSuccess = generation.status === "success";
 
   const handleGenerate = () => {
     if (!text.trim() || isLoading) return;
@@ -56,6 +58,7 @@ export const AiWorkoutForm: React.FC = () => {
           {generation.message}
         </p>
       )}
+      {isSuccess && <AiSuccessActionsContainer onRegenerate={handleGenerate} />}
     </div>
   );
 };


### PR DESCRIPTION
## Summary

PR C from the UX redesign roadmap (Phase 1 leftover). Closes the **last** "dead-end after success" flow identified in the deep-dive trace: when AI generation completes, the user now has explicit next steps instead of being left wondering what to do with the freshly-generated workout.

### Behaviour change

When `generation.status === "success"` and a workout is loaded, a 4-button affordance row appears inside the AI panel:

| Button | Action |
|---|---|
| **Regenerate** | Re-invokes existing `generate(text, sport)` — no new code path |
| **Edit** | Resets `generation.status` to `idle`; user proceeds with editor below |
| **Discard** | `useClearWorkout()` + reset generation state |
| **Save** | Reuses existing `SaveToLibraryButton` molecule (consistent with the rest of the app) |

### Implementation

- New molecule `packages/workout-spa-editor/src/components/molecules/AiSuccessActions/` — pure presentational component, 4 buttons via the `Button` atom plus `SaveToLibraryButton`. Five unit tests.
- New `AiSuccessActionsContainer` next to `AiWorkoutForm` — wires the store reads (`useCurrentWorkout`, `useClearWorkout`, `useAiRuntimeStore.setGeneration`) so `AiWorkoutForm` stays under the 60-line component cap.
- `AiWorkoutForm.tsx`: conditional render of `<AiSuccessActionsContainer />` when `isSuccess` is true.

### Plan reference

See `.omc/plans/ralplan-ux-redesign-phase1-leftovers-and-phase2.md` §"PR C".

## Test plan

- [x] `pnpm -F @kaiord/workout-spa-editor exec vitest run src/components/molecules/AiSuccessActions/ src/components/organisms/AiWorkoutInput/` — 25/25 pass
- [x] `pnpm -F @kaiord/workout-spa-editor lint` — green
- [x] `node scripts/check-no-pii-leakage.mjs` — R-PIIInterpolation green
- [ ] CI required checks
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)