### PR TITLE
chore(spa-editor): bump e2e-tests timeout to 50min for firefox headroom

### DIFF
--- a/.github/workflows/workout-spa-editor-e2e.yml
+++ b/.github/workflows/workout-spa-editor-e2e.yml
@@ -44,7 +44,11 @@ jobs:
 
   e2e-tests:
     name: E2E Tests
-    timeout-minutes: 35
+    # chromium/webkit finish in ~10-20 min; firefox is consistently ~2-3x
+    # slower and hit the previous 35 min cap (e.g. run 26158958084), so
+    # the workflow ends up "cancelled" even when nothing was failing. Bump
+    # the budget to 50 min while we evaluate whether to shard firefox.
+    timeout-minutes: 50
     runs-on: ubuntu-latest
     needs: check-ci-status
     if: needs.check-ci-status.outputs.should-run == 'true'


### PR DESCRIPTION
## Summary

The matrix `E2E Tests` job in `.github/workflows/workout-spa-editor-e2e.yml` shared a single `timeout-minutes: 35` across chromium, firefox, and webkit. On run [26158958084](https://github.com/pablo-albaladejo/kaiord/actions/runs/26158958084) (post-merge for #642):

| Browser       | Runtime  | Outcome    |
| ------------- | -------- | ---------- |
| chromium      | ~10 min  | success    |
| webkit        | ~20 min  | success    |
| Mobile Chrome | ~11 min  | success    |
| Mobile Safari | ~22 min  | success    |
| **firefox**   | 35:16    | **cancelled** at the workflow timeout |

Firefox was actively running when the timeout killed it (the cleanup log shows orphan `firefox` / `Web Content` processes), so the suite passes there too once it has enough wall-clock to finish.

Bump the timeout to 50 min so firefox has headroom for the full suite plus Playwright's two-retry cushion.

## Test plan

- [x] `tsc --noEmit` clean (pre-commit hook)
- [ ] Next run of `Workout SPA Editor E2E Tests` on main is no longer cancelled
- [ ] Firefox completes under the new 50 min budget

## Follow-ups

- Long-term: shard firefox across N runners the way the PR-time `e2e-frontend` job shards chromium (4 shards), to keep wall-clock low without needing higher and higher timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test execution reliability by adjusting timeout configuration for end-to-end testing workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->