### PR TITLE
feat(spa-editor): persist lastScratchSport and aiBannerExpanded (Dexie v15)

### DIFF
--- a/.changeset/user-prefs-scratch-and-ai-banner-state.md
+++ b/.changeset/user-prefs-scratch-and-ai-banner-state.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+feat: persist `userPreferences.lastScratchSport` and `userPreferences.aiBannerExpanded` across sessions (per profile) via a forward-only Dexie v15 migration. The `ScratchEditorSurface` now pre-selects the user's last scratch sport in `MetadataEditMode` and writes the chosen sport back on the auto-init path (library-loaded and e2e-seeded workouts are skipped). `AiBanner` seeds its open/closed state from the persisted preference and writes manual toggles and the one-shot auto-collapse-on-first-success transition back, preserving the existing one-shot semantics.

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v15-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v15-migration.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Forward migration v14 → v15 — userPreferences scratch-sport + AI banner.
+ *
+ * Seeds a raw Dexie at v14 with calendarView-only rows, reopens via
+ * `KaiordDatabase` (which registers v15), and asserts each migrated row
+ * still satisfies `userPreferencesSchema.safeParse(...).success === true`.
+ * The migration is data-only: existing fields are preserved unchanged,
+ * and the new optional fields are normalised to `undefined`.
+ */
+import "fake-indexeddb/auto";
+
+import Dexie from "dexie";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  type UserPreferences,
+  userPreferencesSchema,
+} from "../../types/user-preferences";
+import { KaiordDatabase } from "./dexie-database";
+
+const dbName = (suffix: string) =>
+  `kaiord-test-v15-${suffix}-${Date.now()}-${Math.random()}`;
+
+const SCHEMA_V14 = 14;
+const NOW = "2026-05-22T10:00:00.000Z";
+
+const STORES_V14 = {
+  userPreferences: "profileId",
+} as const;
+
+const seedV14 = async (
+  name: string,
+  rows: ReadonlyArray<Record<string, unknown>>
+): Promise<void> => {
+  const v14 = new Dexie(name);
+  v14.version(SCHEMA_V14).stores(STORES_V14);
+  await v14.open();
+  if (rows.length > 0) await v14.table("userPreferences").bulkAdd([...rows]);
+  v14.close();
+};
+
+describe("Dexie v14 → v15 migration (userPreferences scratch + AI banner)", () => {
+  let name: string;
+
+  beforeEach(() => {
+    name = dbName("scratch-banner");
+  });
+
+  afterEach(async () => {
+    await Dexie.delete(name);
+  });
+
+  it("should preserve existing fields and normalise new fields to undefined", async () => {
+    // Arrange
+    await seedV14(name, [
+      { profileId: "p1", calendarView: "grid", updatedAt: NOW },
+    ]);
+
+    // Act
+    const v15 = new KaiordDatabase(name);
+    await v15.open();
+    const migrated = (await v15
+      .table("userPreferences")
+      .get("p1")) as UserPreferences;
+
+    // Assert
+    expect(migrated.profileId).toBe("p1");
+    expect(migrated.calendarView).toBe("grid");
+    expect(migrated.updatedAt).toBe(NOW);
+    expect(migrated.lastScratchSport).toBeUndefined();
+    expect(migrated.aiBannerExpanded).toBeUndefined();
+    expect(userPreferencesSchema.safeParse(migrated).success).toBe(true);
+    v15.close();
+  });
+
+  it("should migrate every row when multiple profiles exist", async () => {
+    // Arrange
+    await seedV14(name, [
+      { profileId: "p1", calendarView: "grid", updatedAt: NOW },
+      { profileId: "p2", calendarView: "list", updatedAt: NOW },
+    ]);
+
+    // Act
+    const v15 = new KaiordDatabase(name);
+    await v15.open();
+    const all = (await v15
+      .table("userPreferences")
+      .toArray()) as UserPreferences[];
+
+    // Assert
+    expect(all).toHaveLength(2);
+    for (const row of all) {
+      expect(userPreferencesSchema.safeParse(row).success).toBe(true);
+    }
+    v15.close();
+  });
+
+  it("should be a no-op on an empty userPreferences table", async () => {
+    // Arrange
+    await seedV14(name, []);
+
+    // Act
+    const v15 = new KaiordDatabase(name);
+    await v15.open();
+    const all = await v15.table("userPreferences").toArray();
+
+    // Assert
+    expect(all).toHaveLength(0);
+    v15.close();
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v15-migration.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v15-migration.ts
@@ -1,0 +1,37 @@
+/**
+ * v14 → v15 migration — userPreferences scratch-sport + AI-banner state.
+ *
+ * Walks every `userPreferences` row and ensures `lastScratchSport` and
+ * `aiBannerExpanded` exist on the JSON shape. Both fields are optional
+ * in `userPreferencesSchema` so absence is also valid; the explicit
+ * `undefined` assignment normalises shape so consumers can `?? default`
+ * without first probing `in`. Schema is unchanged from v13; this is a
+ * data-only upgrade.
+ *
+ * Forward-only by design. The Zod schema and this migration ship
+ * together; an earlier schema deploying with this migration is harmless
+ * (the extra fields are ignored), but a later schema requiring these
+ * fields without this migration would throw on first read.
+ *
+ * Idempotency is guaranteed by Dexie's version gating (the upgrade
+ * runs exactly once per browser per bump).
+ */
+import type { Transaction } from "dexie";
+
+type UserPrefsRow = {
+  profileId: string;
+  calendarView?: unknown;
+  lastScratchSport?: unknown;
+  aiBannerExpanded?: unknown;
+  updatedAt?: string;
+};
+
+export const applyV15Upgrade = async (tx: Transaction): Promise<void> => {
+  await tx
+    .table("userPreferences")
+    .toCollection()
+    .modify((row: UserPrefsRow) => {
+      if (!("lastScratchSport" in row)) row.lastScratchSport = undefined;
+      if (!("aiBannerExpanded" in row)) row.aiBannerExpanded = undefined;
+    });
+};

--- a/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions-v10-plus.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions-v10-plus.ts
@@ -13,6 +13,7 @@ import { applyV11Upgrade } from "./dexie-v11-migration";
 import { applyV12Upgrade } from "./dexie-v12-migration";
 import { applyV13Upgrade } from "./dexie-v13-migration";
 import { applyV14Upgrade } from "./dexie-v14-migration";
+import { applyV15Upgrade } from "./dexie-v15-migration";
 
 type DexieVersionHost = Pick<Dexie, "version">;
 
@@ -28,7 +29,7 @@ export const registerV10ToV12 = (db: DexieVersionHost): void => {
   db.version(12).stores(SCHEMAS.v8).upgrade(applyV12Upgrade);
 };
 
-export const registerV13AndV14 = (db: DexieVersionHost): void => {
+export const registerV13ToV15 = (db: DexieVersionHost): void => {
   // v13 — workouts become profile-scoped 1–1. Adds `profileId` +
   // `[profileId+date]` indexes on `workouts` and backfills every legacy
   // row from `meta.activeProfileId`. The upgrade throws when workouts
@@ -39,4 +40,9 @@ export const registerV13AndV14 = (db: DexieVersionHost): void => {
   // `compact` and `comfortable` collapse to `grid`) and removes the
   // legacy `calendarDensity` field. Schema unchanged from v13.
   db.version(14).stores(SCHEMAS.v13).upgrade(applyV14Upgrade);
+  // v15 — userPreferences scratch-sport + AI banner state. Adds two
+  // optional fields (`lastScratchSport`, `aiBannerExpanded`) so the
+  // editor can pre-populate the scratch sport picker and persist the
+  // AI banner accordion state across sessions. Schema unchanged.
+  db.version(15).stores(SCHEMAS.v13).upgrade(applyV15Upgrade);
 };

--- a/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions.ts
@@ -18,7 +18,7 @@ import {
 import { backfillLinkedAccounts, SCHEMAS } from "./dexie-schemas";
 import {
   registerV10ToV12,
-  registerV13AndV14,
+  registerV13ToV15,
 } from "./register-kaiord-versions-v10-plus";
 
 // Narrowed handle: only `version()` is needed and Dexie's full surface
@@ -78,5 +78,5 @@ export const registerKaiordVersions = (db: DexieVersionHost): void => {
   registerV4ToV6(db);
   registerV7ToV9(db);
   registerV10ToV12(db);
-  registerV13AndV14(db);
+  registerV13ToV15(db);
 };

--- a/packages/workout-spa-editor/src/application/set-user-preference-fields.test.ts
+++ b/packages/workout-spa-editor/src/application/set-user-preference-fields.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import type { ProfileRepository } from "../ports/persistence-port";
+import { createInMemoryUserPreferencesRepository } from "../test-utils/in-memory-user-preferences-repository";
+import type { Profile } from "../types/profile";
+import { ProfileNotFoundError } from "../types/session-match-errors";
+import { setUserPreferenceFields } from "./set-user-preference-fields";
+
+const stubProfile = (overrides: Partial<Profile> = {}): Profile => ({
+  id: "p1",
+  name: "Athlete",
+  ftpW: 250,
+  thresholdHr: 170,
+  linkedAccounts: [],
+  ...overrides,
+});
+
+const stubProfileRepo = (rows: Profile[]): ProfileRepository => {
+  const map = new Map(rows.map((r) => [r.id, r]));
+  return {
+    getAll: async () => [...map.values()],
+    getById: async (id) => map.get(id),
+    getActiveId: async () => null,
+    setActiveId: async () => {},
+    put: async (p) => {
+      map.set(p.id, p);
+    },
+    delete: async (id) => {
+      map.delete(id);
+    },
+    count: async () => map.size,
+  };
+};
+
+const fixedClock = () => "2026-05-22T12:00:00.000Z";
+
+describe("setUserPreferenceFields", () => {
+  it("should create the row with lastScratchSport on first call", async () => {
+    // Arrange
+    const repository = createInMemoryUserPreferencesRepository();
+    const profileRepository = stubProfileRepo([stubProfile()]);
+
+    // Act
+    await setUserPreferenceFields(
+      { profileId: "p1", patch: { lastScratchSport: "running" } },
+      { clock: fixedClock, repository, profileRepository }
+    );
+
+    // Assert
+    expect(await repository.get("p1")).toEqual({
+      profileId: "p1",
+      calendarView: "grid",
+      lastScratchSport: "running",
+      aiBannerExpanded: undefined,
+      updatedAt: "2026-05-22T12:00:00.000Z",
+    });
+  });
+
+  it("should merge aiBannerExpanded onto an existing row preserving other fields", async () => {
+    // Arrange
+    const repository = createInMemoryUserPreferencesRepository();
+    const profileRepository = stubProfileRepo([stubProfile()]);
+    await setUserPreferenceFields(
+      { profileId: "p1", patch: { lastScratchSport: "swimming" } },
+      {
+        clock: () => "2026-05-22T10:00:00.000Z",
+        repository,
+        profileRepository,
+      }
+    );
+
+    // Act
+    await setUserPreferenceFields(
+      { profileId: "p1", patch: { aiBannerExpanded: true } },
+      {
+        clock: () => "2026-05-22T15:00:00.000Z",
+        repository,
+        profileRepository,
+      }
+    );
+
+    // Assert
+    expect(await repository.get("p1")).toEqual({
+      profileId: "p1",
+      calendarView: "grid",
+      lastScratchSport: "swimming",
+      aiBannerExpanded: true,
+      updatedAt: "2026-05-22T15:00:00.000Z",
+    });
+  });
+
+  it("should throw ProfileNotFoundError when profile is missing", async () => {
+    // Arrange
+    const repository = createInMemoryUserPreferencesRepository();
+    const profileRepository = stubProfileRepo([]);
+
+    // Act
+
+    // Assert
+    await expect(
+      setUserPreferenceFields(
+        { profileId: "p1", patch: { lastScratchSport: "running" } },
+        { clock: fixedClock, repository, profileRepository }
+      )
+    ).rejects.toBeInstanceOf(ProfileNotFoundError);
+    expect(await repository.get("p1")).toBeUndefined();
+  });
+});

--- a/packages/workout-spa-editor/src/application/set-user-preference-fields.ts
+++ b/packages/workout-spa-editor/src/application/set-user-preference-fields.ts
@@ -1,0 +1,53 @@
+/**
+ * setUserPreferenceFields — partial upsert of the per-profile
+ * UserPreferences row. Merges the requested fields onto the existing
+ * row (or the default shape when no row exists yet) and rewrites
+ * `updatedAt` from the injected clock.
+ *
+ * Profile existence is verified before the write so a concurrent
+ * profile delete surfaces as `ProfileNotFoundError` rather than
+ * silently leaving an orphan row — same sequencing as `setCalendarView`.
+ */
+
+import type { ProfileRepository } from "../ports/persistence-port";
+import type { UserPreferencesRepository } from "../ports/user-preferences-repository";
+import { ProfileNotFoundError } from "../types/session-match-errors";
+import type { UserPreferences } from "../types/user-preferences";
+
+export type UserPreferenceFieldsPatch = Partial<
+  Pick<
+    UserPreferences,
+    "calendarView" | "lastScratchSport" | "aiBannerExpanded"
+  >
+>;
+
+export type SetUserPreferenceFieldsInput = {
+  profileId: string;
+  patch: UserPreferenceFieldsPatch;
+};
+
+export type SetUserPreferenceFieldsDeps = {
+  clock: () => string;
+  repository: UserPreferencesRepository;
+  profileRepository: ProfileRepository;
+};
+
+export async function setUserPreferenceFields(
+  input: SetUserPreferenceFieldsInput,
+  deps: SetUserPreferenceFieldsDeps
+): Promise<void> {
+  const profile = await deps.profileRepository.getById(input.profileId);
+  if (!profile) {
+    throw new ProfileNotFoundError(input.profileId);
+  }
+  const existing = await deps.repository.get(input.profileId);
+  const next: UserPreferences = {
+    profileId: input.profileId,
+    calendarView: existing?.calendarView ?? "grid",
+    lastScratchSport: existing?.lastScratchSport,
+    aiBannerExpanded: existing?.aiBannerExpanded,
+    ...input.patch,
+    updatedAt: deps.clock(),
+  };
+  await deps.repository.put(next);
+}

--- a/packages/workout-spa-editor/src/components/molecules/AiBanner/AiBanner.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/AiBanner/AiBanner.test.tsx
@@ -1,11 +1,46 @@
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 
+import { db } from "../../../adapters/dexie/dexie-database";
 import { useAiRuntimeStore } from "../../../store/ai-runtime-store";
+import type { Profile } from "../../../types/profile";
+import type { UserPreferences } from "../../../types/user-preferences";
 import { AiBanner } from "./AiBanner";
+
+const PROFILE_ID = "p1";
+const NOW = "2026-05-22T10:00:00.000Z";
+
+async function seedProfile(): Promise<void> {
+  const profile: Profile = {
+    id: PROFILE_ID,
+    name: "Athlete",
+    ftpW: 250,
+    thresholdHr: 170,
+    linkedAccounts: [],
+  };
+  await db.table<Profile>("profiles").put(profile);
+  await db.table("meta").put({ key: "activeProfileId", value: PROFILE_ID });
+}
+
+async function seedPrefs(expanded: boolean): Promise<void> {
+  const row: UserPreferences = {
+    profileId: PROFILE_ID,
+    calendarView: "grid",
+    aiBannerExpanded: expanded,
+    updatedAt: NOW,
+  };
+  await db.table<UserPreferences>("userPreferences").put(row);
+}
+
+async function readPrefsExpanded(): Promise<boolean | undefined> {
+  const row = await db
+    .table<UserPreferences>("userPreferences")
+    .get(PROFILE_ID);
+  return row?.aiBannerExpanded;
+}
 
 function setGenerationStatus(status: "idle" | "success") {
   return act(async () => {
@@ -23,8 +58,17 @@ function renderBanner() {
 }
 
 describe("AiBanner", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     useAiRuntimeStore.setState({ generation: { status: "idle" } });
+    await db.table("userPreferences").clear();
+    await db.table("profiles").clear();
+    await db.table("meta").clear();
+  });
+
+  afterEach(async () => {
+    await db.table("userPreferences").clear();
+    await db.table("profiles").clear();
+    await db.table("meta").clear();
   });
 
   it("should render closed by default", () => {
@@ -94,5 +138,62 @@ describe("AiBanner", () => {
     expect(
       screen.getByRole("button", { name: /generate with ai/i })
     ).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("should seed open=true when userPreferences.aiBannerExpanded is persisted", async () => {
+    // Arrange
+    await seedProfile();
+    await seedPrefs(true);
+
+    // Act
+    renderBanner();
+
+    // Assert
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /generate with ai/i })
+      ).toHaveAttribute("aria-expanded", "true");
+    });
+  });
+
+  it("should write aiBannerExpanded=true when the user expands the banner", async () => {
+    // Arrange
+    await seedProfile();
+    const user = userEvent.setup();
+    renderBanner();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /generate with ai/i })
+      ).toHaveAttribute("aria-expanded", "false");
+    });
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /generate with ai/i }));
+
+    // Assert
+    await waitFor(async () => {
+      expect(await readPrefsExpanded()).toBe(true);
+    });
+  });
+
+  it("should write aiBannerExpanded=false when auto-collapse fires", async () => {
+    // Arrange
+    await seedProfile();
+    const user = userEvent.setup();
+    renderBanner();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /generate with ai/i })
+      ).toHaveAttribute("aria-expanded", "false");
+    });
+    await user.click(screen.getByRole("button", { name: /generate with ai/i }));
+
+    // Act
+    await setGenerationStatus("success");
+
+    // Assert
+    await waitFor(async () => {
+      expect(await readPrefsExpanded()).toBe(false);
+    });
   });
 });

