### PR TITLE
feat(spa-editor): integration-policy use cases + idempotent export ledger

### DIFF
--- a/.changeset/integration-policy-use-cases.md
+++ b/.changeset/integration-policy-use-cases.md
@@ -1,0 +1,15 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+feat(spa-editor): integration-policy use cases + idempotent export ledger
+
+Adds resolveImportPolicies / resolveExportPolicies / upsertIntegrationPolicy /
+deleteIntegrationPolicy use cases. Adds upsertImportedRecord (natural-key
+upsert against [profileId+sourceBridgeId+externalId]) and recordExport with
+the insert-pending → POST → UPDATE protocol that closes the concurrent-
+trigger race (unique constraint on [kaiordRecordId+destinationBridgeId]
+gates the duplicate POST before the network call). Includes the AC-9
+weight-export-aggregation integration test.
+
+PR 4 of 7. Use cases are present but not yet wired into UI (PR 5/PR 6).

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-export-ledger-repository.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-export-ledger-repository.ts
@@ -1,0 +1,47 @@
+/**
+ * Dexie implementation of ExportLedgerRepository.
+ *
+ * insertPending catches Dexie ConstraintError on the unique
+ * [kaiordRecordId+destinationBridgeId] index and maps it to
+ * { ok: false; reason: 'constraint' } so use cases never depend
+ * on Dexie error types (R-AppDexieImport rule).
+ */
+import type {
+  ExportLedgerRepository,
+  InsertPendingResult,
+} from "../../application/export/export-ledger-repository.port";
+import type { ExportLedgerEntry } from "../../types/export-ledger";
+import type { KaiordDatabase } from "./dexie-database";
+
+export const createDexieExportLedgerRepository = (
+  db: KaiordDatabase
+): ExportLedgerRepository => ({
+  findByNaturalKey: async ({ kaiordRecordId, destinationBridgeId }) =>
+    (await db
+      .table("exportLedger")
+      .where("[kaiordRecordId+destinationBridgeId]")
+      .equals([kaiordRecordId, destinationBridgeId])
+      .first()) as ExportLedgerEntry | undefined,
+
+  insertPending: async (
+    entry: ExportLedgerEntry
+  ): Promise<InsertPendingResult> => {
+    try {
+      await db.table("exportLedger").add(entry);
+      return { ok: true };
+    } catch (e) {
+      if ((e as { name?: string }).name === "ConstraintError") {
+        return { ok: false, reason: "constraint" };
+      }
+      throw e;
+    }
+  },
+
+  update: async (id: string, patch: Partial<ExportLedgerEntry>) => {
+    await db.table("exportLedger").update(id, patch);
+  },
+
+  deleteById: async (id: string) => {
+    await db.table("exportLedger").delete(id);
+  },
+});

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-imported-record-repository.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-imported-record-repository.ts
@@ -1,0 +1,72 @@
+/**
+ * Dexie implementation of ImportedRecordRepository.
+ *
+ * Uses the v17 health stores with the unique compound index
+ * [profileId+sourceBridgeId+externalId] for natural-key dedup.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { ImportedRecordRepository } from "../../application/import/imported-record-repository.port";
+import type { KaiordDatabase } from "./dexie-database";
+import { HEALTH_STORE_FOR_TYPE } from "./health-store-for-type";
+
+type HealthRow = {
+  kaiordRecordId?: string;
+  profileId: string;
+  sourceBridgeId: string;
+  externalId: string;
+  measuredAt: string;
+  krd: Record<string, unknown>;
+};
+
+const getStore = (dataType: ManagedDataType): string => {
+  const name = HEALTH_STORE_FOR_TYPE[dataType];
+  if (!name) {
+    throw new Error(
+      `ImportedRecordRepository: no health store for dataType '${dataType}'`
+    );
+  }
+  return name;
+};
+
+export const createDexieImportedRecordRepository = (
+  db: KaiordDatabase
+): ImportedRecordRepository => ({
+  findByNaturalKey: async ({
+    profileId,
+    dataType,
+    sourceBridgeId,
+    externalId,
+  }) => {
+    const storeName = getStore(dataType);
+    const row = (await db
+      .table(storeName)
+      .where("[profileId+sourceBridgeId+externalId]")
+      .equals([profileId, sourceBridgeId, externalId])
+      .first()) as HealthRow | undefined;
+
+    if (!row?.kaiordRecordId) return undefined;
+    return {
+      kaiordRecordId: row.kaiordRecordId,
+      profileId: row.profileId,
+      sourceBridgeId: row.sourceBridgeId,
+      externalId: row.externalId,
+      payload: row.krd,
+      measuredAt: row.measuredAt,
+    };
+  },
+
+  insert: async ({ dataType, date, record }) => {
+    const storeName = getStore(dataType);
+    await db.table(storeName).add({
+      id: crypto.randomUUID(),
+      kaiordRecordId: record.kaiordRecordId,
+      profileId: record.profileId,
+      date,
+      sourceBridgeId: record.sourceBridgeId,
+      externalId: record.externalId,
+      measuredAt: record.measuredAt,
+      krd: record.payload,
+    });
+  },
+});

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-integration-policy-repository.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-integration-policy-repository.ts
@@ -1,0 +1,37 @@
+/**
+ * Dexie implementation of IntegrationPolicyRepository.
+ *
+ * Uses the v17 integrationPolicies store. All compound-index queries
+ * are expressed as Dexie where().equals() calls; no raw SQL.
+ */
+import type { IntegrationPolicyRepository } from "../../application/integration-policy/integration-policy-repository.port";
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import type { KaiordDatabase } from "./dexie-database";
+
+export const createDexieIntegrationPolicyRepository = (
+  db: KaiordDatabase
+): IntegrationPolicyRepository => ({
+  findByProfileDirection: async ({ profileId, dataType, direction }) =>
+    (await db
+      .table("integrationPolicies")
+      .where("[profileId+dataType+direction]")
+      .equals([profileId, dataType, direction])
+      .toArray()) as IntegrationPolicy[],
+
+  findByNaturalKey: async ({ profileId, dataType, direction, bridgeId }) =>
+    (await db
+      .table("integrationPolicies")
+      .where("[profileId+dataType+direction+bridgeId]")
+      .equals([profileId, dataType, direction, bridgeId])
+      .first()) as IntegrationPolicy | undefined,
+
+  put: async (policy: IntegrationPolicy) => {
+    await db.table("integrationPolicies").put(policy);
+  },
+
+  deleteById: async (id: string) => {
+    await db.table("integrationPolicies").delete(id);
+  },
+});
+
+export type { IntegrationPolicyRepository };

--- a/packages/workout-spa-editor/src/adapters/dexie/health-store-for-type.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/health-store-for-type.ts
@@ -1,0 +1,14 @@
+/**
+ * Maps ManagedDataType values to the Dexie store name that holds
+ * records of that type. Adapter concern — lives here, not in application/.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+export const HEALTH_STORE_FOR_TYPE: Partial<Record<ManagedDataType, string>> = {
+  weight: "healthWeight",
+  sleep: "healthSleep",
+  hrv: "healthHrv",
+  "daily-wellness": "healthDaily",
+  "body-composition": "healthBodyComposition",
+  stress: "healthStress",
+};

--- a/packages/workout-spa-editor/src/application/export/export-ledger-repository.port.ts
+++ b/packages/workout-spa-editor/src/application/export/export-ledger-repository.port.ts
@@ -1,0 +1,22 @@
+/**
+ * Port — ExportLedgerRepository
+ *
+ * Abstract contract for the exportLedger Dexie store.
+ * insertPending maps Dexie ConstraintError to a typed result so use
+ * cases never import Dexie error types (R-AppDexieImport rule).
+ */
+import type { ExportLedgerEntry } from "../../types/export-ledger";
+
+export type InsertPendingResult =
+  | { ok: true }
+  | { ok: false; reason: "constraint" };
+
+export type ExportLedgerRepository = {
+  findByNaturalKey: (input: {
+    kaiordRecordId: string;
+    destinationBridgeId: string;
+  }) => Promise<ExportLedgerEntry | undefined>;
+  insertPending: (entry: ExportLedgerEntry) => Promise<InsertPendingResult>;
+  update: (id: string, patch: Partial<ExportLedgerEntry>) => Promise<void>;
+  deleteById: (id: string) => Promise<void>;
+};

