### PR TITLE
fix(spa-editor): scope coaching-sidebar visual spec to chromium only

### DIFF
--- a/packages/workout-spa-editor/e2e/coaching-sidebar.visual.spec.ts
+++ b/packages/workout-spa-editor/e2e/coaching-sidebar.visual.spec.ts
@@ -20,6 +20,15 @@ const SOURCE_ID = "visual-sidebar-activity";
 const WORKOUT_ID = "visual-sidebar-workout";
 
 test.describe("CoachingSidebar visual regression", () => {
+  // Baselines are generated on ubuntu-latest/chromium only (see
+  // `update-visual-baselines.yml`). Snapshots are not maintained for the
+  // other Playwright projects, so let them skip rather than fail with a
+  // missing-baseline error on every push to main.
+  test.skip(
+    (_fixtures, testInfo) => testInfo.project.name !== "chromium",
+    "Visual baselines are generated only for the chromium project."
+  );
+
   test.beforeEach(async ({ page }) => {
     await disableOnboardingTutorial(page);
   });

--- a/packages/workout-spa-editor/e2e/coaching-sidebar.visual.spec.ts
+++ b/packages/workout-spa-editor/e2e/coaching-sidebar.visual.spec.ts
@@ -20,16 +20,15 @@ const SOURCE_ID = "visual-sidebar-activity";
 const WORKOUT_ID = "visual-sidebar-workout";
 
 test.describe("CoachingSidebar visual regression", () => {
-  // Baselines are generated on ubuntu-latest/chromium only (see
-  // `update-visual-baselines.yml`). Snapshots are not maintained for the
-  // other Playwright projects, so let them skip rather than fail with a
-  // missing-baseline error on every push to main.
-  test.skip(
-    (_fixtures, testInfo) => testInfo.project.name !== "chromium",
-    "Visual baselines are generated only for the chromium project."
-  );
-
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    // Baselines are generated on ubuntu-latest/chromium only (see
+    // `update-visual-baselines.yml`). Snapshots are not maintained for
+    // the other Playwright projects, so let them skip rather than fail
+    // with a missing-baseline error on every push to main.
+    test.skip(
+      testInfo.project.name !== "chromium",
+      "Visual baselines are generated only for the chromium project."
+    );
     await disableOnboardingTutorial(page);
   });
 


### PR DESCRIPTION
## Summary

The `Workout SPA Editor E2E Tests` workflow has been failing on `main` since at least 2026-05-17 — independent of #641 — because `coaching-sidebar.visual.spec.ts` runs across every Playwright project but `update-visual-baselines.yml` only ever generates baselines for `chromium` on `ubuntu-latest`. As a result Mobile Chrome, Mobile Safari, webkit, and firefox all blow up with `A snapshot doesn't exist at ...-<project>-linux.png` on every push to main.

The spec's own header comment already states that baselines are chromium-only. This PR honours that intent by adding `test.skip` at the describe level so the spec runs only under the `chromium` project.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `pnpm lint` (pre-commit hook) clean
- [ ] Post-merge `Workout SPA Editor E2E Tests` workflow goes green
- [ ] Visual baseline regeneration still works on chromium when the header changes

## Alternatives considered

- Generate baselines for every Playwright project: rejected — quadruples the maintenance burden (each header/UI change would require regenerating 5+ project baselines) and the existing workflow only knows how to regen chromium.
- Move the spec into a chromium-only test project: equivalent effect but requires a config change for a single spec; describe-level `test.skip` is the minimal surgical fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated visual regression tests to skip execution on non-chromium browsers, preventing test failures outside the visual baseline update workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/642?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->