### PR TITLE
fix(spa-editor): ImportDropzoneOverlay clears stale currentWorkout on mount

### DIFF
--- a/.changeset/import-overlay-clears-stale-workout.md
+++ b/.changeset/import-overlay-clears-stale-workout.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+fix: `ImportDropzoneOverlay` now calls `clearWorkout()` on mount so a stale `currentWorkout` from a prior route (scratch draft, template preview, etc.) does not trigger `EditorPage`'s `importComplete` branch (`mode === "import" && currentWorkout !== null`) and silently skip rendering the dropzone overlay. Without this, navigating to `/workout/new?action=import` after viewing any other workout would show the populated editor body instead of the file picker.

--- a/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.test.tsx
@@ -98,6 +98,31 @@ describe("ImportDropzoneOverlay", () => {
     });
   });
 
+  it("should clear any stale currentWorkout from a prior route on mount", () => {
+    // Arrange
+
+    useWorkoutStore.setState({
+      currentWorkout: mockKrd,
+      undoHistory: [{ workout: mockKrd, selection: null }],
+      historyIndex: 0,
+      selectedStepId: null,
+      selectedStepIds: [],
+      isEditing: false,
+    });
+    expect(useWorkoutStore.getState().currentWorkout).not.toBeNull();
+    const analytics: Analytics = { pageView: vi.fn(), event: vi.fn() };
+
+    // Act
+
+    renderOverlay(analytics);
+
+    // Assert
+
+    expect(useWorkoutStore.getState().currentWorkout).toBeNull();
+    expect(useWorkoutStore.getState().undoHistory).toEqual([]);
+    expect(useWorkoutStore.getState().historyIndex).toBe(-1);
+  });
+
   it("should mount with a file input attached to the DOM", () => {
     // Arrange
 

--- a/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.tsx
@@ -4,6 +4,7 @@ import { useSearch } from "wouter";
 
 import { useAnalytics } from "../../../contexts/analytics-context";
 import { useAppHandlers } from "../../../hooks/useAppHandlers";
+import { useWorkoutStore } from "../../../store/workout-store";
 import { FileUpload } from "../../molecules/FileUpload/FileUpload";
 import { useImportOnLoad } from "./use-import-on-load";
 
@@ -24,12 +25,18 @@ export function ImportDropzoneOverlay() {
   const search = useSearch();
   const date = new URLSearchParams(search).get("date");
   const onFileLoad = useImportOnLoad(date);
+  const clearWorkout = useWorkoutStore((s) => s.clearWorkout);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const autoClickedRef = useRef(false);
 
   useEffect(() => {
     if (autoClickedRef.current) return;
     autoClickedRef.current = true;
+    // Discard any workout left in the store from a prior route (scratch
+    // draft, template preview, etc.) so `EditorPage`'s `importComplete`
+    // branch — `mode === "import" && currentWorkout !== null` — does not
+    // fire on the stale value and skip rendering this overlay.
+    clearWorkout();
     const node = inputRef.current;
     if (!node) return;
     if (typeof node.scrollIntoView === "function") {
@@ -37,7 +44,7 @@ export function ImportDropzoneOverlay() {
     }
     node.focus();
     node.click();
-  }, []);
+  }, [clearWorkout]);
 
   const handleImported = (format: string) => {
     analytics.event("workout-imported", { format });


### PR DESCRIPTION
## Summary

Production bug: navigating to `/workout/new?action=import&date=...` (e.g., from the calendar empty-day "+ → Import" flow) renders the **populated editor body** instead of the **`ImportDropzoneOverlay`** (file picker) when the Zustand workout store still has a workout from a prior route (scratch draft, loaded template, raw editing).

## Root cause

`packages/workout-spa-editor/src/components/pages/EditorPage.tsx:66`:

```ts
const importComplete = newWorkoutMode === "import" && currentWorkout !== null;
```

This flag was introduced in PR #650 to transition the editor surface from the dropzone overlay to the populated `EditorBody` once `useImportOnLoad` writes the parsed KRD to the store. But Zustand state **survives navigation** — when the user enters import mode while `currentWorkout` is already non-null (because they were last editing anything else), `importComplete` fires on the very first render and the dropzone overlay never mounts. Symptom: user reports "the screen looks like the scratch creation page."

The bug is intermittent / state-dependent: a clean session (post-login / post-reload) starts with `currentWorkout: null` and the overlay renders correctly. Continuous in-session navigation triggers the regression.

## Fix

`ImportDropzoneOverlay`'s mount `useEffect` now calls `clearWorkout()` (the existing single store action — clears `currentWorkout`, `undoHistory`, `historyIndex`, selections, `isEditing`, `pendingFocusTarget`) before the auto-click. This guarantees a clean slate every time the import overlay enters the DOM, so `importComplete` only triggers when the parse pipeline actually populates the store.

## Changes

- `packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.tsx`: import `useWorkoutStore`, subscribe to `clearWorkout`, call it at the start of the mount effect with a comment citing `EditorPage.tsx:66` as the load-bearing dispatch line.
- `packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.test.tsx`: new test `"should clear any stale currentWorkout from a prior route on mount"` — seeds the store with a non-null workout + undo history, mounts the overlay, asserts the store is empty post-mount. Existing 5 tests continue to pass (their `beforeEach` already resets the store, so they were testing the green-path only).

## Test plan

- [x] `pnpm --filter @kaiord/workout-spa-editor lint` clean.
- [x] `pnpm exec vitest run src/components/organisms/ImportDropzoneOverlay` — 6/6 pass.
- [ ] CI: full SPA E2E across 5 browsers.
- [ ] Manual: from `/calendar` empty-day "+ → Import" after scratch-editing another workout, the dropzone overlay renders (not the populated body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the Import overlay would display the populated editor instead of the import file picker when navigating to create a new workout with import action, due to stale workout data from previous routes.

* **Tests**
  * Added test coverage verifying Import overlay correctly clears stale workout state and resets history on mount.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->