--- a/packages/workout-spa-editor/src/application/export/record-export-concurrent-trigger.test.ts
+++ b/packages/workout-spa-editor/src/application/export/record-export-concurrent-trigger.test.ts
@@ -1,0 +1,77 @@
+/**
+ * AC-8 load-bearing concurrent-trigger test.
+ *
+ * Two parallel invocations of recordExport targeting the same
+ * (kaiordRecordId, destinationBridgeId) must result in exactly one
+ * POST call and exactly one exportLedger row.
+ *
+ * Wires the real Dexie adapter — the unique index constraint is what
+ * closes the race; this test must use a real IDB to exercise it.
+ */
+import "fake-indexeddb/auto";
+
+import Dexie from "dexie";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KaiordDatabase } from "../../adapters/dexie/dexie-database";
+import { createDexieExportLedgerRepository } from "../../adapters/dexie/dexie-export-ledger-repository";
+import { recordExport } from "./record-export.use-case";
+
+const dbName = () =>
+  `test-record-export-concurrent-${Date.now()}-${Math.random()}`;
+
+const KAIO_ID = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const DEST_BRIDGE = "garmin-bridge";
+const PAYLOAD = { weightKilograms: 75 };
+
+describe("recordExport — concurrent trigger", () => {
+  let name: string;
+  let db: KaiordDatabase;
+
+  beforeEach(async () => {
+    name = dbName();
+    db = new KaiordDatabase(name);
+    await db.open();
+  });
+
+  afterEach(async () => {
+    db.close();
+    await Dexie.delete(name);
+  });
+
+  it("should fire postFn exactly once when two parallel invocations target the same (kaiordRecordId, destinationBridgeId)", async () => {
+    // Arrange
+    let postCallCount = 0;
+    const postFn = vi.fn().mockImplementation(async () => {
+      postCallCount++;
+      return { externalId: `ext-${postCallCount}` };
+    });
+    const ledgerRepo = createDexieExportLedgerRepository(db);
+    const deps = { ledgerRepo };
+    const input = {
+      kaiordRecordId: KAIO_ID,
+      dataType: "weight" as const,
+      destinationBridgeId: DEST_BRIDGE,
+      payload: PAYLOAD,
+      postFn,
+    };
+
+    // Act
+    const results = await Promise.all([
+      recordExport(deps, input),
+      recordExport(deps, input),
+    ]);
+
+    // Assert
+    expect(postFn).toHaveBeenCalledTimes(1);
+    const ledgerRows = await db.table("exportLedger").toArray();
+    expect(ledgerRows).toHaveLength(1);
+    const outcomes = results.map((r) => r.outcome);
+    expect(outcomes).toContain("created");
+    expect(
+      outcomes.filter(
+        (o) => o === "created" || o === "lost-race" || o === "skipped"
+      )
+    ).toHaveLength(2);
+  });
+});

--- a/packages/workout-spa-editor/src/application/export/record-export-constraint.ts
+++ b/packages/workout-spa-editor/src/application/export/record-export-constraint.ts
@@ -1,0 +1,46 @@
+/**
+ * handleConstraintResult — resolves the outcome when insertPending returns
+ * { ok: false; reason: 'constraint' } (a row already exists for the natural key).
+ *
+ * Three cases:
+ *   skipped   — same contentHash, nothing to do
+ *   lost-race — existing row is still pending, another caller owns the work
+ *   updated   — stale committed row, re-POST and update the ledger
+ */
+import type { ExportLedgerRepository } from "./export-ledger-repository.port";
+import type { RecordExportResult } from "./record-export.use-case";
+
+export const handleConstraintResult = async (
+  ledgerRepo: ExportLedgerRepository,
+  kaiordRecordId: string,
+  destinationBridgeId: string,
+  contentHash: string,
+  payload: Record<string, unknown>,
+  postFn: (p: Record<string, unknown>) => Promise<{ externalId: string }>,
+  now: string
+): Promise<RecordExportResult> => {
+  const existing = await ledgerRepo.findByNaturalKey({
+    kaiordRecordId,
+    destinationBridgeId,
+  });
+
+  if (!existing) {
+    throw new Error("exportLedger: constraint violated but no row found");
+  }
+
+  if (existing.contentHash === contentHash) {
+    return { ledgerId: existing.id, outcome: "skipped" };
+  }
+  if (existing.destinationExternalId === "pending") {
+    return { ledgerId: existing.id, outcome: "lost-race" };
+  }
+
+  // Stale committed row — update remote then update ledger.
+  const { externalId } = await postFn(payload);
+  await ledgerRepo.update(existing.id, {
+    destinationExternalId: externalId,
+    contentHash,
+    exportedAt: now,
+  });
+  return { ledgerId: existing.id, outcome: "updated" };
+};

