### PR TITLE
feat(spa-editor): Library page short-circuits scheduling when ?date= is in URL

### DIFF
--- a/.changeset/library-date-short-circuit.md
+++ b/.changeset/library-date-short-circuit.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+feat(spa-editor): library page short-circuits scheduling when entered with `?source=template-picker&date=YYYY-MM-DD`. Clicking a template card now dispatches `scheduleTemplate` directly with the URL's date and navigates to `/calendar`, instead of opening `ScheduleDateDialog`. Invalid or absent `?date=`, or a different `?source=`, keeps the existing explicit-dialog flow. Implementation reuses `usePickerSchedule` (PR #650) via a new `useLibrarySchedule` hook so the library schedule call site stays a single line.

--- a/packages/workout-spa-editor/src/components/pages/LibraryPage.short-circuit.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/LibraryPage.short-circuit.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * LibraryPage `?date=` short-circuit tests.
+ *
+ * Covers the four URL-derived paths for the schedule action:
+ * 1. `?source=template-picker&date=YYYY-MM-DD` → schedule directly,
+ *    navigate to `/calendar`, no `ScheduleDateDialog`.
+ * 2. No query params → explicit `ScheduleDateDialog` flow.
+ * 3. Malformed `?date=` → explicit dialog flow.
+ * 4. `?date=` present but `?source=` is not `template-picker` →
+ *    explicit dialog flow.
+ *
+ * Co-located with the existing `LibraryPage.test.tsx`; lives in its own
+ * file because these tests require a wouter `Router` wrapper for
+ * `useSearch()` reads, whereas the existing tests do not.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+
+import { db } from "../../adapters/dexie/dexie-database";
+import { createDexiePersistence } from "../../adapters/dexie/dexie-persistence-adapter";
+import { CoachingRegistryProvider } from "../../contexts/coaching-registry-context";
+import { GarminBridgeProvider } from "../../contexts/garmin-bridge-context";
+import { PersistenceProvider } from "../../contexts/persistence-context";
+import { ThemeProvider } from "../../contexts/ThemeContext";
+import { useWorkoutStore } from "../../store/workout-store";
+import type { WorkoutTemplate } from "../../types/workout-library";
+import { AppToastProvider } from "../providers/AppToastProvider";
+import LibraryPage from "./LibraryPage";
+
+const PROFILE_ID = "00000000-0000-4000-8000-0000000000e1";
+const TARGET_DATE = "2026-06-01";
+
+function makeTemplate(
+  overrides: Partial<WorkoutTemplate> = {}
+): WorkoutTemplate {
+  const id = overrides.id ?? crypto.randomUUID();
+  return {
+    id,
+    name: "Easy Ride",
+    sport: "cycling",
+    krd: {
+      version: "1.0",
+      type: "structured_workout",
+      metadata: { created: "2026-01-01T00:00:00Z", sport: "cycling" },
+      extensions: {
+        structured_workout: { name: "Easy Ride", sport: "cycling", steps: [] },
+      },
+    },
+    tags: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderLibrary(path = "/library") {
+  const loc = memoryLocation({ path, record: true });
+  const ui = (
+    <ThemeProvider>
+      <PersistenceProvider persistence={createDexiePersistence(db)}>
+        <GarminBridgeProvider>
+          <CoachingRegistryProvider factories={[]}>
+            <AppToastProvider>
+              <Router hook={loc.hook}>
+                <LibraryPage />
+              </Router>
+            </AppToastProvider>
+          </CoachingRegistryProvider>
+        </GarminBridgeProvider>
+      </PersistenceProvider>
+    </ThemeProvider>
+  );
+  return { ...render(ui), location: loc };
+}
+
+describe("LibraryPage short-circuit scheduling", () => {
+  beforeEach(async () => {
+    useWorkoutStore.setState({ currentWorkout: null });
+    await db.table("templates").clear();
+    await db.table("workouts").clear();
+    await db.table("profiles").clear();
+    await db.table("meta").clear();
+    await db.table("profiles").put({
+      id: PROFILE_ID,
+      name: "Tester",
+      sportZones: {},
+      linkedAccounts: [],
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    });
+    await db.table("meta").put({ key: "activeProfileId", value: PROFILE_ID });
+    await db
+      .table("templates")
+      .add(makeTemplate({ id: "t1", name: "Easy Ride", sport: "cycling" }));
+  });
+
+  it("should short-circuit scheduling when ?source=template-picker and ?date= is valid", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const { location } = renderLibrary(
+      `/library?source=template-picker&date=${TARGET_DATE}`
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Easy Ride")).toBeInTheDocument();
+    });
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /schedule/i }));
+
+    // Assert
+    await waitFor(async () => {
+      const workouts = await db.table("workouts").toArray();
+      expect(workouts).toHaveLength(1);
+      expect(workouts[0].date).toBe(TARGET_DATE);
+      expect(workouts[0].profileId).toBe(PROFILE_ID);
+    });
+    expect(screen.queryByText("Schedule Workout")).not.toBeInTheDocument();
+    expect(location.history.at(-1)).toBe("/calendar");
+  });
+
+  it("should fall through to ScheduleDateDialog when ?date= is absent", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const { location } = renderLibrary("/library?source=template-picker");
+    const initialPath = location.history.at(-1);
+
+    await waitFor(() => {
+      expect(screen.getByText("Easy Ride")).toBeInTheDocument();
+    });
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /schedule/i }));
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByText("Schedule Workout")).toBeInTheDocument();
+    });
+    const workouts = await db.table("workouts").toArray();
+    expect(workouts).toHaveLength(0);
+    expect(location.history.at(-1)).toBe(initialPath);
+  });
+
+  it("should fall through to ScheduleDateDialog when ?date= is malformed", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderLibrary("/library?source=template-picker&date=not-a-date");
+
+    await waitFor(() => {
+      expect(screen.getByText("Easy Ride")).toBeInTheDocument();
+    });
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /schedule/i }));
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByText("Schedule Workout")).toBeInTheDocument();
+    });
+    const workouts = await db.table("workouts").toArray();
+    expect(workouts).toHaveLength(0);
+  });
+
+  it("should fall through to ScheduleDateDialog when ?source is not template-picker", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderLibrary(`/library?date=${TARGET_DATE}`);
+
+    await waitFor(() => {
+      expect(screen.getByText("Easy Ride")).toBeInTheDocument();
+    });
+
+    // Act
+    await user.click(screen.getByRole("button", { name: /schedule/i }));
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByText("Schedule Workout")).toBeInTheDocument();
+    });
+    const workouts = await db.table("workouts").toArray();
+    expect(workouts).toHaveLength(0);
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/LibraryPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/LibraryPage.tsx
@@ -13,6 +13,12 @@
  * (SPA navigation) so the in-memory editor state is preserved; a hard
  * reload would drop the just-loaded workout from Zustand.
  *
