### PR TITLE
fix(spa-editor): unblock post-merge Mobile E2E after PR 2

### DIFF
--- a/packages/workout-spa-editor/e2e/calendar-workouts.spec.ts
+++ b/packages/workout-spa-editor/e2e/calendar-workouts.spec.ts
@@ -189,7 +189,7 @@ test.describe("Calendar Workouts", () => {
     await expect(page.getByTestId("empty-day-dialog")).toBeVisible();
   });
 
-  test('EmptyDayDialog "Create new" navigates to /workout/new?date=X', async ({
+  test('EmptyDayDialog "Create new" navigates to /workout/new?source=scratch&date=X', async ({
     page,
   }) => {
     const dates = getWeekDates();
@@ -203,7 +203,12 @@ test.describe("Calendar Workouts", () => {
     await expect(page.getByTestId("empty-day-dialog")).toBeVisible();
 
     await page.getByRole("button", { name: /Create new workout/i }).click();
-    await page.waitForURL(new RegExp(`/workout/new\\?date=${dates[0]}`));
+    // `source=scratch` is the new explicit signal that bypasses the
+    // NewWorkoutPicker (introduced in PR #645) so the editor mounts
+    // directly with the date prefilled.
+    await page.waitForURL(
+      new RegExp(`/workout/new\\?source=scratch&date=${dates[0]}`)
+    );
   });
 
   test('EmptyDayDialog "Add from Library" opens the in-flow template picker (no navigation)', async ({

--- a/packages/workout-spa-editor/e2e/helpers/seed-dexie.ts
+++ b/packages/workout-spa-editor/e2e/helpers/seed-dexie.ts
@@ -69,6 +69,7 @@ export async function clearDexie(page: Page) {
       "syncState",
       "usage",
       "meta",
+      "userPreferences",
     ];
     await Promise.all(tables.map((t) => db.table(t).clear()));
   });

--- a/packages/workout-spa-editor/e2e/helpers/seed-profile.ts
+++ b/packages/workout-spa-editor/e2e/helpers/seed-profile.ts
@@ -33,6 +33,16 @@ export async function seedDefaultProfile(page: Page): Promise<string> {
       },
     ]);
     await db.table("meta").put({ key: "activeProfileId", value: profileId });
+    // Seed `calendarView: "grid"` so every e2e starts on the grid view
+    // regardless of viewport. The viewport-aware default (list on <768
+    // px) is intentional for real users but would make Mobile-Chrome /
+    // Mobile-Safari Playwright projects flaky across grid-affordance
+    // tests (the existing tests assume grid).
+    await db.table("userPreferences").put({
+      profileId,
+      calendarView: "grid",
+      updatedAt: now,
+    });
   }, E2E_DEFAULT_PROFILE_ID);
   return E2E_DEFAULT_PROFILE_ID;
 }

--- a/packages/workout-spa-editor/src/components/molecules/EmptyDayDialog/EmptyDayDialog.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/EmptyDayDialog/EmptyDayDialog.test.tsx
@@ -234,6 +234,8 @@ describe("EmptyDayDialog", () => {
     // Assert
 
     expect(onClose).toHaveBeenCalledOnce();
-    expect(location.history).toContain("/workout/new?date=2025-03-15");
+    expect(location.history).toContain(
+      "/workout/new?source=scratch&date=2025-03-15"
+    );
   });
 });

--- a/packages/workout-spa-editor/src/components/molecules/EmptyDayDialog/EmptyDayDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/EmptyDayDialog/EmptyDayDialog.tsx
@@ -45,7 +45,7 @@ export function EmptyDayDialog({ date, onClose }: EmptyDayDialogProps) {
 
   const handleCreate = () => {
     onClose();
-    navigate(`/workout/new?date=${date}`);
+    navigate(`/workout/new?source=scratch&date=${date}`);
   };
 
   const handlePick = (templateId: string) => {

--- a/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/RawWorkoutContent.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/RawWorkoutContent.tsx
@@ -49,7 +49,9 @@ export function RawWorkoutContent({
         onProcess={onProcess}
         onSkip={onSkip}
         onUnskip={onUnskip}
-        onManual={() => navigate(`/workout/new?date=${workout.date}`)}
+        onManual={() =>
+          navigate(`/workout/new?source=scratch&date=${workout.date}`)
+        }
         disabled={isSubmitting}
       />
     </div>


### PR DESCRIPTION
## Summary

Two regressions surfaced in the multi-browser post-merge `Workout SPA Editor E2E Tests` run after PR #646 (calendar-view-and-dnd) landed:

1. **`/workout/new?date=X` lands on the NewWorkoutPicker, not the editor.** PR #645's `AppRoutes` requires `?action=import` or `?source=scratch` to bypass the picker. `EmptyDayDialog` ("Create new") and `RawWorkoutContent` ("Create manually") were still sending users to `/workout/new?date=X`. Both now pass `?source=scratch&date=X` so the editor mounts in blank mode with the date pre-filled.

2. **Mobile Playwright projects (Mobile Chrome / Mobile Safari) default to the new List view.** PR #646's `viewportDefaultView()` returns `"list"` at `< 768 px`, which is intentional for real users but flakes the existing grid-affordance e2e tests. Extend `seedDefaultProfile` to seed `userPreferences.calendarView = "grid"` so every e2e starts on the grid view regardless of viewport, and add `userPreferences` to the tables `clearDexie` wipes so reseed is clean.

## Test plan

- [x] `pnpm test` (workout-spa-editor) — EmptyDayDialog tests green
- [x] `pnpm lint` (workout-spa-editor)
- [ ] Post-merge `Workout SPA Editor E2E Tests` workflow goes green on Mobile Chrome + Mobile Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to ensure consistent grid calendar view across all test runs.
  * Enhanced test assertions for workout creation navigation flow.

* **Bug Fixes**
  * Improved workout creation flow with additional parameter tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/647?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->