### PR TITLE
feat(spa-editor): calendar + chooser — add workout or wellness metric

### DIFF
--- a/.changeset/calendar-add-workout-or-wellness.md
+++ b/.changeset/calendar-add-workout-or-wellness.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+Calendar `+` now disambiguates adding a workout vs a wellness metric. The per-day `+` affordance renders on every day (grid and list views, no longer gated to empty training days) and opens a Workout | Wellness chooser. Workout preserves the existing `/workout/new?date=` flow; Wellness opens a manual-entry form (weight, sleep score, HRV, steps) plus a file-dated FIT import option. Manual entries persist via a new application use case that upserts one record per day per metric (reusing the existing `[profileId+date]` row id); a manual steps save merge-preserves any prior imported calories/intensity and overrides only the step count. Drag-to-reschedule is unaffected by the always-visible `+`.

--- a/openspec/changes/calendar-add-workout-or-wellness/design.md
+++ b/openspec/changes/calendar-add-workout-or-wellness/design.md
@@ -1,0 +1,84 @@
+## Context
+
+The predecessor change (`remove-subtabs-unify-calendar`) ships per-day wellness bands on the calendar (sleep/HRV/weight/steps badges, present-only, drill-down via `WELLNESS_BADGE_ROUTES`). The bands are read-only. There is no path to add wellness data from the calendar. Additionally, the `+` affordance is gated on `total === 0` (training bucket count), so it disappears on days that already have a workout.
+
+This change removes the gate and adds a two-step add-entry chooser, a manual wellness entry form, and a write-path use case. The six decisions below were reached through the ralplan consensus cycle.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- The `+` affordance renders on every calendar day, in both grid and list views, regardless of whether a workout is already present.
+- Clicking `+` opens a two-step chooser: Workout → existing flow; Wellness → manual entry surface.
+- The wellness entry surface accepts weight, sleep score, HRV, and steps (one form, one Save), plus an "Import a file" action for FIT health files.
+- Saving a metric persists a schema-valid KRD record via the new use case; the live wellness query causes the badge to appear on the calendar automatically.
+- For steps, saving preserves prior `activeCalories` / `intensityMinutes` from any existing daily row (merge-preserve).
+- Exactly one record remains per date+metric after sequential saves (reuse-by-id upsert).
+
+**Non-Goals:**
+
+- No full-fidelity sleep/body-composition/stress manual editing — weight, sleep score, HRV (spot), and steps only.
+- No retroactive change to imported-data semantics — the FIT import path is unchanged; imported records are file-dated and remain as-is (only the `id` is reused for upsert when a manual save follows an import).
+- No new Dexie tables or schema migration; no `core`/adapter/MCP changes.
+- No overwrite-confirm dialog (silent overwrite, chosen).
+- No unit toggle for weight (kg assumed).
+- No sidebar or replacement navigation chrome.
+
+## Decisions
+
+### 1. Chooser as a two-step dialog (Option C)
+
+Three options were considered:
+
+- **Option A — Single dialog** with Workout section and Wellness section side-by-side. Rejected: cluttered for the narrow-column case (140px); mixing distinct flows in one surface breaks the single-responsibility model.
+- **Option B — Bottom-sheet / live-region announcer style.** Invalidated by the live-announcer churn introduced in Option B prototypes — switching from sheet-open to sheet-close triggered repeated announcements on NVDA/JAWS, producing a poor a11y experience. The chooser-as-dialog (Option C) lets Radix focus-trap manage the entire interaction with a single dialog lifecycle.
+- **Option C (chosen) — Two-step Radix Dialog.** Step 1 is the chooser tile pair (Workout | Wellness). Choosing Workout closes the dialog and navigates; choosing Wellness replaces the dialog content with the `WellnessEntryDialog` for the clicked day. Each step has its own accessible name (`aria-label`). The browser back button closes without losing the calendar route because the dialog is controlled React state, not a router push.
+
+### 2. Find-then-upsert + port-API divergence
+
+**Port-API divergence:** No `find-by-[profileId+date]` method exists. Adding one would touch the Dexie adapter, the in-memory adapter, and all per-metric repos for zero functional gain — the existing `HealthRecordRepository.getByProfileAndDateRange(profileId, day, day)` already returns exactly that day's rows for a given metric table. Because **each metric lives in its own Dexie table** (`healthSleep`, `healthHrv`, `healthWeight`, `healthDaily` — `persistence-port.ts:78-83`), no `krd.kind` filter is needed. The use case selects the metric's table, calls `getByProfileAndDateRange(profileId, day, day)`, and reuses `rows[0]?.id`. No new port method is added.
+
+**Concurrency note:** The use case alone cannot serialize the check-then-act race. The in-memory `transaction` is snapshot/restore with no mutual exclusion (`in-memory-persistence.ts:108-121`), so two concurrent calls for the same day+metric can both read zero rows and both insert — producing two rows. This is documented in Phase 1 as a passing assertion describing reality (the concurrent race inserts 2 rows). The row-count==1 guarantee is closed in Phase 2 at the form/hook layer: `use-save-wellness.ts` owns a single in-flight submit lock (`useRef` boolean + `isSaving` state); while one submit promise is pending, re-entrant calls are ignored and the Save button is disabled.
+
+### 3. Minimal KRD payloads
+
+Each metric's KRD payload is the smallest valid structure that passes `schema.parse`:
+
+- **Sleep:** `{ startTime, endTime, totalDurationSeconds: 0, stages: [], score }`. `endTime` is required by `sleep.ts:34` and is set equal to `startTime` (0-duration, score-only entry). Manual sleep entry captures a score, not a duration; duration entry is a future additive follow-up.
+- **Steps (DailyWellness):** merge-preserve. When a prior row exists, the mapper returns `{ ...prior, steps }` — overriding only `steps`, preserving `activeCalories`, `restingCalories`, `intensityMinutes`. When no prior row exists, the mapper zero-fills: `{ steps, activeCalories: 0, restingCalories: 0, intensityMinutes: { moderate: 0, vigorous: 0 } }`. This reconciles AC6 (one record, overwrite) with the Non-Goal (no retroactive change to imported calories/intensity).
+- **HRV:** `measurementWindow: "spot"` — the only valid value for a manual spot reading.
+- **Weight:** standard `WeightMeasurement` with `measuredAt` derived from `${day}T12:00:00.000Z`.
+
+### 4. Import-date asymmetry
+
+The "Import a file" action in the wellness entry surface reuses the existing FIT health-import path (`use-import-on-load.ts:42-54`), which ignores `?date=` and dates the imported record by the FIT file's own metadata. This is a deliberate asymmetry with the manual entry path (which uses the clicked day's date). Accordingly:
+
+- The import action does NOT pass `?date=<clickedDay>` to the import flow.
+- After import, the user lands on the corresponding Health Hub page (as driven by `health-destination.ts`), not on the calendar day's date.
+- This asymmetry is documented in the "Manual wellness entry" spec scenarios so it is not read as a bug.
+
+### 5. AC6 ↔ Non-Goal reconciliation (merge-preserve for steps)
+
+AC6 requires that saving a metric leaves exactly one record for that date+metric (the prior record is replaced). The Non-Goal prohibits retroactive changes to imported-data semantics. For weight, sleep, and HRV these never conflict — the manual payload fully defines the metric. For **steps**, a full clobber would erase the imported daily row's `activeCalories` and `intensityMinutes` fields. The merge-preserve fork resolves the tension: the row's `id` is reused (one record, AC6 ✓) but only `steps` is overwritten (calories/intensity survive, Non-Goal ✓).
+
+### 6. Open Questions
+
+The following questions were identified during the ralplan consensus cycle and are either decided or deferred to implementation-time confirmation:
+
+1. **Sleep manual entry default:** score (chosen) vs duration-hours. Duration entry is a future additive follow-up. Confirm product intent before Phase 2.
+2. **Weight unit:** kg assumed. No profile unit preference is modeled today. Confirm no unit toggle is wanted in this change.
+3. **Overwrite-confirm UX:** silent overwrite chosen for this change. A confirm dialog ("A sleep score already exists for this day — overwrite?") is a future additive follow-up.
+4. **Wellness surface shape:** Option C (two-step dialog) recommended and chosen per Decision 1 above.
+
+## Dependencies / Ordering
+
+- **Must follow `remove-subtabs-unify-calendar`** in archive order — that change owns the "Calendar day cells surface per-day wellness" requirement this proposal modifies, and introduces the live wellness query and `WellnessBand` component that manual save leverages.
+- No new Dexie schema version is needed (v16 tables suffice).
+- Visual baselines will need regeneration in CI after Phase 3 (the `+` is now always visible, shifting calendar screenshots). Trigger `update-visual-baselines.yml` (Linux/chromium) as a CI step after PR-3 is up; do NOT regenerate locally.
+
+## Risks
+
+- **Concurrent submit duplication.** Mitigated by the single in-flight lock in `use-save-wellness.ts` (Phase 2). The use case's unlocked behavior is explicitly documented and tested in Phase 1 so the mitigation is not forgotten.
+- **Steps merge-preserve complexity.** The mapper is a pure function exercised by the use-case tests; the merge logic is isolated and verifiable without UI.
+- **`+` ungate visual regression.** The button now appears on busy days; DayColumn's vertical budget is fixed. Mitigation: the `+` button is compact; the wellness band (introduced by the predecessor) already occupied space.
+- **Import-date asymmetry confusion.** Mitigated by the spec scenario and an optional in-dialog note that import is file-dated.