--- a/packages/workout-spa-editor/src/application/export/record-export.use-case.test.ts
+++ b/packages/workout-spa-editor/src/application/export/record-export.use-case.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Tests for recordExport use case — the insert-pending → POST → UPDATE protocol.
+ * Uses in-memory port mocks — no Dexie dependency.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { ExportLedgerEntry } from "../../types/export-ledger";
+import type {
+  ExportLedgerRepository,
+  InsertPendingResult,
+} from "./export-ledger-repository.port";
+import { recordExport } from "./record-export.use-case";
+
+const KAIO_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const DEST_BRIDGE = "garmin-bridge";
+const PAYLOAD = { weightKilograms: 75 };
+
+const makeRepo = (): ExportLedgerRepository & {
+  store: Map<string, ExportLedgerEntry>;
+} => {
+  const store = new Map<string, ExportLedgerEntry>();
+  const naturalKeyIndex = new Map<string, string>();
+
+  const naturalKey = (krd: string, dest: string) => `${krd}::${dest}`;
+
+  return {
+    store,
+    findByNaturalKey: async ({ kaiordRecordId, destinationBridgeId }) => {
+      const id = naturalKeyIndex.get(
+        naturalKey(kaiordRecordId, destinationBridgeId)
+      );
+      return id ? store.get(id) : undefined;
+    },
+    insertPending: async (entry): Promise<InsertPendingResult> => {
+      const key = naturalKey(entry.kaiordRecordId, entry.destinationBridgeId);
+      if (naturalKeyIndex.has(key)) return { ok: false, reason: "constraint" };
+      store.set(entry.id, entry);
+      naturalKeyIndex.set(key, entry.id);
+      return { ok: true };
+    },
+    update: async (id, patch) => {
+      const existing = store.get(id);
+      if (existing) store.set(id, { ...existing, ...patch });
+    },
+    deleteById: async (id) => {
+      const entry = store.get(id);
+      if (entry) {
+        naturalKeyIndex.delete(
+          naturalKey(entry.kaiordRecordId, entry.destinationBridgeId)
+        );
+        store.delete(id);
+      }
+    },
+  };
+};
+
+describe("recordExport", () => {
+  it("should POST and create a ledger entry on first call", async () => {
+    // Arrange
+    const postFn = vi.fn().mockResolvedValue({ externalId: "ext-001" });
+    const ledgerRepo = makeRepo();
+    const deps = { ledgerRepo };
+
+    // Act
+    const result = await recordExport(deps, {
+      kaiordRecordId: KAIO_ID,
+      dataType: "weight",
+      destinationBridgeId: DEST_BRIDGE,
+      payload: PAYLOAD,
+      postFn,
+    });
+
+    // Assert
+    expect(postFn).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("created");
+    expect(ledgerRepo.store.size).toBe(1);
+    const entry = [...ledgerRepo.store.values()][0];
+    expect(entry?.destinationExternalId).toBe("ext-001");
+  });
+
+  it("should skip POST when contentHash matches existing committed entry", async () => {
+    // Arrange
+    const postFn = vi.fn().mockResolvedValue({ externalId: "ext-001" });
+    const ledgerRepo = makeRepo();
+    const deps = { ledgerRepo };
+    await recordExport(deps, {
+      kaiordRecordId: KAIO_ID,
+      dataType: "weight",
+      destinationBridgeId: DEST_BRIDGE,
+      payload: PAYLOAD,
+      postFn,
+    });
+    postFn.mockClear();
+
+    // Act
+    const result = await recordExport(deps, {
+      kaiordRecordId: KAIO_ID,
+      dataType: "weight",
+      destinationBridgeId: DEST_BRIDGE,
+      payload: PAYLOAD,
+      postFn,
+    });
+
+    // Assert
+    expect(postFn).not.toHaveBeenCalled();
+    expect(result.outcome).toBe("skipped");
+  });
+
+  it("should update the ledger entry when contentHash differs from existing committed entry", async () => {
+    // Arrange
+    const postFn = vi
+      .fn()
+      .mockResolvedValueOnce({ externalId: "ext-001" })
+      .mockResolvedValueOnce({ externalId: "ext-002" });
+    const ledgerRepo = makeRepo();
+    const deps = { ledgerRepo };
+    await recordExport(deps, {
+      kaiordRecordId: KAIO_ID,
+      dataType: "weight",
+      destinationBridgeId: DEST_BRIDGE,
+      payload: PAYLOAD,
+      postFn,
+    });
+
+    // Act
+    const result = await recordExport(deps, {
+      kaiordRecordId: KAIO_ID,
+      dataType: "weight",
+      destinationBridgeId: DEST_BRIDGE,
+      payload: { weightKilograms: 80 },
+      postFn,
+    });
+
+    // Assert
+    expect(result.outcome).toBe("updated");
+    expect(ledgerRepo.store.size).toBe(1);
+    const entry = [...ledgerRepo.store.values()][0];
+    expect(entry?.destinationExternalId).toBe("ext-002");
+  });
+
+  it("should DELETE the pending ledger row when postFn throws", async () => {
+    // Arrange
+    const postFn = vi.fn().mockRejectedValue(new Error("network error"));
+    const ledgerRepo = makeRepo();
+    const deps = { ledgerRepo };
+
+    // Act
+    let error: unknown;
+    try {
+      await recordExport(deps, {
+        kaiordRecordId: KAIO_ID,
+        dataType: "weight",
+        destinationBridgeId: DEST_BRIDGE,
+        payload: PAYLOAD,
+        postFn,
+      });
+    } catch (e) {
+      error = e;
+    }
+
+    // Assert
+    expect(error).toBeDefined();
+    expect(ledgerRepo.store.size).toBe(0);
+  });
+
+  it("should return lost-race when another caller has a pending row", async () => {
+    // Arrange
+    const ledgerRepo = makeRepo();
+    const existingId = crypto.randomUUID();
+    ledgerRepo.store.set(existingId, {
+      id: existingId,
+      kaiordRecordId: KAIO_ID,
+      dataType: "weight",
+      destinationBridgeId: DEST_BRIDGE,
+      destinationExternalId: "pending",
+      contentHash: "different-hash",
+      exportedAt: new Date().toISOString(),
+    });
+    // Manually prime the natural-key index so insertPending sees the conflict.
+    const findResult = await ledgerRepo.findByNaturalKey({
+      kaiordRecordId: KAIO_ID,
+      destinationBridgeId: DEST_BRIDGE,
+    });
+    // findByNaturalKey won't find it since naturalKeyIndex wasn't primed via insertPending.
+    // Re-create the repo with a pre-seeded constraint row via insertPending.
+    const freshRepo = makeRepo();
+    await freshRepo.insertPending({
+      id: existingId,
+      kaiordRecordId: KAIO_ID,
+      dataType: "weight",
+      destinationBridgeId: DEST_BRIDGE,
+      destinationExternalId: "pending",
+      contentHash: "different-hash",
+      exportedAt: new Date().toISOString(),
+    });
+    const postFn = vi.fn().mockResolvedValue({ externalId: "ext-001" });
+
+    // Act
+    const result = await recordExport(
+      { ledgerRepo: freshRepo },
+      {
+        kaiordRecordId: KAIO_ID,
+        dataType: "weight",
+        destinationBridgeId: DEST_BRIDGE,
+        payload: PAYLOAD,
+        postFn,
+      }
+    );
+
+    // Assert
+    expect(postFn).not.toHaveBeenCalled();
+    expect(result.outcome).toBe("lost-race");
+    // findResult just consumed; suppress unused warning
+    void findResult;
+  });
+});

--- a/packages/workout-spa-editor/src/application/export/record-export.use-case.ts
+++ b/packages/workout-spa-editor/src/application/export/record-export.use-case.ts
@@ -1,0 +1,103 @@
+/**
+ * recordExport — insert-pending → POST → UPDATE idempotency protocol.
+ *
+ * The unique index &[kaiordRecordId+destinationBridgeId] on exportLedger
+ * acts as a mutex: only one caller can insert a 'pending' row for a given
+ * (kaiordRecordId, destinationBridgeId) pair. The second concurrent
+ * caller receives { ok: false; reason: 'constraint' } from insertPending
+ * and returns 'lost-race' without ever calling postFn. This closes the
+ * concurrent-trigger race (AC-8).
+ */
+import type { ManagedDataType } from "@kaiord/core";
+import { canonicalHash, MANAGED_DATA_REGISTRY } from "@kaiord/core";
+
+import type { ExportLedgerEntry } from "../../types/export-ledger";
+import type { ExportLedgerRepository } from "./export-ledger-repository.port";
+import { handleConstraintResult } from "./record-export-constraint";
+
+export type RecordExportDeps = {
+  ledgerRepo: ExportLedgerRepository;
+};
+
+export type RecordExportInput = {
+  kaiordRecordId: string;
+  dataType: ManagedDataType;
+  destinationBridgeId: string;
+  payload: Record<string, unknown>;
+  postFn: (payload: Record<string, unknown>) => Promise<{ externalId: string }>;
+};
+
+export type RecordExportOutcome =
+  | "created"
+  | "updated"
+  | "skipped"
+  | "lost-race";
+
+export type RecordExportResult = {
+  ledgerId: string;
+  outcome: RecordExportOutcome;
+};
+
+const computeHash = (
+  dataType: ManagedDataType,
+  payload: Record<string, unknown>
+): string => {
+  const entry = MANAGED_DATA_REGISTRY[dataType];
+  const projected = entry?.hashProjection
+    ? entry.hashProjection(payload)
+    : payload;
+  return canonicalHash(projected as Record<string, unknown>);
+};
+
+export const recordExport = async (
+  deps: RecordExportDeps,
+  input: RecordExportInput
+): Promise<RecordExportResult> => {
+  const { ledgerRepo } = deps;
+  const { kaiordRecordId, dataType, destinationBridgeId, payload, postFn } =
+    input;
+  const contentHash = computeHash(dataType, payload);
+  const ledgerId = crypto.randomUUID();
+  const now = new Date().toISOString();
+
+  const pending: ExportLedgerEntry = {
+    id: ledgerId,
+    kaiordRecordId,
+    dataType,
+    destinationBridgeId,
+    destinationExternalId: "pending",
+    contentHash,
+    exportedAt: now,
+  };
+
+  // Step 1: attempt insert of pending row — races are gated here.
+  const insertResult = await ledgerRepo.insertPending(pending);
+
+  if (!insertResult.ok) {
+    return handleConstraintResult(
+      ledgerRepo,
+      kaiordRecordId,
+      destinationBridgeId,
+      contentHash,
+      payload,
+      postFn,
+      now
+    );
+  }
+
+  // Step 2: we won the race — call postFn.
+  let externalId: string;
+  try {
+    ({ externalId } = await postFn(payload));
+  } catch (postErr) {
+    await ledgerRepo.deleteById(ledgerId);
+    throw postErr;
+  }
+
+  // Step 3: commit — update pending row with real externalId.
+  await ledgerRepo.update(ledgerId, {
+    destinationExternalId: externalId,
+    exportedAt: new Date().toISOString(),
+  });
+  return { ledgerId, outcome: "created" };
+};

