### PR TITLE
fix(spa-editor): revert accidental gap-4 on LayoutHeader

### DIFF
--- a/.changeset/revert-layout-header-gap-4.md
+++ b/.changeset/revert-layout-header-gap-4.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Revert accidental `gap-4` addition on LayoutHeader's inner flex container introduced as a drive-by in #632. The class shifts the header layout and breaks the `coaching-sidebar-mobile.png` visual snapshot at 768px, blocking every downstream PR.

--- a/packages/workout-spa-editor/src/components/templates/MainLayout/LayoutHeader.tsx
+++ b/packages/workout-spa-editor/src/components/templates/MainLayout/LayoutHeader.tsx
@@ -28,7 +28,7 @@ export const LayoutHeader = ({ onReplayTutorial }: LayoutHeaderProps) => {
 
   return (
     <header className="sticky top-0 z-50 border-b border-gray-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
+      <div className="mx-auto flex h-16 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <HeaderLogo />
         {spineHeader ? (
           <StatusHeader />


### PR DESCRIPTION
## Summary

PR #632 (an AI-retry fix) included an unrelated drive-by edit adding `gap-4` to LayoutHeader's inner flex container. The class shifts the sticky header layout and breaks the `coaching-sidebar-mobile.png` visual snapshot at 768px — every open PR against main fails `e2e-frontend (2)` because the snapshot was authored without that gap.

This PR restores the pre-#632 classes (single-line revert) so the visual snapshot suite goes green and downstream PRs (e.g. #634) can merge.

## Test plan

- [x] `git diff` shows only the `gap-4` token removed from LayoutHeader
- [x] Changeset present (patch bump for `@kaiord/workout-spa-editor`)
- [ ] CI: `e2e-frontend (2)` passes the `coaching-sidebar-mobile.png` snapshot
- [ ] All other checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)