--- a/openspec/changes/calendar-add-workout-or-wellness/proposal.md
+++ b/openspec/changes/calendar-add-workout-or-wellness/proposal.md
@@ -1,0 +1,34 @@
+> Depends on remove-subtabs-unify-calendar
+
+## Why
+
+The predecessor change (`remove-subtabs-unify-calendar`) folded wellness into the calendar and added per-day wellness bands that show sleep, HRV, weight, and steps badges. Each badge drills down to the corresponding per-metric history page. However, there is currently no path to **add** wellness data for a given day from the calendar — clicking the `+` affordance on an empty day navigates directly to `/workout/new?date=<day>` without offering a wellness entry option.
+
+Additionally, the `+` affordance is gated on the training bucket count being zero — it only appears on days with no workouts. An athlete who has already planned or logged a workout for a day cannot trigger it at all.
+
+This change adds the **add-entry chooser**: a two-step dialog that appears when any calendar `+` is activated (on every day, in both grid and list views), offering a **Workout** or **Wellness** choice. The Workout branch preserves existing behavior (`/workout/new?date=<day>`). The Wellness branch opens a manual entry surface with a form (weight / sleep score / HRV / steps) and an "Import a file" action for FIT health files. Manual entries are persisted as schema-valid KRD records via a new application use case; the live wellness query already in place causes the badge to appear on the calendar after save.
+
+> **Depends on `remove-subtabs-unify-calendar`.** That change ADDED the "Calendar day cells surface per-day wellness with explicit training/wellness differentiation" requirement this proposal modifies. It MUST be archived first (its `spa-routing` deltas synced into the canonical `openspec/specs/spa-routing/spec.md`) so the MODIFIED delta here composes against an up-to-date canonical spec.
+
+## What Changes
+
+- **Ungate the `+` button.** Remove the `total === 0` guard from `DayColumn`; the add button renders on every day, not only empty ones. The same change applies to the list-view day rows in `CalendarWeekList`.
+- **Add the add-entry chooser.** A Radix `Dialog` with two `PickerTile`-style tiles — **Workout** and **Wellness** — opens when `+` is clicked. Choosing Workout navigates to `/workout/new?date=<day>`. Choosing Wellness opens the wellness entry surface for that day.
+- **Add the wellness entry surface.** A `WellnessEntryDialog` (Radix controlled `Dialog`) hosts a four-field form (weight, sleep score, HRV, steps) and an "Import a file" action. Saving persists every filled field as a KRD record via `saveManualHealthMetric`; the existing `useCalendarWellnessWeekLive` live query causes the badge to appear. Import reuses the existing FIT health-import path, which is file-dated (the clicked day's date is ignored).
+- **Add the write-path use case.** `save-manual-health-metric.use-case.ts` (under `packages/workout-spa-editor/src/application/health/`) performs a find-then-upsert for each metric using `getByProfileAndDateRange(profileId, day, day)` against the metric's own Dexie table. Steps use merge-preserve: only the `steps` field is overwritten; prior `activeCalories`/`intensityMinutes` are preserved.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `spa-routing`: modifies the "Calendar day cells surface per-day wellness with explicit training/wellness differentiation" requirement so the `+` affordance renders on every day (no longer gated on training count) and on click opens the add-entry chooser (Workout | Wellness) rather than navigating directly; adds the "Per-day add-entry chooser" and "Manual wellness entry" surface requirements.
+
+## Impact
+
+- **Code (SPA only)**:
+  - Write path: new `application/health/manual-health-payload.mapper.ts`, `application/health/manual-health-metric.ts`, `application/health/save-manual-health-metric.use-case.ts`, and their tests.
+  - Chooser: new `components/molecules/AddEntryChooser/AddEntryChooser.tsx`; `use-calendar-state.ts` extended; `DayColumn.tsx` ungate; `DayColumnAddButton.tsx` prop rename; prop threading through `CalendarWeekGrid`, `CalendarBodyView`, `CalendarPage`, `CalendarPageView`, `CalendarWeekList`.
+  - Wellness entry surface: new `components/molecules/WellnessEntryDialog/` (dialog, form, metric field, `use-save-wellness` hook).
+- **Tests**: write-path unit tests (AAA); form + hook tests; chooser tests; Phase 4 integration badge-refresh test.
+- **No `core`/adapter/MCP changes**; no new Dexie schema or migration (v16 tables suffice); no change to the FIT import pipeline or `health-destination.ts`.
+- **Breaking changes**: none (private `@kaiord/workout-spa-editor` only). A `patch`/`minor` changeset for the private SPA package.

--- a/openspec/changes/calendar-add-workout-or-wellness/specs/spa-routing/spec.md
+++ b/openspec/changes/calendar-add-workout-or-wellness/specs/spa-routing/spec.md
@@ -1,0 +1,145 @@
+## MODIFIED Requirements
+
+### Requirement: Calendar day cells surface per-day wellness with explicit training/wellness differentiation
+
+Each calendar day cell (`DayColumn`) SHALL render a per-day **wellness band** above its training cards when the active profile has any wellness record for that date. The band SHALL be visually differentiated from training: a muted/neutral palette separated from the brand-coloured training cards by a divider, so training and wellness are explicitly distinguishable at a glance.
+
+The band SHALL show a compact badge only for the metrics **present that day**, among: **sleep** (score or duration), **HRV/recovery** (rMSSD), **weight** (kg), and **steps/daily-activity**. Body composition and stress are NOT inline badges. When a day has no wellness records, the band SHALL be omitted entirely; the cell SHALL still show a `+` add-entry affordance on every day (grid and list), regardless of the training bucket count, and clicking it SHALL open the add-entry chooser (Workout | Wellness) rather than navigating directly.
+
+Each badge SHALL be an independently activatable link/button with an accessible label, navigating to the corresponding per-metric page via a badge-name→route map `WELLNESS_BADGE_ROUTES` co-located with the band component (distinct from the `FileType`-keyed `health-destination.ts` import map): sleep → `/health/sleep`, weight → `/health/weight`, HRV → `/health/recovery`, steps → `/health/activity`.
+
+The visible week's wellness SHALL be read through a single `useLiveQuery` keyed by `(profileId, weekStart..weekEnd)` returning a per-day map, threaded down the calendar component chain. A single query is used for **atomicity** — a day's badges resolve in one loading transition and never appear one at a time — not to satisfy a query-count rule. The map's contract SHALL distinguish three states: `undefined` = the week's wellness is still loading; an absent day key = no wellness that day; a present day key always carries ≥1 metric. The band SHALL NOT intercept the grid's drag-to-reschedule pointer handlers.
+
+#### Scenario: A day with recorded wellness shows a differentiated band
+
+- **GIVEN** the active profile has a sleep score, HRV, weight, and steps for Monday
+- **WHEN** the calendar week containing Monday renders
+- **THEN** Monday's cell shows a muted wellness band above the training cards with a badge for each of sleep, HRV, weight, and steps, and the training cards below remain brand-coloured and visually distinct
+
+#### Scenario: Partial day shows only present metrics
+
+- **GIVEN** Tuesday has only a weight measurement
+- **WHEN** the week renders
+- **THEN** Tuesday's band shows only the weight badge with no empty slots for the missing metrics
+
+#### Scenario: Empty day shows no band
+
+- **GIVEN** Wednesday has no wellness records and no training
+- **WHEN** the week renders
+- **THEN** Wednesday's cell shows no wellness band and still shows the `+` add-entry affordance (which opens the Workout | Wellness chooser)
+
+#### Scenario: Clicking a wellness badge drills down to its page
+
+- **WHEN** the user clicks the sleep badge on a day cell
+- **THEN** the SPA navigates to `/health/sleep`; clicking the weight badge instead navigates to `/health/weight`
+
+#### Scenario: The wellness band does not break drag-to-reschedule
+
+- **WHEN** the user drags a workout card to another day on a viewport ≥ 768px
+- **THEN** the reschedule completes as before; pointer interactions on the wellness band do not start or capture a drag
+
+#### Scenario: No band flicker while the week's wellness is loading
+
+- **GIVEN** the calendar's training data has hydrated but the week's wellness query has not yet resolved (`wellnessByDay` is undefined)
+- **WHEN** the calendar renders
+- **THEN** every cell renders training-only with no wellness band and no placeholder, and bands appear in a single transition once wellness resolves — badges SHALL NOT pop in one metric at a time
+
+#### Scenario: A dense day renders four badges without clipping
+
+- **GIVEN** a day has sleep, HRV, weight, and steps recorded
+- **WHEN** the cell renders in the narrowest supported column (≈140px on mobile)
+- **THEN** all four badges are visible without overflow or clipping (wrapping or scrolling within the band), and the training cards below remain fully visible
+
+## ADDED Requirements
+
+### Requirement: Per-day add-entry chooser
+
+When the user activates the `+` add-entry affordance on any calendar day cell (grid or list view), the SPA SHALL open a two-step add-entry chooser dialog presenting exactly two choices: **Workout** and **Wellness**. Choosing Workout SHALL navigate to `/workout/new?date=<day>` (preserving existing create-workout behavior). Choosing Wellness SHALL open the wellness entry surface for the clicked day. The chooser SHALL be keyboard-navigable, SHALL have an accessible name, and SHALL close via the browser back button without losing the calendar route. The `+` affordance SHALL render on every day regardless of whether the training bucket count is zero.
+
+#### Scenario: Clicking `+` opens the chooser with Workout and Wellness options
+
+- **WHEN** the user clicks the `+` affordance on any calendar day cell
+- **THEN** the add-entry chooser dialog opens with exactly two choices — Workout and Wellness — and does not navigate away from the calendar
+
+#### Scenario: Choosing Workout navigates to the create-workout flow
+
+- **WHEN** the user opens the chooser and selects Workout
+- **THEN** the SPA navigates to `/workout/new?date=<day>` where `<day>` is the ISO date of the clicked cell
+
+#### Scenario: Choosing Wellness opens the wellness entry surface
+
+- **WHEN** the user opens the chooser and selects Wellness
+- **THEN** the wellness entry surface opens for the clicked day and the chooser closes
+
+#### Scenario: Chooser is keyboard-navigable with an accessible name
+
+- **WHEN** the chooser opens
+- **THEN** focus is trapped within the dialog, the dialog has an accessible name, both tiles are reachable and activatable via keyboard, and Tab cycles between them without escaping the dialog
+
+#### Scenario: Browser back button closes the chooser without losing the calendar route
+
+- **WHEN** the chooser is open and the user presses the browser back button
+- **THEN** the chooser closes and the SPA remains on the calendar route without a full navigation
+
+#### Scenario: `+` renders on a day that already has a workout
+
+- **GIVEN** a calendar day cell already contains one or more training cards
+- **WHEN** the week renders in the grid view
+- **THEN** the `+` add-entry affordance is still visible in that cell
+
+#### Scenario: `+` renders on every day in the list view
+
+- **WHEN** the calendar is displayed in list view for a week containing a mix of days with and without workouts
+- **THEN** every day row shows the `+` add-entry affordance
+
+### Requirement: Manual wellness entry
+
+The wellness entry surface SHALL offer a manual entry form with labeled fields for **weight**, **sleep score**, **HRV**, and **steps**, and an **"Import a file"** action for FIT health files. The form SHALL have a single Save button that persists every filled field in one submission; empty fields SHALL write nothing. When a metric value is saved, the SPA SHALL persist a schema-valid KRD record for the active profile and the clicked day; the live wellness query SHALL cause the corresponding badge to appear on that calendar day after it refreshes. No user-entered metric value SHALL appear in any toast message.
+
+When the user saves a metric for a day that already has a record for that metric, the prior record SHALL be replaced — exactly one record remains for that date and metric. For **steps specifically**, only the `steps` value is replaced; any prior `activeCalories`, `restingCalories`, and `intensityMinutes` fields in the existing daily-wellness record are preserved (merge-preserve, not clobber).
+
+When the user uses "Import a file", the imported health record SHALL be dated by the FIT file's own date — NOT the clicked day — and the user SHALL land on the corresponding Health Hub page. Empty fields write nothing to persistence.
+
+#### Scenario: Wellness surface offers a manual form and an import action
+
+- **WHEN** the wellness entry surface opens for a given day
+- **THEN** it shows labeled input fields for weight, sleep score, HRV, and steps, a single Save button, and an "Import a file" action
+
+#### Scenario: Saving a metric value persists a KRD record and shows a badge
+
+- **WHEN** the user enters a weight value and saves
+- **THEN** a schema-valid KRD weight record for the active profile and clicked day is persisted, and the weight badge appears in that day's wellness band after the live query refreshes
+
+#### Scenario: Saving a metric for a day that already has it replaces the prior record
+
+- **GIVEN** a weight record already exists for a given day
+- **WHEN** the user enters a new weight value and saves
+- **THEN** exactly one weight record remains for that date and the displayed value reflects the new entry
+
+#### Scenario: Saving steps preserves prior calories and intensity
+
+- **GIVEN** a daily-wellness record exists for a day with `activeCalories: 300` and `intensityMinutes.moderate: 20` (from a prior import or save)
+- **WHEN** the user enters a new steps value and saves
+- **THEN** the persisted record has the new steps value AND retains `activeCalories: 300` and `intensityMinutes.moderate: 20`
+
+#### Scenario: Empty fields write nothing
+
+- **GIVEN** the user opens the wellness entry surface and leaves all fields empty
+- **WHEN** the user clicks Save
+- **THEN** no KRD records are written and no badge appears
+
+#### Scenario: Partial entry saves only filled fields
+
+- **GIVEN** the user enters a weight value and leaves HRV, sleep, and steps empty
+- **WHEN** the user clicks Save
+- **THEN** exactly one KRD record (weight) is persisted and no records for HRV, sleep, or steps are written
+
+#### Scenario: No user-entered metric value appears in a toast
+
+- **WHEN** the user saves a wellness metric
+- **THEN** any success toast contains only a static message with no interpolated metric value
+
+#### Scenario: Import a file uses the FIT file's date, not the clicked day
+
+- **WHEN** the user chooses "Import a file" from the wellness entry surface and imports a FIT health file whose internal date is different from the clicked calendar day
+- **THEN** the persisted record is dated by the FIT file's own date, the user lands on the corresponding Health Hub page, and no record is written for the clicked day's date

--- a/openspec/changes/calendar-add-workout-or-wellness/tasks.md
+++ b/openspec/changes/calendar-add-workout-or-wellness/tasks.md
@@ -1,0 +1,80 @@
+<!-- opsx-ship: chunking
+PR 1 (write-path):      §1
+PR 2 (wellness-ui):     §2
+PR 3 (chooser+ungate):  §3
+PR 4 (gates):           §4
+PR 5 (verify+archive):  §5
+-->
+
+> Tasks: 28 completed, 2 deferred
+
+## 1. Application use case + mapper (the write path) [PR-1]
+
+- [x] 1.1 Add `application/health/manual-health-metric.ts` — shared `type ManualHealthMetric = "weight" | "sleep" | "hrv" | "steps"`, a metric→repo selector (each metric → its own Dexie table), and `datePart` reuse helper.
+- [x] 1.2 Add `application/health/manual-health-payload.mapper.ts` — pure builders: `(value, day) → WeightMeasurement | HrvSummary | SleepRecord` for weight/HRV/sleep; `(steps, day, prior?: DailyWellness) → DailyWellness` for steps (merge-preserve). Sleep: `{ startTime, endTime: startTime, totalDurationSeconds: 0, stages: [], score }`. HRV: `measurementWindow: "spot"`. Weight: `measuredAt` from `${day}T12:00:00.000Z`. No tests (mapper convention — exercised by use-case tests).
+- [x] 1.3 Add `application/health/save-manual-health-metric.use-case.ts` — `saveManualHealthMetric(deps, input) => Promise<{recordId}>`. Selects metric's repo; calls `getByProfileAndDateRange(profileId, day, day)` (no `krd.kind` filter — table already isolates metric); reuses `rows[0]?.id`; builds payload via mapper (passes `rows[0]?.krd` as `prior` for steps merge-preserve); `repo.put(...)`. Wrapped in `persistence.transaction(...)`.
+- [x] 1.4 Add `application/health/save-manual-health-metric.use-case.test.ts` — AAA tests vs in-memory persistence:
+  - should write a new weight record for a day with no prior weight
+  - should reuse the existing record id when a weight already exists for that day (assert range query returns exactly 1 row after two awaited saves)
+  - should insert TWO rows when the unlocked use case is called concurrently (race demonstration — `Promise.all` same day+metric; asserts `length === 2`; documents the check-then-act gap, motivates Phase 2 lock)
+  - should overwrite an imported value with a manual value for the same date+metric (weight/sleep/hrv)
+  - should preserve prior calories/intensity when overwriting steps (seed `steps:1000, activeCalories:300`; save `steps:8000`; assert `steps:8000` AND `activeCalories:300`)
+  - should zero-fill calories/intensity when saving steps for a day with no prior daily row
+  - should build a minimal valid sleep payload (`startTime == endTime`, 0 duration, empty stages, score) that passes `sleepRecordSchema.parse`
+  - should build a minimal valid daily payload (steps-only, calories/intensity zero-filled) that passes `dailyWellnessSchema.parse`
+  - should set hrv `measurementWindow` to a valid enum value (`"spot"`)
+  - should not write when the value is empty/undefined (per-metric)
+- [x] 1.5 Run `pnpm --filter @kaiord/workout-spa-editor test` — all new tests pass, coverage ≥70% for new files, zero warnings.
+
+## 2. Wellness entry UI (form + import action) [PR-2]
+
+- [x] 2.1 Add `components/molecules/WellnessEntryDialog/WellnessMetricField.tsx` — one labeled `<input type="number">` with `aria-label`; keeps the form file small.
+- [x] 2.2 Add `components/molecules/WellnessEntryDialog/WellnessEntryForm.tsx` — four labeled fields (weight/sleep-score/HRV/steps) as ephemeral `useState`; ONE Save button; collects only filled fields into `{metric → value}` and calls `submit(values)`. Save disabled while `isSaving`.
+- [x] 2.3 Add `components/molecules/WellnessEntryDialog/use-save-wellness.ts` — `usePersistence()` + `getActiveId()`; exposes `{ submit, isSaving }`. `submit` iterates filled metrics, calls `saveManualHealthMetric` for each; owns single in-flight lock (`useRef` boolean + `isSaving` state) — re-entrant calls are ignored while lock is held. Static toast constants `TOAST_WELLNESS_SAVED` / `TOAST_WELLNESS_SAVE_FAILED` at module top (R-PIIInterpolation).
+- [x] 2.4 Add `components/molecules/WellnessEntryDialog/WellnessEntryDialog.tsx` — Radix `Dialog.Root` controlled by parent `useState`; reuses `DIALOG_CONTENT_CLASSES` / `DIALOG_OVERLAY_CLASSES`; title includes the date (a11y); hosts form + import action.
+- [x] 2.5 Add `components/molecules/WellnessEntryDialog/wellness-import-action.tsx` — "Import a file" button that enters the existing FIT health-import flow. Does NOT pass `?date=<clickedDay>`; import is file-dated, not clicked-day-dated.
+- [x] 2.6 Add tests for dialog + form + hook (AAA):
+  - should render four metric fields with accessible labels
+  - should persist every filled metric in a single submit (fill weight AND steps → assert both rows written)
+  - should submit only filled fields (partial entry); unfilled fields write nothing
+  - should not write when all fields are empty
+  - should show a static success toast on submit (assert no interpolated value)
+  - should keep exactly one row when the submit is fired twice without awaiting (single in-flight lock — double-click Save + assert `getByProfileAndDateRange(day,day).length === 1`)
+  - should disable the Save button while `isSaving`
+  - should enter the FIT import flow when "Import a file" is chosen, without passing `?date=<day>`
+  - should be keyboard-navigable / focus-trapped (Radix dialog)
+- [x] 2.7 Run `pnpm --filter @kaiord/workout-spa-editor test` — 100% pass, ≥70% coverage, zero warnings.
+
+## 3. Chooser + intercept + ungate (`+` on every day) [PR-3]
+
+- [x] 3.1 Add `components/molecules/AddEntryChooser/AddEntryChooser.tsx` — Radix `Dialog` with two `PickerTile`-style tiles (Workout | Wellness); `onChoose("workout" | "wellness")`; accessible name; keyboard-navigable; browser back button closes without losing calendar route.
+- [x] 3.2 Extend `components/pages/use-calendar-state.ts` — add `addEntryDate: string | null` + `setAddEntryDate` + `wellnessDate` state; rename `handleEmptyDayClick` → `handleAddClick(date)`; add `handleChooseWorkout` (navigate `/workout/new?date=<day>`) and `handleChooseWellness` (open `WellnessEntryDialog`). Extract `use-add-entry-chooser.ts` if the file would exceed 80 lines.
+- [x] 3.3 Update `molecules/WorkoutCard/DayColumn.tsx` — remove `{total === 0 && …}` gate; always render the add button (`DayColumnAddButton`) with `onAddClick` prop.
+- [x] 3.4 Update `molecules/WorkoutCard/DayColumnAddButton.tsx` — rename prop `onEmptyDayClick` → `onAddClick`.
+- [x] 3.5 Thread the renamed prop `onAddClick` end-to-end: `CalendarWeekGrid.tsx`, `CalendarBodyView.tsx`, `CalendarPage.tsx`, `CalendarPageView.tsx`. Rewire the list-view `+` in `CalendarWeekList.tsx` to the chooser callback.
+- [x] 3.6 Mount `<AddEntryChooser>` and `<WellnessEntryDialog>` in `CalendarPage.tsx` / `CalendarPageView.tsx`, bound to the new state.
+- [x] 3.7 Add tests (AAA):
+  - should open the chooser (not navigate) when `+` is clicked
+  - should render the `+` on a day that already has a workout (grid)
+  - should render the `+` on every list-view day
+  - should navigate to `/workout/new?date=<day>` when Workout is chosen
+  - should open the wellness entry surface when Wellness is chosen
+  - should NOT start a drag when the `+` is pressed (pointerdown)
+  - should still reschedule when a workout is dropped on a cell that shows the `+`
+- [x] 3.8 Run `pnpm --filter @kaiord/workout-spa-editor test` — 100% pass, ≥70% coverage.
+
+## 4. Integration, read-back, quality gates [PR-3 tail or PR-4]
+
+- [x] 4.1 Integration test: save weight for a day via `saveManualHealthMetric` → assert the weight badge renders in that day's `WellnessBand` after `useCalendarWellnessWeekLive` refreshes (AC5).
+- [x] 4.2 `pnpm --filter @kaiord/workout-spa-editor lint:fix` then `lint` — zero ESLint/TypeScript/Prettier warnings.
+- [x] 4.3 `pnpm --filter @kaiord/workout-spa-editor test` — 100% pass, ≥70% coverage, zero warnings.
+- [x] 4.4 `pnpm --filter @kaiord/workout-spa-editor build` — clean output.
+- [x] 4.5 `pnpm test:scripts` — all mechanical guards green (R-PIIInterpolation, R-SessionMatchIdShape, no-zustand-writethrough, no-library-dual-mount).
+- [x] 4.6 Add a `patch`/`minor` changeset (`pnpm exec changeset`) for `@kaiord/workout-spa-editor`.
+
+## 5. OpenSpec verify + visual baselines + archive
+
+- [x] 5.1 `npx openspec validate calendar-add-workout-or-wellness` — passes.
+- [x] 5.2 `pnpm lint:specs` — passes (no orphaned scenario, no format violation).
+- [ ] 5.3 Trigger `update-visual-baselines.yml` workflow (Linux/chromium) in CI after PR-3 is up — the always-visible `+` shifts calendar screenshots. Do NOT regenerate locally. _(DEFERRED — CI-only step once the PR is open; cannot run on macOS.)_
+- [ ] 5.4 After merge: `/opsx:archive` (date-prefix the change folder, set `> Completed:`), then `pnpm archive:index`. _(DEFERRED — post-merge lifecycle step.)_

--- a/packages/workout-spa-editor/e2e/calendar-workouts.spec.ts
+++ b/packages/workout-spa-editor/e2e/calendar-workouts.spec.ts
@@ -187,6 +187,8 @@ test.describe("Calendar Workouts", () => {
     const btn = page.getByTestId(`empty-day-${dates[1]}`);
     await btn.scrollIntoViewIfNeeded();
     await btn.click({ force: true });
+    // The "+" opens the Workout | Wellness chooser; pick Workout.
+    await page.getByTestId("add-entry-choose-workout").click();
 
     await page.waitForURL(new RegExp(`/workout/new\\?date=${dates[1]}`));
     await expect(page.getByTestId("new-workout-picker")).toBeVisible();
@@ -203,6 +205,8 @@ test.describe("Calendar Workouts", () => {
     const btn = page.getByTestId(`empty-day-${dates[0]}`);
     await btn.scrollIntoViewIfNeeded();
     await btn.click({ force: true });
+    // The "+" opens the Workout | Wellness chooser; pick Workout.
+    await page.getByTestId("add-entry-choose-workout").click();
 
     await page.waitForURL(new RegExp(`/workout/new\\?date=${dates[0]}`));
     await page.getByTestId("new-workout-picker-scratch").click();
@@ -226,6 +230,8 @@ test.describe("Calendar Workouts", () => {
     const btn = page.getByTestId(`empty-day-${dates[0]}`);
     await btn.scrollIntoViewIfNeeded();
     await btn.click({ force: true });
+    // The "+" opens the Workout | Wellness chooser; pick Workout.
+    await page.getByTestId("add-entry-choose-workout").click();
     await page.waitForURL(new RegExp(`/workout/new\\?date=${dates[0]}`));
 
     await page.getByTestId("new-workout-picker-template").click();

--- a/packages/workout-spa-editor/e2e/library-calendar.spec.ts
+++ b/packages/workout-spa-editor/e2e/library-calendar.spec.ts
@@ -127,6 +127,8 @@ test.describe("Library-Calendar Integration", () => {
     const btn = page.getByTestId(`empty-day-${dates[1]}`);
     await btn.scrollIntoViewIfNeeded();
     await btn.click({ force: true });
+    // The "+" opens the Workout | Wellness chooser; pick Workout.
+    await page.getByTestId("add-entry-choose-workout").click();
 
     await page.waitForURL(new RegExp(`/workout/new\\?date=${dates[1]}`));
     await expect(page.getByTestId("new-workout-picker")).toBeVisible();

--- a/packages/workout-spa-editor/e2e/library-flows.spec.ts
+++ b/packages/workout-spa-editor/e2e/library-flows.spec.ts
@@ -109,6 +109,8 @@ test.describe("Library flows", () => {
     const cell = page.getByTestId(`empty-day-${targetDate}`);
     await cell.scrollIntoViewIfNeeded();
     await cell.click({ force: true });
+    // The "+" opens the Workout | Wellness chooser; pick Workout.
+    await page.getByTestId("add-entry-choose-workout").click();
 
     await page.waitForURL(new RegExp(`/workout/new\\?date=${targetDate}`));
     await expect(page.getByTestId("new-workout-picker")).toBeVisible();
@@ -171,6 +173,8 @@ test.describe("Library flows", () => {
     const cell = page.getByTestId(`empty-day-${targetDate}`);
     await cell.scrollIntoViewIfNeeded();
     await cell.click({ force: true });
+    // The "+" opens the Workout | Wellness chooser; pick Workout.
+    await page.getByTestId("add-entry-choose-workout").click();
     await page.waitForURL(new RegExp(`/workout/new\\?date=${targetDate}`));
     await page.getByTestId("new-workout-picker-template").click();
     await expect(page.getByTestId("template-picker-dialog")).toBeVisible();

--- a/packages/workout-spa-editor/src/application/health/manual-health-metric.ts
+++ b/packages/workout-spa-editor/src/application/health/manual-health-metric.ts
@@ -1,0 +1,51 @@
+/**
+ * Manual health metric — the four metrics a user can enter by hand from
+ * the calendar add-entry chooser, plus a selector mapping each metric to
+ * its own Dexie-backed repository.
+ *
+ * Each metric lives in a SEPARATE health store (persistence-port.ts),
+ * so selecting the repo by metric is enough to isolate it — no `krd.kind`
+ * filter is needed when reading back the day's existing record.
+ */
+import {
+  dailyWellnessSchema,
+  hrvSummarySchema,
+  sleepRecordSchema,
+  weightMeasurementSchema,
+} from "@kaiord/core";
+import type { z } from "zod";
+
+import type {
+  HealthRecord,
+  HealthRecordRepository,
+} from "../../ports/health-record-repository";
+import type { PersistencePort } from "../../ports/persistence-port";
+
+export type ManualHealthMetric = "weight" | "sleep" | "hrv" | "steps";
+
+export type ManualMetricRepo = HealthRecordRepository<HealthRecord<unknown>>;
+
+export const repoForMetric = (
+  persistence: PersistencePort,
+  metric: ManualHealthMetric
+): ManualMetricRepo => {
+  const byMetric: Record<ManualHealthMetric, ManualMetricRepo> = {
+    weight: persistence.healthWeight as ManualMetricRepo,
+    sleep: persistence.healthSleep as ManualMetricRepo,
+    hrv: persistence.healthHrv as ManualMetricRepo,
+    steps: persistence.healthDaily as ManualMetricRepo,
+  };
+  return byMetric[metric];
+};
+
+export const schemaForMetric = (
+  metric: ManualHealthMetric
+): z.ZodType<unknown> => {
+  const byMetric: Record<ManualHealthMetric, z.ZodType<unknown>> = {
+    weight: weightMeasurementSchema,
+    sleep: sleepRecordSchema,
+    hrv: hrvSummarySchema,
+    steps: dailyWellnessSchema,
+  };
+  return byMetric[metric];
+};

--- a/packages/workout-spa-editor/src/application/health/manual-health-payload.mapper.ts
+++ b/packages/workout-spa-editor/src/application/health/manual-health-payload.mapper.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure builders for minimal valid KRD v2.0 health payloads entered by
+ * hand. Every metric derives its timestamp from the clicked `day`
+ * (YYYY-MM-DD) at noon UTC, sidestepping timezone-boundary drift.
+ *
+ * Steps is the only merge-preserving builder: a prior daily row (e.g.
+ * imported) keeps its calorie/intensity fields; only `steps` is
+ * overridden. With no prior row the non-entered required fields are
+ * deterministically zero-filled.
+ */
+import type {
+  DailyWellness,
+  HrvSummary,
+  SleepRecord,
+  WeightMeasurement,
+} from "@kaiord/core";
+
+const KRD_VERSION = "2.0";
+
+const noonOf = (day: string): string => `${day}T12:00:00.000Z`;
+
+export const buildWeightPayload = (
+  weightKilograms: number,
+  day: string
+): WeightMeasurement => ({
+  kind: "weight",
+  version: KRD_VERSION,
+  measuredAt: noonOf(day),
+  weightKilograms,
+});
+
+export const buildSleepPayload = (score: number, day: string): SleepRecord => {
+  const at = noonOf(day);
+  return {
+    kind: "sleep",
+    version: KRD_VERSION,
+    startTime: at,
+    endTime: at,
+    totalDurationSeconds: 0,
+    stages: [],
+    score,
+  };
+};
+
+export const buildHrvPayload = (rMSSD: number, day: string): HrvSummary => ({
+  kind: "hrv",
+  version: KRD_VERSION,
+  measuredAt: noonOf(day),
+  rMSSD,
+  measurementWindow: "spot",
+});
+
+export const buildStepsPayload = (
+  steps: number,
+  day: string,
+  prior?: DailyWellness
+): DailyWellness =>
+  prior
+    ? { ...prior, steps }
+    : {
+        kind: "daily",
+        version: KRD_VERSION,
+        date: day,
+        steps,
+        activeCalories: 0,
+        restingCalories: 0,
+        intensityMinutes: { moderate: 0, vigorous: 0 },
+      };

--- a/packages/workout-spa-editor/src/application/health/save-manual-health-metric.use-case.test.ts
+++ b/packages/workout-spa-editor/src/application/health/save-manual-health-metric.use-case.test.ts
@@ -1,0 +1,315 @@
+import {
+  type DailyWellness,
+  dailyWellnessSchema,
+  sleepRecordSchema,
+} from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import { createInMemoryPersistence } from "../../test-utils/in-memory-persistence";
+import { saveManualHealthMetric } from "./save-manual-health-metric.use-case";
+
+const PROFILE_ID = "p-1";
+const DAY = "2026-05-23";
+const SAMPLE_WEIGHT_KG = 75;
+const SAMPLE_WEIGHT_KG_2 = 80;
+const SAMPLE_SLEEP_SCORE = 88;
+const SAMPLE_RMSSD = 45;
+const PRIOR_STEPS = 1000;
+const NEW_STEPS = 8000;
+const PRIOR_ACTIVE_KCAL = 300;
+const PRIOR_REST_KCAL = 1700;
+const PRIOR_MODERATE_MIN = 20;
+const PRIOR_VIGOROUS_MIN = 5;
+
+let counter = 0;
+const sequentialNewId = (): string => `id-${(counter += 1)}`;
+
+const priorDaily = (): DailyWellness => ({
+  kind: "daily",
+  version: "2.0",
+  date: DAY,
+  steps: PRIOR_STEPS,
+  activeCalories: PRIOR_ACTIVE_KCAL,
+  restingCalories: PRIOR_REST_KCAL,
+  intensityMinutes: {
+    moderate: PRIOR_MODERATE_MIN,
+    vigorous: PRIOR_VIGOROUS_MIN,
+  },
+});
+
+describe("saveManualHealthMetric", () => {
+  it("should write a new weight record for a day with no prior weight", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "weight", day: DAY, value: SAMPLE_WEIGHT_KG }
+    );
+
+    // Assert
+    const rows = await persistence.healthWeight.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.krd.weightKilograms).toBe(SAMPLE_WEIGHT_KG);
+    expect(result?.recordId).toBe(rows[0]?.id);
+  });
+
+  it("should reuse the existing record id when a weight already exists for that day", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const deps = { persistence, profileId: PROFILE_ID, newId: sequentialNewId };
+
+    // Act
+    const first = await saveManualHealthMetric(deps, {
+      metric: "weight",
+      day: DAY,
+      value: SAMPLE_WEIGHT_KG,
+    });
+    const second = await saveManualHealthMetric(deps, {
+      metric: "weight",
+      day: DAY,
+      value: SAMPLE_WEIGHT_KG_2,
+    });
+
+    // Assert
+    const rows = await persistence.healthWeight.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(rows).toHaveLength(1);
+    expect(second?.recordId).toBe(first?.recordId);
+    expect(rows[0]?.krd.weightKilograms).toBe(SAMPLE_WEIGHT_KG_2);
+  });
+
+  it("should insert two rows when the unlocked use case is called concurrently", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const deps = { persistence, profileId: PROFILE_ID, newId: sequentialNewId };
+
+    // Act
+    await Promise.all([
+      saveManualHealthMetric(deps, {
+        metric: "weight",
+        day: DAY,
+        value: SAMPLE_WEIGHT_KG,
+      }),
+      saveManualHealthMetric(deps, {
+        metric: "weight",
+        day: DAY,
+        value: SAMPLE_WEIGHT_KG_2,
+      }),
+    ]);
+
+    // Assert
+    const rows = await persistence.healthWeight.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(rows).toHaveLength(2);
+  });
+
+  it("should overwrite an imported value with a manual value for the same date and metric", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    await persistence.healthWeight.put({
+      id: "imported-1",
+      profileId: PROFILE_ID,
+      date: DAY,
+      krd: {
+        kind: "weight",
+        version: "2.0",
+        measuredAt: `${DAY}T08:00:00.000Z`,
+        weightKilograms: SAMPLE_WEIGHT_KG,
+      },
+    });
+
+    // Act
+    await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "weight", day: DAY, value: SAMPLE_WEIGHT_KG_2 }
+    );
+
+    // Assert
+    const rows = await persistence.healthWeight.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.id).toBe("imported-1");
+    expect(rows[0]?.krd.weightKilograms).toBe(SAMPLE_WEIGHT_KG_2);
+  });
+
+  it("should preserve prior calories and intensity when overwriting steps", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    await persistence.healthDaily.put({
+      id: "imported-daily",
+      profileId: PROFILE_ID,
+      date: DAY,
+      krd: priorDaily(),
+    });
+
+    // Act
+    await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "steps", day: DAY, value: NEW_STEPS }
+    );
+
+    // Assert
+    const rows = await persistence.healthDaily.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(rows[0]?.krd.steps).toBe(NEW_STEPS);
+    expect(rows[0]?.krd.activeCalories).toBe(PRIOR_ACTIVE_KCAL);
+    expect(rows[0]?.krd.intensityMinutes.moderate).toBe(PRIOR_MODERATE_MIN);
+  });
+
+  it("should zero-fill calories and intensity when saving steps for a day with no prior daily row", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "steps", day: DAY, value: NEW_STEPS }
+    );
+
+    // Assert
+    const rows = await persistence.healthDaily.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(rows[0]?.krd.steps).toBe(NEW_STEPS);
+    expect(rows[0]?.krd.activeCalories).toBe(0);
+    expect(rows[0]?.krd.intensityMinutes).toEqual({ moderate: 0, vigorous: 0 });
+  });
+
+  it("should build a minimal valid sleep payload that passes sleepRecordSchema.parse", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "sleep", day: DAY, value: SAMPLE_SLEEP_SCORE }
+    );
+
+    // Assert
+    const rows = await persistence.healthSleep.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(() => sleepRecordSchema.parse(rows[0]?.krd)).not.toThrow();
+    expect(rows[0]?.krd.score).toBe(SAMPLE_SLEEP_SCORE);
+  });
+
+  it("should build a minimal valid daily payload that passes dailyWellnessSchema.parse", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "steps", day: DAY, value: NEW_STEPS }
+    );
+
+    // Assert
+    const rows = await persistence.healthDaily.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(() => dailyWellnessSchema.parse(rows[0]?.krd)).not.toThrow();
+  });
+
+  it("should set hrv measurementWindow to a valid enum value", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "hrv", day: DAY, value: SAMPLE_RMSSD }
+    );
+
+    // Assert
+    const rows = await persistence.healthHrv.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(rows[0]?.krd.measurementWindow).toBe("spot");
+  });
+
+  it("should not write when the value is non-finite", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "weight", day: DAY, value: Number.NaN }
+    );
+
+    // Assert
+    expect(result).toBeUndefined();
+    const rows = await persistence.healthWeight.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it("should not persist an out-of-range sleep score", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "sleep", day: DAY, value: 150 }
+    );
+
+    // Assert
+    expect(result).toBeUndefined();
+    const rows = await persistence.healthSleep.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(rows).toHaveLength(0);
+  });
+
+  it("should not persist a fractional sleep score", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "sleep", day: DAY, value: 88.5 }
+    );
+
+    // Assert
+    expect(result).toBeUndefined();
+    const rows = await persistence.healthSleep.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(rows).toHaveLength(0);
+  });
+});