--- a/packages/workout-spa-editor/src/application/export/weight-export-aggregation.test.ts
+++ b/packages/workout-spa-editor/src/application/export/weight-export-aggregation.test.ts
@@ -1,0 +1,161 @@
+/**
+ * AC-9 — weight-export aggregation integration test.
+ *
+ * Profile P has weight imports from 3 different sourceBridgeId values
+ * for the same day. Pushing weight to garmin-bridge must export all 3
+ * records (one POST each). Re-running must produce 3x SKIP.
+ *
+ * Wires real Dexie adapters to exercise the full stack end-to-end.
+ */
+import "fake-indexeddb/auto";
+
+import Dexie from "dexie";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { KaiordDatabase } from "../../adapters/dexie/dexie-database";
+import { createDexieExportLedgerRepository } from "../../adapters/dexie/dexie-export-ledger-repository";
+import { createDexieImportedRecordRepository } from "../../adapters/dexie/dexie-imported-record-repository";
+import { upsertImportedRecord } from "../import/upsert-imported-record.use-case";
+import { recordExport } from "./record-export.use-case";
+
+const dbName = () => `test-weight-export-agg-${Date.now()}-${Math.random()}`;
+
+const PROFILE_ID = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+const DATE = "2026-05-26";
+
+describe("weight export aggregation (AC-9)", () => {
+  let name: string;
+  let db: KaiordDatabase;
+
+  beforeEach(async () => {
+    name = dbName();
+    db = new KaiordDatabase(name);
+    await db.open();
+  });
+
+  afterEach(async () => {
+    db.close();
+    await Dexie.delete(name);
+  });
+
+  it("should export all three weight rows when a profile has weight imports from three different sources for the same day", async () => {
+    // Arrange
+    const recordRepo = createDexieImportedRecordRepository(db);
+    const ledgerRepo = createDexieExportLedgerRepository(db);
+    const sources = ["garmin-bridge", "withings-bridge", "manual"] as const;
+    const kaiordIds: string[] = [];
+    for (const src of sources) {
+      const r = await upsertImportedRecord(
+        { recordRepo },
+        {
+          profileId: PROFILE_ID,
+          dataType: "weight",
+          sourceBridgeId: src,
+          externalId: `${src}-weight-${DATE}`,
+          date: DATE,
+          payload: { weightKilograms: 75 },
+          measuredAt: `${DATE}T08:00:00.000Z`,
+        }
+      );
+      kaiordIds.push(r.kaiordRecordId);
+    }
+    let postCount = 0;
+    const postFn = vi.fn().mockImplementation(async () => {
+      postCount++;
+      return { externalId: `garmin-ext-${postCount}` };
+    });
+
+    // Act
+    const results = await Promise.all(
+      kaiordIds.map((kaiordRecordId) =>
+        recordExport(
+          { ledgerRepo },
+          {
+            kaiordRecordId,
+            dataType: "weight",
+            destinationBridgeId: "garmin-bridge",
+            payload: { weightKilograms: 75 },
+            postFn,
+          }
+        )
+      )
+    );
+
+    // Assert
+    expect(postFn).toHaveBeenCalledTimes(sources.length);
+    const ledgerRows = await db.table("exportLedger").toArray();
+    expect(ledgerRows).toHaveLength(sources.length);
+    expect(results.map((r) => r.outcome)).toEqual([
+      "created",
+      "created",
+      "created",
+    ]);
+  });
+
+  it("should be a 3x SKIP when re-running export on the same day", async () => {
+    // Arrange
+    const recordRepo = createDexieImportedRecordRepository(db);
+    const ledgerRepo = createDexieExportLedgerRepository(db);
+    const sources = ["garmin-bridge", "withings-bridge", "manual"] as const;
+    const kaiordIds: string[] = [];
+    for (const src of sources) {
+      const r = await upsertImportedRecord(
+        { recordRepo },
+        {
+          profileId: PROFILE_ID,
+          dataType: "weight",
+          sourceBridgeId: src,
+          externalId: `${src}-weight-${DATE}`,
+          date: DATE,
+          payload: { weightKilograms: 75 },
+          measuredAt: `${DATE}T08:00:00.000Z`,
+        }
+      );
+      kaiordIds.push(r.kaiordRecordId);
+    }
+    let postCount = 0;
+    const postFn = vi.fn().mockImplementation(async () => {
+      postCount++;
+      return { externalId: `garmin-ext-${postCount}` };
+    });
+    for (const kaiordRecordId of kaiordIds) {
+      await recordExport(
+        { ledgerRepo },
+        {
+          kaiordRecordId,
+          dataType: "weight",
+          destinationBridgeId: "garmin-bridge",
+          payload: { weightKilograms: 75 },
+          postFn,
+        }
+      );
+    }
+    postFn.mockClear();
+
+    // Act
+    const rerunResults = await Promise.all(
+      kaiordIds.map((kaiordRecordId) =>
+        recordExport(
+          { ledgerRepo },
+          {
+            kaiordRecordId,
+            dataType: "weight",
+            destinationBridgeId: "garmin-bridge",
+            payload: { weightKilograms: 75 },
+            postFn,
+          }
+        )
+      )
+    );
+
+    // Assert
+    expect(postFn).not.toHaveBeenCalled();
+    const ledgerRows = await db.table("exportLedger").toArray();
+    expect(ledgerRows).toHaveLength(sources.length);
+    expect(rerunResults.map((r) => r.outcome)).toEqual([
+      "skipped",
+      "skipped",
+      "skipped",
+    ]);
+  });
+});

