### PR TITLE
feat(spa-editor): reserve /settings route + R-StranglerExpiry + R-SettingsSingleEntry

### DIFF
--- a/.changeset/ux-redesign-settings-route.md
+++ b/.changeset/ux-redesign-settings-route.md
@@ -1,0 +1,35 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+UX redesign Phase 2.4: reserve the `/settings/:tab?` route and ship
+two mechanical guards that future PRs will rely on.
+
+This is PR E of the Phase 1+2 roadmap. The route is registered behind
+the `ux2026.unifiedSettings` feature flag (default `false`); when the
+flag is on, the new `SettingsPage` renders a stub that redirects
+`/settings` to `/settings/profile` and validates the tab name against
+the six canonical tabs (`profile`, `zones`, `connections`, `ai`,
+`appearance`, `privacy`). When the flag is off, the route redirects
+to `/calendar` so legacy behaviour is unchanged. Migrating the actual
+tab content from `SettingsPanel` and `ProfileManager` is a follow-up
+(PR E+1) to keep this PR reviewable.
+
+New mechanical guards (shipped, not deferred):
+
+- **`R-StranglerExpiry`** (`scripts/check-strangler-expiry.mjs`) —
+  every `// @strangler-until: YYYY-MM-DD` marker in
+  `packages/workout-spa-editor/src/**` MUST have a date on or after
+  today. Past dates fail CI, forcing strangler shims to be deleted
+  (or their TTL extended with explicit justification). Pattern
+  mirrored from `scripts/check-archive-dates.mjs`.
+- **`R-SettingsSingleEntry`** (`scripts/check-settings-single-entry.mjs`)
+  — when `ux2026.unifiedSettings` is `true`, files under
+  `packages/workout-spa-editor/src/components/**` (outside the
+  `ALLOWLIST`) MUST NOT import `SettingsPanel` or `ProfileManager`
+  directly; the canonical entry is `/settings/<tab>`. No-op while the
+  flag is `false` so the strangler period stays unblocked.
+
+Both guards have co-located `node:test` suites and are picked up by
+`pnpm test:scripts`. This is a `minor` bump because the new
+`/settings/:tab?` route is a public surface change.

--- a/packages/workout-spa-editor/src/App.tsx
+++ b/packages/workout-spa-editor/src/App.tsx
@@ -1,61 +1,16 @@
-import type { Analytics } from "@kaiord/core";
-import { lazy, Suspense, useEffect } from "react";
-import { Redirect, Route, Switch, useLocation } from "wouter";
+import { useEffect } from "react";
+import { useLocation } from "wouter";
 
+import { AppRoutes } from "./AppRoutes";
 import { AppKeyboardShortcuts } from "./components/AppKeyboardShortcuts";
 import { AppTutorial } from "./components/AppTutorial";
-import { RouteSpinner } from "./components/atoms/RouteSpinner";
 import { MigrationBoot } from "./components/MigrationBoot";
-import { RouteErrorBoundary } from "./components/molecules/RouteErrorBoundary";
 import { AppToastProvider } from "./components/providers/AppToastProvider";
 import { MainLayout } from "./components/templates/MainLayout";
 import { useAnalytics } from "./contexts";
 import { useOnboardingTutorial } from "./hooks/use-onboarding-tutorial";
 import { useProfileSnapshotPush } from "./hooks/use-profile-snapshot-push";
 import { useStoreHydration } from "./hooks/use-store-hydration";