--- a/packages/workout-spa-editor/src/application/health/save-manual-health-metric.use-case.ts
+++ b/packages/workout-spa-editor/src/application/health/save-manual-health-metric.use-case.ts
@@ -1,0 +1,80 @@
+/**
+ * saveManualHealthMetric — application use case for a hand-entered
+ * wellness value from the calendar add-entry chooser.
+ *
+ * Finds the day's existing record for the metric via the metric's own
+ * Dexie table (range query for [day, day]) and reuses `rows[0]?.id`,
+ * else mints a fresh id — the find-then-reuse upsert that keeps exactly
+ * one record per day per metric on AWAITED saves. The read+put run
+ * inside `persistence.transaction(...)`; note this alone is NOT
+ * concurrency-safe (the in-memory transaction has no mutual exclusion),
+ * so the form-submit lock in Phase 2 closes the un-awaited race.
+ */
+import type { DailyWellness } from "@kaiord/core";
+
+import type { HealthRecord } from "../../ports/health-record-repository";
+import type { PersistencePort } from "../../ports/persistence-port";
+import type { ManualHealthMetric } from "./manual-health-metric";
+import { repoForMetric, schemaForMetric } from "./manual-health-metric";
+import {
+  buildHrvPayload,
+  buildSleepPayload,
+  buildStepsPayload,
+  buildWeightPayload,
+} from "./manual-health-payload.mapper";
+
+export type SaveManualHealthMetricDeps = {
+  persistence: PersistencePort;
+  profileId: string;
+  newId?: () => string;
+};
+
+export type SaveManualHealthMetricInput = {
+  metric: ManualHealthMetric;
+  day: string;
+  value: number;
+};
+
+export type SaveManualHealthMetricResult = { recordId: string };
+
+const buildPayload = (
+  metric: ManualHealthMetric,
+  value: number,
+  day: string,
+  prior: HealthRecord<unknown> | undefined
+): unknown => {
+  switch (metric) {
+    case "weight":
+      return buildWeightPayload(value, day);
+    case "sleep":
+      return buildSleepPayload(value, day);
+    case "hrv":
+      return buildHrvPayload(value, day);
+    case "steps":
+      return buildStepsPayload(value, day, prior?.krd as DailyWellness);
+  }
+};
+
+export const saveManualHealthMetric = async (
+  deps: SaveManualHealthMetricDeps,
+  input: SaveManualHealthMetricInput
+): Promise<SaveManualHealthMetricResult | undefined> => {
+  // Defensive guard: a non-finite value is a no-op (no write).
+  if (!Number.isFinite(input.value)) return undefined;
+  const { persistence, profileId } = deps;
+  const repo = repoForMetric(persistence, input.metric);
+  return persistence.transaction(async () => {
+    // No `krd.kind` filter — the metric's table already isolates it.
+    const rows = await repo.getByProfileAndDateRange(
+      profileId,
+      input.day,
+      input.day
+    );
+    const id = rows[0]?.id ?? deps.newId?.() ?? crypto.randomUUID();
+    const krd = buildPayload(input.metric, input.value, input.day, rows[0]);
+    const parsed = schemaForMetric(input.metric).safeParse(krd);
+    if (!parsed.success) return undefined;
+    await repo.put({ id, profileId, date: input.day, krd: parsed.data });
+    return { recordId: id };
+  });
+};