--- a/packages/workout-spa-editor/src/application/import/imported-record-repository.port.ts
+++ b/packages/workout-spa-editor/src/application/import/imported-record-repository.port.ts
@@ -1,0 +1,30 @@
+/**
+ * Port — ImportedRecordRepository
+ *
+ * Abstract contract for inbound health-record natural-key upsert.
+ * Use cases depend only on this interface (R-AppDexieImport rule).
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+export type ImportedRecord = {
+  kaiordRecordId: string;
+  profileId: string;
+  sourceBridgeId: string;
+  externalId: string;
+  payload: Record<string, unknown>;
+  measuredAt: string;
+};
+
+export type ImportedRecordRepository = {
+  findByNaturalKey: (input: {
+    profileId: string;
+    dataType: ManagedDataType;
+    sourceBridgeId: string;
+    externalId: string;
+  }) => Promise<ImportedRecord | undefined>;
+  insert: (input: {
+    dataType: ManagedDataType;
+    date: string;
+    record: ImportedRecord;
+  }) => Promise<void>;
+};

--- a/packages/workout-spa-editor/src/application/import/inbound-idempotency.integration.test.ts
+++ b/packages/workout-spa-editor/src/application/import/inbound-idempotency.integration.test.ts
@@ -1,0 +1,57 @@
+/**
+ * AC-7 acceptance criterion integration test:
+ * "zero new rows when the same Garmin weight import runs twice"
+ *
+ * Wires the real Dexie adapter to exercise the full stack.
+ */
+import "fake-indexeddb/auto";
+
+import Dexie from "dexie";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { KaiordDatabase } from "../../adapters/dexie/dexie-database";
+import { createDexieImportedRecordRepository } from "../../adapters/dexie/dexie-imported-record-repository";
+import { upsertImportedRecord } from "./upsert-imported-record.use-case";
+
+const dbName = () => `test-inbound-idempotency-${Date.now()}-${Math.random()}`;
+
+describe("inbound idempotency — Garmin weight import", () => {
+  let name: string;
+  let db: KaiordDatabase;
+
+  beforeEach(async () => {
+    name = dbName();
+    db = new KaiordDatabase(name);
+    await db.open();
+  });
+
+  afterEach(async () => {
+    db.close();
+    await Dexie.delete(name);
+  });
+
+  it("should produce zero new rows when the same Garmin weight import runs twice", async () => {
+    // Arrange
+    const recordRepo = createDexieImportedRecordRepository(db);
+    const deps = { recordRepo };
+    const importInput = {
+      profileId: "11111111-1111-4111-8111-111111111111",
+      dataType: "weight" as const,
+      sourceBridgeId: "garmin-bridge",
+      externalId: "garmin-weight-2026-05-26-001",
+      date: "2026-05-26",
+      payload: { weightKilograms: 75.5 },
+      measuredAt: "2026-05-26T07:30:00.000Z",
+    };
+    await upsertImportedRecord(deps, importInput);
+    const countAfterFirst = await db.table("healthWeight").count();
+
+    // Act
+    await upsertImportedRecord(deps, importInput);
+    const countAfterSecond = await db.table("healthWeight").count();
+
+    // Assert
+    expect(countAfterFirst).toBe(1);
+    expect(countAfterSecond).toBe(1);
+  });
+});

--- a/packages/workout-spa-editor/src/application/import/upsert-imported-record.use-case.test.ts
+++ b/packages/workout-spa-editor/src/application/import/upsert-imported-record.use-case.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for upsertImportedRecord use case (inbound natural-key upsert).
+ * Uses in-memory port mocks — no Dexie dependency.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  ImportedRecord,
+  ImportedRecordRepository,
+} from "./imported-record-repository.port";
+import { upsertImportedRecord } from "./upsert-imported-record.use-case";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+const DATE = "2026-05-26";
+const MEASURED_AT = "2026-05-26T08:00:00.000Z";
+
+const baseInput = {
+  profileId: PROFILE_ID,
+  dataType: "weight" as const,
+  sourceBridgeId: "garmin-bridge",
+  externalId: "ext-001",
+  date: DATE,
+  payload: { weightKilograms: 75 },
+  measuredAt: MEASURED_AT,
+};
+
+const makeRepo = (): ImportedRecordRepository & {
+  rows: ImportedRecord[];
+} => {
+  const rows: ImportedRecord[] = [];
+  return {
+    rows,
+    findByNaturalKey: async ({ profileId, sourceBridgeId, externalId }) =>
+      rows.find(
+        (r) =>
+          r.profileId === profileId &&
+          r.sourceBridgeId === sourceBridgeId &&
+          r.externalId === externalId
+      ),
+    insert: async ({ record }) => {
+      rows.push(record);
+    },
+  };
+};
+
+describe("upsertImportedRecord", () => {
+  it("should create a new record on first call", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const deps = { recordRepo: repo };
+
+    // Act
+    const result = await upsertImportedRecord(deps, baseInput);
+
+    // Assert
+    expect(result.created).toBe(true);
+    expect(result.kaiordRecordId).toBeTruthy();
+    expect(repo.rows).toHaveLength(1);
+  });
+
+  it("should skip insert and return existing kaiordRecordId on second call with same natural key", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const deps = { recordRepo: repo };
+    const first = await upsertImportedRecord(deps, baseInput);
+
+    // Act
+    const second = await upsertImportedRecord(deps, baseInput);
+
+    // Assert
+    expect(second.created).toBe(false);
+    expect(second.kaiordRecordId).toBe(first.kaiordRecordId);
+    expect(repo.rows).toHaveLength(1);
+  });
+
+  it("should create separate records for different sourceBridgeId on same date", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const deps = { recordRepo: repo };
+
+    // Act
+    const garmin = await upsertImportedRecord(deps, {
+      ...baseInput,
+      sourceBridgeId: "garmin-bridge",
+    });
+    const withings = await upsertImportedRecord(deps, {
+      ...baseInput,
+      sourceBridgeId: "withings-bridge",
+    });
+
+    // Assert
+    expect(garmin.created).toBe(true);
+    expect(withings.created).toBe(true);
+    expect(garmin.kaiordRecordId).not.toBe(withings.kaiordRecordId);
+    expect(repo.rows).toHaveLength(2);
+  });
+
+  it("should create separate records for different externalId on same date", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const deps = { recordRepo: repo };
+
+    // Act
+    const result1 = await upsertImportedRecord(deps, {
+      ...baseInput,
+      externalId: "ext-001",
+    });
+    const result2 = await upsertImportedRecord(deps, {
+      ...baseInput,
+      externalId: "ext-002",
+    });
+
+    // Assert
+    expect(result1.created).toBe(true);
+    expect(result2.created).toBe(true);
+    expect(result1.kaiordRecordId).not.toBe(result2.kaiordRecordId);
+    expect(repo.rows).toHaveLength(2);
+  });
+});