--- a/packages/workout-spa-editor/src/components/molecules/AiBanner/AiBanner.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/AiBanner/AiBanner.tsx
@@ -1,8 +1,8 @@
 import { ChevronDown, Sparkles } from "lucide-react";
-import { lazy, Suspense, useEffect, useState } from "react";
+import { lazy, Suspense } from "react";
 import { useLocation } from "wouter";
 
-import { useAiRuntimeStore } from "../../../store/ai-runtime-store";
+import { useAiBannerState } from "./use-ai-banner-state";
 
 const AiWorkoutInput = lazy(() =>
   import("../../organisms/AiWorkoutInput/AiWorkoutInput").then((m) => ({
@@ -13,33 +13,14 @@ const AiWorkoutInput = lazy(() =>
 /**
  * Collapsed-by-default banner that wraps `AiWorkoutInput`.
  *
- * Auto-collapse rule (per plan A4): the panel auto-collapses ONLY on
- * the first AI-generation success after the user expanded it. Manual
- * step adds (`+ Add first step`) never collapse it. Subsequent AI
- * successes do not auto-collapse either — the user has now seen the
- * banner and owns the state.
+ * Open/armed/auto-collapse state and persistence are owned by
+ * `useAiBannerState` — this component stays a pure render. The hook
+ * seeds from `userPreferences.aiBannerExpanded`, writes toggles back,
+ * and runs the one-shot auto-collapse-on-first-success rule.
  */
 export function AiBanner() {
   const [, navigate] = useLocation();
-  const [open, setOpen] = useState(false);
-  const [armed, setArmed] = useState(false);
-  const [hasAutoCollapsed, setHasAutoCollapsed] = useState(false);
-  const generation = useAiRuntimeStore((s) => s.generation);
-
-  useEffect(() => {
-    if (!open) return;
-    if (generation.status === "success" && armed) {
-      setOpen(false);
-      setArmed(false);
-      setHasAutoCollapsed(true);
-    }
-  }, [generation.status, open, armed]);
-
-  const handleToggle = () => {
-    const next = !open;
-    setOpen(next);
-    if (next && !hasAutoCollapsed) setArmed(true);
-  };
+  const { open, toggle } = useAiBannerState();
 
   return (
     <div
@@ -48,7 +29,7 @@ export function AiBanner() {
     >
       <button
         type="button"
-        onClick={handleToggle}
+        onClick={toggle}
         aria-expanded={open}
         aria-controls="ai-banner-panel"
         className="flex w-full items-center justify-between gap-2 px-4 py-3 text-left"

--- a/packages/workout-spa-editor/src/components/molecules/AiBanner/use-ai-banner-state.ts
+++ b/packages/workout-spa-editor/src/components/molecules/AiBanner/use-ai-banner-state.ts
@@ -1,0 +1,67 @@
+/**
+ * useAiBannerState — owns the open/armed/auto-collapse FSM for
+ * `AiBanner` and persists transitions to `userPreferences.aiBannerExpanded`
+ * for the active profile.
+ *
+ * Auto-collapse rule (per plan A4): the panel auto-collapses ONLY on
+ * the first AI-generation success after the user expanded it. Manual
+ * step adds never collapse it; subsequent successes don't auto-collapse
+ * either — the user owns the state after the first auto-collapse.
+ *
+ * Seed runs once when the live prefs query resolves; manual toggles
+ * and the auto-collapse both write the new value back.
+ */
+
+import { useEffect, useRef, useState } from "react";
+
+import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useSetUserPreferenceFields } from "../../../hooks/use-set-user-preference-fields";
+import { useUserPreferences } from "../../../hooks/use-user-preferences";
+import { useAiRuntimeStore } from "../../../store/ai-runtime-store";
+
+export type AiBannerState = {
+  open: boolean;
+  toggle: () => void;
+};
+
+export function useAiBannerState(): AiBannerState {
+  const [open, setOpen] = useState(false);
+  const seededRef = useRef(false);
+  const userTouchedRef = useRef(false);
+  const [armed, setArmed] = useState(false);
+  const [hasAutoCollapsed, setHasAutoCollapsed] = useState(false);
+  const generation = useAiRuntimeStore((s) => s.generation);
+  const profileId = useActiveProfileLive()?.id ?? null;
+  const prefs = useUserPreferences({ profileId, defaultView: "grid" });
+  const setPrefs = useSetUserPreferenceFields(profileId);
+
+  useEffect(() => {
+    if (seededRef.current) return;
+    if (prefs === undefined) return;
+    seededRef.current = true;
+    // A user toggle that races ahead of the live-prefs resolution must
+    // win — only seed when the user has NOT yet interacted.
+    if (userTouchedRef.current) return;
+    setOpen(prefs.aiBannerExpanded ?? false);
+  }, [prefs]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (generation.status === "success" && armed) {
+      setOpen(false);
+      setArmed(false);
+      setHasAutoCollapsed(true);
+      void setPrefs({ aiBannerExpanded: false });
+    }
+  }, [generation.status, open, armed, setPrefs]);
+
+  const toggle = () => {
+    userTouchedRef.current = true;
+    const next = !open;
+    setOpen(next);
+    if (next && !hasAutoCollapsed) setArmed(true);
+    void setPrefs({ aiBannerExpanded: next });
+  };
+
+  return { open, toggle };
+}

--- a/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchEditorSurface.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchEditorSurface.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 
@@ -9,8 +9,38 @@ import { GarminBridgeProvider } from "../../../contexts/garmin-bridge-context";
 import { PersistenceProvider } from "../../../contexts/persistence-context";
 import { ToastContextProvider } from "../../../contexts/ToastContext";
 import { useWorkoutStore } from "../../../store/workout-store";
+import type { Profile } from "../../../types/profile";
+import type { UserPreferences } from "../../../types/user-preferences";
 import { ToastProvider } from "../../atoms/Toast";
 import { ScratchEditorSurface } from "./ScratchEditorSurface";
+
+const PROFILE_ID = "p1";
+const NOW = "2026-05-22T10:00:00.000Z";
+const NEGATIVE_ASSERT_DELAY_MS = 50;
+
+async function seedActiveProfile(): Promise<void> {
+  const profile: Profile = {
+    id: PROFILE_ID,
+    name: "Athlete",
+    ftpW: 250,
+    thresholdHr: 170,
+    linkedAccounts: [],
+  };
+  await db.table<Profile>("profiles").put(profile);
+  await db.table("meta").put({ key: "activeProfileId", value: PROFILE_ID });
+}
+
+async function seedLastScratchSport(
+  sport: UserPreferences["lastScratchSport"]
+): Promise<void> {
+  const row: UserPreferences = {
+    profileId: PROFILE_ID,
+    calendarView: "grid",
+    lastScratchSport: sport,
+    updatedAt: NOW,
+  };
+  await db.table<UserPreferences>("userPreferences").put(row);
+}
 
 function renderSurface() {
   const { hook } = memoryLocation({
@@ -35,6 +65,9 @@ function renderSurface() {
 describe("ScratchEditorSurface", () => {
   beforeEach(async () => {
     await db.table("workouts").clear();
+    await db.table("userPreferences").clear();
+    await db.table("profiles").clear();
+    await db.table("meta").clear();
     useWorkoutStore.setState({
       currentWorkout: null,
       undoHistory: [],
@@ -43,6 +76,12 @@ describe("ScratchEditorSurface", () => {
       selectedStepIds: [],
       isEditing: false,
     });
+  });
+
+  afterEach(async () => {
+    await db.table("userPreferences").clear();
+    await db.table("profiles").clear();
+    await db.table("meta").clear();
   });
 
   it("should seed an empty cycling workout when currentWorkout is null", async () => {
@@ -132,5 +171,102 @@ describe("ScratchEditorSurface", () => {
       expect(useWorkoutStore.getState().currentWorkout).not.toBeNull();
     });
     expect(put).not.toHaveBeenCalled();
+  });
+
+  it("should seed the workout with lastScratchSport from userPreferences", async () => {
+    // Arrange
+    await seedActiveProfile();
+    await seedLastScratchSport("running");
+
+    // Act
+    renderSurface();
+
+    // Assert
+    await waitFor(() => {
+      const state = useWorkoutStore.getState();
+      expect(state.currentWorkout?.extensions?.structured_workout?.sport).toBe(
+        "running"
+      );
+    });
+  });
+
+  it("should write lastScratchSport back to userPreferences when sport changes on auto-init", async () => {
+    // Arrange
+    await seedActiveProfile();
+    await seedLastScratchSport("cycling");
+
+    // Act
+    renderSurface();
+    await waitFor(() => {
+      const state = useWorkoutStore.getState();
+      expect(state.currentWorkout?.extensions?.structured_workout?.sport).toBe(
+        "cycling"
+      );
+    });
+    const krd = useWorkoutStore.getState().currentWorkout!;
+    useWorkoutStore.getState().updateWorkout({
+      ...krd,
+      metadata: { ...krd.metadata, sport: "swimming" },
+      extensions: {
+        ...krd.extensions,
+        structured_workout: {
+          ...krd.extensions!.structured_workout!,
+          sport: "swimming",
+        },
+      },
+    });
+
+    // Assert
+    await waitFor(async () => {
+      const row = await db
+        .table<UserPreferences>("userPreferences")
+        .get(PROFILE_ID);
+      expect(row?.lastScratchSport).toBe("swimming");
+    });
+  });
+
+  it("should NOT write lastScratchSport when workout is pre-populated (no auto-init)", async () => {
+    // Arrange
+    await seedActiveProfile();
+    const seeded = {
+      version: "1.0",
+      type: "structured_workout" as const,
+      metadata: { created: "2026-01-01T00:00:00Z", sport: "running" },
+      extensions: {
+        structured_workout: {
+          name: "Template Run",
+          sport: "running" as const,
+          steps: [],
+        },
+      },
+    };
+    useWorkoutStore.getState().loadWorkout(seeded);
+
+    // Act
+    renderSurface();
+    await waitFor(() => {
+      expect(screen.getByTestId("ai-banner")).toBeInTheDocument();
+    });
+    const krd = useWorkoutStore.getState().currentWorkout!;
+    useWorkoutStore.getState().updateWorkout({
+      ...krd,
+      metadata: { ...krd.metadata, sport: "swimming" },
+      extensions: {
+        ...krd.extensions,
+        structured_workout: {
+          ...krd.extensions!.structured_workout!,
+          sport: "swimming",
+        },
+      },
+    });
+
+    // Assert
+    await new Promise((resolve) =>
+      setTimeout(resolve, NEGATIVE_ASSERT_DELAY_MS)
+    );
+    const row = await db
+      .table<UserPreferences>("userPreferences")
+      .get(PROFILE_ID);
+    expect(row?.lastScratchSport).toBeUndefined();
   });
 });

--- a/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchEditorSurface.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchEditorSurface.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef } from "react";
 
+import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useSetUserPreferenceFields } from "../../../hooks/use-set-user-preference-fields";
+import { useUserPreferences } from "../../../hooks/use-user-preferences";
 import { useAppHandlers } from "../../../hooks/useAppHandlers";
 import {
   useCreateEmptyWorkout,
@@ -7,12 +10,13 @@ import {
 } from "../../../store/selectors";
 import { useWorkoutStore } from "../../../store/workout-store";
 import type { Workout } from "../../../types/krd";
+import type { Sport } from "../../../types/krd-core";
 import { AiBanner } from "../../molecules/AiBanner/AiBanner";
 import { useCoachingSidebar } from "../../organisms/CoachingSidebar/use-coaching-sidebar";
 import { EditorBody } from "../../pages/EditorBody";
 import { WorkoutSection } from "../../pages/WorkoutSection/WorkoutSection";
 
-const DEFAULT_SCRATCH_SPORT = "cycling";
+const DEFAULT_SCRATCH_SPORT: Sport = "cycling";
 const DEFAULT_SCRATCH_NAME = "Untitled workout";
 
 /**
@@ -28,6 +32,12 @@ const DEFAULT_SCRATCH_NAME = "Untitled workout";
  * path opens `WorkoutHeader.MetadataEditMode` so a fresh scratch user
  * commits sport/name inline. Pre-populated workouts (library template
  * load, e2e seeds) already have sport/name and render in view mode.
+ *
+ * The initial sport is sourced from `userPreferences.lastScratchSport`
+ * for the active profile when set; the on-save effect writes the
+ * current sport back so the next scratch session pre-selects it.
+ * Both reads/writes are gated on `autoCreatedRef.current` so library
+ * / e2e-seeded workouts never leak into the preference.
  */
 export function ScratchEditorSurface() {
   const currentWorkout = useCurrentWorkout();
@@ -38,16 +48,39 @@ export function ScratchEditorSurface() {
   const { handleStepSelect } = useAppHandlers();
   const sidebarData = useCoachingSidebar(null, undefined);
   const autoCreatedRef = useRef(false);
+  const activeProfile = useActiveProfileLive();
+  const profileId = activeProfile?.id ?? null;
+  const prefs = useUserPreferences({ profileId, defaultView: "grid" });
+  const setPrefs = useSetUserPreferenceFields(profileId);
+  const initialSportRef = useRef<Sport | null>(null);
 
   useEffect(() => {
     if (currentWorkout !== null) return;
+    // Wait for the active-profile live query to resolve. Then, when a
+    // profile is active, also wait for its userPreferences row so the
+    // seed picks `lastScratchSport`. With no active profile the prefs
+    // query returns undefined permanently — fall through to the
+    // hard-coded default so the editor still mounts.
+    if (activeProfile === undefined) return;
+    if (profileId !== null && prefs === undefined) return;
     autoCreatedRef.current = true;
-    createEmpty(DEFAULT_SCRATCH_NAME, DEFAULT_SCRATCH_SPORT);
-  }, [currentWorkout, createEmpty]);
+    const sport = prefs?.lastScratchSport ?? DEFAULT_SCRATCH_SPORT;
+    initialSportRef.current = sport;
+    createEmpty(DEFAULT_SCRATCH_NAME, sport);
+  }, [currentWorkout, createEmpty, prefs, profileId, activeProfile]);
 
   const workout = currentWorkout?.extensions?.structured_workout as
     | Workout
     | undefined;
+  const currentSport = workout?.sport;
+
+  useEffect(() => {
+    if (!autoCreatedRef.current) return;
+    if (!currentSport) return;
+    if (currentSport === initialSportRef.current) return;
+    initialSportRef.current = currentSport;
+    void setPrefs({ lastScratchSport: currentSport });
+  }, [currentSport, setPrefs]);
 
   return (
     <div className="space-y-6">

--- a/packages/workout-spa-editor/src/hooks/use-set-user-preference-fields.ts
+++ b/packages/workout-spa-editor/src/hooks/use-set-user-preference-fields.ts
@@ -1,0 +1,35 @@
+/**
+ * Wires the `setUserPreferenceFields` use case with Dexie-backed
+ * adapters and an injected clock. Returned callback persists the
+ * partial patch onto the per-profile UserPreferences row; the
+ * underlying live-query subscription re-fires the consuming
+ * components.
+ */
+
+import { useCallback } from "react";
+
+import { db } from "../adapters/dexie/dexie-database";
+import { createDexiePersistence } from "../adapters/dexie/dexie-persistence-adapter";
+import { createDexieUserPreferencesRepository } from "../adapters/dexie/dexie-user-preferences-repository";
+import {
+  setUserPreferenceFields,
+  type UserPreferenceFieldsPatch,
+} from "../application/set-user-preference-fields";
+
+export function useSetUserPreferenceFields(profileId: string | null) {
+  return useCallback(
+    async (patch: UserPreferenceFieldsPatch): Promise<void> => {
+      if (!profileId) return;
+      const persistence = createDexiePersistence(db);
+      await setUserPreferenceFields(
+        { profileId, patch },
+        {
+          clock: () => new Date().toISOString(),
+          repository: createDexieUserPreferencesRepository(db),
+          profileRepository: persistence.profiles,
+        }
+      );
+    },
+    [profileId]
+  );
+}

--- a/packages/workout-spa-editor/src/types/user-preferences.ts
+++ b/packages/workout-spa-editor/src/types/user-preferences.ts
@@ -8,6 +8,7 @@
  * `updatedAt` is sourced from an injected clock to keep tests deterministic.
  */
 
+import { sportSchema } from "@kaiord/core";
 import { z } from "zod";
 
 export const calendarViewSchema = z.enum(["grid", "list"]);
@@ -17,6 +18,10 @@ export type CalendarView = z.infer<typeof calendarViewSchema>;
 export const userPreferencesSchema = z.object({
   profileId: z.string().min(1),
   calendarView: calendarViewSchema,
+  // Optional: pre-v15 rows lack these fields. The Dexie v15 migration is
+  // data-only; absence remains a valid state until the user first writes.
+  lastScratchSport: sportSchema.optional(),
+  aiBannerExpanded: z.boolean().optional(),
   updatedAt: z.iso.datetime(),
 });
 


### PR DESCRIPTION
## Summary

Adds two optional fields to `userPreferences` — `lastScratchSport` and `aiBannerExpanded` — and persists them across sessions per profile via a single forward-only Dexie v15 migration.

- **`ScratchEditorSurface`** now sources its initial sport from the active profile's `lastScratchSport` (falls back to `"cycling"`) and writes the chosen sport back when the user commits sport on the auto-init path. Library-loaded and e2e-seeded workouts are skipped via the existing `autoCreatedRef` guard so pre-populated state never leaks into the preference.
- **`AiBanner`** seeds its open/closed state from `userPreferences.aiBannerExpanded` and writes manual toggles plus the one-shot auto-collapse-on-first-success transition back. The existing `hasAutoCollapsed` semantics are preserved — subsequent AI successes do not auto-collapse. A new `useAiBannerState` hook owns the FSM so `AiBanner` stays a pure render.
- **Persistence path**: a new `setUserPreferenceFields` use case (partial upsert with `ProfileNotFoundError` guard, mirroring `setCalendarView`) and a `useSetUserPreferenceFields` hook.

Source plan: `.omc/plans/followups-post-648-650.md` (PR C + PR D, combined).

## Migration

`dexie-v15-migration.ts` is forward-only, data-only — schema is unchanged from v13. Both new fields are optional in `userPreferencesSchema`, so pre-v15 rows (which lack them) continue to parse. The migration walks `userPreferences` rows and normalises the JSON shape to include the two fields as `undefined`.

## Test plan

- [x] `pnpm test:scripts` — 485 mechanical guards pass (no R-DexieImport / R-PersistStateImport / R-PIIInterpolation regressions).
- [x] `pnpm --filter @kaiord/workout-spa-editor lint` — clean (TypeScript + ESLint + Prettier).
- [x] `pnpm -r build` — green across all packages.
- [x] `pnpm --filter @kaiord/workout-spa-editor test` — 3929 / 3929 pass.
- [x] New unit suites: `dexie-v15-migration.test.ts` (3 cases) and `set-user-preference-fields.test.ts` (3 cases).
- [x] Extended `AiBanner.test.tsx` covering: seed from prefs, write-on-toggle, write-on-auto-collapse.
- [x] Extended `ScratchEditorSurface.test.tsx` covering: read `lastScratchSport`, write back on sport change (auto-init path), no-write for pre-populated workout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)