--- a/packages/workout-spa-editor/src/components/molecules/AddEntryChooser/AddEntryChooser.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/AddEntryChooser/AddEntryChooser.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * AddEntryChooser tests — the first step of the per-day add-entry flow.
+ * Asserts the two choices are presented, that each fires `onChoose` with
+ * the right branch, and that the accessible name carries the bound date.
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { AddEntryChooser } from "./AddEntryChooser";
+
+const DAY = "2026-05-04";
+
+describe("AddEntryChooser", () => {
+  it("should render exactly the Workout and Wellness choices", () => {
+    // Arrange
+
+    // Act
+    render(
+      <AddEntryChooser
+        open
+        onOpenChange={vi.fn()}
+        date={DAY}
+        onChoose={vi.fn()}
+      />
+    );
+
+    // Assert
+    expect(screen.getByTestId("add-entry-choose-workout")).toBeInTheDocument();
+    expect(screen.getByTestId("add-entry-choose-wellness")).toBeInTheDocument();
+  });
+
+  it("should call onChoose with workout when the Workout tile is clicked", async () => {
+    // Arrange
+    const onChoose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AddEntryChooser
+        open
+        onOpenChange={vi.fn()}
+        date={DAY}
+        onChoose={onChoose}
+      />
+    );
+
+    // Act
+    await user.click(screen.getByTestId("add-entry-choose-workout"));
+
+    // Assert
+    expect(onChoose).toHaveBeenCalledWith("workout");
+  });
+
+  it("should call onChoose with wellness when the Wellness tile is clicked", async () => {
+    // Arrange
+    const onChoose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AddEntryChooser
+        open
+        onOpenChange={vi.fn()}
+        date={DAY}
+        onChoose={onChoose}
+      />
+    );
+
+    // Act
+    await user.click(screen.getByTestId("add-entry-choose-wellness"));
+
+    // Assert
+    expect(onChoose).toHaveBeenCalledWith("wellness");
+  });
+
+  it("should include the formatted date in the dialog accessible name", () => {
+    // Arrange
+
+    // Act
+    render(
+      <AddEntryChooser
+        open
+        onOpenChange={vi.fn()}
+        date={DAY}
+        onChoose={vi.fn()}
+      />
+    );
+
+    // Assert
+    expect(
+      screen.getByRole("dialog", { name: /Monday, May 4/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/AddEntryChooser/AddEntryChooser.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/AddEntryChooser/AddEntryChooser.tsx
@@ -1,0 +1,81 @@
+/**
+ * AddEntryChooser — first step of the per-day add-entry flow.
+ *
+ * Radix `Dialog.Root` controlled by parent `useState` (mirrors
+ * `TemplatePickerDialog`). Presents exactly two tiles, Workout and
+ * Wellness; choosing one calls `onChoose` so the parent can navigate
+ * (workout) or open the wellness entry surface (wellness). The
+ * accessible name includes the date so SR users hear the bound day.
+ */
+import * as Dialog from "@radix-ui/react-dialog";
+import { useId } from "react";
+
+import {
+  DIALOG_CONTENT_CLASSES,
+  DIALOG_OVERLAY_CLASSES,
+} from "../../organisms/WorkoutLibrary/constants";
+import { formatDateLabel } from "../TemplatePickerDialog/format-date-label";
+
+export type AddEntryChoice = "workout" | "wellness";
+
+export type AddEntryChooserProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  date: string;
+  onChoose: (choice: AddEntryChoice) => void;
+};
+
+const TILE_CLASSES =
+  "flex flex-1 flex-col items-center gap-1 rounded-lg border border-gray-200 px-4 py-6 text-sm font-medium text-gray-900 transition-colors hover:border-primary-400 hover:text-primary-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary-500 dark:border-gray-700 dark:text-white";
+
+export function AddEntryChooser({
+  open,
+  onOpenChange,
+  date,
+  onChoose,
+}: AddEntryChooserProps) {
+  const titleId = useId();
+  const dateLabel = formatDateLabel(date);
+  const titleText = dateLabel
+    ? `Add to ${dateLabel}`
+    : "What do you want to add?";
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={DIALOG_OVERLAY_CLASSES} />
+        <Dialog.Content
+          aria-labelledby={titleId}
+          aria-describedby={undefined}
+          className={DIALOG_CONTENT_CLASSES}
+          data-testid="add-entry-chooser"
+        >
+          <Dialog.Title
+            id={titleId}
+            className="mb-4 text-lg font-semibold text-gray-900 dark:text-white"
+          >
+            {titleText}
+          </Dialog.Title>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              data-testid="add-entry-choose-workout"
+              className={TILE_CLASSES}
+              onClick={() => onChoose("workout")}
+            >
+              Workout
+            </button>
+            <button
+              type="button"
+              data-testid="add-entry-choose-wellness"
+              className={TILE_CLASSES}
+              onClick={() => onChoose("wellness")}
+            >
+              Wellness
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessEntryDialog.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessEntryDialog.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * WellnessEntryDialog tests.
+ *
+ * The dialog hosts the entry form + the file-dated import action.
+ * Import navigation is exercised through a `memoryLocation` Router so
+ * we can assert the target URL carries NO `?date=` (the FIT file dates
+ * the imported record, not the clicked day).
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import { Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+
+import type { PersistencePort } from "../../../ports/persistence-port";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../test-utils";
+import { createInMemoryPersistence } from "../../../test-utils/in-memory-persistence";
+import { WellnessEntryDialog } from "./WellnessEntryDialog";
+
+const DAY = "2026-05-04";
+const PROFILE_ID = "00000000-0000-4000-8000-0000000000a1";
+
+const setup = async (): Promise<PersistencePort> => {
+  const persistence = createInMemoryPersistence();
+  await persistence.profiles.setActiveId(PROFILE_ID);
+  return persistence;
+};
+
+const renderDialog = (
+  persistence: PersistencePort,
+  hook: ReturnType<typeof memoryLocation>["hook"],
+  onOpenChange = vi.fn()
+) =>
+  renderWithProviders(
+    <Router hook={hook}>
+      <WellnessEntryDialog open onOpenChange={onOpenChange} date={DAY} />
+    </Router>,
+    { persistence }
+  );
+
+describe("WellnessEntryDialog", () => {
+  it("should include the formatted date in the dialog accessible name", async () => {
+    // Arrange
+    const persistence = await setup();
+    const { hook } = memoryLocation({ path: "/calendar", record: true });
+
+    // Act
+    renderDialog(persistence, hook);
+
+    // Assert
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: /Monday, May 4/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should enter the FIT import flow without passing a date param", async () => {
+    // Arrange
+    const persistence = await setup();
+    const { hook, history } = memoryLocation({
+      path: "/calendar",
+      record: true,
+    });
+    const user = userEvent.setup();
+    renderDialog(persistence, hook);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Import a file" }));
+
+    // Assert
+    const target = history[history.length - 1];
+    expect(target).toBe("/workout/new?action=import");
+    expect(target).not.toContain("date=");
+  });
+
+  it("should expose a focus-trapped dialog reachable by keyboard", async () => {
+    // Arrange
+    const persistence = await setup();
+    const { hook } = memoryLocation({ path: "/calendar", record: true });
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    renderDialog(persistence, hook, onOpenChange);
+
+    // Act
+    await waitFor(() => {
+      expect(screen.getByTestId("wellness-entry-dialog")).toBeInTheDocument();
+    });
+    await user.keyboard("{Escape}");
+
+    // Assert
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessEntryDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessEntryDialog.tsx
@@ -1,0 +1,65 @@
+/**
+ * WellnessEntryDialog — narrow in-flow surface for hand-entering a day's
+ * wellness metrics from the calendar.
+ *
+ * Radix `Dialog.Root` controlled by parent `useState` (mirrors
+ * `TemplatePickerDialog`). The accessible name MUST include the date so
+ * SR users hear the day the dialog is bound to. The body hosts the entry
+ * form plus the file-dated import action; a successful save closes it.
+ */
+import * as Dialog from "@radix-ui/react-dialog";
+import { useId } from "react";
+
+import {
+  DIALOG_CONTENT_CLASSES,
+  DIALOG_OVERLAY_CLASSES,
+} from "../../organisms/WorkoutLibrary/constants";
+import { formatDateLabel } from "../TemplatePickerDialog/format-date-label";
+import { WellnessImportAction } from "./wellness-import-action";
+import { WellnessEntryForm } from "./WellnessEntryForm";
+
+export type WellnessEntryDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  date: string;
+};
+
+export function WellnessEntryDialog({
+  open,
+  onOpenChange,
+  date,
+}: WellnessEntryDialogProps) {
+  const titleId = useId();
+  const dateLabel = formatDateLabel(date);
+  const titleText = dateLabel
+    ? `Add wellness for ${dateLabel}`
+    : "Add wellness";
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={DIALOG_OVERLAY_CLASSES} />
+        <Dialog.Content
+          aria-labelledby={titleId}
+          aria-describedby={undefined}
+          className={DIALOG_CONTENT_CLASSES}
+          data-testid="wellness-entry-dialog"
+        >
+          <Dialog.Title
+            id={titleId}
+            className="mb-4 text-lg font-semibold text-gray-900 dark:text-white"
+          >
+            {titleText}
+          </Dialog.Title>
+          <div className="flex flex-col gap-4">
+            <WellnessEntryForm
+              date={date}
+              onSaved={() => onOpenChange(false)}
+            />
+            <WellnessImportAction />
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessEntryForm.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessEntryForm.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * WellnessEntryForm + use-save-wellness tests.
+ *
+ * Rendered through `renderWithProviders` (in-memory persistence +
+ * AppToastProvider) with an active profile seeded so the use case can
+ * resolve `getActiveId()`. Persisted rows are read back via the
+ * metric's own in-memory repo (`getByProfileAndDateRange`).
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PersistencePort } from "../../../ports/persistence-port";
+import {
+  renderWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from "../../../test-utils";
+import { createInMemoryPersistence } from "../../../test-utils/in-memory-persistence";
+import { WellnessEntryForm } from "./WellnessEntryForm";
+
+const DAY = "2026-05-04";
+const PROFILE_ID = "00000000-0000-4000-8000-0000000000a1";
+
+const setup = async (): Promise<PersistencePort> => {
+  const persistence = createInMemoryPersistence();
+  await persistence.profiles.setActiveId(PROFILE_ID);
+  return persistence;
+};
+
+const renderForm = (persistence: PersistencePort, onSaved = vi.fn()) =>
+  renderWithProviders(<WellnessEntryForm date={DAY} onSaved={onSaved} />, {
+    persistence,
+  });
+
+const fillAndSave = async (
+  user: ReturnType<typeof userEvent.setup>,
+  entries: Record<string, string>
+) => {
+  for (const [label, value] of Object.entries(entries)) {
+    await user.type(screen.getByLabelText(label), value);
+  }
+  await user.click(screen.getByRole("button", { name: "Save" }));
+};
+
+describe("WellnessEntryForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render four metric fields with accessible labels", async () => {
+    // Arrange
+    const persistence = await setup();
+
+    // Act
+    renderForm(persistence);
+
+    // Assert
+    expect(screen.getByLabelText("Weight (kg)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Sleep score")).toBeInTheDocument();
+    expect(screen.getByLabelText("HRV (ms)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Steps")).toBeInTheDocument();
+  });
+
+  it("should persist every filled metric in a single submit", async () => {
+    // Arrange
+    const persistence = await setup();
+    const user = userEvent.setup();
+    renderForm(persistence);
+
+    // Act
+    await fillAndSave(user, { "Weight (kg)": "72", Steps: "8000" });
+
+    // Assert
+    await waitFor(async () => {
+      const weight = await persistence.healthWeight.getByProfileAndDateRange(
+        PROFILE_ID,
+        DAY,
+        DAY
+      );
+      const daily = await persistence.healthDaily.getByProfileAndDateRange(
+        PROFILE_ID,
+        DAY,
+        DAY
+      );
+      expect(weight).toHaveLength(1);
+      expect(daily).toHaveLength(1);
+    });
+  });
+
+  it("should submit only filled fields when entry is partial", async () => {
+    // Arrange
+    const persistence = await setup();
+    const user = userEvent.setup();
+    renderForm(persistence);
+
+    // Act
+    await fillAndSave(user, { "Weight (kg)": "72" });
+
+    // Assert
+    await waitFor(async () => {
+      const weight = await persistence.healthWeight.getByProfileAndDateRange(
+        PROFILE_ID,
+        DAY,
+        DAY
+      );
+      expect(weight).toHaveLength(1);
+    });
+    const daily = await persistence.healthDaily.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    const hrv = await persistence.healthHrv.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(daily).toHaveLength(0);
+    expect(hrv).toHaveLength(0);
+  });
+
+  it("should not write when all fields are empty", async () => {
+    // Arrange
+    const persistence = await setup();
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    renderForm(persistence, onSaved);
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    // Assert
+    const weight = await persistence.healthWeight.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(weight).toHaveLength(0);
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("should show a static success toast on submit", async () => {
+    // Arrange
+    const persistence = await setup();
+    const user = userEvent.setup();
+    renderForm(persistence);
+
+    // Act
+    await fillAndSave(user, { "Weight (kg)": "72" });
+
+    // Assert
+    expect(await screen.findByText("Wellness saved")).toBeInTheDocument();
+  });
+
+  it("should keep exactly one row when the submit is fired twice without awaiting", async () => {
+    // Arrange
+    const persistence = await setup();
+    const user = userEvent.setup();
+    renderForm(persistence);
+    await user.type(screen.getByLabelText("Weight (kg)"), "72");
+    const save = screen.getByRole("button", { name: "Save" });
+
+    // Act
+    await user.click(save);
+    await user.click(save);
+
+    // Assert
+    await waitFor(async () => {
+      const weight = await persistence.healthWeight.getByProfileAndDateRange(
+        PROFILE_ID,
+        DAY,
+        DAY
+      );
+      expect(weight).toHaveLength(1);
+    });
+  });
+
+  it("should keep the dialog open and toast a failure when the save is rejected", async () => {
+    // Arrange
+    const persistence = await setup();
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    renderForm(persistence, onSaved);
+
+    // Act
+    await fillAndSave(user, { "Sleep score": "150" });
+
+    // Assert
+    expect(
+      await screen.findByText("Could not save — please retry")
+    ).toBeInTheDocument();
+    expect(onSaved).not.toHaveBeenCalled();
+    const sleep = await persistence.healthSleep.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(sleep).toHaveLength(0);
+  });
+
+  it("should disable the Save button while isSaving", async () => {
+    // Arrange
+    const persistence = await setup();
+    const user = userEvent.setup();
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const original = persistence.profiles.getActiveId;
+    persistence.profiles.getActiveId = async () => {
+      await gate;
+      return original();
+    };
+    renderForm(persistence);
+    await user.type(screen.getByLabelText("Weight (kg)"), "72");
+
+    // Act
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    });
+    release?.();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessEntryForm.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessEntryForm.test.tsx
@@ -199,6 +199,29 @@ describe("WellnessEntryForm", () => {
     expect(sleep).toHaveLength(0);
   });
 
+  it("should treat a partial save as failure and keep the dialog open", async () => {
+    // Arrange
+    const persistence = await setup();
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    renderForm(persistence, onSaved);
+
+    // Act
+    await fillAndSave(user, { "Weight (kg)": "72", "Sleep score": "150" });
+
+    // Assert
+    expect(
+      await screen.findByText("Could not save — please retry")
+    ).toBeInTheDocument();
+    expect(onSaved).not.toHaveBeenCalled();
+    const sleep = await persistence.healthSleep.getByProfileAndDateRange(
+      PROFILE_ID,
+      DAY,
+      DAY
+    );
+    expect(sleep).toHaveLength(0);
+  });
+
   it("should disable the Save button while isSaving", async () => {
     // Arrange
     const persistence = await setup();

--- a/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessEntryForm.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessEntryForm.tsx
@@ -1,0 +1,90 @@
+/**
+ * WellnessEntryForm — four ephemeral number fields (weight / sleep score
+ * / HRV / steps) and ONE Save button. On submit it collects every FILLED
+ * field into a `{metric → number}` set and hands the whole set to a
+ * single `submit(values)` call (NOT one save per field). Empty/blank
+ * fields are excluded; an all-empty submit is a no-op.
+ */
+import { useState } from "react";
+
+import type { ManualHealthMetric } from "../../../application/health/manual-health-metric";
+import { useSaveWellness, type WellnessValues } from "./use-save-wellness";
+import { WellnessMetricField } from "./WellnessMetricField";
+
+export type WellnessEntryFormProps = {
+  date: string;
+  onSaved: () => void;
+};
+
+type Fields = Record<ManualHealthMetric, string>;
+
+const EMPTY_FIELDS: Fields = { weight: "", sleep: "", hrv: "", steps: "" };
+
+const collectFilled = (fields: Fields): WellnessValues => {
+  const values: WellnessValues = {};
+  for (const [metric, raw] of Object.entries(fields)) {
+    if (raw.trim() === "") continue;
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed)) values[metric as ManualHealthMetric] = parsed;
+  }
+  return values;
+};
+
+export function WellnessEntryForm({ date, onSaved }: WellnessEntryFormProps) {
+  const [fields, setFields] = useState<Fields>(EMPTY_FIELDS);
+  const { submit, isSaving } = useSaveWellness(date);
+
+  const setField = (metric: ManualHealthMetric) => (value: string) =>
+    setFields((prev) => ({ ...prev, [metric]: value }));
+
+  const handleSubmit = async () => {
+    const values = collectFilled(fields);
+    if (Object.keys(values).length === 0) return;
+    const ok = await submit(values);
+    if (ok) onSaved();
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <WellnessMetricField
+        label="Weight"
+        unit="kg"
+        value={fields.weight}
+        onChange={setField("weight")}
+        min={0.1}
+        step={0.1}
+      />
+      <WellnessMetricField
+        label="Sleep score"
+        value={fields.sleep}
+        onChange={setField("sleep")}
+        min={0}
+        max={100}
+        step={1}
+      />
+      <WellnessMetricField
+        label="HRV"
+        unit="ms"
+        value={fields.hrv}
+        onChange={setField("hrv")}
+        min={0.1}
+        step={0.1}
+      />
+      <WellnessMetricField
+        label="Steps"
+        value={fields.steps}
+        onChange={setField("steps")}
+        min={0}
+        step={1}
+      />
+      <button
+        type="button"
+        disabled={isSaving}
+        onClick={handleSubmit}
+        className="mt-2 rounded bg-blue-600 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+      >
+        Save
+      </button>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessMetricField.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/WellnessMetricField.tsx
@@ -1,0 +1,52 @@
+/**
+ * WellnessMetricField — one labeled number input for a single wellness
+ * metric. The `<label>` is associated to the input via `useId` so the
+ * field has an accessible name (SR users hear the metric + unit).
+ */
+import { useId } from "react";
+
+export type WellnessMetricFieldProps = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  unit?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+};
+
+export function WellnessMetricField({
+  label,
+  value,
+  onChange,
+  unit,
+  min,
+  max,
+  step,
+}: WellnessMetricFieldProps) {
+  const inputId = useId();
+  const labelText = unit ? `${label} (${unit})` : label;
+
+  return (
+    <div className="flex flex-col gap-1">
+      <label
+        htmlFor={inputId}
+        className="text-sm font-medium text-gray-900 dark:text-white"
+      >
+        {labelText}
+      </label>
+      <input
+        id={inputId}
+        type="number"
+        inputMode="decimal"
+        value={value}
+        aria-label={labelText}
+        min={min}
+        max={max}
+        step={step}
+        onChange={(event) => onChange(event.target.value)}
+        className="rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+      />
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/use-save-wellness.ts
+++ b/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/use-save-wellness.ts
@@ -54,7 +54,10 @@ export function useSaveWellness(day: string): UseSaveWellnessResult {
         );
         if (result) savedCount += 1;
       }
-      if (savedCount === 0) {
+      // Anything short of all-saved is a failure: a rejected metric (e.g.
+      // an out-of-range value) must keep the dialog open so the entry is
+      // not silently lost behind a success toast.
+      if (savedCount < entries.length) {
         toast.error(TOAST_WELLNESS_SAVE_FAILED);
         return false;
       }

--- a/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/use-save-wellness.ts
+++ b/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/use-save-wellness.ts
@@ -1,0 +1,73 @@
+/**
+ * use-save-wellness — UI hook bridging the wellness form to the
+ * `saveManualHealthMetric` application use case.
+ *
+ * Persists EVERY filled metric inside ONE awaited pass: each metric
+ * writes its own Dexie table (persistence-port.ts:78-83), so the
+ * distinct metrics in a single submit never race one another.
+ *
+ * Owns the single in-flight submit lock (`useRef` set synchronously
+ * before the first `await`): a re-entrant `submit(...)` while the one
+ * promise is pending is ignored, closing the un-awaited same-metric
+ * race. `isSaving` mirrors the lock for the disabled Save button.
+ */
+import { useRef, useState } from "react";
+
+import type { ManualHealthMetric } from "../../../application/health/manual-health-metric";
+import { saveManualHealthMetric } from "../../../application/health/save-manual-health-metric.use-case";
+import { usePersistence } from "../../../contexts/persistence-context";
+import { useToastContext } from "../../../contexts/ToastContext";
+
+const TOAST_WELLNESS_SAVED = "Wellness saved";
+const TOAST_WELLNESS_SAVE_FAILED = "Could not save — please retry";
+
+export type WellnessValues = Partial<Record<ManualHealthMetric, number>>;
+
+export type UseSaveWellnessResult = {
+  submit: (values: WellnessValues) => Promise<boolean>;
+  isSaving: boolean;
+};
+
+export function useSaveWellness(day: string): UseSaveWellnessResult {
+  const persistence = usePersistence();
+  const toast = useToastContext();
+  const inFlight = useRef(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const submit = async (values: WellnessValues): Promise<boolean> => {
+    if (inFlight.current) return false;
+    const entries = Object.entries(values) as [ManualHealthMetric, number][];
+    if (entries.length === 0) return false;
+    inFlight.current = true;
+    setIsSaving(true);
+    try {
+      const profileId = await persistence.profiles.getActiveId();
+      if (!profileId) {
+        toast.error(TOAST_WELLNESS_SAVE_FAILED);
+        return false;
+      }
+      let savedCount = 0;
+      for (const [metric, value] of entries) {
+        const result = await saveManualHealthMetric(
+          { persistence, profileId },
+          { metric, day, value }
+        );
+        if (result) savedCount += 1;
+      }
+      if (savedCount === 0) {
+        toast.error(TOAST_WELLNESS_SAVE_FAILED);
+        return false;
+      }
+      toast.success(TOAST_WELLNESS_SAVED);
+      return true;
+    } catch {
+      toast.error(TOAST_WELLNESS_SAVE_FAILED);
+      return false;
+    } finally {
+      inFlight.current = false;
+      setIsSaving(false);
+    }
+  };
+
+  return { submit, isSaving };
+}

--- a/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/wellness-import-action.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WellnessEntryDialog/wellness-import-action.tsx
@@ -1,0 +1,29 @@
+/**
+ * wellness-import-action — "Import a file" entry into the existing FIT
+ * health-import flow.
+ *
+ * The imported record is dated by the FIT file, NOT the clicked day:
+ * the import path ignores `?date=` (use-import-on-load.ts:42-54). So
+ * this action navigates to `/workout/new?action=import` with NO
+ * `&date=` — the file's own date drives persistence + Hub navigation.
+ */
+import { useLocation } from "wouter";
+
+export function WellnessImportAction() {
+  const [, navigate] = useLocation();
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={() => navigate("/workout/new?action=import")}
+        className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-900 dark:border-gray-600 dark:text-white"
+      >
+        Import a file
+      </button>
+      <p className="text-xs text-muted-foreground">
+        Imported files use their own date.
+      </p>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/WorkoutCard/DayColumn.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WorkoutCard/DayColumn.test.tsx
@@ -1,8 +1,9 @@
 /**
  * DayColumn wellness-band integration: present/absent rendering, the
- * unchanged `+ Add` gate, and the two drag invariants from the design
- * Risks section — a badge pointerdown does not start a drag, and a drop
- * onto a band-bearing cell still hit-tests to the day via `[data-day]`.
+ * always-visible `+ Add` affordance, and the drag invariants from the
+ * design Risks section — a badge/`+` pointerdown does not start a drag,
+ * and a drop onto a band-bearing cell still hit-tests to the day via
+ * `[data-day]`.
  */
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -57,7 +58,7 @@ function renderColumn(
         date={DATE}
         isToday={false}
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
         wellness={wellness}
         {...extra}
       />
@@ -89,7 +90,7 @@ describe("DayColumn wellness band", () => {
     expect(screen.queryByTestId("wellness-band")).not.toBeInTheDocument();
   });
 
-  it("should keep the + Add affordance gated on training only", () => {
+  it("should render the + Add affordance on an empty day", () => {
     // Arrange
     const wellness: DayWellness = { sleep: "82" };
 
@@ -98,6 +99,34 @@ describe("DayColumn wellness band", () => {
 
     // Assert
     expect(screen.getByTestId(`empty-day-${DATE}`)).toBeInTheDocument();
+  });
+
+  it("should render the + Add affordance on a day that already has a workout", () => {
+    // Arrange
+    const wellness: DayWellness = { sleep: "82" };
+
+    // Act
+    renderColumn(wellness, { soloActuals: [makeWorkout()] });
+
+    // Assert
+    expect(screen.getByTestId(`empty-day-${DATE}`)).toBeInTheDocument();
+  });
+
+  it("should not start a drag when the + Add button is pressed", () => {
+    // Arrange
+    const dragHandler = vi.fn();
+    const bind = vi.fn(() => () => dragHandler());
+    renderColumn(
+      { sleep: "82" },
+      { soloActuals: [makeWorkout()], workoutCardPointerDownFor: bind }
+    );
+    const addButton = screen.getByTestId(`empty-day-${DATE}`);
+
+    // Act
+    fireEvent.pointerDown(addButton);
+
+    // Assert
+    expect(dragHandler).not.toHaveBeenCalled();
   });
 
   it("should not bind a drag handler to the wellness badge", () => {

--- a/packages/workout-spa-editor/src/components/molecules/WorkoutCard/DayColumn.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WorkoutCard/DayColumn.tsx
@@ -17,7 +17,7 @@ export type DayColumnProps = {
   soloPlans?: CoachingActivity[];
   soloActuals?: WorkoutRecord[];
   onWorkoutClick: (workout: WorkoutRecord) => void;
-  onEmptyDayClick: (date: string) => void;
+  onAddClick: (date: string) => void;
   onActivityClick?: (activity: CoachingActivity) => void;
   workoutCardPointerDownFor?: (
     workoutId: string
@@ -37,13 +37,12 @@ export function DayColumn({
   soloPlans = [],
   soloActuals = [],
   onWorkoutClick,
-  onEmptyDayClick,
+  onAddClick,
   onActivityClick,
   workoutCardPointerDownFor,
   dropTargetActive = false,
   wellness,
 }: DayColumnProps) {
-  const total = matchedSessions.length + soloPlans.length + soloActuals.length;
   const tint = isToday ? TODAY_BODY_TINT : "";
   const dropRing = dropTargetActive ? DROP_RING : "";
   return (
@@ -68,9 +67,7 @@ export function DayColumn({
           workoutCardPointerDownFor,
         })}
       </div>
-      {total === 0 && (
-        <DayColumnAddButton date={date} onEmptyDayClick={onEmptyDayClick} />
-      )}
+      <DayColumnAddButton date={date} onAddClick={onAddClick} />
     </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/molecules/WorkoutCard/DayColumnAddButton.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WorkoutCard/DayColumnAddButton.tsx
@@ -2,12 +2,12 @@ import { getDayLabel } from "./day-label";
 
 export type DayColumnAddButtonProps = {
   date: string;
-  onEmptyDayClick: (date: string) => void;
+  onAddClick: (date: string) => void;
 };
 
 export function DayColumnAddButton({
   date,
-  onEmptyDayClick,
+  onAddClick,
 }: DayColumnAddButtonProps) {
   const label = getDayLabel(date);
   return (
@@ -16,7 +16,7 @@ export function DayColumnAddButton({
       data-testid={`empty-day-${date}`}
       aria-label={`Add to ${label.name} ${label.num}`}
       className="mt-1 flex-1 rounded border border-dashed border-gray-300 text-xs text-muted-foreground transition-colors hover:border-primary-400 hover:text-primary-600 dark:border-gray-600"
-      onClick={() => onEmptyDayClick(date)}
+      onClick={() => onAddClick(date)}
     >
       + Add
     </button>

--- a/packages/workout-spa-editor/src/components/pages/CalendarAddEntryDialogs.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarAddEntryDialogs.tsx
@@ -1,0 +1,34 @@
+/**
+ * CalendarAddEntryDialogs — mounts the per-day add-entry chooser and the
+ * wellness entry dialog, bound to the chooser state on `useCalendarState`.
+ */
+
+import { AddEntryChooser } from "../molecules/AddEntryChooser/AddEntryChooser";
+import { WellnessEntryDialog } from "../molecules/WellnessEntryDialog/WellnessEntryDialog";
+import type { CalendarPageReadyState } from "./use-calendar-page";
+
+export type CalendarAddEntryDialogsProps = {
+  s: CalendarPageReadyState["s"];
+};
+
+export function CalendarAddEntryDialogs({ s }: CalendarAddEntryDialogsProps) {
+  return (
+    <>
+      <AddEntryChooser
+        open={s.addEntryDate !== null}
+        onOpenChange={(open) => !open && s.setAddEntryDate(null)}
+        date={s.addEntryDate ?? ""}
+        onChoose={(choice) =>
+          choice === "workout"
+            ? s.handleChooseWorkout()
+            : s.handleChooseWellness()
+        }
+      />
+      <WellnessEntryDialog
+        open={s.wellnessDate !== null}
+        onOpenChange={(open) => !open && s.setWellnessDate(null)}
+        date={s.wellnessDate ?? ""}
+      />
+    </>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/CalendarBodyView.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarBodyView.tsx
@@ -29,7 +29,7 @@ export function CalendarBodyView({
         soloActualsByDay={buckets.soloActualsByDay}
         todayDate={todayDate}
         onWorkoutClick={s.handleWorkoutClick}
-        onEmptyDayClick={s.handleEmptyDayClick}
+        onAddClick={s.handleAddClick}
         onActivityClick={setSelectedActivity}
         wellnessByDay={wellnessByDay}
       />
@@ -44,7 +44,7 @@ export function CalendarBodyView({
       todayDate={todayDate}
       view={view}
       onWorkoutClick={s.handleWorkoutClick}
-      onEmptyDayClick={s.handleEmptyDayClick}
+      onAddClick={s.handleAddClick}
       onActivityClick={setSelectedActivity}
       wellnessByDay={wellnessByDay}
     />

--- a/packages/workout-spa-editor/src/components/pages/CalendarPage.add-entry.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPage.add-entry.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * CalendarPage add-entry flow: the `+` opens the Workout|Wellness chooser
+ * (it no longer navigates directly), choosing Workout navigates to
+ * `/workout/new?date=<day>`, choosing Wellness opens the wellness entry
+ * surface, and the always-visible `+` neither starts a drag nor breaks
+ * drop-to-reschedule onto a cell that shows it.
+ */
+
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Route, Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+
+import { db } from "../../adapters/dexie/dexie-database";
+import { CoachingRegistryProvider } from "../../contexts/coaching-registry-context";
+import { GarminBridgeProvider } from "../../contexts/garmin-bridge-context";
+import { PersistenceProvider } from "../../contexts/persistence-context";
+import { createInMemoryPersistence } from "../../test-utils/in-memory-persistence";
+import type { WorkoutRecord } from "../../types/calendar-record";
+import { AppToastProvider } from "../providers/AppToastProvider";
+import CalendarPage from "./CalendarPage";
+
+const PROFILE_ID = "00000000-0000-4000-8000-0000000000c2";
+
+function makeWorkout(overrides: Partial<WorkoutRecord> = {}): WorkoutRecord {
+  return {
+    id: crypto.randomUUID(),
+    profileId: PROFILE_ID,
+    date: "2026-04-06",
+    sport: "running",
+    source: "kaiord",
+    sourceId: null,
+    planId: null,
+    state: "raw",
+    raw: {
+      title: "Easy run",
+      description: "30 min easy",
+      comments: [],
+      distance: null,
+      duration: { value: 1800, unit: "s" },
+      prescribedRpe: null,
+      rawHash: "abc123",
+    },
+    krd: null,
+    lastProcessingError: null,
+    feedback: null,
+    aiMeta: null,
+    garminPushId: null,
+    tags: [],
+    previousState: null,
+    createdAt: "2026-04-06T08:00:00.000Z",
+    modifiedAt: null,
+    updatedAt: "2026-04-06T08:00:00.000Z",
+    ...overrides,
+  } as WorkoutRecord;
+}
+
+function renderCalendar(path = "/calendar/2026-W15") {
+  const loc = memoryLocation({ path, record: true });
+  const view = render(
+    <PersistenceProvider persistence={createInMemoryPersistence()}>
+      <GarminBridgeProvider>
+        <CoachingRegistryProvider factories={[]}>
+          <AppToastProvider>
+            <Router hook={loc.hook}>
+              <Route path="/calendar/:weekId?">
+                <CalendarPage />
+              </Route>
+            </Router>
+          </AppToastProvider>
+        </CoachingRegistryProvider>
+      </GarminBridgeProvider>
+    </PersistenceProvider>
+  );
+  return { ...view, history: loc.history };
+}
+
+const setMatchMedia = (matches: boolean): void => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: () => ({
+      matches,
+      media: "(min-width: 768px)",
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  });
+};
+
+const stubElementFromPoint = (day: string | null): void => {
+  Object.defineProperty(document, "elementFromPoint", {
+    configurable: true,
+    value: () => {
+      if (!day) return null;
+      const node = document.createElement("div");
+      node.setAttribute("data-day", day);
+      return node;
+    },
+  });
+};
+
+describe("CalendarPage add-entry flow", () => {
+  beforeEach(async () => {
+    setMatchMedia(false);
+    await db.table("workouts").clear();
+    await db.table("profiles").clear();
+    await db.table("meta").clear();
+    await db.table("profiles").put({
+      id: PROFILE_ID,
+      name: "Tester",
+      sportZones: {},
+      linkedAccounts: [],
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    });
+    await db.table("meta").put({ key: "activeProfileId", value: PROFILE_ID });
+  });
+
+  it("should open the chooser instead of navigating when + is clicked", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const { history } = renderCalendar();
+    const addButton = await screen.findByTestId("empty-day-2026-04-06");
+
+    // Act
+    await user.click(addButton);
+
+    // Assert
+    expect(await screen.findByTestId("add-entry-chooser")).toBeInTheDocument();
+    expect(history.at(-1)).not.toContain("/workout/new");
+  });
+
+  it("should navigate to /workout/new with the day when Workout is chosen", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    const { history } = renderCalendar();
+    await user.click(await screen.findByTestId("empty-day-2026-04-06"));
+
+    // Act
+    await user.click(await screen.findByTestId("add-entry-choose-workout"));
+
+    // Assert
+    expect(history.at(-1)).toBe("/workout/new?date=2026-04-06");
+  });
+
+  it("should open the wellness entry surface when Wellness is chosen", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    renderCalendar();
+    await user.click(await screen.findByTestId("empty-day-2026-04-06"));
+
+    // Act
+    await user.click(await screen.findByTestId("add-entry-choose-wellness"));
+
+    // Assert
+    expect(
+      await screen.findByTestId("wellness-entry-dialog")
+    ).toBeInTheDocument();
+  });
+
+  it("should render the + on a day that already has a workout", async () => {
+    // Arrange
+    await db.table("workouts").add(makeWorkout({ id: "w-mon" }));
+
+    // Act
+    renderCalendar();
+
+    // Assert
+    await screen.findByTestId("workout-card-w-mon");
+    const dayColumn = screen.getByTestId("day-column-2026-04-06");
+    expect(
+      within(dayColumn).getByTestId("empty-day-2026-04-06")
+    ).toBeInTheDocument();
+  });
+
+  it("should still reschedule a workout dropped onto a cell that shows the +", async () => {
+    // Arrange
+    setMatchMedia(true);
+    stubElementFromPoint("2026-04-09");
+    await db.table("workouts").add(makeWorkout({ id: "w-mon" }));
+    renderCalendar();
+    const card = await screen.findByTestId("workout-card-w-mon");
+
+    // Act
+    act(() => {
+      card.dispatchEvent(
+        new PointerEvent("pointerdown", { bubbles: true, pointerType: "mouse" })
+      );
+    });
+    act(() => {
+      const ev = new Event("pointerup") as Event & {
+        clientX: number;
+        clientY: number;
+      };
+      Object.defineProperty(ev, "clientX", { value: 10 });
+      Object.defineProperty(ev, "clientY", { value: 10 });
+      window.dispatchEvent(ev);
+    });
+
+    // Assert
+    await waitFor(async () => {
+      const moved = await db.table("workouts").get("w-mon");
+      expect(moved?.date).toBe("2026-04-09");
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/CalendarPageView.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPageView.tsx
@@ -1,5 +1,6 @@
 import { ROUTE_HEADING_ATTR } from "../../routing/constants";
 import { AutoMatchBanner } from "../organisms/AutoMatchBanner/AutoMatchBanner";
+import { CalendarAddEntryDialogs } from "./CalendarAddEntryDialogs";
 import { CalendarBodyView } from "./CalendarBodyView";
 import { CalendarDialogs } from "./CalendarDialogs";
 import { CalendarHeader } from "./CalendarHeader";
@@ -52,6 +53,7 @@ export function CalendarPageView({
         expandActivity={coaching.expandActivity}
         onOpenExecuted={s.handleWorkoutClick}
       />
+      <CalendarAddEntryDialogs s={s} />
     </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/CalendarWeekGrid.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarWeekGrid.test.tsx
@@ -55,7 +55,7 @@ describe("CalendarWeekGrid", () => {
         workoutsByDay={{}}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -74,7 +74,7 @@ describe("CalendarWeekGrid", () => {
         workoutsByDay={{ "2026-04-07": [makeWorkout("w1", "2026-04-07")] }}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -95,7 +95,7 @@ describe("CalendarWeekGrid", () => {
         }}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -119,7 +119,7 @@ describe("CalendarWeekGrid", () => {
         }}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -127,28 +127,27 @@ describe("CalendarWeekGrid", () => {
     expect(screen.getByTestId("coaching-card-c2")).toBeInTheDocument();
   });
 
-  it("should show empty-day button only when no workouts AND no coaching", () => {
+  it("should render the + Add button on a day that already has activities", () => {
     // Arrange
 
     // Act
     renderWithToast(
       <CalendarWeekGrid
         days={DAYS}
-        workoutsByDay={{}}
+        workoutsByDay={{ "2026-04-07": [makeWorkout("w1", "2026-04-07")] }}
         coachingByDay={{
           "2026-04-06": [makeCoaching("c3", "2026-04-06")],
         }}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
     // Assert
-    expect(
-      screen.queryByTestId("empty-day-2026-04-06")
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("empty-day-2026-04-06")).toBeInTheDocument();
     expect(screen.getByTestId("empty-day-2026-04-07")).toBeInTheDocument();
+    expect(screen.getAllByTestId(/^empty-day-/)).toHaveLength(DAYS_IN_WEEK);
   });
 
   it("should render with empty coaching data (no registry)", () => {
@@ -161,7 +160,7 @@ describe("CalendarWeekGrid", () => {
         workoutsByDay={{}}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -179,7 +178,7 @@ describe("CalendarWeekGrid", () => {
         workoutsByDay={{}}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -204,7 +203,7 @@ describe("CalendarWeekGrid", () => {
         workoutsByDay={{}}
         todayDate="2026-04-09"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -232,7 +231,7 @@ describe("CalendarWeekGrid", () => {
         }}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 

--- a/packages/workout-spa-editor/src/components/pages/CalendarWeekGrid.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarWeekGrid.tsx
@@ -35,7 +35,7 @@ export type CalendarWeekGridProps = {
   todayDate: string;
   view?: CalendarView;
   onWorkoutClick: (workout: WorkoutRecord) => void;
-  onEmptyDayClick: (date: string) => void;
+  onAddClick: (date: string) => void;
   onActivityClick?: (activity: CoachingActivity) => void;
   wellnessByDay?: Record<string, DayWellness>;
 };
@@ -50,7 +50,7 @@ export function CalendarWeekGrid({
   todayDate,
   view,
   onWorkoutClick,
-  onEmptyDayClick,
+  onAddClick,
   onActivityClick,
   wellnessByDay,
 }: CalendarWeekGridProps) {
@@ -85,7 +85,7 @@ export function CalendarWeekGrid({
             soloPlans={plans[date] ?? []}
             soloActuals={actuals[date] ?? []}
             onWorkoutClick={onWorkoutClick}
-            onEmptyDayClick={onEmptyDayClick}
+            onAddClick={onAddClick}
             onActivityClick={onActivityClick}
             workoutCardPointerDownFor={bind}
             dropTargetActive={dropTargetId === date}

--- a/packages/workout-spa-editor/src/components/pages/CalendarWeekList.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarWeekList.test.tsx
@@ -49,7 +49,7 @@ describe("CalendarWeekList", () => {
         days={DAYS}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -73,7 +73,7 @@ describe("CalendarWeekList", () => {
         }}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -94,7 +94,7 @@ describe("CalendarWeekList", () => {
         }}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -115,7 +115,7 @@ describe("CalendarWeekList", () => {
         }}
         todayDate="2026-04-06"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 
@@ -128,6 +128,25 @@ describe("CalendarWeekList", () => {
     ).toBeInTheDocument();
   });
 
+  it("should render the + Add button on every list-view day", () => {
+    // Arrange
+
+    // Act
+    render(
+      <CalendarWeekList
+        days={DAYS}
+        todayDate="2026-04-06"
+        onWorkoutClick={vi.fn()}
+        onAddClick={vi.fn()}
+      />
+    );
+
+    // Assert
+    expect(screen.getAllByTestId(/^calendar-list-add-/)).toHaveLength(
+      DAYS_IN_WEEK
+    );
+  });
+
   it("should mark today's section with data-today and aria-current", () => {
     // Arrange
 
@@ -137,7 +156,7 @@ describe("CalendarWeekList", () => {
         days={DAYS}
         todayDate="2026-04-09"
         onWorkoutClick={vi.fn()}
-        onEmptyDayClick={vi.fn()}
+        onAddClick={vi.fn()}
       />
     );
 

--- a/packages/workout-spa-editor/src/components/pages/CalendarWeekList.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarWeekList.tsx
@@ -23,7 +23,7 @@ export type CalendarWeekListProps = {
   soloActualsByDay?: Record<string, WorkoutRecord[]>;
   todayDate: string;
   onWorkoutClick: (workout: WorkoutRecord) => void;
-  onEmptyDayClick: (date: string) => void;
+  onAddClick: (date: string) => void;
   onActivityClick?: (activity: CoachingActivity) => void;
   wellnessByDay?: Record<string, DayWellness>;
 };
@@ -35,7 +35,7 @@ export function CalendarWeekList({
   soloActualsByDay = {},
   todayDate,
   onWorkoutClick,
-  onEmptyDayClick,
+  onAddClick,
   onActivityClick,
   wellnessByDay,
 }: CalendarWeekListProps) {
@@ -73,7 +73,7 @@ export function CalendarWeekList({
               type="button"
               data-testid={`calendar-list-add-${date}`}
               aria-label={`Add to ${formatHeading(date)}`}
-              onClick={() => onEmptyDayClick(date)}
+              onClick={() => onAddClick(date)}
               className="mt-2 w-full rounded border border-dashed border-gray-300 px-3 py-2 text-xs text-muted-foreground transition-colors hover:border-primary-400 hover:text-primary-600 dark:border-gray-600"
             >
               + Add

--- a/packages/workout-spa-editor/src/components/pages/use-add-entry-chooser.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-add-entry-chooser.ts
@@ -1,0 +1,40 @@
+/**
+ * useAddEntryChooser — owns the two-step add-entry surface state.
+ *
+ * `handleAddClick(date)` opens the chooser for a day. Choosing Workout
+ * navigates to `/workout/new?date=`; choosing Wellness closes the
+ * chooser and opens the wellness entry dialog for the same date.
+ */
+
+import { useCallback, useState } from "react";
+import { useLocation } from "wouter";
+
+export function useAddEntryChooser() {
+  const [, navigate] = useLocation();
+  const [addEntryDate, setAddEntryDate] = useState<string | null>(null);
+  const [wellnessDate, setWellnessDate] = useState<string | null>(null);
+
+  const handleAddClick = useCallback((date: string) => {
+    setAddEntryDate(date);
+  }, []);
+
+  const handleChooseWorkout = useCallback(() => {
+    if (addEntryDate) navigate(`/workout/new?date=${addEntryDate}`);
+    setAddEntryDate(null);
+  }, [addEntryDate, navigate]);
+
+  const handleChooseWellness = useCallback(() => {
+    setWellnessDate(addEntryDate);
+    setAddEntryDate(null);
+  }, [addEntryDate]);
+
+  return {
+    addEntryDate,
+    wellnessDate,
+    setAddEntryDate,
+    setWellnessDate,
+    handleAddClick,
+    handleChooseWorkout,
+    handleChooseWellness,
+  };
+}

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-state.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-state.ts
@@ -10,6 +10,7 @@ import { useActiveProfileLive } from "../../hooks/use-active-profile-live";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import { getWeekIdForDate } from "../../utils/week-utils";
 import { useCalendarData } from "./calendar-hooks";
+import { useAddEntryChooser } from "./use-add-entry-chooser";
 import { useBatchState } from "./use-batch-state";
 import {
   useAiProviderCountLive,
@@ -27,13 +28,7 @@ export function useCalendarState() {
   const batch = useBatchState(data.weekStart, data.weekEnd);
   const latestWorkout = useLatestWorkoutLive(profileId);
   const aiProviderCount = useAiProviderCountLive();
-
-  const handleEmptyDayClick = useCallback(
-    (date: string) => {
-      navigate(`/workout/new?date=${date}`);
-    },
-    [navigate]
-  );
+  const addEntry = useAddEntryChooser();
 
   const handleGoToLatest = useCallback(() => {
     if (latestWorkout?.date) {
@@ -73,7 +68,7 @@ export function useCalendarState() {
     hasReadyWorkouts,
     handleGoToLatest,
     handleWorkoutClick,
-    handleEmptyDayClick,
     setSelectedWorkout,
+    ...addEntry,
   };
 }

--- a/packages/workout-spa-editor/src/hooks/health/manual-save-refreshes-badge.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/health/manual-save-refreshes-badge.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * AC5 integration: a manual wellness save flows end-to-end through the
+ * write use case -> Dexie -> the calendar's reactive read-back hook, so
+ * the saved metric surfaces as a day badge. Ties the application write
+ * path to `useCalendarWellnessWeekLive` (not just the unit pieces).
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { db } from "../../adapters/dexie/dexie-database";
+import { createDexiePersistence } from "../../adapters/dexie/dexie-persistence-adapter";
+import { saveManualHealthMetric } from "../../application/health/save-manual-health-metric.use-case";
+import { useCalendarWellnessWeekLive } from "./use-calendar-wellness-week-live";
+
+const PROFILE_ID = "p-1";
+const WEEK_START = "2026-05-18";
+const WEEK_END = "2026-05-24";
+const DAY = "2026-05-20";
+
+const clear = () =>
+  Promise.all([
+    db.table("healthSleep").clear(),
+    db.table("healthHrv").clear(),
+    db.table("healthWeight").clear(),
+    db.table("healthDaily").clear(),
+  ]);
+
+describe("manual save refreshes the calendar wellness badge", () => {
+  beforeEach(clear);
+  afterEach(clear);
+
+  it("should surface a manually saved weight as that day's badge", async () => {
+    // Arrange
+    const persistence = createDexiePersistence(db);
+
+    // Act
+    await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "weight", day: DAY, value: 71.5 }
+    );
+    const { result } = renderHook(() =>
+      useCalendarWellnessWeekLive(PROFILE_ID, WEEK_START, WEEK_END)
+    );
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current?.[DAY]).toEqual({ weight: "71.5" });
+    });
+  });
+
+  it("should surface a manually saved steps count as that day's badge", async () => {
+    // Arrange
+    const persistence = createDexiePersistence(db);
+
+    // Act
+    await saveManualHealthMetric(
+      { persistence, profileId: PROFILE_ID },
+      { metric: "steps", day: DAY, value: 8000 }
+    );
+    const { result } = renderHook(() =>
+      useCalendarWellnessWeekLive(PROFILE_ID, WEEK_START, WEEK_END)
+    );
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current?.[DAY]).toEqual({ steps: "8000" });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The calendar day-cell `+` previously assumed "add workout" and only appeared on empty training days. It now renders on **every** day (grid **and** list views) and opens a **Workout | Wellness** chooser:

- **Workout** → unchanged `/workout/new?date=<day>` flow.
- **Wellness** → a manual-entry form (weight / sleep score / HRV / steps) **plus** a file-dated FIT import action.

This completes the TrainingPeaks "one calendar, both data kinds" model started by `remove-subtabs-unify-calendar` (#670).

## What changed

- **New write path** (`application/health/save-manual-health-metric.use-case.ts` + `manual-health-payload.mapper.ts` + `manual-health-metric.ts`): upserts **one record per day per metric** by reusing the existing `[profileId+date]` row id (the PK is a random string and the compound is a non-unique index, so a naive `put` would duplicate the day). Builds a **minimal valid KRD v2.0** payload and **`safeParse`s it against the metric schema before persisting** — out-of-range/fractional values are refused.
- **Steps = merge-preserve**: a manual steps save overrides only `steps` and **preserves** any prior imported `activeCalories`/`restingCalories`/`intensityMinutes`/`floorsClimbed` (honors the "no retroactive change to imported data" Non-Goal).
- **Wellness UI** (`components/molecules/WellnessEntryDialog/*`): one **single-submit** form with **one in-flight lock** that persists all filled metrics in a single awaited pass (distinct metrics → distinct tables → no race; a double-click cannot duplicate). React never touches Dexie — it goes through the use case via `usePersistence()`. Static toasts (no PII interpolation). On a failed save the dialog stays open and the typed values are kept.
- **Chooser + ungate** (`AddEntryChooser`, `use-add-entry-chooser.ts`, `DayColumn` ungated, prop `onEmptyDayClick`→`onAddClick` threaded end-to-end): drag-to-reschedule is unaffected (the `+` is `onClick`-only; `closest("[data-day]")` hit-test intact).
- **Wellness import is dated by the file** (the FIT health-import path ignores `?date=` and routes to the Hub) — a deliberate, documented asymmetry vs the workout-import branch.

## Process

deep-dive (trace + interview) → **consensus** (Planner / Architect / Critic, APPROVE at iteration 3) → autopilot (5 phases) → multi-agent Phase-4 validation → fixes. Spec: `openspec/changes/calendar-add-workout-or-wellness/` (`spa-routing` delta: full MODIFIED requirement + 2 ADDED requirements). Changeset: `minor` (private SPA package).

## Verification

- ✅ `pnpm --filter @kaiord/workout-spa-editor test` — **4079 tests pass**, coverage **90.4% stmts / 82.6% branch** (≥70% gate)
- ✅ `pnpm --filter @kaiord/workout-spa-editor build` — clean
- ✅ `pnpm lint` — 0 errors (tsc + eslint + prettier + `test:scripts` 485/485 incl. R-PIIInterpolation)
- ✅ `openspec validate calendar-add-workout-or-wellness` + `pnpm lint:specs` — valid, no orphaned scenarios

## Follow-ups (deferred, tracked in tasks.md)

- **Visual baselines**: the always-visible `+` shifts calendar Playwright screenshots — regenerate via the `update-visual-baselines.yml` workflow (Linux/chromium) after this PR is up (not regenerated locally on macOS).
- OpenSpec archive after merge (`/opsx:archive` + `pnpm archive:index`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Add entry chooser**: Clicking the "+" button on any calendar day now opens a dialog offering to add either a Workout or a Wellness entry.
* **Manual wellness logging**: Users can now enter wellness metrics (weight, sleep score, HRV, steps) for any day, with data persisting to the calendar.
* **Health file import**: Added ability to import FIT health files through the wellness entry flow.
* **Always-visible add button**: The "+" button now appears on every day, including days with existing workouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->