### PR TITLE
feat(spa-editor): provenance fields + IntegrationPolicy/ExportLedger schemas

### DIFF
--- a/.changeset/integration-policy-domain-schemas.md
+++ b/.changeset/integration-policy-domain-schemas.md
@@ -1,0 +1,10 @@
+---
+"@kaiord/core": minor
+"@kaiord/workout-spa-editor": minor
+---
+
+feat(core,spa): domain provenance fields + IntegrationPolicy/ExportLedger schemas
+
+Adds kaiordRecordId, sourceBridgeId, externalId as optional fields to the six health Zod schemas (sleep, weight, hrv, daily, body-composition, stress); introduces deriveExternalId mapper in @kaiord/core/ingest; adds IntegrationPolicy + ExportLedgerEntry Zod schemas in @kaiord/workout-spa-editor; removes syncZones from linkedCoachingAccountSchema (Zod only — Dexie column retained as rollback buffer until v18).
+
+PR 2 of 7 implementing integration-policy-per-profile-routing.

--- a/packages/core/src/domain/schemas/health/body-composition.ts
+++ b/packages/core/src/domain/schemas/health/body-composition.ts
@@ -19,6 +19,9 @@ export const bodyCompositionSchema = z
     boneMassKilograms: z.number().positive().optional(),
     bodyWaterPercent: z.number().min(0).max(100).optional(),
     bmi: z.number().positive().optional(),
+    kaiordRecordId: z.string().uuid().optional(),
+    sourceBridgeId: z.string().optional(),
+    externalId: z.string().optional(),
   })
   .superRefine((value, ctx) => {
     const hasAny =

--- a/packages/core/src/domain/schemas/health/daily.ts
+++ b/packages/core/src/domain/schemas/health/daily.ts
@@ -21,6 +21,9 @@ export const dailyWellnessSchema = z.object({
     vigorous: z.number().int().nonnegative(),
   }),
   floorsClimbed: z.number().int().nonnegative().optional(),
+  kaiordRecordId: z.string().uuid().optional(),
+  sourceBridgeId: z.string().optional(),
+  externalId: z.string().optional(),
 });
 
 export type DailyWellness = z.infer<typeof dailyWellnessSchema>;

--- a/packages/core/src/domain/schemas/health/hrv.ts
+++ b/packages/core/src/domain/schemas/health/hrv.ts
@@ -12,6 +12,9 @@ export const hrvSummarySchema = z.object({
   rMSSD: z.number().positive(),
   measurementWindow: z.enum(["overnight", "spot"]),
   score: z.number().int().min(0).max(100).optional(),
+  kaiordRecordId: z.string().uuid().optional(),
+  sourceBridgeId: z.string().optional(),
+  externalId: z.string().optional(),
 });
 
 export type HrvSummary = z.infer<typeof hrvSummarySchema>;

--- a/packages/core/src/domain/schemas/health/sleep.ts
+++ b/packages/core/src/domain/schemas/health/sleep.ts
@@ -36,6 +36,9 @@ export const sleepRecordSchema = z
     stages: z.array(sleepStageSchema),
     score: z.number().int().min(0).max(100).optional(),
     restingHeartRate: z.number().int().positive().optional(),
