### PR TITLE
chore(spa-editor): SSR-guard the __KAIORD_DB__ dev exposure

### DIFF
--- a/.changeset/kaiord-db-ssr-guard.md
+++ b/.changeset/kaiord-db-ssr-guard.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+chore: SSR guard the `__KAIORD_DB__` dev-only exposure with `typeof window !== "undefined"` so the module is safe to import from node tooling that doesn't provide a DOM. Matches the symmetric `__KAIORD_WORKOUT_STORE__` guard in `workout-store.ts`. Production builds are unaffected — Vite tree-shakes the `import.meta.env.DEV` block.

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
@@ -25,8 +25,11 @@ export class KaiordDatabase extends Dexie {
 
 export const db = new KaiordDatabase();
 
-// Expose for e2e test seeding (dev mode only)
-if (import.meta.env.DEV) {
+// Expose for e2e test seeding (dev mode only). The `typeof window` guard
+// matches the symmetric `__KAIORD_WORKOUT_STORE__` exposure in
+// `src/store/workout-store.ts` so this module remains safe to import
+// from node tooling that doesn't provide a DOM (SSR-style consumers).
+if (import.meta.env.DEV && typeof window !== "undefined") {
   const w = window as unknown as Record<string, unknown>;
   w.__KAIORD_DB__ = db;
   const aiRepo = createDexieAiProviderRepository(db);


### PR DESCRIPTION
## Summary

Mirrors the `typeof window !== "undefined"` guard that landed for the `__KAIORD_WORKOUT_STORE__` exposure in `workout-store.ts` (PR #648, commit `21e91e51`). The PR #648 commit message explicitly deferred this symmetric change for `dexie-database.ts`:

> Skipping the same change in `dexie-database.ts` since that file is not touched by this PR; will land in a separate cleanup.

This is that cleanup.

## Changes

- `packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts:28`: `if (import.meta.env.DEV)` → `if (import.meta.env.DEV && typeof window !== "undefined")`.

## Why this is safe

- Production builds are unchanged — Vite tree-shakes the `import.meta.env.DEV` block, so the guard never even reaches the production bundle.
- Dev builds always run in a browser context where `window` is defined, so the additional condition is satisfied identically to before.
- The change makes the module importable from node tooling (test harnesses, scripts) without crashing on `window is not defined`.

## Test plan

- [x] `pnpm --filter @kaiord/workout-spa-editor lint` clean.
- [x] TypeScript type check passes via husky pre-commit + pre-push.
- [ ] CI: existing e2e specs that rely on `__KAIORD_DB__` (15+ via `seed-empty-workout.ts` and the calendar performance spec) continue to pass — no behavioural change.

Follow-up plan: [`.omc/plans/followups-post-648-650.md`](.omc/plans/followups-post-648-650.md) — PR B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed module import compatibility in server-side rendering environments by adding safety checks for browser-only features. The module now safely imports in Node.js environments without errors. Production behavior remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/652?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->