--- a/packages/workout-spa-editor/src/application/import/upsert-imported-record.use-case.ts
+++ b/packages/workout-spa-editor/src/application/import/upsert-imported-record.use-case.ts
@@ -1,0 +1,65 @@
+/**
+ * upsertImportedRecord — inbound natural-key upsert.
+ *
+ * Looks up an existing health row by [profileId+sourceBridgeId+externalId].
+ * If found, returns the existing kaiordRecordId without a second write
+ * (idempotent). If absent, generates a new kaiordRecordId and inserts via
+ * the repository port.
+ *
+ * AC-7: two consecutive imports of the same (sourceBridgeId, externalId)
+ * payload must produce exactly one row in the target store.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { ImportedRecordRepository } from "./imported-record-repository.port";
+
+export type UpsertImportedRecordDeps = {
+  recordRepo: ImportedRecordRepository;
+};
+
+export type UpsertImportedRecordInput = {
+  profileId: string;
+  dataType: ManagedDataType;
+  sourceBridgeId: string;
+  externalId: string;
+  date: string;
+  payload: Record<string, unknown>;
+  measuredAt: string;
+};
+
+export type UpsertImportedRecordResult = {
+  kaiordRecordId: string;
+  created: boolean;
+};
+
+export const upsertImportedRecord = async (
+  deps: UpsertImportedRecordDeps,
+  input: UpsertImportedRecordInput
+): Promise<UpsertImportedRecordResult> => {
+  const existing = await deps.recordRepo.findByNaturalKey({
+    profileId: input.profileId,
+    dataType: input.dataType,
+    sourceBridgeId: input.sourceBridgeId,
+    externalId: input.externalId,
+  });
+
+  if (existing) {
+    return { kaiordRecordId: existing.kaiordRecordId, created: false };
+  }
+
+  const kaiordRecordId = crypto.randomUUID();
+  await deps.recordRepo.insert({
+    dataType: input.dataType,
+    date: input.date,
+    record: {
+      kaiordRecordId,
+      profileId: input.profileId,
+      sourceBridgeId: input.sourceBridgeId,
+      externalId: input.externalId,
+      payload: input.payload,
+      measuredAt: input.measuredAt,
+    },
+  });
+
+  return { kaiordRecordId, created: true };
+};

--- a/packages/workout-spa-editor/src/application/integration-policy/delete-integration-policy.use-case.test.ts
+++ b/packages/workout-spa-editor/src/application/integration-policy/delete-integration-policy.use-case.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for deleteIntegrationPolicy use case.
+ * Uses in-memory port mocks — no Dexie dependency.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import { deleteIntegrationPolicy } from "./delete-integration-policy.use-case";
+import type { IntegrationPolicyRepository } from "./integration-policy-repository.port";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const makeRepo = (): IntegrationPolicyRepository & {
+  store: Map<string, IntegrationPolicy>;
+} => {
+  const store = new Map<string, IntegrationPolicy>();
+  return {
+    store,
+    findByProfileDirection: async () => [],
+    findByNaturalKey: async () => undefined,
+    put: async (p) => {
+      store.set(p.id, p);
+    },
+    deleteById: async (id) => {
+      store.delete(id);
+    },
+  };
+};
+
+describe("deleteIntegrationPolicy", () => {
+  it("should delete the policy row by id", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const policyId = crypto.randomUUID();
+    repo.store.set(policyId, {
+      id: policyId,
+      profileId: PROFILE_ID,
+      dataType: "weight",
+      bridgeId: "garmin-bridge",
+      direction: "import",
+      mode: "manual",
+      enabled: true,
+      updatedAt: "2026-05-26T00:00:00.000Z",
+    });
+    const deps = { policyRepo: repo };
+
+    // Act
+    await deleteIntegrationPolicy(deps, { id: policyId });
+
+    // Assert
+    expect(repo.store.size).toBe(0);
+  });
+
+  it("should be a no-op when the id does not exist", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const deps = { policyRepo: repo };
+
+    // Act
+    let error: unknown;
+    try {
+      await deleteIntegrationPolicy(deps, { id: crypto.randomUUID() });
+    } catch (e) {
+      error = e;
+    }
+
+    // Assert
+    expect(error).toBeUndefined();
+    expect(repo.store.size).toBe(0);
+  });
+});

--- a/packages/workout-spa-editor/src/application/integration-policy/delete-integration-policy.use-case.ts
+++ b/packages/workout-spa-editor/src/application/integration-policy/delete-integration-policy.use-case.ts
@@ -1,0 +1,16 @@
+/**
+ * deleteIntegrationPolicy — deletes an IntegrationPolicy row by id.
+ * No-op when the row is already absent.
+ */
+import type { IntegrationPolicyDeps } from "./integration-policy-deps";
+
+export type DeleteIntegrationPolicyInput = {
+  id: string;
+};
+
+export const deleteIntegrationPolicy = async (
+  deps: IntegrationPolicyDeps,
+  input: DeleteIntegrationPolicyInput
+): Promise<void> => {
+  await deps.policyRepo.deleteById(input.id);
+};

--- a/packages/workout-spa-editor/src/application/integration-policy/integration-policy-deps.ts
+++ b/packages/workout-spa-editor/src/application/integration-policy/integration-policy-deps.ts
@@ -1,0 +1,9 @@
+/**
+ * Shared dependency type for integration-policy use cases.
+ * Use cases depend only on the repository port — no Dexie imports here.
+ */
+import type { IntegrationPolicyRepository } from "./integration-policy-repository.port";
+
+export type IntegrationPolicyDeps = {
+  policyRepo: IntegrationPolicyRepository;
+};

