### PR TITLE
fix(e2e): raise calendar-performance budgets for chromium runner

### DIFF
--- a/.changeset/chromium-perf-budget.md
+++ b/.changeset/chromium-perf-budget.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+fix(e2e): raise calendar-performance budgets to chromium-runner-tolerant ceilings (FCP 1800ms, useMatchedSessions 60ms). The test runs ONLY on chromium engines (skipped on firefox/webkit/Mobile Safari upstream), so both desktop chromium and Mobile Chrome share the same GH Actions runner contention envelope. PR #651's Mobile-Chrome-only relaxation was insufficient — desktop chromium hit the same flake post-merge of PRs #654 and #655.

--- a/packages/workout-spa-editor/e2e/calendar-performance.spec.ts
+++ b/packages/workout-spa-editor/e2e/calendar-performance.spec.ts
@@ -4,11 +4,11 @@
  * "CalendarPage performance budget".
  *
  * Asserts that the redesigned CalendarPage renders its first contentful
- * paint within 200 ms on the project's reference baseline (Linux
- * ubuntu-latest CI runner with CDP CPU throttling factor 4×) when the
- * visible week contains 30 cards distributed as 10 matched / 10 solo
- * plan / 10 solo actual. The `useMatchedSessions` hook contributes no
- * more than 30 ms to that budget.
+ * paint within the CI-calibrated envelope on the project's reference
+ * baseline (Linux ubuntu-latest runner with CDP CPU throttling factor 4×)
+ * when the visible week contains 30 cards distributed as 10 matched /
+ * 10 solo plan / 10 solo actual. The `useMatchedSessions` hook
+ * contributes no more than 60 ms to that budget.
  *
  * Seed flow:
  *   1. Goto /calendar to let the SPA boot (Dexie initialises the schema
@@ -33,19 +33,23 @@ import { expect, test } from "./fixtures/base";
 // CDP throttle 4×). The archived design D11 named 200ms as the
 // reference-device aspirational target (Moto G Power 2022); CI hardware
 // is a different baseline so the assertion here uses a regression-
-// detection envelope (~1.5s, ~25% above observed worst at PR-E push)
-// rather than the aspirational figure. The architecturally meaningful
-// guardrail is the per-hook slice (USE_MATCHED_SESSIONS_BUDGET_MS); FCP
-// stays measured to catch broad regressions but does not enforce the
-// reference-device target.
-const FCP_BUDGET_MS = 1500;
-const USE_MATCHED_SESSIONS_BUDGET_MS = 30;
-// Mobile Chrome runs the chromium engine on a CI runner that consistently
-// exhibits 2x the CPU contention of desktop chromium (worst-measure samples
-// 43-48ms observed in PR #648 and #650 post-merge runs, vs ~10-20ms on
-// desktop chromium). Give the Mobile Chrome project a 60ms ceiling so the
-// gate is meaningful without producing recurring CI noise on every PR.
-const USE_MATCHED_SESSIONS_BUDGET_MS_MOBILE_CHROME = 60;
+// detection envelope (~1.8s) rather than the aspirational figure. The
+// architecturally meaningful guardrail is the per-hook slice
+// (USE_MATCHED_SESSIONS_BUDGET_MS); FCP stays measured to catch broad
+// regressions but does not enforce the reference-device target.
+//
+// Both budgets apply uniformly to all chromium-engine projects (desktop
+// chromium + Mobile Chrome). The test is already skipped on firefox /
+// webkit / Mobile Safari via `test.skip(browserName !== "chromium")`
+// below, so there is no need for a per-project branch. GH Actions
+// ubuntu-latest runners exhibit consistent CPU contention across both
+// chromium projects: worst-measure useMatchedSessions samples of
+// 40.4 / 41.1 / 44.1 / 49.2ms and FCP samples of 1548 / 1576ms were
+// observed on desktop chromium post-merge of PRs #648, #650, #654, and
+// #655. PR #651 relaxed Mobile Chrome to 60ms but desktop chromium hit
+// the same envelope, so both projects now share the same ceiling.
+const FCP_BUDGET_MS = 1800;
+const USE_MATCHED_SESSIONS_BUDGET_MS = 60;
 const CPU_THROTTLE_RATE = 4;
 const WEEK_ID = "2026-W18";
 const VISIBLE_DAY = "2026-04-29";
@@ -68,13 +72,10 @@ test.describe("CalendarPage performance budget", () => {
     "CDP CPU throttle is Chromium-only (newCDPSession is unavailable on firefox/webkit)"
   );
 
-  test("FCP ≤ 200ms and useMatchedSessions ≤ 30ms with 30-card week", async ({
+  test("FCP ≤ 200ms and useMatchedSessions ≤ 60ms with 30-card week", async ({
     page,
   }, testInfo) => {
-    const useMatchedBudgetMs =
-      testInfo.project.name === "Mobile Chrome"
-        ? USE_MATCHED_SESSIONS_BUDGET_MS_MOBILE_CHROME
-        : USE_MATCHED_SESSIONS_BUDGET_MS;
+    const useMatchedBudgetMs = USE_MATCHED_SESSIONS_BUDGET_MS;
     // 1. Boot the SPA (no throttling — only the calendar nav is measured).
     await page.goto("/calendar");
     await page.waitForFunction(

--- a/packages/workout-spa-editor/e2e/calendar-performance.spec.ts
+++ b/packages/workout-spa-editor/e2e/calendar-performance.spec.ts
@@ -72,7 +72,7 @@ test.describe("CalendarPage performance budget", () => {
     "CDP CPU throttle is Chromium-only (newCDPSession is unavailable on firefox/webkit)"
   );
 
-  test("FCP ≤ 200ms and useMatchedSessions ≤ 60ms with 30-card week", async ({
+  test("FCP ≤ 1.8s and useMatchedSessions ≤ 60ms with 30-card week", async ({
     page,
   }, testInfo) => {
     const useMatchedBudgetMs = USE_MATCHED_SESSIONS_BUDGET_MS;


### PR DESCRIPTION
## Summary

- Extends the per-browser performance budget relaxation from PR #651 to desktop chromium.
- Raises `FCP_BUDGET_MS` from 1500 → 1800 and `USE_MATCHED_SESSIONS_BUDGET_MS` from 30 → 60 for all chromium-engine projects.
- Removes the now-redundant `USE_MATCHED_SESSIONS_BUDGET_MS_MOBILE_CHROME` constant and the per-project branch that selected it.

## Background

PR #651 relaxed `useMatchedSessions` to 60ms on **Mobile Chrome only**. Post-merge CI runs on PRs #648, #650, #654, and #655 showed **desktop chromium** hitting the same flake:

| Sample | useMatchedSessions | FCP |
|--------|-------------------|-----|
| Run 1 | 40.4ms | 1548ms |
| Run 2 | 41.1ms | 1576ms |
| Run 3 | 44.1ms | — |
| Run 4 | 49.2ms | — |

Both exceed the old 30ms / 1500ms budgets.

The test already skips firefox / webkit / Mobile Safari via `test.skip(browserName !== "chromium")`, so the budget gates only chromium-engine projects (desktop chromium + Mobile Chrome). Both share the same GH Actions ubuntu-latest runner contention envelope, so they warrant the same ceiling.

## Test plan

- [ ] 3 consecutive post-merge CI runs on main show green for the `CalendarPage performance budget` test on both desktop chromium and Mobile Chrome projects.
- [ ] `pnpm --filter @kaiord/workout-spa-editor lint` passes locally (verified pre-push).
- [ ] Pre-push hook passes: lint-staged, tsc, scripts tests all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated e2e calendar performance budget expectations (FCP increased to 1800ms, matched sessions to 60ms)
  * Simplified test validation logic to use consistent performance metrics across test scenarios
  * Refreshed test documentation to clarify per-hook performance guardrails

* **Chores**
  * Added changeset entry marking workout-spa-editor patch release

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/656?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->