### PR TITLE
chore: ignore .understand-anything/ tool directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ packages/docs/.vitepress/cache/
 
 # Self-improve git worktrees
 worktrees/
+
+# understand-anything CLI knowledge graph (local tool, not part of repo)
+.understand-anything/


### PR DESCRIPTION
Adds `.understand-anything/` to `.gitignore`.

It's the local output directory of the understand-anything CLI (knowledge
graph, fingerprints, meta) — a developer tool artifact, not part of the
repo. This keeps `git status` clean for anyone who runs `/understand`
locally.

Follow-up context on the generated graph itself: #668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version control configuration for better repository management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/669?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->