--- a/packages/workout-spa-editor/src/application/integration-policy/integration-policy-repository.port.ts
+++ b/packages/workout-spa-editor/src/application/integration-policy/integration-policy-repository.port.ts
@@ -1,0 +1,26 @@
+/**
+ * Port — IntegrationPolicyRepository
+ *
+ * Abstract contract for reading and writing IntegrationPolicy rows.
+ * The Dexie implementation lives in adapters/dexie/; use cases depend
+ * only on this interface (R-AppDexieImport rule).
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { IntegrationPolicy } from "../../types/integration-policy";
+
+export type IntegrationPolicyRepository = {
+  findByProfileDirection: (input: {
+    profileId: string;
+    dataType: ManagedDataType;
+    direction: "import" | "export";
+  }) => Promise<IntegrationPolicy[]>;
+  findByNaturalKey: (input: {
+    profileId: string;
+    dataType: ManagedDataType;
+    direction: "import" | "export";
+    bridgeId: string;
+  }) => Promise<IntegrationPolicy | undefined>;
+  put: (policy: IntegrationPolicy) => Promise<void>;
+  deleteById: (id: string) => Promise<void>;
+};

--- a/packages/workout-spa-editor/src/application/integration-policy/resolve-export-policies.use-case.test.ts
+++ b/packages/workout-spa-editor/src/application/integration-policy/resolve-export-policies.use-case.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for resolveExportPolicies use case.
+ * Uses in-memory port mocks — no Dexie dependency.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import type { IntegrationPolicyRepository } from "./integration-policy-repository.port";
+import { resolveExportPolicies } from "./resolve-export-policies.use-case";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const makePolicy = (
+  overrides: Partial<IntegrationPolicy> = {}
+): IntegrationPolicy => ({
+  id: crypto.randomUUID(),
+  profileId: PROFILE_ID,
+  dataType: "workout",
+  bridgeId: "garmin-bridge",
+  direction: "export",
+  mode: "manual",
+  enabled: true,
+  updatedAt: "2026-05-26T00:00:00.000Z",
+  ...overrides,
+});
+
+const makeRepo = (rows: IntegrationPolicy[]): IntegrationPolicyRepository => ({
+  findByProfileDirection: async ({ profileId, dataType, direction }) =>
+    rows.filter(
+      (r) =>
+        r.profileId === profileId &&
+        r.dataType === dataType &&
+        r.direction === direction
+    ),
+  findByNaturalKey: async () => undefined,
+  put: async () => undefined,
+  deleteById: async () => undefined,
+});
+
+describe("resolveExportPolicies", () => {
+  it("should return an empty array when no export policies exist for the profile", async () => {
+    // Arrange
+    const deps = { policyRepo: makeRepo([]) };
+
+    // Act
+    const result = await resolveExportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "workout",
+    });
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("should return a single export policy for the profile and dataType", async () => {
+    // Arrange
+    const deps = { policyRepo: makeRepo([makePolicy()]) };
+
+    // Act
+    const result = await resolveExportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "workout",
+    });
+
+    // Assert
+    expect(result).toHaveLength(1);
+    expect(result[0]?.bridgeId).toBe("garmin-bridge");
+  });
+
+  it("should return multiple policies ordered by bridgeId alphabetically", async () => {
+    // Arrange
+    const rows = [
+      makePolicy({ bridgeId: "strava-bridge" }),
+      makePolicy({ bridgeId: "garmin-bridge" }),
+    ];
+    const deps = { policyRepo: makeRepo(rows) };
+
+    // Act
+    const result = await resolveExportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "workout",
+    });
+
+    // Assert
+    expect(result).toHaveLength(2);
+    expect(result[0]?.bridgeId).toBe("garmin-bridge");
+    expect(result[1]?.bridgeId).toBe("strava-bridge");
+  });
+
+  it("should return disabled rows as well as enabled rows", async () => {
+    // Arrange
+    const rows = [
+      makePolicy({ enabled: true }),
+      makePolicy({ bridgeId: "strava-bridge", enabled: false }),
+    ];
+    const deps = { policyRepo: makeRepo(rows) };
+
+    // Act
+    const result = await resolveExportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "workout",
+    });
+
+    // Assert
+    expect(result).toHaveLength(2);
+  });
+
+  it("should exclude import-direction rows when querying export", async () => {
+    // Arrange
+    const deps = {
+      policyRepo: makeRepo([makePolicy({ direction: "import" })]),
+    };
+
+    // Act
+    const result = await resolveExportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "workout",
+    });
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("should exclude rows from other profiles", async () => {
+    // Arrange
+    const deps = {
+      policyRepo: makeRepo([makePolicy({ profileId: "other-p" })]),
+    };
+
+    // Act
+    const result = await resolveExportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "workout",
+    });
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/workout-spa-editor/src/application/integration-policy/resolve-export-policies.use-case.ts
+++ b/packages/workout-spa-editor/src/application/integration-policy/resolve-export-policies.use-case.ts
@@ -1,0 +1,30 @@
+/**
+ * resolveExportPolicies — returns all IntegrationPolicy rows for the
+ * given (profileId, dataType) where direction='export', ordered by
+ * bridgeId alphabetically for stable UI rendering.
+ *
+ * Returns all rows (enabled and disabled). Callers decide whether to
+ * filter by enabled/mode for their specific affordance.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import type { IntegrationPolicyDeps } from "./integration-policy-deps";
+
+export type ResolveExportPoliciesInput = {
+  profileId: string;
+  dataType: ManagedDataType;
+};
+
+export const resolveExportPolicies = async (
+  deps: IntegrationPolicyDeps,
+  input: ResolveExportPoliciesInput
+): Promise<IntegrationPolicy[]> => {
+  const rows = await deps.policyRepo.findByProfileDirection({
+    profileId: input.profileId,
+    dataType: input.dataType,
+    direction: "export",
+  });
+
+  return rows.slice().sort((a, b) => a.bridgeId.localeCompare(b.bridgeId));
+};

--- a/packages/workout-spa-editor/src/application/integration-policy/resolve-import-policies.use-case.test.ts
+++ b/packages/workout-spa-editor/src/application/integration-policy/resolve-import-policies.use-case.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for resolveImportPolicies use case.
+ * Uses in-memory port mocks — no Dexie dependency.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import type { IntegrationPolicyRepository } from "./integration-policy-repository.port";
+import { resolveImportPolicies } from "./resolve-import-policies.use-case";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const makePolicy = (
+  overrides: Partial<IntegrationPolicy> = {}
+): IntegrationPolicy => ({
+  id: crypto.randomUUID(),
+  profileId: PROFILE_ID,
+  dataType: "weight",
+  bridgeId: "garmin-bridge",
+  direction: "import",
+  mode: "manual",
+  enabled: true,
+  updatedAt: "2026-05-26T00:00:00.000Z",
+  ...overrides,
+});
+
+const makeRepo = (rows: IntegrationPolicy[]): IntegrationPolicyRepository => ({
+  findByProfileDirection: async ({ profileId, dataType, direction }) =>
+    rows.filter(
+      (r) =>
+        r.profileId === profileId &&
+        r.dataType === dataType &&
+        r.direction === direction
+    ),
+  findByNaturalKey: async () => undefined,
+  put: async () => undefined,
+  deleteById: async () => undefined,
+});
+
+describe("resolveImportPolicies", () => {
+  it("should return an empty array when no policies exist for the profile", async () => {
+    // Arrange
+    const deps = { policyRepo: makeRepo([]) };
+
+    // Act
+    const result = await resolveImportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "weight",
+    });
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("should return a single enabled import policy for the profile and dataType", async () => {
+    // Arrange
+    const deps = { policyRepo: makeRepo([makePolicy()]) };
+
+    // Act
+    const result = await resolveImportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "weight",
+    });
+
+    // Assert
+    expect(result).toHaveLength(1);
+    expect(result[0]?.bridgeId).toBe("garmin-bridge");
+  });
+
+  it("should return multiple enabled policies ordered by bridgeId alphabetically", async () => {
+    // Arrange
+    const rows = [
+      makePolicy({ bridgeId: "withings-bridge" }),
+      makePolicy({ bridgeId: "garmin-bridge" }),
+    ];
+    const deps = { policyRepo: makeRepo(rows) };
+
+    // Act
+    const result = await resolveImportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "weight",
+    });
+
+    // Assert
+    expect(result).toHaveLength(2);
+    expect(result[0]?.bridgeId).toBe("garmin-bridge");
+    expect(result[1]?.bridgeId).toBe("withings-bridge");
+  });
+
+  it("should return disabled rows as well as enabled rows", async () => {
+    // Arrange
+    const rows = [
+      makePolicy({ enabled: true }),
+      makePolicy({ bridgeId: "withings-bridge", enabled: false }),
+    ];
+    const deps = { policyRepo: makeRepo(rows) };
+
+    // Act
+    const result = await resolveImportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "weight",
+    });
+
+    // Assert
+    expect(result).toHaveLength(2);
+  });
+
+  it("should exclude export-direction rows when querying import", async () => {
+    // Arrange
+    const deps = {
+      policyRepo: makeRepo([makePolicy({ direction: "export" })]),
+    };
+
+    // Act
+    const result = await resolveImportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "weight",
+    });
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("should exclude rows from other profiles", async () => {
+    // Arrange
+    const deps = {
+      policyRepo: makeRepo([makePolicy({ profileId: "other-p" })]),
+    };
+
+    // Act
+    const result = await resolveImportPolicies(deps, {
+      profileId: PROFILE_ID,
+      dataType: "weight",
+    });
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/workout-spa-editor/src/application/integration-policy/resolve-import-policies.use-case.ts
+++ b/packages/workout-spa-editor/src/application/integration-policy/resolve-import-policies.use-case.ts
@@ -1,0 +1,30 @@
+/**
+ * resolveImportPolicies — returns all IntegrationPolicy rows for the
+ * given (profileId, dataType) where direction='import', ordered by
+ * bridgeId alphabetically for stable UI rendering.
+ *
+ * Returns all rows (enabled and disabled). Callers decide whether to
+ * filter by enabled/mode for their specific affordance.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import type { IntegrationPolicyDeps } from "./integration-policy-deps";
+
+export type ResolveImportPoliciesInput = {
+  profileId: string;
+  dataType: ManagedDataType;
+};
+
+export const resolveImportPolicies = async (
+  deps: IntegrationPolicyDeps,
+  input: ResolveImportPoliciesInput
+): Promise<IntegrationPolicy[]> => {
+  const rows = await deps.policyRepo.findByProfileDirection({
+    profileId: input.profileId,
+    dataType: input.dataType,
+    direction: "import",
+  });
+
+  return rows.slice().sort((a, b) => a.bridgeId.localeCompare(b.bridgeId));
+};

--- a/packages/workout-spa-editor/src/application/integration-policy/upsert-integration-policy.use-case.test.ts
+++ b/packages/workout-spa-editor/src/application/integration-policy/upsert-integration-policy.use-case.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for upsertIntegrationPolicy use case.
+ * Uses in-memory port mocks — no Dexie dependency.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import type { IntegrationPolicyRepository } from "./integration-policy-repository.port";
+import { upsertIntegrationPolicy } from "./upsert-integration-policy.use-case";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const baseInput = {
+  profileId: PROFILE_ID,
+  dataType: "weight" as const,
+  bridgeId: "garmin-bridge",
+  direction: "import" as const,
+  mode: "manual" as const,
+  enabled: true,
+};
+
+const makeRepo = (): IntegrationPolicyRepository & {
+  store: Map<string, IntegrationPolicy>;
+} => {
+  const store = new Map<string, IntegrationPolicy>();
+  return {
+    store,
+    findByProfileDirection: async ({ profileId, dataType, direction }) =>
+      [...store.values()].filter(
+        (r) =>
+          r.profileId === profileId &&
+          r.dataType === dataType &&
+          r.direction === direction
+      ),
+    findByNaturalKey: async ({ profileId, dataType, direction, bridgeId }) =>
+      [...store.values()].find(
+        (r) =>
+          r.profileId === profileId &&
+          r.dataType === dataType &&
+          r.direction === direction &&
+          r.bridgeId === bridgeId
+      ),
+    put: async (policy) => {
+      store.set(policy.id, policy);
+    },
+    deleteById: async (id) => {
+      store.delete(id);
+    },
+  };
+};
+
+describe("upsertIntegrationPolicy", () => {
+  it("should insert a new row when no matching policy exists", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const deps = { policyRepo: repo };
+
+    // Act
+    const result = await upsertIntegrationPolicy(deps, baseInput);
+
+    // Assert
+    expect(repo.store.size).toBe(1);
+    expect(result.id).toBeTruthy();
+    expect(result.profileId).toBe(PROFILE_ID);
+  });
+
+  it("should update mode and enabled when a row with the same natural key exists", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const deps = { policyRepo: repo };
+    const first = await upsertIntegrationPolicy(deps, baseInput);
+
+    // Act
+    const result = await upsertIntegrationPolicy(deps, {
+      ...baseInput,
+      mode: "auto",
+      enabled: false,
+    });
+
+    // Assert
+    expect(repo.store.size).toBe(1);
+    expect(result.id).toBe(first.id);
+    expect(result.mode).toBe("auto");
+    expect(result.enabled).toBe(false);
+  });
+
+  it("should produce the same single row when called twice with identical input", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const deps = { policyRepo: repo };
+
+    // Act
+    const first = await upsertIntegrationPolicy(deps, baseInput);
+    const second = await upsertIntegrationPolicy(deps, baseInput);
+
+    // Assert
+    expect(repo.store.size).toBe(1);
+    expect(first.id).toBe(second.id);
+  });
+
+  it("should create separate rows for different bridgeIds on the same profile+dataType+direction", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const deps = { policyRepo: repo };
+
+    // Act
+    await upsertIntegrationPolicy(deps, {
+      ...baseInput,
+      bridgeId: "garmin-bridge",
+    });
+    await upsertIntegrationPolicy(deps, {
+      ...baseInput,
+      bridgeId: "withings-bridge",
+    });
+
+    // Assert
+    expect(repo.store.size).toBe(2);
+  });
+
+  it("should reject an invalid dataType", async () => {
+    // Arrange
+    const repo = makeRepo();
+    const deps = { policyRepo: repo };
+
+    // Act
+    let error: unknown;
+    try {
+      await upsertIntegrationPolicy(deps, {
+        ...baseInput,
+        dataType: "invalid-type" as never,
+      });
+    } catch (e) {
+      error = e;
+    }
+
+    // Assert
+    expect(error).toBeDefined();
+  });
+});

--- a/packages/workout-spa-editor/src/application/integration-policy/upsert-integration-policy.use-case.ts
+++ b/packages/workout-spa-editor/src/application/integration-policy/upsert-integration-policy.use-case.ts
@@ -1,0 +1,51 @@
+/**
+ * upsertIntegrationPolicy — natural-key upsert on
+ * [profileId+dataType+direction+bridgeId].
+ *
+ * If a row already exists for that composite key, updates mode/enabled/
+ * updatedAt in place. If not, inserts a new row with a fresh id.
+ * Validates input against the integrationPolicySchema (minus id/updatedAt)
+ * so callers receive a ZodError for invalid dataType/direction/mode values.
+ */
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import { integrationPolicySchema } from "../../types/integration-policy";
+import type { IntegrationPolicyDeps } from "./integration-policy-deps";
+
+export type NewIntegrationPolicy = Omit<IntegrationPolicy, "id" | "updatedAt">;
+
+const inputSchema = integrationPolicySchema.omit({ id: true, updatedAt: true });
+
+export const upsertIntegrationPolicy = async (
+  deps: IntegrationPolicyDeps,
+  input: NewIntegrationPolicy
+): Promise<IntegrationPolicy> => {
+  inputSchema.parse(input);
+
+  const existing = await deps.policyRepo.findByNaturalKey({
+    profileId: input.profileId,
+    dataType: input.dataType,
+    direction: input.direction,
+    bridgeId: input.bridgeId,
+  });
+
+  const now = new Date().toISOString();
+
+  if (existing) {
+    const updated: IntegrationPolicy = {
+      ...existing,
+      mode: input.mode,
+      enabled: input.enabled,
+      updatedAt: now,
+    };
+    await deps.policyRepo.put(updated);
+    return updated;
+  }
+
+  const row: IntegrationPolicy = {
+    ...input,
+    id: crypto.randomUUID(),
+    updatedAt: now,
+  };
+  await deps.policyRepo.put(row);
+  return row;
+};


