### PR TITLE
fix(spa-editor): stack header vertically on mobile

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/StatusHeader/StatusHeader.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StatusHeader/StatusHeader.tsx
@@ -10,13 +10,13 @@ export function StatusHeader({ onHelpClick }: StatusHeaderProps) {
   return (
     <nav
       aria-label="Main navigation"
-      className="flex flex-wrap items-center justify-end gap-x-3 gap-y-2 text-sm"
+      className="flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-sm sm:justify-end"
       data-testid="status-header"
     >
       <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
         <StatusIndicators />
       </div>
-      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+      <div className="flex flex-wrap items-center justify-center gap-x-2 gap-y-1 sm:justify-start">
         <StatusEntryButtons onHelpClick={onHelpClick} />
         <ThemeToggle />
       </div>

--- a/packages/workout-spa-editor/src/components/templates/MainLayout/LayoutHeader.tsx
+++ b/packages/workout-spa-editor/src/components/templates/MainLayout/LayoutHeader.tsx
@@ -17,7 +17,7 @@ export const LayoutHeader = ({ onReplayTutorial }: LayoutHeaderProps) => {
 
   return (
     <header className="sticky top-0 z-50 border-b border-gray-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
-      <div className="mx-auto flex min-h-16 max-w-7xl items-center justify-between gap-4 px-4 py-2 sm:px-6 lg:px-8">
+      <div className="mx-auto flex min-h-16 max-w-7xl flex-col items-center justify-between gap-2 px-4 py-2 sm:flex-row sm:gap-4 sm:px-6 lg:px-8">
         <HeaderLogo />
         <StatusHeader onHelpClick={help.show} />
       </div>


### PR DESCRIPTION
## Summary

On viewports below `sm` (640px), the LayoutHeader's `flex justify-between` row pinned "Kaiord Editor" to the left column and crammed every nav button into the right column, producing a lopsided layout.

This PR switches the outer container to `flex-col` on mobile so the logo lives on its own row and the StatusHeader wraps underneath as a horizontal toolbar. The inner nav is `justify-center` on mobile and `justify-end` from `sm`+ so the desktop look (logo left, status right) is preserved.

| Before (375px) | After (375px) |
| -------------- | ------------- |
| Logo column on the left + cramped icons on the right | Centered logo on top, navigation toolbar below |

## Test plan

- [x] `pnpm test` (StatusHeader + LayoutHeader): 22/22 passing
- [x] Manual: mobile (375px), desktop (1280px) — Calendar route
- [x] `tsc --noEmit` clean (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)