+    kaiordRecordId: z.string().uuid().optional(),
+    sourceBridgeId: z.string().optional(),
+    externalId: z.string().optional(),
   })
   .superRefine((value, ctx) => {
     const stagesSum = value.stages.reduce(

--- a/packages/core/src/domain/schemas/health/stress.ts
+++ b/packages/core/src/domain/schemas/health/stress.ts
@@ -13,6 +13,9 @@ export const stressEpisodeSchema = z
     endTime: z.iso.datetime(),
     averageLevel: z.number().int().min(0).max(100),
     peakLevel: z.number().int().min(0).max(100),
+    kaiordRecordId: z.string().uuid().optional(),
+    sourceBridgeId: z.string().optional(),
+    externalId: z.string().optional(),
   })
   .superRefine((value, ctx) => {
     if (

--- a/packages/core/src/domain/schemas/health/weight.ts
+++ b/packages/core/src/domain/schemas/health/weight.ts
@@ -12,6 +12,9 @@ export const weightMeasurementSchema = z.object({
   version: z.string().regex(/^2\.\d+$/),
   measuredAt: z.iso.datetime(),
   weightKilograms: z.number().positive(),
+  kaiordRecordId: z.string().uuid().optional(),
+  sourceBridgeId: z.string().optional(),
+  externalId: z.string().optional(),
 });
 
 export type WeightMeasurement = z.infer<typeof weightMeasurementSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -180,3 +180,6 @@ export {
   MANAGED_DATA_REGISTRY,
   managedDataTypes,
 } from "./domain";
+
+// Ingest utilities
+export { deriveExternalId } from "./ingest/derive-external-id";

--- a/packages/core/src/ingest/derive-external-id.test.ts
+++ b/packages/core/src/ingest/derive-external-id.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveExternalId } from "./derive-external-id";
+
+describe("deriveExternalId", () => {
+  it("should produce a stable hash for the same payload + measuredAt", () => {
+    // Arrange
+    const input = {
+      payload: { weightKilograms: 75.5, kind: "weight" },
+      measuredAt: "2026-01-01T08:00:00.000Z",
+    };
+
+    // Act
+    const first = deriveExternalId(input);
+    const second = deriveExternalId(input);
+
+    // Assert
+    expect(first).toBe(second);
+  });
+
+  it("should produce a different hash when measuredAt changes", () => {
+    // Arrange
+    const payload = { weightKilograms: 75.5, kind: "weight" };
+
+    // Act
+    const a = deriveExternalId({
+      payload,
+      measuredAt: "2026-01-01T08:00:00.000Z",
+    });
+    const b = deriveExternalId({
+      payload,
+      measuredAt: "2026-01-02T08:00:00.000Z",
+    });
+
+    // Assert
+    expect(a).not.toBe(b);
+  });
+
+  it("should produce a different hash when payload changes", () => {
+    // Arrange
+    const measuredAt = "2026-01-01T08:00:00.000Z";
+
+    // Act
+    const a = deriveExternalId({
+      payload: { weightKilograms: 75.5 },
+      measuredAt,
+    });
+    const b = deriveExternalId({
+      payload: { weightKilograms: 80.0 },
+      measuredAt,
+    });
+
+    // Assert
+    expect(a).not.toBe(b);
+  });
+
+  it("should produce the same hash regardless of payload key order", () => {
+    // Arrange
+    const measuredAt = "2026-01-01T08:00:00.000Z";
+
+    // Act
+    const a = deriveExternalId({ payload: { a: 1, b: 2 }, measuredAt });
+    const b = deriveExternalId({ payload: { b: 2, a: 1 }, measuredAt });
+
+    // Assert
+    expect(a).toBe(b);
+  });
+
+  it("should prefix output with the k1: version tag", () => {
+    // Arrange
+    const input = {
+      payload: { rMSSD: 42, kind: "hrv" },
+      measuredAt: "2026-05-01T06:00:00.000Z",
+    };
+
+    // Act
+    const result = deriveExternalId(input);
+
+    // Assert
+    expect(result.startsWith("k1:")).toBe(true);
+  });
+});

--- a/packages/core/src/ingest/derive-external-id.ts
+++ b/packages/core/src/ingest/derive-external-id.ts
@@ -1,0 +1,16 @@
+import { canonicalHash } from "../hash/canonical-hash";
+
+/**
+ * Derives a stable external id for a health record from its payload +
+ * measuredAt timestamp.
+ *
+ * The `k1:` prefix is a version tag: if the hash projection ever changes,
+ * the prefix can be bumped to `k2:` so downstream migration code can
+ * distinguish old ids from new ones without inspecting content.
+ */
+export const deriveExternalId = (input: {
+  payload: Record<string, unknown>;
+  measuredAt: string;
+}): string =>
+  "k1:" +
+  canonicalHash({ payload: input.payload, measuredAt: input.measuredAt });

--- a/packages/workout-spa-editor/src/adapters/train2go/should-fan-out-zones.ts
+++ b/packages/workout-spa-editor/src/adapters/train2go/should-fan-out-zones.ts
@@ -3,6 +3,8 @@
  * the linked account for `source` has the `Sync zones` toggle on.
  * Defensively returns `false` when the profile/link no longer exists,
  * so a connect/sync race can never trigger a phantom zones-sync.
+ *
+ * TODO(PR 6): replace with IntegrationPolicy(direction='import',dataType='training-zones')
  */
 import type { PersistencePort } from "../../ports/persistence-port";
 
@@ -13,5 +15,8 @@ export const shouldFanOutZones = async (
 ): Promise<boolean> => {
   const profile = await p.profiles.getById(profileId);
   const link = profile?.linkedAccounts.find((a) => a.source === source);
-  return link?.syncZones === true;
+  const syncZones: boolean | undefined = (
+    link as Record<string, unknown> | undefined
+  )?.["syncZones"] as boolean | undefined;
+  return syncZones ?? false;
 };

--- a/packages/workout-spa-editor/src/adapters/train2go/should-fan-out-zones.ts
+++ b/packages/workout-spa-editor/src/adapters/train2go/should-fan-out-zones.ts
@@ -15,8 +15,5 @@ export const shouldFanOutZones = async (
 ): Promise<boolean> => {
   const profile = await p.profiles.getById(profileId);
   const link = profile?.linkedAccounts.find((a) => a.source === source);
-  const syncZones: boolean | undefined = (
-    link as Record<string, unknown> | undefined
-  )?.["syncZones"] as boolean | undefined;
-  return syncZones ?? false;
+  return (link as Record<string, unknown> | undefined)?.["syncZones"] === true;
 };

--- a/packages/workout-spa-editor/src/adapters/train2go/use-train2go-actions-fanout.test.tsx
+++ b/packages/workout-spa-editor/src/adapters/train2go/use-train2go-actions-fanout.test.tsx
@@ -48,18 +48,20 @@ const analytics: Analytics = {
   reset: vi.fn(),
 } as unknown as Analytics;
 
-const T2G_LINK_WITH_FLAG: LinkedCoachingAccount = {
+// syncZones retained in Dexie as nullable rollback buffer (v17 → v18 F-4).
+// TODO(PR 6): replace with IntegrationPolicy(direction='import',dataType='training-zones')
+const T2G_LINK_WITH_FLAG = {
   source: "train2go",
   externalUserId: "99999",
   externalUserName: "Pablo",
   linkedAt: "2026-04-28T10:00:00.000Z",
   syncZones: true,
-};
+} as unknown as LinkedCoachingAccount;
 
-const T2G_LINK_WITHOUT_FLAG: LinkedCoachingAccount = {
+const T2G_LINK_WITHOUT_FLAG = {
   ...T2G_LINK_WITH_FLAG,
   syncZones: false,
-};
+} as unknown as LinkedCoachingAccount;
 
 const makeProfile = (link: LinkedCoachingAccount): Profile => ({
   id: "p1",

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones-bands.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones-bands.test.ts
@@ -38,6 +38,7 @@ import {
   Z5_LOWER_269,
 } from "../../test-utils/application-fixtures";
 import { createInMemoryProfileRepository } from "../../test-utils/in-memory-profile-repository";
+import type { LinkedCoachingAccount } from "../../types/coaching-account";
 import type {
   ConflictDecision,
   FieldKey,
@@ -57,13 +58,15 @@ const makeProfile = (overrides: Partial<Profile> = {}): Profile => ({
   name: "Pablo",
   sportZones: {},
   linkedAccounts: [
+    // syncZones retained in Dexie as nullable rollback buffer (v17 → v18 F-4).
+    // TODO(PR 6): replace with IntegrationPolicy(direction='import',dataType='training-zones')
     {
       source: "train2go",
       externalUserId: "99999",
       externalUserName: "Pablo",
       linkedAt: NOW,
       syncZones: true,
-    },
+    } as unknown as LinkedCoachingAccount,
   ],
   createdAt: NOW,
   updatedAt: NOW,
@@ -201,7 +204,8 @@ describe("syncZones full-bands — cycling power watts→%FTP", () => {
     // Act
     await syncZones(PROFILE_ID, transport, repo);
 
-    // Assert — Z4: 240W..268W with FTP=268 → 90%..100% (exact integer)
+    // Assert
+    // Z4: 240W..268W with FTP=268 → 90%..100% (exact integer).
     const persisted = await repo.getById(PROFILE_ID);
     const z4 = persisted?.sportZones.cycling?.powerZones?.zones[3];
     expect(z4?.minPercent).toBe(Z4_MIN_PERCENT_90);
@@ -242,7 +246,8 @@ describe("syncZones full-bands — running pace inversion", () => {
     // Act
     await syncZones(PROFILE_ID, transport, repo);
 
-    // Assert — Z4 lower 4:44 (slower) → maxPace 284s; upper 4:10 (faster) → minPace 250s
+    // Assert
+    // Z4 lower 4:44 (slower) → maxPace 284s; upper 4:10 (faster) → minPace 250s.
     const persisted = await repo.getById(PROFILE_ID);
     const z4 = persisted?.sportZones.running?.paceZones?.zones[3];
     expect(z4?.minPace).toBe(PACE_Z4_MIN_SEC_250);
@@ -261,7 +266,8 @@ describe("syncZones full-bands — re-sync stability (round-trip)", () => {
     // First sync — silent-fills the empty profile.
     await syncZones(PROFILE_ID, transport, repo);
 
-    // Act — second sync against identical data.
+    // Act
+    // Second sync against identical data.
     const result = await syncZones(PROFILE_ID, transport, repo);
 
     // Assert
@@ -329,7 +335,8 @@ describe("commitConflictResolution full-bands — band-level merge", () => {
       })
     );
 
-    // Act — accept Z4 maxBpm (170 → 174), reject Z2 maxBpm (145 → 147)
+    // Act
+    // Accept Z4 maxBpm (170 → 174), reject Z2 maxBpm (145 → 147).
     const decisions = {
       "cycling.heartRateZones.z4.maxBpm": "accept",
       "cycling.heartRateZones.z2.maxBpm": "reject",
@@ -359,7 +366,8 @@ describe("mapPayloadToIncoming — direct unit tests for the band paths", () => 
     // Act
     const map = mapPayloadToIncoming(payload);
 
-    // Assert — bpmRest must not flow into the IncomingMap.
+    // Assert
+    // bpmRest must not flow into the IncomingMap.
     for (const key of map.keys()) {
       expect(key.toLowerCase()).not.toContain("rest");
     }

--- a/packages/workout-spa-editor/src/application/coaching/sync-zones.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/sync-zones.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { createInMemoryProfileRepository } from "../../test-utils/in-memory-profile-repository";
+import type { LinkedCoachingAccount } from "../../types/coaching-account";
 import type {
   ConflictDecision,
   FieldKey,
@@ -37,13 +38,15 @@ const makeProfile = (overrides: Partial<Profile> = {}): Profile => ({
   name: IDS.externalUserName,
   sportZones: {},
   linkedAccounts: [
+    // syncZones retained in Dexie as nullable rollback buffer (v17 → v18 F-4).
+    // TODO(PR 6): replace with IntegrationPolicy(direction='import',dataType='training-zones')
     {
       source: IDS.source,
       externalUserId: IDS.externalUserId,
       externalUserName: IDS.externalUserName,
       linkedAt: NOW,
       syncZones: true,
-    },
+    } as unknown as LinkedCoachingAccount,
   ],
   createdAt: NOW,
   updatedAt: NOW,

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/LinkedAccountRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/LinkedAccountRow.tsx
@@ -61,11 +61,7 @@ export function LinkedAccountRow({
       {linked && supportsZones ? (
         <SyncZonesToggle
           sourceId={sourceMeta.id}
-          checked={
-            ((linked as Record<string, unknown>)["syncZones"] as
-              | boolean
-              | undefined) ?? false
-          }
+          checked={(linked as Record<string, unknown>)["syncZones"] === true}
           onChange={handleToggleSyncZones}
         />
       ) : null}

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/LinkedAccountRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/LinkedAccountRow.tsx
@@ -57,10 +57,15 @@ export function LinkedAccountRow({
           </button>
         )}
       </div>
+      {/* TODO(PR 6): replace with IntegrationPolicy(direction='import',dataType='training-zones') */}
       {linked && supportsZones ? (
         <SyncZonesToggle
           sourceId={sourceMeta.id}
-          checked={linked.syncZones === true}
+          checked={
+            ((linked as Record<string, unknown>)["syncZones"] as
+              | boolean
+              | undefined) ?? false
+          }
           onChange={handleToggleSyncZones}
         />
       ) : null}

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/LinkedAccountsSection.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/LinkedAccountsSection.test.tsx
@@ -185,9 +185,11 @@ describe("LinkedAccountsSection", () => {
     const after = await persistence.profiles.getById("p1");
 
     // Assert
-
+    // syncZones retained in Dexie as nullable rollback buffer (v17 → v18 F-4).
+    // TODO(PR 6): replace with IntegrationPolicy(direction='import',dataType='training-zones')
+    const account = after?.linkedAccounts.find((a) => a.source === "train2go");
     expect(
-      after?.linkedAccounts.find((a) => a.source === "train2go")?.syncZones
+      (account as Record<string, unknown> | undefined)?.["syncZones"]
     ).toBe(true);
   });
 });

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/use-linked-account-row.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/use-linked-account-row.ts
@@ -10,6 +10,7 @@ import { unlinkAccount } from "../../../../application/coaching/unlink-account";
 import { useAnalytics } from "../../../../contexts";
 import { usePersistence } from "../../../../contexts/persistence-context";
 import { useToastContext } from "../../../../contexts/ToastContext";
+import type { ProfileRepository } from "../../../../ports/persistence-port";
 import type { Profile } from "../../../../types/profile";
 
 export type SourceMeta = {
@@ -19,6 +20,25 @@ export type SourceMeta = {
 
 const ACCOUNT_LINKED_TOAST = "Coaching account linked";
 const ACCOUNT_DISCONNECTED_TOAST = "Coaching account disconnected";
+
+// TODO(PR 6): replace with IntegrationPolicy(direction='import',dataType='training-zones')
+const writeSyncZones = async (
+  repo: ProfileRepository,
+  profileId: string,
+  sourceId: string,
+  next: boolean
+): Promise<void> => {
+  const refreshed = await repo.getById(profileId);
+  if (!refreshed) return;
+  const linkedAccounts = refreshed.linkedAccounts.map((a) =>
+    a.source === sourceId ? ({ ...a, syncZones: next } as typeof a) : a
+  );
+  await repo.put({
+    ...refreshed,
+    linkedAccounts,
+    updatedAt: new Date().toISOString(),
+  });
+};
 
 export const useLinkedAccountRow = (
   profile: Profile,
@@ -38,16 +58,11 @@ export const useLinkedAccountRow = (
     setBusy(true);
     try {
       await t2gSource.connect(profile.id);
-      // connect() returns void on abort / session-not-active / errors;
-      // verify the link was actually persisted before claiming success.
       const refreshed = await persistence.profiles.getById(profile.id);
       const linked = refreshed?.linkedAccounts.some(
         (a) => a.source === sourceMeta.id
       );
       if (!linked) return;
-      // Static toast string keeps user-typed and external-account fields
-      // out of the user-facing message; the source/profile context is
-      // already implicit from the row the user clicked.
       toasts.success(ACCOUNT_LINKED_TOAST);
     } finally {
       setBusy(false);
@@ -67,25 +82,10 @@ export const useLinkedAccountRow = (
   }, [persistence, profile, sourceMeta, toasts, analytics]);
 
   const handleToggleSyncZones = useCallback(
-    async (next: boolean) => {
-      const refreshed = await persistence.profiles.getById(profile.id);
-      if (!refreshed) return;
-      const updatedAccounts = refreshed.linkedAccounts.map((a) =>
-        a.source === sourceMeta.id ? { ...a, syncZones: next } : a
-      );
-      await persistence.profiles.put({
-        ...refreshed,
-        linkedAccounts: updatedAccounts,
-        updatedAt: new Date().toISOString(),
-      });
-    },
+    async (next: boolean) =>
+      writeSyncZones(persistence.profiles, profile.id, sourceMeta.id, next),
     [persistence, profile, sourceMeta]
   );
 
-  return {
-    busy,
-    handleConnect,
-    handleDisconnect,
-    handleToggleSyncZones,
-  };
+  return { busy, handleConnect, handleDisconnect, handleToggleSyncZones };
 };

--- a/packages/workout-spa-editor/src/types/coaching-account.ts
+++ b/packages/workout-spa-editor/src/types/coaching-account.ts
@@ -52,12 +52,12 @@ export type LastSyncedZonesSnapshot = z.infer<
   typeof lastSyncedZonesSnapshotSchema
 >;
 
+// 'syncZones' removed in v17 — superseded by IntegrationPolicy(dataType='training-zones', direction='import'). Dexie column retained nullable as rollback buffer; full drop in v18 (F-4).
 export const linkedCoachingAccountSchema = z.object({
   source: z.string().min(1),
   externalUserId: z.string().min(1),
   externalUserName: z.string().min(1),
   linkedAt: z.iso.datetime(),
-  syncZones: z.boolean().optional(),
   lastSyncedZonesSnapshot: lastSyncedZonesSnapshotSchema.optional(),
 });
 

--- a/packages/workout-spa-editor/src/types/export-ledger.test.ts
+++ b/packages/workout-spa-editor/src/types/export-ledger.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { exportLedgerEntrySchema } from "./export-ledger";
+
+const VALID_ENTRY = {
+  id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  kaiordRecordId: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  dataType: "weight",
+  destinationBridgeId: "garmin-bridge",
+  destinationExternalId: "gc-12345",
+  contentHash: "abc123def456",
+  exportedAt: "2026-05-01T08:00:00.000Z",
+} as const;
+
+describe("exportLedgerEntrySchema", () => {
+  it("should accept a valid export ledger entry", () => {
+    // Arrange
+
+    // Act
+    const result = exportLedgerEntrySchema.safeParse(VALID_ENTRY);
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept the pending sentinel value for destinationExternalId", () => {
+    // Arrange
+    const input = { ...VALID_ENTRY, destinationExternalId: "pending" };
+
+    // Act
+    const result = exportLedgerEntrySchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject an invalid uuid for id field", () => {
+    // Arrange
+    const input = { ...VALID_ENTRY, id: "not-a-uuid" };
+
+    // Act
+    const result = exportLedgerEntrySchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject an invalid uuid for kaiordRecordId field", () => {
+    // Arrange
+    const input = { ...VALID_ENTRY, kaiordRecordId: "bad-id" };
+
+    // Act
+    const result = exportLedgerEntrySchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/workout-spa-editor/src/types/export-ledger.ts
+++ b/packages/workout-spa-editor/src/types/export-ledger.ts
@@ -1,0 +1,13 @@
+import { managedDataTypes } from "@kaiord/core";
+import { z } from "zod";
+
+export const exportLedgerEntrySchema = z.object({
+  id: z.string().uuid(),
+  kaiordRecordId: z.string().uuid(),
+  dataType: z.enum(managedDataTypes),
+  destinationBridgeId: z.string().min(1),
+  destinationExternalId: z.string(),
+  contentHash: z.string(),
+  exportedAt: z.iso.datetime(),
+});
+export type ExportLedgerEntry = z.infer<typeof exportLedgerEntrySchema>;

--- a/packages/workout-spa-editor/src/types/export-ledger.ts
+++ b/packages/workout-spa-editor/src/types/export-ledger.ts
@@ -6,8 +6,8 @@ export const exportLedgerEntrySchema = z.object({
   kaiordRecordId: z.string().uuid(),
   dataType: z.enum(managedDataTypes),
   destinationBridgeId: z.string().min(1),
-  destinationExternalId: z.string(),
-  contentHash: z.string(),
+  destinationExternalId: z.string().min(1),
+  contentHash: z.string().min(1),
   exportedAt: z.iso.datetime(),
 });
 export type ExportLedgerEntry = z.infer<typeof exportLedgerEntrySchema>;

--- a/packages/workout-spa-editor/src/types/integration-policy.test.ts
+++ b/packages/workout-spa-editor/src/types/integration-policy.test.ts
@@ -1,0 +1,128 @@
+import { managedDataTypes } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  integrationPolicyDirectionSchema,
+  integrationPolicyModeSchema,
+  integrationPolicySchema,
+} from "./integration-policy";
+
+const VALID_POLICY = {
+  id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  profileId: "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+  dataType: "weight",
+  bridgeId: "garmin-bridge",
+  direction: "import",
+  mode: "auto",
+  enabled: true,
+  updatedAt: "2026-05-01T08:00:00.000Z",
+} as const;
+
+describe("integrationPolicySchema", () => {
+  it("should accept a valid integration policy object", () => {
+    // Arrange
+
+    // Act
+    const result = integrationPolicySchema.safeParse(VALID_POLICY);
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject an invalid uuid for id field", () => {
+    // Arrange
+    const input = { ...VALID_POLICY, id: "not-a-uuid" };
+
+    // Act
+    const result = integrationPolicySchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject an invalid uuid for profileId field", () => {
+    // Arrange
+    const input = { ...VALID_POLICY, profileId: "bad-id" };
+
+    // Act
+    const result = integrationPolicySchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+
+  it("should accept each of the 9 managed data types", () => {
+    // Arrange
+
+    // Act
+    const results = managedDataTypes.map((dt) =>
+      integrationPolicySchema.safeParse({ ...VALID_POLICY, dataType: dt })
+    );
+
+    // Assert
+    for (const result of results) {
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("should reject an unknown dataType value", () => {
+    // Arrange
+    const input = { ...VALID_POLICY, dataType: "unknown-type" };
+
+    // Act
+    const result = integrationPolicySchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("integrationPolicyModeSchema", () => {
+  it("should accept manual and auto modes", () => {
+    // Arrange
+
+    // Act
+    const manual = integrationPolicyModeSchema.safeParse("manual");
+    const auto = integrationPolicyModeSchema.safeParse("auto");
+
+    // Assert
+    expect(manual.success).toBe(true);
+    expect(auto.success).toBe(true);
+  });
+
+  it("should reject an invalid mode value", () => {
+    // Arrange
+    const input = "scheduled";
+
+    // Act
+    const result = integrationPolicyModeSchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("integrationPolicyDirectionSchema", () => {
+  it("should accept import and export directions", () => {
+    // Arrange
+
+    // Act
+    const imp = integrationPolicyDirectionSchema.safeParse("import");
+    const exp = integrationPolicyDirectionSchema.safeParse("export");
+
+    // Assert
+    expect(imp.success).toBe(true);
+    expect(exp.success).toBe(true);
+  });
+
+  it("should reject an invalid direction value", () => {
+    // Arrange
+    const input = "sync";
+
+    // Act
+    const result = integrationPolicyDirectionSchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/workout-spa-editor/src/types/integration-policy.ts
+++ b/packages/workout-spa-editor/src/types/integration-policy.ts
@@ -1,0 +1,22 @@
+import { managedDataTypes } from "@kaiord/core";
+import { z } from "zod";
+
+export const integrationPolicyModeSchema = z.enum(["manual", "auto"]);
+export type IntegrationPolicyMode = z.infer<typeof integrationPolicyModeSchema>;
+
+export const integrationPolicyDirectionSchema = z.enum(["import", "export"]);
+export type IntegrationPolicyDirection = z.infer<
+  typeof integrationPolicyDirectionSchema
+>;
+
+export const integrationPolicySchema = z.object({
+  id: z.string().uuid(),
+  profileId: z.string().uuid(),
+  dataType: z.enum(managedDataTypes),
+  bridgeId: z.string().min(1),
+  direction: integrationPolicyDirectionSchema,
+  mode: integrationPolicyModeSchema,
+  enabled: z.boolean(),
+  updatedAt: z.iso.datetime(),
+});
+export type IntegrationPolicy = z.infer<typeof integrationPolicySchema>;


### PR DESCRIPTION
## Summary

PR 2 of 7 implementing **integration-policy-per-profile-routing**. Stacked on PR #690.

Adds the data-model layer: provenance fields on the six health Zod schemas, `deriveExternalId` ingest mapper, new `IntegrationPolicy` and `ExportLedgerEntry` SPA schemas, and drops `syncZones` from the Zod schema (Dexie column retained for v17 as rollback buffer).

## What's inside

- **Health schemas** (`@kaiord/core/domain/schemas/health/*.ts`) — six schemas (sleep, weight, hrv, daily, body-composition, stress) gain optional `kaiordRecordId`, `sourceBridgeId`, `externalId` (plain `z.string().optional()`; **no `.transform`-based sha256**).
- **`@kaiord/core/ingest/derive-external-id.ts`** — `deriveExternalId({ payload, measuredAt })` → `'k1:' + sha256(canonicalJson)`. Lives outside `domain/` so it can import `node:crypto` via the canonical-hash util from PR 1 (R-ArchDomainExt).
- **`@kaiord/workout-spa-editor/src/types/integration-policy.ts`** — Zod schema + types for `IntegrationPolicy`, `IntegrationPolicyMode`, `IntegrationPolicyDirection`.
- **`@kaiord/workout-spa-editor/src/types/export-ledger.ts`** — Zod schema + types for `ExportLedgerEntry` (with `'pending'`-tolerant `destinationExternalId`).
- **`syncZones` removed** from `linkedCoachingAccountSchema` (Zod only). Dexie column kept nullable; full drop in v18 follow-up (F-4). Seven SPA consumers use `as unknown as` transitions — removed in PR 5 (resolver re-wiring) and PR 6 (Data Flows UI).

## Acceptance criteria (PR 2 slice)

- [x] AC-3 contribution (data-model side): provenance fields are part of the v17 Dexie migration's source-of-truth schemas
- [x] AC-7 prereq: natural-key fields exist on every health schema (Dexie index added in PR 3)
- [x] AC-8 prereq: `IntegrationPolicy` + `ExportLedger` schemas exist; resolver consumes them in PR 4

## Test plan

- [x] `pnpm -r build` — green
- [x] `pnpm lint` — green
- [x] `pnpm -r test` — core 326 ↑ (+5), spa 4095 ↑ (+13), mcp 141, cli 241, docs 26 — all passing
- [x] `pnpm test:scripts` — 485 passed
- [ ] CI to confirm on a fresh checkout

## Stacking note

Base: `feat/integration-policy-core-registry` (PR #690). When that merges, this PR's base auto-updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional provenance fields to health records for improved integration tracking
  * Introduced an integration policy model to control import/export rules and directions
  * Added an export ledger to record data export activity
  * New stable external-ID derivation utility for consistent record matching

* **Chores**
  * Removed legacy syncZones field from the schema while preserving stored values as a nullable rollback buffer

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/691?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->