### PR DESCRIPTION
## Summary

PR 4 of 7 — the idempotency-critical PR. Stacked on PR #692.

Adds the application layer: policy CRUD + resolvers, inbound natural-key upsert, and the outbound export ledger with insert-pending → POST → UPDATE / DELETE / no-op-on-lose-race that closes the concurrent-trigger race.

## What's inside

- **Policy CRUD + resolvers** — `resolveImportPolicies`, `resolveExportPolicies`, `upsertIntegrationPolicy`, `deleteIntegrationPolicy` use cases under `packages/workout-spa-editor/src/application/integration-policy/`.
- **Inbound idempotency** — `upsertImportedRecord` uses the v17 unique compound index `[profileId+sourceBridgeId+externalId]`; second call with same key returns existing kaiordRecordId, no insert.
- **Outbound idempotency** — `recordExport` implements the load-bearing algorithm:
  1. Insert ledger row with `destinationExternalId='pending'` in a Dexie transaction; the unique constraint on `[kaiordRecordId+destinationBridgeId]` is the race gate.
  2. POST to remote → newExternalId.
  3. UPDATE ledger row with newExternalId.
  4. On POST failure → DELETE the pending row (release slot for retry).
  5. On constraint-error during insert → branch: skip if contentHash matches, lost-race if pending, patch if stale.
- **Architecture**: use cases accept repository ports (`IntegrationPolicyRepository`, `ExportLedgerRepository`, `ImportedRecordRepository`) — never import Dexie. Adapters under `adapters/dexie/`. The ConstraintError → typed `{ ok: false; reason: 'constraint' }` translation is the adapter's responsibility. Satisfies **R-AppDexieImport**.

## Acceptance criteria (PR 4 slice)

- [x] AC-7 (inbound idempotency): `inbound-idempotency.integration.test.ts` — same Garmin import twice = zero new rows
- [x] AC-8 (outbound idempotency): `record-export-concurrent-trigger.test.ts` — two parallel `recordExport` invocations against same `(kaiordRecordId, destinationBridgeId)` fire postFn exactly once + one ledger row
- [x] AC-9 (aggregation): `weight-export-aggregation.test.ts` — 3 sources → 3 POSTs first run, 3× SKIP on re-run

## Test plan

- [x] `pnpm -r build` — green
- [x] `pnpm lint` — green (no-magic-numbers fixed via `sources.length`)
- [x] `pnpm -r test` — all 4811+ passing including the 3 new acceptance tests
- [x] `pnpm test:scripts` — 485 passed (R-AppDexieImport satisfied via ports)
- [ ] CI to confirm on a fresh checkout

## Stacking note

Base: `feat/integration-policy-dexie-v17-migration` (PR #692).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added backend infrastructure for integration policy management (resolve, create, and delete operations)
  * Implemented idempotent imported record handling with natural-key deduplication
  * Added export record functionality with concurrent operation safety

* **Tests**
  * Integrated test coverage for weight export aggregation, inbound record idempotency, and concurrent export protection

**Note:** These capabilities are not yet connected to the user interface and will be available in upcoming releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->