+ * When entered with `?source=template-picker&date=YYYY-MM-DD`, the
+ * schedule click bypasses the explicit `ScheduleDateDialog` and
+ * dispatches `scheduleTemplate` directly with the URL's date. Invalid
+ * or absent `?date=` uses the explicit dialog flow — see
+ * `useLibrarySchedule` for the branch.
+ *
  * The `<h1>` marked with `[data-route-heading]` is rendered eagerly
  * (even while templates load) so the `useFocusOnRouteChange` hook
  * finds it on the post-paint rAF; otherwise focus would fall back to
@@ -30,6 +36,7 @@ import type { WorkoutTemplate } from "../../types/workout-library";
 import { ScheduleDateDialog } from "../molecules/ScheduleDateDialog";
 import { LibraryPageContent } from "./LibraryPageContent";
 import { LibraryPageHeader } from "./LibraryPageHeader";
+import { useLibrarySchedule } from "./use-library-schedule";
 import { useScheduleTemplate } from "./use-schedule-template";
 
 export default function LibraryPage() {
@@ -38,6 +45,7 @@ export default function LibraryPage() {
   const { error: showError, success: showSuccess } = useToastContext();
   const { scheduling, openScheduler, closeScheduler, confirmSchedule } =
     useScheduleTemplate();
+  const handleSchedule = useLibrarySchedule(openScheduler);
   const currentWorkout = useCurrentWorkout();
   const loadWorkout = useLoadWorkout();
   const [, navigate] = useLocation();
@@ -83,7 +91,7 @@ export default function LibraryPage() {
             templates={templates}
             hasCurrentWorkout={hasCurrentWorkout}
             onDelete={handleDelete}
-            onSchedule={openScheduler}
+            onSchedule={handleSchedule}
             onLoad={handleLoad}
           />
           <ScheduleDateDialog

--- a/packages/workout-spa-editor/src/components/pages/use-library-schedule.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-library-schedule.ts
@@ -1,0 +1,28 @@
+/**
+ * Picks the LibraryPage schedule handler based on the URL.
+ *
+ * When entered with `?source=template-picker&date=YYYY-MM-DD`, returns
+ * a handler that dispatches `scheduleTemplate` directly with the URL's
+ * date and navigates to the calendar (via `usePickerSchedule`). Other
+ * URLs return `openScheduler`, which opens the explicit
+ * `ScheduleDateDialog`. Caller wires the chosen handler into
+ * `LibraryPageContent`'s `onSchedule` prop.
+ */
+
+import type { WorkoutTemplate } from "../../types/workout-library";
+import { useLibraryShortCircuitDate } from "./use-library-short-circuit";
+import { usePickerSchedule } from "./use-picker-schedule";
+
+export function useLibrarySchedule(
+  openScheduler: (template: WorkoutTemplate) => void
+): (template: WorkoutTemplate) => void {
+  const shortCircuitDate = useLibraryShortCircuitDate();
+  const scheduleForUrlDate = usePickerSchedule(shortCircuitDate);
+  return (template) => {
+    if (shortCircuitDate) {
+      void scheduleForUrlDate(template.id);
+      return;
+    }
+    openScheduler(template);
+  };
+}

--- a/packages/workout-spa-editor/src/components/pages/use-library-short-circuit.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-library-short-circuit.ts
@@ -1,0 +1,24 @@
+/**
+ * Reads the LibraryPage URL params (`?source=` + `?date=`) and returns
+ * a short-circuit date when entered from the new-workout picker with a
+ * valid ISO date. Pairs with `usePickerSchedule` in `LibraryPage` to
+ * bypass `ScheduleDateDialog` on a single template-card click.
+ *
+ * Invalid or absent `?date=`, or a different `?source=`, returns `null`
+ * so the explicit dialog flow remains the default.
+ */
+
+import { useSearch } from "wouter";
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+const TEMPLATE_PICKER_SOURCE = "template-picker";
+
+export function useLibraryShortCircuitDate(): string | null {
+  const search = useSearch();
+  const params = new URLSearchParams(search);
+  const source = params.get("source");
+  const dateParam = params.get("date");
+  if (source !== TEMPLATE_PICKER_SOURCE) return null;
+  if (dateParam === null || !ISO_DATE_REGEX.test(dateParam)) return null;
+  return dateParam;
+}


### PR DESCRIPTION
## Summary

Implements **PR E** from `.omc/plans/followups-post-648-650.md`. When the Library page is entered with `?source=template-picker&date=YYYY-MM-DD`, clicking a template card now dispatches `scheduleTemplate` directly with the URL's date and navigates to `/calendar` — collapsing the previous 3-click flow (template -> Schedule -> confirm date in `ScheduleDateDialog`) to a single click.

The branch is purely additive: invalid or absent `?date=`, or a different `?source=`, keeps today's explicit-dialog flow byte-for-byte. Reuses `usePickerSchedule` (shipped in PR #650) so persistence semantics and the success toast match the inline `TemplatePickerDialog` flow on `NewWorkoutPicker`.

### Files

- `LibraryPage.tsx` — wires the new schedule resolver into `LibraryPageContent`'s `onSchedule` prop.
- `use-library-short-circuit.ts` — new hook: reads `?source=` + `?date=`, validates ISO `YYYY-MM-DD`, returns the date or `null`.
- `use-library-schedule.ts` — new hook: chooses between `usePickerSchedule` (URL-date) and `openScheduler` (explicit dialog).
- `LibraryPage.short-circuit.test.tsx` — co-located tests for the four URL paths.
- `.changeset/library-date-short-circuit.md` — `minor` bump for `@kaiord/workout-spa-editor`.

## Acceptance criteria coverage

| AC | Path | Test |
|----|------|------|
| E1 | `?source=template-picker&date=2026-06-01` -> direct schedule, toast, route `/calendar`, no dialog | `should short-circuit scheduling when ?source=template-picker and ?date= is valid` |
| E2 | No query params -> `ScheduleDateDialog` opens | `should fall through to ScheduleDateDialog when ?date= is absent` |
| E3 | `?date=not-a-date` (malformed ISO) -> dialog opens | `should fall through to ScheduleDateDialog when ?date= is malformed` |
| E4 | Template tile in `NewWorkoutPicker` (no date) -> `/library?source=template-picker` | Existing `should navigate to /library?source=template-picker when From template is clicked without date` in `NewWorkoutPicker.test.tsx` (preserved, asserted by re-running the suite) |

Extra non-regression test: `should fall through to ScheduleDateDialog when ?source is not template-picker` (e.g. `?date=2026-06-01` alone — date without picker source).

## Test plan

- [x] `pnpm test:scripts` — mechanical guards green (0 fail / 0 cancelled / 0 skipped).
- [x] `pnpm --filter @kaiord/workout-spa-editor lint` — `tsc --noEmit && eslint . && prettier --check src e2e` green.
- [x] `pnpm -r build` — all packages built (incl. `packages/docs` SSG).
- [x] `pnpm --filter @kaiord/workout-spa-editor test` — **440 test files, 3921 tests, all passing**.
- [x] Targeted re-run: `vitest run src/components/pages/LibraryPage` — 14 tests pass (10 existing + 4 new short-circuit).
- [x] Targeted non-regression: `vitest run src/components/pages/NewWorkoutPicker.test.tsx` — 9 tests pass.

## Notes

- The new `use-library-short-circuit.ts` inlines the same `/^\d{4}-\d{2}-\d{2}$/` regex used in `use-import-on-load.ts` (PR #648 CodeRabbit fix) — no new shared util introduced for a 1-line constant used in 2 sites.
- Split the schedule resolver into a separate `use-library-schedule.ts` hook so `LibraryPage`'s component body stays within the 60-line `max-lines-per-function` ESLint cap.
- Branch built on commit `67970483` (after PR #650 merge); no rebase required.

Refs: `.omc/plans/followups-post-648-650.md` (PR E), `.omc/state/ralph/prd-followups-post-648-650.json` (story `PR-E`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)