### PR TITLE
fix(spa-editor): drop auto-click on ImportDropzoneOverlay mount

### DIFF
--- a/.changeset/remove-import-auto-click.md
+++ b/.changeset/remove-import-auto-click.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+fix: `ImportDropzoneOverlay` no longer auto-clicks the hidden file input on mount. The user now lands on the dropzone overlay and explicitly chooses when to open the OS file picker (via the visible "Choose file" affordance or drag-and-drop). Reverts the auto-open behaviour from PR #648 — the explicit-click flow gives the user more control and avoids the OS file picker appearing unexpectedly. `clearWorkout()` on mount (from PR #657) is retained.

--- a/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.test.tsx
@@ -138,7 +138,7 @@ describe("ImportDropzoneOverlay", () => {
     expect(document.querySelector('input[type="file"]')).not.toBeNull();
   });
 
-  it("should auto-click the hidden input on mount so the OS picker opens", () => {
+  it("should NOT auto-open the OS file picker on mount so the user keeps control", () => {
     // Arrange
 
     const clickSpy = vi.spyOn(HTMLInputElement.prototype, "click");
@@ -150,7 +150,8 @@ describe("ImportDropzoneOverlay", () => {
 
     // Assert
 
-    expect(clickSpy).toHaveBeenCalled();
+    expect(clickSpy).not.toHaveBeenCalled();
+    expect(screen.getByTestId("import-dropzone-overlay")).toBeInTheDocument();
   });
 
   it("should fire workout-imported with the detected format on a successful upload", async () => {

--- a/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.tsx
@@ -11,8 +11,10 @@ import { useImportOnLoad } from "./use-import-on-load";
 /**
  * Centered overlay rendered when the editor mounts with
  * `?action=import`. Reuses `FileUpload` (which owns the parse pipeline
- * via `useFileUpload`) and auto-clicks its hidden `<input type="file">`
- * on mount so the OS file picker opens without a second user gesture.
+ * via `useFileUpload`). The hidden `<input type="file">` is focused +
+ * scrolled into view on mount, but the OS file picker is NOT opened
+ * automatically — the user clicks the "Choose file" affordance or
+ * drops a file onto the dropzone.
  *
  * When mounted with `?date=Y-M-D`, a successful import persists the
  * resulting KRD as a `WorkoutRecord` tagged with that date and routes
@@ -27,11 +29,11 @@ export function ImportDropzoneOverlay() {
   const onFileLoad = useImportOnLoad(date);
   const clearWorkout = useWorkoutStore((s) => s.clearWorkout);
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const autoClickedRef = useRef(false);
+  const mountInitializedRef = useRef(false);
 
   useEffect(() => {
-    if (autoClickedRef.current) return;
-    autoClickedRef.current = true;
+    if (mountInitializedRef.current) return;
+    mountInitializedRef.current = true;
     // Discard any workout left in the store from a prior route (scratch
     // draft, template preview, etc.) so `EditorPage`'s `importComplete`
     // branch — `mode === "import" && currentWorkout !== null` — does not
@@ -43,7 +45,6 @@ export function ImportDropzoneOverlay() {
       node.scrollIntoView({ block: "center" });
     }
     node.focus();
-    node.click();
   }, [clearWorkout]);
 
   const handleImported = (format: string) => {
@@ -61,7 +62,7 @@ export function ImportDropzoneOverlay() {
           Drop a FIT, TCX, ZWO, GCN, or KRD file
         </p>
         <p className="text-xs text-gray-500 dark:text-gray-400">
-          The file picker opens automatically. Cancel to retry.
+          Or click below to choose one from your device.
         </p>
         <FileUpload
           onFileLoad={onFileLoad}


### PR DESCRIPTION
## Summary

After PR #657 fixed the dispatch regression (so the dropzone overlay actually renders on `?action=import`), production behaviour showed that the **auto-open OS file picker** affordance from PR #648 is surprising in practice. The user lands on the import route and the OS file picker appears before they've even seen the dropzone — they reported it as "the file picker opens without me clicking anything." This PR removes the auto-click so the user explicitly chooses when to open the picker (via the visible "Choose file" button or drag-and-drop).

## Changes

- `ImportDropzoneOverlay.tsx`:
  - Remove `node.click()` from the mount `useEffect`. Keep `node.focus()` + `scrollIntoView()` so the input is still ready for keyboard interaction (`Enter` on a focused file input still opens the picker).
  - Rename `autoClickedRef` → `mountInitializedRef` to match the new responsibility (the effect now only clears the store + focuses the input).
  - Update visible copy: "The file picker opens automatically. Cancel to retry." → "Or click below to choose one from your device."
  - Update JSDoc to reflect the new behaviour.
- `ImportDropzoneOverlay.test.tsx`: invert the test that asserted the auto-click — now asserts the click does NOT fire on mount and the dropzone testid is in the document.
- `.changeset/remove-import-auto-click.md`: patch bump.

## What stays from PR #657

`clearWorkout()` on mount is retained — `EditorPage.tsx:66`'s `importComplete` branch still depends on it. Without that line, navigating to `?action=import` after editing anything else would still render the populated body instead of the dropzone (the original bug #657 fixed).

## Why this reverses a design decision from PR #648

Q3 of the #648 deep-dive picked "Auto-open en `/workout/new?action=import` al montar" precisely to save a click. In prod, the unsolicited OS file picker turned out to feel intrusive: the user is mid-mental-model of "I navigated to the import surface" when the OS dialog steals focus before they can orient. Switching to the explicit-click flow gives back that orientation moment without any cost to the success path (single click on a visible button).

## Test plan

- [x] `pnpm --filter @kaiord/workout-spa-editor lint` clean.
- [x] `pnpm exec vitest run src/components/organisms/ImportDropzoneOverlay` — 6/6 pass.
- [ ] CI: full SPA E2E across 5 browsers.
- [ ] Manual: from `/calendar` "+ → Import" the dropzone is visible immediately, OS picker only opens after clicking the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)