-
-const CalendarPage = lazy(() => import("./components/pages/CalendarPage"));
-const LibraryPage = lazy(() => import("./components/pages/LibraryPage"));
-const EditorPage = lazy(() => import("./components/pages/EditorPage"));
-
-type AppRoutesProps = { analytics: Analytics };
-
-function AppRoutes({ analytics }: AppRoutesProps) {
-  return (
-    <Suspense fallback={<RouteSpinner />}>
-      <Switch>
-        <Route path="/">
-          <Redirect to="/calendar" />
-        </Route>
-        <Route path="/calendar/:weekId?">
-          <RouteErrorBoundary analytics={analytics}>
-            <CalendarPage />
-          </RouteErrorBoundary>
-        </Route>
-        <Route path="/library">
-          <RouteErrorBoundary analytics={analytics}>
-            <LibraryPage />
-          </RouteErrorBoundary>
-        </Route>
-        <Route path="/workout/new">
-          <RouteErrorBoundary analytics={analytics}>
-            <EditorPage />
-          </RouteErrorBoundary>
-        </Route>
-        <Route path="/workout/:id">
-          {(params) => (
-            <RouteErrorBoundary analytics={analytics}>
-              <EditorPage id={params.id} />
-            </RouteErrorBoundary>
-          )}
-        </Route>
-        <Route>
-          <Redirect to="/calendar" />
-        </Route>
-      </Switch>
-    </Suspense>
-  );
-}
 
 function App() {
   useStoreHydration();

--- a/packages/workout-spa-editor/src/AppRoutes.tsx
+++ b/packages/workout-spa-editor/src/AppRoutes.tsx
@@ -1,0 +1,55 @@
+import type { Analytics } from "@kaiord/core";
+import { lazy, Suspense } from "react";
+import { Redirect, Route, Switch } from "wouter";
+
+import { RouteSpinner } from "./components/atoms/RouteSpinner";
+import { RouteErrorBoundary } from "./components/molecules/RouteErrorBoundary";
+
+const CalendarPage = lazy(() => import("./components/pages/CalendarPage"));
+const LibraryPage = lazy(() => import("./components/pages/LibraryPage"));
+const EditorPage = lazy(() => import("./components/pages/EditorPage"));
+const SettingsPage = lazy(() => import("./components/pages/SettingsPage"));
+
+export type AppRoutesProps = { analytics: Analytics };
+
+export function AppRoutes({ analytics }: AppRoutesProps) {
+  return (
+    <Suspense fallback={<RouteSpinner />}>
+      <Switch>
+        <Route path="/">
+          <Redirect to="/calendar" />
+        </Route>
+        <Route path="/calendar/:weekId?">
+          <RouteErrorBoundary analytics={analytics}>
+            <CalendarPage />
+          </RouteErrorBoundary>
+        </Route>
+        <Route path="/library">
+          <RouteErrorBoundary analytics={analytics}>
+            <LibraryPage />
+          </RouteErrorBoundary>
+        </Route>
+        <Route path="/workout/new">
+          <RouteErrorBoundary analytics={analytics}>
+            <EditorPage />
+          </RouteErrorBoundary>
+        </Route>
+        <Route path="/workout/:id">
+          {(params) => (
+            <RouteErrorBoundary analytics={analytics}>
+              <EditorPage id={params.id} />
+            </RouteErrorBoundary>
+          )}
+        </Route>
+        <Route path="/settings/:tab?">
+          <RouteErrorBoundary analytics={analytics}>
+            <SettingsPage />
+          </RouteErrorBoundary>
+        </Route>
+        <Route>
+          <Redirect to="/calendar" />
+        </Route>
+      </Switch>
+    </Suspense>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+
+import { useFeatureFlag } from "../../lib/feature-flags";
+import SettingsPage from "./SettingsPage";
+
+function renderAtPath(path: string) {
+  const { hook } = memoryLocation({ path, record: true });
+  return render(
+    <Router hook={hook}>
+      <SettingsPage />
+    </Router>
+  );
+}
+
+describe("SettingsPage", () => {
+  describe("flag off (default)", () => {
+    it("should not render the page stub when ux2026.unifiedSettings is false", () => {
+      // Arrange
+
+      // Act
+
+      const enabled = useFeatureFlag("ux2026.unifiedSettings");
+      const { queryByTestId } = renderAtPath("/settings/profile");
+
+      // Assert
+
+      expect(enabled).toBe(false);
+      expect(queryByTestId("settings-page")).toBeNull();
+    });
+  });
+
+  describe("redirect", () => {
+    it("should render nothing for an unknown tab when the flag is off", () => {
+      // Arrange
+
+      // Act
+
+      renderAtPath("/settings/unknown");
+
+      // Assert
+
+      expect(screen.queryByTestId("settings-page")).toBeNull();
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage.test.tsx
@@ -1,48 +1,126 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { Router } from "wouter";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 
-import { useFeatureFlag } from "../../lib/feature-flags";
+import type * as FeatureFlagsModule from "../../lib/feature-flags";
 import SettingsPage from "./SettingsPage";
 
+vi.mock("../../lib/feature-flags", async () => {
+  const actual = await vi.importActual<typeof FeatureFlagsModule>(
+    "../../lib/feature-flags"
+  );
+  return {
+    ...actual,
+    useFeatureFlag: vi.fn(),
+  };
+});
+
+const { useFeatureFlag } = await import("../../lib/feature-flags");
+const mockUseFeatureFlag = vi.mocked(useFeatureFlag);
+
 function renderAtPath(path: string) {
-  const { hook } = memoryLocation({ path, record: true });
-  return render(
-    <Router hook={hook}>
-      <SettingsPage />
+  const memory = memoryLocation({ path, record: true });
+  const view = render(
+    <Router hook={memory.hook}>
+      <Route path="/settings/:tab?">
+        <SettingsPage />
+      </Route>
     </Router>
   );
+  return { ...view, memory };
 }
 
 describe("SettingsPage", () => {
-  describe("flag off (default)", () => {
-    it("should not render the page stub when ux2026.unifiedSettings is false", () => {
+  beforeEach(() => {
+    mockUseFeatureFlag.mockReset();
+  });
+
+  describe("flag off", () => {
+    it("should not render the stub when ux2026.unifiedSettings is false", () => {
       // Arrange
+      mockUseFeatureFlag.mockReturnValue(false);
 
       // Act
-
-      const enabled = useFeatureFlag("ux2026.unifiedSettings");
       const { queryByTestId } = renderAtPath("/settings/profile");
 
       // Assert
-
-      expect(enabled).toBe(false);
       expect(queryByTestId("settings-page")).toBeNull();
     });
-  });
 
-  describe("redirect", () => {
     it("should render nothing for an unknown tab when the flag is off", () => {
       // Arrange
+      mockUseFeatureFlag.mockReturnValue(false);
 
       // Act
-
       renderAtPath("/settings/unknown");
 
       // Assert
-
       expect(screen.queryByTestId("settings-page")).toBeNull();
+    });
+  });
+
+  describe("flag on, valid tab", () => {
+    it("should render the stub with the tab name when flag is on", () => {
+      // Arrange
+      mockUseFeatureFlag.mockReturnValue(true);
+
+      // Act
+      renderAtPath("/settings/zones");
+
+      // Assert
+      expect(screen.getByTestId("settings-page")).toBeInTheDocument();
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+        "Settings · zones"
+      );
+      expect(screen.getByTestId("settings-page-stub-note")).toBeInTheDocument();
+    });
+
+    it.each([
+      ["profile"],
+      ["zones"],
+      ["connections"],
+      ["ai"],
+      ["appearance"],
+      ["privacy"],
+    ])("should render the heading for tab '%s'", (tab) => {
+      // Arrange
+      mockUseFeatureFlag.mockReturnValue(true);
+
+      // Act
+      renderAtPath(`/settings/${tab}`);
+
+      // Assert
+      expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+        `Settings · ${tab}`
+      );
+    });
+  });
+
+  describe("flag on, missing tab", () => {
+    it("should redirect to /settings/profile when the tab segment is absent", () => {
+      // Arrange
+      mockUseFeatureFlag.mockReturnValue(true);
+
+      // Act
+      const { memory } = renderAtPath("/settings");
+
+      // Assert
+      expect(memory.history).toContain("/settings/profile");
+    });
+  });
+
+  describe("flag on, invalid tab", () => {
+    it("should render nothing and not redirect when the tab is unknown", () => {
+      // Arrange
+      mockUseFeatureFlag.mockReturnValue(true);
+
+      // Act
+      const { memory } = renderAtPath("/settings/unknown");
+
+      // Assert
+      expect(screen.queryByTestId("settings-page")).toBeNull();
+      expect(memory.history).not.toContain("/settings/profile");
     });
   });
 });

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage.tsx
@@ -26,10 +26,10 @@ export default function SettingsPage() {
   const resolvedTab = isValidTab(tab) ? tab : null;
 
   useEffect(() => {
-    if (flagOn && resolvedTab === null) {
+    if (flagOn && tab === undefined) {
       navigate("/settings/profile", { replace: true });
     }
-  }, [flagOn, resolvedTab, navigate]);
+  }, [flagOn, tab, navigate]);
 
   if (!flagOn) return <Redirect to="/calendar" />;
   if (resolvedTab === null) return null;

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import { Redirect, useLocation, useParams } from "wouter";
+
+import { useFeatureFlag } from "../../lib/feature-flags";
+import { ROUTE_HEADING_ATTR } from "../../routing/constants";
+
+type SettingsPageParams = { tab?: string };
+
+const VALID_TABS = [
+  "profile",
+  "zones",
+  "connections",
+  "ai",
+  "appearance",
+  "privacy",
+] as const;
+type SettingsTab = (typeof VALID_TABS)[number];
+
+const isValidTab = (tab: string | undefined): tab is SettingsTab =>
+  VALID_TABS.includes(tab as SettingsTab);
+
+export default function SettingsPage() {
+  const { tab } = useParams<SettingsPageParams>();
+  const [, navigate] = useLocation();
+  const flagOn = useFeatureFlag("ux2026.unifiedSettings");
+  const resolvedTab = isValidTab(tab) ? tab : null;
+
+  useEffect(() => {
+    if (flagOn && resolvedTab === null) {
+      navigate("/settings/profile", { replace: true });
+    }
+  }, [flagOn, resolvedTab, navigate]);
+
+  if (!flagOn) return <Redirect to="/calendar" />;
+  if (resolvedTab === null) return null;
+
+  return (
+    <div className="space-y-6 p-4" data-testid="settings-page">
+      <h1
+        tabIndex={-1}
+        {...{ [ROUTE_HEADING_ATTR]: "" }}
+        className="text-xl font-semibold text-gray-900 dark:text-white"
+      >
+        Settings · {resolvedTab}
+      </h1>
+      <p
+        className="text-sm text-gray-600 dark:text-gray-400"
+        data-testid="settings-page-stub-note"
+      >
+        Tab content is migrated in a follow-up PR (E+1). The route, tab routing,
+        and mechanical guards (R-StranglerExpiry, R-SettingsSingleEntry) ship in
+        this PR so the rest of the roadmap can build against a stable URL
+        contract.
+      </p>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/lib/ai-sdk-gateway-stub.ts
+++ b/packages/workout-spa-editor/src/lib/ai-sdk-gateway-stub.ts
@@ -37,4 +37,15 @@ export class GatewayAuthenticationError extends Error {
     super(message ?? "GatewayAuthenticationError");
     this.name = "GatewayAuthenticationError";
   }
+
+  // The `ai` SDK invokes `GatewayAuthenticationError.isInstance(error)`
+  // inside `wrapGatewayError` to decide whether to rewrap with a
+  // friendly "configure AI_GATEWAY_API_KEY" message. The SPA never
+  // talks to the gateway, so the answer is always `false`. Returning
+  // it preserves the original error (typically APICallError from the
+  // chosen provider) — otherwise the call throws TypeError and the
+  // executeWithRetry catch retries the request unnecessarily.
+  static isInstance(): boolean {
+    return false;
+  }
 }

--- a/scripts/check-settings-single-entry.mjs
+++ b/scripts/check-settings-single-entry.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Mechanical guard: when `ux2026.unifiedSettings` is `true` in
+ * `packages/workout-spa-editor/src/lib/feature-flags.ts`, no file
+ * under `packages/workout-spa-editor/src/components/**` (outside the
+ * approved ALLOWLIST) may import `SettingsPanel` or `ProfileManager`
+ * directly. The canonical Settings destination is `/settings/<tab>`.
+ *
+ * Rule R-SettingsSingleEntry — when the flag is `true`:
+ *
+ *   import { SettingsPanel } from ".../SettingsPanel/...";
+ *   import { ProfileManager } from ".../ProfileManager/...";
+ *
+ * Both shapes fail CI unless the importing file path is in ALLOWLIST.
+ * When the flag is `false`, the guard is a no-op so the strangler
+ * period stays unblocked.
+ *
+ * ALLOWLIST is intentionally empty in production initial — see
+ * design D9 (R-PIIInterpolation) for the same shape.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+const SCAN_ROOT = resolve(
+  REPO_ROOT,
+  "packages/workout-spa-editor/src/components"
+);
+const FLAGS_PATH = resolve(
+  REPO_ROOT,
+  "packages/workout-spa-editor/src/lib/feature-flags.ts"
+);
+
+export const ALLOWLIST = new Set();
+
+const IGNORED_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".next",
+  "coverage",
+]);
+
+const IMPORT_PATTERN =
+  /import\s+(?:type\s+)?\{[^}]*\b(SettingsPanel|ProfileManager)\b[^}]*\}\s+from\s+["'][^"']*(?:SettingsPanel|ProfileManager)/;
+
+function walk(dir, files = []) {
+  for (const entry of readdirSync(dir)) {
+    if (IGNORED_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      walk(full, files);
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+export function isFlagEnabled(flagsSource) {
+  const match = flagsSource.match(
+    /"ux2026\.unifiedSettings"\s*:\s*(true|false)/
+  );
+  if (!match) return false;
+  return match[1] === "true";
+}
+
+export function checkSingleEntry(content, filePath, allowlist = ALLOWLIST) {
+  const errors = [];
+  if (allowlist.has(filePath)) return errors;
+  const lines = content.split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    if (IMPORT_PATTERN.test(line)) {
+      const symbol = line.match(IMPORT_PATTERN)?.[1] ?? "(unknown)";
+      errors.push(
+        `R-SettingsSingleEntry: ${filePath}:${idx + 1} — direct import of ${symbol} is forbidden when ux2026.unifiedSettings is true; route through /settings/<tab> instead`
+      );
+    }
+  });
+  return errors;
+}
+
+function main() {
+  const flagsSource = readFileSync(FLAGS_PATH, "utf8");
+  if (!isFlagEnabled(flagsSource)) {
+    console.log(
+      "R-SettingsSingleEntry: ux2026.unifiedSettings is false — guard is a no-op."
+    );
+    return;
+  }
+  const files = walk(SCAN_ROOT);
+  let totalErrors = 0;
+  for (const file of files) {
+    const relativePath = relative(REPO_ROOT, file);
+    const content = readFileSync(file, "utf8");
+    const errors = checkSingleEntry(content, relativePath);
+    if (errors.length > 0) {
+      for (const error of errors) console.error(error);
+      totalErrors += errors.length;
+    }
+  }
+  if (totalErrors > 0) {
+    console.error(
+      `\nR-SettingsSingleEntry: ${totalErrors} forbidden direct import(s) found.`
+    );
+    process.exit(1);
+  }
+  console.log(
+    `R-SettingsSingleEntry: scanned ${files.length} files — no direct SettingsPanel/ProfileManager imports.`
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/check-settings-single-entry.mjs
+++ b/scripts/check-settings-single-entry.mjs
@@ -1,27 +1,31 @@
 #!/usr/bin/env node
-/**
- * Mechanical guard: when `ux2026.unifiedSettings` is `true` in
- * `packages/workout-spa-editor/src/lib/feature-flags.ts`, no file
- * under `packages/workout-spa-editor/src/components/**` (outside the
- * approved ALLOWLIST) may import `SettingsPanel` or `ProfileManager`
- * directly. The canonical Settings destination is `/settings/<tab>`.
- *
- * Rule R-SettingsSingleEntry — when the flag is `true`:
- *
- *   import { SettingsPanel } from ".../SettingsPanel/...";
- *   import { ProfileManager } from ".../ProfileManager/...";
- *
- * Both shapes fail CI unless the importing file path is in ALLOWLIST.
- * When the flag is `false`, the guard is a no-op so the strangler
- * period stays unblocked.
- *
- * ALLOWLIST is intentionally empty in production initial — see
- * design D9 (R-PIIInterpolation) for the same shape.
- */
+//
+// Mechanical guard: when `ux2026.unifiedSettings` is `true` in
+// `packages/workout-spa-editor/src/lib/feature-flags.ts`, no file
+// under `packages/workout-spa-editor/src/components/**` (outside the
+// approved ALLOWLIST) may import `SettingsPanel` or `ProfileManager`
+// directly. The canonical Settings destination is `/settings/<tab>`.
+//
+// Rule R-SettingsSingleEntry — when the flag is `true`:
+//
+//   import { SettingsPanel } from ".../SettingsPanel/...";
+//   import { ProfileManager } from ".../ProfileManager/...";
+//
+// Both shapes fail CI unless the importing file path is in ALLOWLIST.
+// When the flag is `false`, the guard is a no-op so the strangler
+// period stays unblocked.
+//
+// ALLOWLIST is intentionally empty initially — see design D9
+// (R-PIIInterpolation) for the same shape.
+//
+// CLI:
+//   node scripts/check-settings-single-entry.mjs            # full-tree
+//   node scripts/check-settings-single-entry.mjs --changed-files
 
+import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
@@ -45,8 +49,18 @@ const IGNORED_DIRS = new Set([
   "coverage",
 ]);
 
+// Tolerant flag-state matcher: accepts either string key (single or
+// double quoted) or bare identifier key, with optional whitespace.
+const FLAG_PATTERN =
+  /(?:"ux2026\.unifiedSettings"|'ux2026\.unifiedSettings'|\bux2026\.unifiedSettings\b)\s*:\s*(true|false)/;
+
+// Multiline-aware import detector. The `s` flag lets `.` cross
+// newlines so split-across-lines imports are still caught.
 const IMPORT_PATTERN =
-  /import\s+(?:type\s+)?\{[^}]*\b(SettingsPanel|ProfileManager)\b[^}]*\}\s+from\s+["'][^"']*(?:SettingsPanel|ProfileManager)/;
+  /import\s+(?:type\s+)?\{[^}]*\b(SettingsPanel|ProfileManager)\b[^}]*\}\s+from\s+["'][^"']*(?:SettingsPanel|ProfileManager)[^"']*["']/s;
+
+const IMPORT_STATEMENT_RE = /import\s[^;]*?;/gs;
+const MAX_REPORTED_PATHS = 3;
 
 function walk(dir, files = []) {
   for (const entry of readdirSync(dir)) {
@@ -63,26 +77,52 @@ function walk(dir, files = []) {
 }
 
 export function isFlagEnabled(flagsSource) {
-  const match = flagsSource.match(
-    /"ux2026\.unifiedSettings"\s*:\s*(true|false)/
-  );
+  const match = flagsSource.match(FLAG_PATTERN);
   if (!match) return false;
   return match[1] === "true";
+}
+
+function lineOfOffset(content, offset) {
+  let line = 1;
+  for (let i = 0; i < offset && i < content.length; i++) {
+    if (content.charCodeAt(i) === 10) line++;
+  }
+  return line;
 }
 
 export function checkSingleEntry(content, filePath, allowlist = ALLOWLIST) {
   const errors = [];
   if (allowlist.has(filePath)) return errors;
-  const lines = content.split(/\r?\n/);
-  lines.forEach((line, idx) => {
-    if (IMPORT_PATTERN.test(line)) {
-      const symbol = line.match(IMPORT_PATTERN)?.[1] ?? "(unknown)";
-      errors.push(
-        `R-SettingsSingleEntry: ${filePath}:${idx + 1} — direct import of ${symbol} is forbidden when ux2026.unifiedSettings is true; route through /settings/<tab> instead`
-      );
-    }
-  });
+  let match;
+  while ((match = IMPORT_STATEMENT_RE.exec(content)) !== null) {
+    const stmt = match[0];
+    const m = stmt.match(IMPORT_PATTERN);
+    if (!m) continue;
+    const symbol = m[1];
+    const line = lineOfOffset(content, match.index);
+    errors.push(
+      `R-SettingsSingleEntry: ${filePath}:${line} — direct import of ${symbol} is forbidden when ux2026.unifiedSettings is true; route through /settings/<tab> instead`
+    );
+  }
   return errors;
+}
+
+function gitChangedFiles() {
+  try {
+    const out = execFileSync(
+      "git",
+      ["diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+      { cwd: REPO_ROOT, encoding: "utf8" }
+    ).trim();
+    if (!out) return [];
+    const scanRel = relative(REPO_ROOT, SCAN_ROOT).replaceAll("\\", "/");
+    return out
+      .split(/\n/)
+      .filter((p) => /\.(ts|tsx)$/.test(p) && p.startsWith(`${scanRel}/`))
+      .map((p) => resolve(REPO_ROOT, p));
+  } catch {
+    return [];
+  }
 }
 
 function main() {
@@ -93,28 +133,45 @@ function main() {
     );
     return;
   }
-  const files = walk(SCAN_ROOT);
+  const changedFilesMode = process.argv.includes("--changed-files");
+  const files = changedFilesMode ? gitChangedFiles() : walk(SCAN_ROOT);
+  if (changedFilesMode && files.length === 0) return;
+  const offendingPaths = new Set();
   let totalErrors = 0;
+  const sampleErrors = [];
   for (const file of files) {
     const relativePath = relative(REPO_ROOT, file);
     const content = readFileSync(file, "utf8");
     const errors = checkSingleEntry(content, relativePath);
-    if (errors.length > 0) {
-      for (const error of errors) console.error(error);
-      totalErrors += errors.length;
+    if (errors.length === 0) continue;
+    offendingPaths.add(relativePath);
+    totalErrors += errors.length;
+    if (sampleErrors.length < MAX_REPORTED_PATHS) {
+      const remaining = MAX_REPORTED_PATHS - sampleErrors.length;
+      sampleErrors.push(...errors.slice(0, remaining));
     }
   }
   if (totalErrors > 0) {
+    for (const message of sampleErrors) console.error("%s", message);
+    if (offendingPaths.size > MAX_REPORTED_PATHS) {
+      const extra = offendingPaths.size - MAX_REPORTED_PATHS;
+      console.error("…and %d more file(s) with violations", extra);
+    }
     console.error(
-      `\nR-SettingsSingleEntry: ${totalErrors} forbidden direct import(s) found.`
+      "R-SettingsSingleEntry: %d forbidden direct import(s) across %d file(s).",
+      totalErrors,
+      offendingPaths.size
     );
     process.exit(1);
   }
-  console.log(
-    `R-SettingsSingleEntry: scanned ${files.length} files — no direct SettingsPanel/ProfileManager imports.`
-  );
+  if (!changedFilesMode) {
+    console.log(
+      "R-SettingsSingleEntry: scanned %d files — no direct SettingsPanel/ProfileManager imports.",
+      files.length
+    );
+  }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }

--- a/scripts/check-settings-single-entry.test.mjs
+++ b/scripts/check-settings-single-entry.test.mjs
@@ -8,49 +8,85 @@ import {
 } from "./check-settings-single-entry.mjs";
 
 describe("isFlagEnabled", () => {
-  it("returns false when flag is set to false", () => {
+  it("should return false when flag is set to false", () => {
+    // Arrange
     const src = `export const FEATURE_FLAGS = { "ux2026.unifiedSettings": false };`;
-    assert.equal(isFlagEnabled(src), false);
+
+    // Act
+    const result = isFlagEnabled(src);
+
+    // Assert
+    assert.equal(result, false);
   });
 
-  it("returns true when flag is set to true", () => {
+  it("should return true when flag is set to true", () => {
+    // Arrange
     const src = `export const FEATURE_FLAGS = { "ux2026.unifiedSettings": true };`;
-    assert.equal(isFlagEnabled(src), true);
+
+    // Act
+    const result = isFlagEnabled(src);
+
+    // Assert
+    assert.equal(result, true);
   });
 
-  it("returns false when the flag entry is missing", () => {
+  it("should return false when the flag entry is missing", () => {
+    // Arrange
     const src = `export const FEATURE_FLAGS = { "ux2026.spineHeader": true };`;
-    assert.equal(isFlagEnabled(src), false);
+
+    // Act
+    const result = isFlagEnabled(src);
+
+    // Assert
+    assert.equal(result, false);
   });
 
-  it("returns true when the key uses single quotes", () => {
+  it("should return true when the key uses single quotes", () => {
+    // Arrange
     const src = `export const FEATURE_FLAGS = { 'ux2026.unifiedSettings': true };`;
-    assert.equal(isFlagEnabled(src), true);
+
+    // Act
+    const result = isFlagEnabled(src);
+
+    // Assert
+    assert.equal(result, true);
   });
 
-  it("returns true when the key is a bare identifier (no quotes)", () => {
+  it("should return true when the key is a bare identifier (no quotes)", () => {
+    // Arrange
     const src = `export const FEATURE_FLAGS = { ux2026.unifiedSettings: true };`;
-    assert.equal(isFlagEnabled(src), true);
+
+    // Act
+    const result = isFlagEnabled(src);
+
+    // Assert
+    assert.equal(result, true);
   });
 });
 
 describe("checkSingleEntry", () => {
   describe("no direct imports", () => {
-    it("returns no errors for files that do not import SettingsPanel or ProfileManager", () => {
-      const errors = checkSingleEntry(
-        `import { Button } from "../atoms/Button/Button";`,
-        "src/foo.tsx"
-      );
+    it("should return no errors for files that do not import SettingsPanel or ProfileManager", () => {
+      // Arrange
+      const src = `import { Button } from "../atoms/Button/Button";`;
+
+      // Act
+      const errors = checkSingleEntry(src, "src/foo.tsx");
+
+      // Assert
       assert.deepEqual(errors, []);
     });
   });
 
   describe("direct SettingsPanel import", () => {
-    it("flags a direct import of SettingsPanel", () => {
-      const errors = checkSingleEntry(
-        `import { SettingsPanel } from "../organisms/SettingsPanel/SettingsPanel";`,
-        "src/foo.tsx"
-      );
+    it("should flag a direct import of SettingsPanel", () => {
+      // Arrange
+      const src = `import { SettingsPanel } from "../organisms/SettingsPanel/SettingsPanel";`;
+
+      // Act
+      const errors = checkSingleEntry(src, "src/foo.tsx");
+
+      // Assert
       assert.equal(errors.length, 1);
       assert.ok(errors[0].includes("SettingsPanel"));
       assert.ok(errors[0].includes("src/foo.tsx:1"));
@@ -58,37 +94,47 @@ describe("checkSingleEntry", () => {
   });
 
   describe("direct ProfileManager import", () => {
-    it("flags a direct import of ProfileManager", () => {
-      const errors = checkSingleEntry(
-        `import { ProfileManager } from "../organisms/ProfileManager/ProfileManager";`,
-        "src/foo.tsx"
-      );
+    it("should flag a direct import of ProfileManager", () => {
+      // Arrange
+      const src = `import { ProfileManager } from "../organisms/ProfileManager/ProfileManager";`;
+
+      // Act
+      const errors = checkSingleEntry(src, "src/foo.tsx");
+
+      // Assert
       assert.equal(errors.length, 1);
       assert.ok(errors[0].includes("ProfileManager"));
     });
   });
 
   describe("allowlist", () => {
-    it("exempts files in the allowlist", () => {
+    it("should exempt files in the allowlist", () => {
+      // Arrange
       const allow = new Set(["src/legacy.tsx"]);
-      const errors = checkSingleEntry(
-        `import { SettingsPanel } from "../organisms/SettingsPanel/SettingsPanel";`,
-        "src/legacy.tsx",
-        allow
-      );
+      const src = `import { SettingsPanel } from "../organisms/SettingsPanel/SettingsPanel";`;
+
+      // Act
+      const errors = checkSingleEntry(src, "src/legacy.tsx", allow);
+
+      // Assert
       assert.deepEqual(errors, []);
     });
   });
 
   describe("multiline imports", () => {
-    it("flags a SettingsPanel import split across multiple lines", () => {
+    it("should flag a SettingsPanel import split across multiple lines", () => {
+      // Arrange
       const src = [
         "import {",
         "  SettingsPanel,",
         '} from "../organisms/SettingsPanel/SettingsPanel";',
         "",
       ].join("\n");
+
+      // Act
       const errors = checkSingleEntry(src, "src/multi.tsx");
+
+      // Assert
       assert.equal(errors.length, 1);
       assert.ok(errors[0].includes("SettingsPanel"));
       assert.ok(errors[0].includes("src/multi.tsx:1"));
@@ -96,8 +142,14 @@ describe("checkSingleEntry", () => {
   });
 
   describe("ALLOWLIST is empty initially", () => {
-    it("ships with an empty allowlist (production initial)", () => {
-      assert.equal(ALLOWLIST.size, 0);
+    it("should ship with an empty allowlist (production initial)", () => {
+      // Arrange
+
+      // Act
+      const size = ALLOWLIST.size;
+
+      // Assert
+      assert.equal(size, 0);
     });
   });
 });

--- a/scripts/check-settings-single-entry.test.mjs
+++ b/scripts/check-settings-single-entry.test.mjs
@@ -1,0 +1,78 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ALLOWLIST,
+  checkSingleEntry,
+  isFlagEnabled,
+} from "./check-settings-single-entry.mjs";
+
+describe("isFlagEnabled", () => {
+  it("returns false when flag is set to false", () => {
+    const src = `export const FEATURE_FLAGS = { "ux2026.unifiedSettings": false };`;
+    assert.equal(isFlagEnabled(src), false);
+  });
+
+  it("returns true when flag is set to true", () => {
+    const src = `export const FEATURE_FLAGS = { "ux2026.unifiedSettings": true };`;
+    assert.equal(isFlagEnabled(src), true);
+  });
+
+  it("returns false when the flag entry is missing", () => {
+    const src = `export const FEATURE_FLAGS = { "ux2026.spineHeader": true };`;
+    assert.equal(isFlagEnabled(src), false);
+  });
+});
+
+describe("checkSingleEntry", () => {
+  describe("no direct imports", () => {
+    it("returns no errors for files that do not import SettingsPanel or ProfileManager", () => {
+      const errors = checkSingleEntry(
+        `import { Button } from "../atoms/Button/Button";`,
+        "src/foo.tsx"
+      );
+      assert.deepEqual(errors, []);
+    });
+  });
+
+  describe("direct SettingsPanel import", () => {
+    it("flags a direct import of SettingsPanel", () => {
+      const errors = checkSingleEntry(
+        `import { SettingsPanel } from "../organisms/SettingsPanel/SettingsPanel";`,
+        "src/foo.tsx"
+      );
+      assert.equal(errors.length, 1);
+      assert.ok(errors[0].includes("SettingsPanel"));
+      assert.ok(errors[0].includes("src/foo.tsx:1"));
+    });
+  });
+
+  describe("direct ProfileManager import", () => {
+    it("flags a direct import of ProfileManager", () => {
+      const errors = checkSingleEntry(
+        `import { ProfileManager } from "../organisms/ProfileManager/ProfileManager";`,
+        "src/foo.tsx"
+      );
+      assert.equal(errors.length, 1);
+      assert.ok(errors[0].includes("ProfileManager"));
+    });
+  });
+
+  describe("allowlist", () => {
+    it("exempts files in the allowlist", () => {
+      const allow = new Set(["src/legacy.tsx"]);
+      const errors = checkSingleEntry(
+        `import { SettingsPanel } from "../organisms/SettingsPanel/SettingsPanel";`,
+        "src/legacy.tsx",
+        allow
+      );
+      assert.deepEqual(errors, []);
+    });
+  });
+
+  describe("ALLOWLIST is empty initially", () => {
+    it("ships with an empty allowlist (production initial)", () => {
+      assert.equal(ALLOWLIST.size, 0);
+    });
+  });
+});

--- a/scripts/check-settings-single-entry.test.mjs
+++ b/scripts/check-settings-single-entry.test.mjs
@@ -22,6 +22,16 @@ describe("isFlagEnabled", () => {
     const src = `export const FEATURE_FLAGS = { "ux2026.spineHeader": true };`;
     assert.equal(isFlagEnabled(src), false);
   });
+
+  it("returns true when the key uses single quotes", () => {
+    const src = `export const FEATURE_FLAGS = { 'ux2026.unifiedSettings': true };`;
+    assert.equal(isFlagEnabled(src), true);
+  });
+
+  it("returns true when the key is a bare identifier (no quotes)", () => {
+    const src = `export const FEATURE_FLAGS = { ux2026.unifiedSettings: true };`;
+    assert.equal(isFlagEnabled(src), true);
+  });
 });
 
 describe("checkSingleEntry", () => {
@@ -67,6 +77,21 @@ describe("checkSingleEntry", () => {
         allow
       );
       assert.deepEqual(errors, []);
+    });
+  });
+
+  describe("multiline imports", () => {
+    it("flags a SettingsPanel import split across multiple lines", () => {
+      const src = [
+        "import {",
+        "  SettingsPanel,",
+        '} from "../organisms/SettingsPanel/SettingsPanel";',
+        "",
+      ].join("\n");
+      const errors = checkSingleEntry(src, "src/multi.tsx");
+      assert.equal(errors.length, 1);
+      assert.ok(errors[0].includes("SettingsPanel"));
+      assert.ok(errors[0].includes("src/multi.tsx:1"));
     });
   });
 

--- a/scripts/check-strangler-expiry.mjs
+++ b/scripts/check-strangler-expiry.mjs
@@ -1,30 +1,32 @@
 #!/usr/bin/env node
-/**
- * Mechanical guard: every `// @strangler-until: YYYY-MM-DD` marker in
- * `packages/workout-spa-editor/src/**` MUST have a date that is on or
- * after today. Past dates fail CI, forcing the strangler shim to be
- * deleted (or its TTL extended with explicit justification).
- *
- * Rule R-StranglerExpiry — single rule, single shape:
- *
- *   // @strangler-until: YYYY-MM-DD
- *
- * Anything else (missing date, malformed date, past date) fails. The
- * marker is intended to outlive its scope only as long as the date
- * allows; this guard enforces that contract.
- *
- * Mirror pattern: scripts/check-archive-dates.mjs.
- */
+//
+// Mechanical guard: every `// @strangler-until: YYYY-MM-DD` marker in
+// `packages/workout-spa-editor/src/**` MUST have a date that is on or
+// after today. Past dates fail CI, forcing the strangler shim to be
+// deleted (or its TTL extended with explicit justification).
+//
+// Rule R-StranglerExpiry — single rule, single shape:
+//
+//   // @strangler-until: YYYY-MM-DD
+//
+// Anything else (missing date, malformed date, past date) fails.
+//
+// CLI:
+//   node scripts/check-strangler-expiry.mjs            # full-tree
+//   node scripts/check-strangler-expiry.mjs --changed-files
+//
+// `--changed-files` mode mirrors check-test-aaa.mjs.
 
+import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..");
-
 const SCAN_ROOT = resolve(REPO_ROOT, "packages/workout-spa-editor/src");
 const MARKER = /\/\/\s*@strangler-until:\s*(\S+)\s*$/;
+const MAX_REPORTED_PATHS = 3;
 
 const IGNORED_DIRS = new Set([
   "node_modules",
@@ -77,29 +79,64 @@ export function checkStranglerExpiry(content, filePath, today = new Date()) {
   return errors;
 }
 
+function gitChangedFiles() {
+  try {
+    const out = execFileSync(
+      "git",
+      ["diff", "--cached", "--name-only", "--diff-filter=ACMR"],
+      { cwd: REPO_ROOT, encoding: "utf8" }
+    ).trim();
+    if (!out) return [];
+    const scanRel = relative(REPO_ROOT, SCAN_ROOT).replaceAll("\\", "/");
+    return out
+      .split(/\n/)
+      .filter((p) => /\.(ts|tsx)$/.test(p) && p.startsWith(`${scanRel}/`))
+      .map((p) => resolve(REPO_ROOT, p));
+  } catch {
+    return [];
+  }
+}
+
 function main() {
   const today = new Date();
-  const files = walk(SCAN_ROOT);
+  const changedFilesMode = process.argv.includes("--changed-files");
+  const files = changedFilesMode ? gitChangedFiles() : walk(SCAN_ROOT);
+  if (changedFilesMode && files.length === 0) return;
+  const offendingPaths = new Set();
   let totalErrors = 0;
+  const sampleErrors = [];
   for (const file of files) {
     const content = readFileSync(file, "utf8");
     const errors = checkStranglerExpiry(content, file, today);
-    if (errors.length > 0) {
-      for (const error of errors) console.error(error);
-      totalErrors += errors.length;
+    if (errors.length === 0) continue;
+    offendingPaths.add(file);
+    totalErrors += errors.length;
+    if (sampleErrors.length < MAX_REPORTED_PATHS) {
+      const remaining = MAX_REPORTED_PATHS - sampleErrors.length;
+      sampleErrors.push(...errors.slice(0, remaining));
     }
   }
   if (totalErrors > 0) {
+    for (const message of sampleErrors) console.error("%s", message);
+    if (offendingPaths.size > MAX_REPORTED_PATHS) {
+      const extra = offendingPaths.size - MAX_REPORTED_PATHS;
+      console.error("…and %d more file(s) with violations", extra);
+    }
     console.error(
-      `\nR-StranglerExpiry: ${totalErrors} expired strangler marker(s) found.`
+      "R-StranglerExpiry: %d expired strangler marker(s) across %d file(s).",
+      totalErrors,
+      offendingPaths.size
     );
     process.exit(1);
   }
-  console.log(
-    `R-StranglerExpiry: scanned ${files.length} files — no expired strangler markers.`
-  );
+  if (!changedFilesMode) {
+    console.log(
+      "R-StranglerExpiry: scanned %d files — no expired strangler markers.",
+      files.length
+    );
+  }
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
   main();
 }

--- a/scripts/check-strangler-expiry.mjs
+++ b/scripts/check-strangler-expiry.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+/**
+ * Mechanical guard: every `// @strangler-until: YYYY-MM-DD` marker in
+ * `packages/workout-spa-editor/src/**` MUST have a date that is on or
+ * after today. Past dates fail CI, forcing the strangler shim to be
+ * deleted (or its TTL extended with explicit justification).
+ *
+ * Rule R-StranglerExpiry — single rule, single shape:
+ *
+ *   // @strangler-until: YYYY-MM-DD
+ *
+ * Anything else (missing date, malformed date, past date) fails. The
+ * marker is intended to outlive its scope only as long as the date
+ * allows; this guard enforces that contract.
+ *
+ * Mirror pattern: scripts/check-archive-dates.mjs.
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..");
+
+const SCAN_ROOT = resolve(REPO_ROOT, "packages/workout-spa-editor/src");
+const MARKER = /\/\/\s*@strangler-until:\s*(\S+)\s*$/;
+
+const IGNORED_DIRS = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".next",
+  "coverage",
+]);
+
+function walk(dir, files = []) {
+  for (const entry of readdirSync(dir)) {
+    if (IGNORED_DIRS.has(entry)) continue;
+    const full = join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      walk(full, files);
+    } else if (/\.(ts|tsx)$/.test(entry)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+export function checkStranglerExpiry(content, filePath, today = new Date()) {
+  const errors = [];
+  const lines = content.split(/\r?\n/);
+  lines.forEach((line, idx) => {
+    const match = line.match(MARKER);
+    if (!match) return;
+    const dateStr = match[1];
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+      errors.push(
+        `R-StranglerExpiry: ${filePath}:${idx + 1} — malformed date "${dateStr}" (expected YYYY-MM-DD)`
+      );
+      return;
+    }
+    const expiry = new Date(`${dateStr}T23:59:59Z`);
+    if (Number.isNaN(expiry.getTime())) {
+      errors.push(
+        `R-StranglerExpiry: ${filePath}:${idx + 1} — invalid date "${dateStr}"`
+      );
+      return;
+    }
+    if (expiry.getTime() < today.getTime()) {
+      errors.push(
+        `R-StranglerExpiry: ${filePath}:${idx + 1} — strangler-until ${dateStr} has passed (today ${today.toISOString().slice(0, 10)}); delete the shim or extend the TTL with justification`
+      );
+    }
+  });
+  return errors;
+}
+
+function main() {
+  const today = new Date();
+  const files = walk(SCAN_ROOT);
+  let totalErrors = 0;
+  for (const file of files) {
+    const content = readFileSync(file, "utf8");
+    const errors = checkStranglerExpiry(content, file, today);
+    if (errors.length > 0) {
+      for (const error of errors) console.error(error);
+      totalErrors += errors.length;
+    }
+  }
+  if (totalErrors > 0) {
+    console.error(
+      `\nR-StranglerExpiry: ${totalErrors} expired strangler marker(s) found.`
+    );
+    process.exit(1);
+  }
+  console.log(
+    `R-StranglerExpiry: scanned ${files.length} files — no expired strangler markers.`
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/scripts/check-strangler-expiry.test.mjs
+++ b/scripts/check-strangler-expiry.test.mjs
@@ -8,31 +8,40 @@ const PAST = "2000-01-01";
 
 describe("checkStranglerExpiry", () => {
   describe("no marker", () => {
-    it("returns no errors when file has no strangler-until comment", () => {
-      const errors = checkStranglerExpiry(
-        "export const x = 1;\nexport const y = 2;\n",
-        "src/foo.ts"
-      );
+    it("should return no errors when file has no strangler-until comment", () => {
+      // Arrange
+      const src = "export const x = 1;\nexport const y = 2;\n";
+
+      // Act
+      const errors = checkStranglerExpiry(src, "src/foo.ts");
+
+      // Assert
       assert.deepEqual(errors, []);
     });
   });
 
   describe("future date", () => {
-    it("returns no errors when strangler-until is in the future", () => {
-      const errors = checkStranglerExpiry(
-        `// @strangler-until: ${FUTURE}\nexport const x = 1;\n`,
-        "src/foo.ts"
-      );
+    it("should return no errors when strangler-until is in the future", () => {
+      // Arrange
+      const src = `// @strangler-until: ${FUTURE}\nexport const x = 1;\n`;
+
+      // Act
+      const errors = checkStranglerExpiry(src, "src/foo.ts");
+
+      // Assert
       assert.deepEqual(errors, []);
     });
   });
 
   describe("past date", () => {
-    it("flags an expired strangler-until marker", () => {
-      const errors = checkStranglerExpiry(
-        `// @strangler-until: ${PAST}\nexport const x = 1;\n`,
-        "src/foo.ts"
-      );
+    it("should flag an expired strangler-until marker", () => {
+      // Arrange
+      const src = `// @strangler-until: ${PAST}\nexport const x = 1;\n`;
+
+      // Act
+      const errors = checkStranglerExpiry(src, "src/foo.ts");
+
+      // Assert
       assert.equal(errors.length, 1);
       assert.ok(errors[0].includes("has passed"));
       assert.ok(errors[0].includes("src/foo.ts:1"));
@@ -40,22 +49,28 @@ describe("checkStranglerExpiry", () => {
   });
 
   describe("malformed date", () => {
-    it("flags a non-YYYY-MM-DD date", () => {
-      const errors = checkStranglerExpiry(
-        `// @strangler-until: tomorrow\nexport const x = 1;\n`,
-        "src/foo.ts"
-      );
+    it("should flag a non-YYYY-MM-DD date", () => {
+      // Arrange
+      const src = `// @strangler-until: tomorrow\nexport const x = 1;\n`;
+
+      // Act
+      const errors = checkStranglerExpiry(src, "src/foo.ts");
+
+      // Assert
       assert.equal(errors.length, 1);
       assert.ok(errors[0].includes("malformed"));
     });
   });
 
   describe("multiple markers", () => {
-    it("flags each expired marker independently", () => {
-      const errors = checkStranglerExpiry(
-        `// @strangler-until: ${PAST}\nconst a = 1;\n// @strangler-until: ${PAST}\nconst b = 2;\n`,
-        "src/foo.ts"
-      );
+    it("should flag each expired marker independently", () => {
+      // Arrange
+      const src = `// @strangler-until: ${PAST}\nconst a = 1;\n// @strangler-until: ${PAST}\nconst b = 2;\n`;
+
+      // Act
+      const errors = checkStranglerExpiry(src, "src/foo.ts");
+
+      // Assert
       assert.equal(errors.length, 2);
       assert.ok(errors[0].includes("src/foo.ts:1"));
       assert.ok(errors[1].includes("src/foo.ts:3"));

--- a/scripts/check-strangler-expiry.test.mjs
+++ b/scripts/check-strangler-expiry.test.mjs
@@ -1,0 +1,64 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { checkStranglerExpiry } from "./check-strangler-expiry.mjs";
+
+const FUTURE = "2099-01-01";
+const PAST = "2000-01-01";
+
+describe("checkStranglerExpiry", () => {
+  describe("no marker", () => {
+    it("returns no errors when file has no strangler-until comment", () => {
+      const errors = checkStranglerExpiry(
+        "export const x = 1;\nexport const y = 2;\n",
+        "src/foo.ts"
+      );
+      assert.deepEqual(errors, []);
+    });
+  });
+
+  describe("future date", () => {
+    it("returns no errors when strangler-until is in the future", () => {
+      const errors = checkStranglerExpiry(
+        `// @strangler-until: ${FUTURE}\nexport const x = 1;\n`,
+        "src/foo.ts"
+      );
+      assert.deepEqual(errors, []);
+    });
+  });
+
+  describe("past date", () => {
+    it("flags an expired strangler-until marker", () => {
+      const errors = checkStranglerExpiry(
+        `// @strangler-until: ${PAST}\nexport const x = 1;\n`,
+        "src/foo.ts"
+      );
+      assert.equal(errors.length, 1);
+      assert.ok(errors[0].includes("has passed"));
+      assert.ok(errors[0].includes("src/foo.ts:1"));
+    });
+  });
+
+  describe("malformed date", () => {
+    it("flags a non-YYYY-MM-DD date", () => {
+      const errors = checkStranglerExpiry(
+        `// @strangler-until: tomorrow\nexport const x = 1;\n`,
+        "src/foo.ts"
+      );
+      assert.equal(errors.length, 1);
+      assert.ok(errors[0].includes("malformed"));
+    });
+  });
+
+  describe("multiple markers", () => {
+    it("flags each expired marker independently", () => {
+      const errors = checkStranglerExpiry(
+        `// @strangler-until: ${PAST}\nconst a = 1;\n// @strangler-until: ${PAST}\nconst b = 2;\n`,
+        "src/foo.ts"
+      );
+      assert.equal(errors.length, 2);
+      assert.ok(errors[0].includes("src/foo.ts:1"));
+      assert.ok(errors[1].includes("src/foo.ts:3"));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**PR E — final PR of the Phase 1+2 UX redesign roadmap.** Reserves the `/settings/:tab?` URL contract and ships two mechanical guards that subsequent PRs (E+1 content migration, future Phase 3-6) rely on.

### Route scaffold

- New `/settings/:tab?` route in `AppRoutes` (extracted from `App.tsx` to keep both files under their line caps).
- `SettingsPage` is gated by `useFeatureFlag("ux2026.unifiedSettings")`:
  - **Flag off (default):** route redirects to `/calendar` — legacy behaviour unchanged.
  - **Flag on:** `SettingsPage` validates `:tab` against six canonical tabs (`profile`, `zones`, `connections`, `ai`, `appearance`, `privacy`); `/settings` (no tab) redirects to `/settings/profile`; unknown tabs render `null`.

### Mechanical guards (shipped, not deferred)

- **`R-StranglerExpiry`** (`scripts/check-strangler-expiry.mjs`) — scans `packages/workout-spa-editor/src/**` for `// @strangler-until: YYYY-MM-DD` markers and fails CI when any date has passed. Mirrors `scripts/check-archive-dates.mjs`.
- **`R-SettingsSingleEntry`** (`scripts/check-settings-single-entry.mjs`) — when `ux2026.unifiedSettings` is `true`, bans direct `SettingsPanel` / `ProfileManager` imports under `components/**` (outside an explicit `ALLOWLIST`, currently empty). No-op while the flag is `false` so the strangler period stays unblocked.

Both guards have `node:test` suites (13 cases total) picked up by `pnpm test:scripts`.

### Out of scope (PR E+1)

- Migrating the actual tab content from `SettingsPanel` and `ProfileManager` into `SettingsPage`'s tab views. Kept separate to keep this PR reviewable; the strangler shim + the two guards above guarantee the migration ships before its `@strangler-until` date.

### Plan reference

See `.omc/plans/ralplan-ux-redesign-phase1-leftovers-and-phase2.md` §"PR E".

## Test plan

- [x] `node --test scripts/check-strangler-expiry.test.mjs scripts/check-settings-single-entry.test.mjs` — 13/13 pass
- [x] `pnpm -F @kaiord/workout-spa-editor exec vitest run src/routes.test.tsx src/App.test.tsx` — 18/18 pass
- [x] `pnpm -F @kaiord/workout-spa-editor lint` — green
- [x] `node scripts/check-strangler-expiry.mjs` + `node scripts/check-settings-single-entry.mjs` — both green
- [ ] CI required checks
- [ ] CodeRabbit review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified settings flow gated by a feature flag: `/settings` redirects to `/settings/profile` when enabled, validates tab segments, and preserves legacy redirect when disabled.
  * Routing moved into a dedicated routes component for cleaner app composition.

* **Tests**
  * Expanded tests for settings routing/behavior under both flag states.
  * Added tests covering CI guard logic for marker expiry and single-entry rules.

* **Chores**
  * Added CI guards enforcing strangler expiry and single-entry settings entry.
* **Chores**
  * Bumped package version via a changeset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->