### PR TITLE
fix(spa-editor): Data Flows zero-state keyed on bridge presence, not policy count

### DIFF
--- a/.changeset/fix-data-flows-zero-state-dead-end.md
+++ b/.changeset/fix-data-flows-zero-state-dead-end.md
@@ -1,0 +1,13 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+fix(spa-editor): Data Flows zero-state no longer dead-ends a fresh profile
+
+The "Data Flows" tab keyed its zero-state banner on whether any
+IntegrationPolicy already existed, so a profile with a connected bridge but
+no policies showed "Connect a bridge to start syncing data with kaiord" and
+rendered no groups — leaving the "+ Add source/destination" buttons (the only
+way to create the first policy) unreachable. The banner is now keyed on bridge
+presence: groups render as soon as a bridge is discovered, and the banner only
+appears when no bridge is connected.

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/DataFlowsSection.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/DataFlowsSection.test.tsx
@@ -1,11 +1,14 @@
 import type { ManagedDataType } from "@kaiord/core";
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { DiscoveredBridge } from "../../../../hooks/use-discovered-bridges";
 import type { UseDataFlowsResult } from "./useDataFlows";
 
+let mockBridges: readonly DiscoveredBridge[] = [];
+
 vi.mock("../../../../hooks/use-discovered-bridges", () => ({
-  useDiscoveredBridges: () => [],
+  useDiscoveredBridges: () => mockBridges,
 }));
 
 vi.mock("./useDataFlows", () => ({
@@ -23,6 +26,11 @@ import { useDataFlows } from "./useDataFlows";
 
 const mockUseDataFlows = vi.mocked(useDataFlows);
 
+const TRAIN2GO: DiscoveredBridge = {
+  bridgeId: "train2go-bridge",
+  extensionId: "ext-1",
+};
+
 const emptyResult: UseDataFlowsResult = {
   policies: [],
   byDataType: new Map(),
@@ -30,9 +38,14 @@ const emptyResult: UseDataFlowsResult = {
 };
 
 describe("DataFlowsSection", () => {
-  it("should render the zero-state banner when the profile has no policies", () => {
-    // Arrange
+  beforeEach(() => {
+    mockBridges = [];
     mockUseDataFlows.mockReturnValue(emptyResult);
+  });
+
+  it("should render the zero-state banner when no bridge is connected", () => {
+    // Arrange
+    mockBridges = [];
 
     // Act
     render(<DataFlowsSection profileId="p1" />);
@@ -44,8 +57,24 @@ describe("DataFlowsSection", () => {
     ).toBeInTheDocument();
   });
 
-  it("should render groups for managed data types when at least one policy exists", () => {
+  it("should render groups when a bridge is connected even with no policies yet", () => {
     // Arrange
+    mockBridges = [TRAIN2GO];
+    mockUseDataFlows.mockReturnValue(emptyResult);
+
+    // Act
+    render(<DataFlowsSection profileId="p1" />);
+
+    // Assert
+    expect(
+      screen.queryByTestId("data-flows-zero-state")
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("group-workout")).toBeInTheDocument();
+  });
+
+  it("should render groups when a bridge is connected and policies exist", () => {
+    // Arrange
+    mockBridges = [TRAIN2GO];
     const byDataType = new Map<ManagedDataType, { import: []; export: [] }>([
       ["workout", { import: [], export: [] }],
     ]);

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/DataFlowsSection.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/DataFlowsSection.tsx
@@ -1,8 +1,11 @@
 /**
  * DataFlowsSection — top-level section rendered on the "Data Flows" tab.
- * Reads all integration policies for the active profile; shows a zero-state
- * banner when none exist, otherwise renders one DataFlowsGroup per managed
- * data type.
+ * Renders one DataFlowsGroup per managed data type whenever at least one
+ * bridge has been discovered, so the "+ Add source/destination" affordances
+ * are reachable even before any policy exists. The zero-state banner is keyed
+ * on bridge presence (not policy count): it shows only when no bridge is
+ * connected — otherwise a fresh profile would dead-end with no way to create
+ * its first data flow.
  */
 import { MANAGED_DATA_REGISTRY, managedDataTypes } from "@kaiord/core";
 
@@ -15,13 +18,14 @@ type Props = {
 };
 
 export function DataFlowsSection({ profileId }: Props) {
-  const { byDataType, hasAny } = useDataFlows(profileId);
+  const { byDataType } = useDataFlows(profileId);
   const allBridges = useDiscoveredBridges();
+  const hasBridge = allBridges.length > 0;
 
   return (
     <div data-testid="data-flows-section" className="space-y-3">
       <h3 className="text-sm font-semibold">Data Flows</h3>
-      {!hasAny ? (
+      {!hasBridge ? (
         <p
           data-testid="data-flows-zero-state"
           className="rounded border border-dashed p-4 text-center text-sm text-gray-400"


### PR DESCRIPTION
## Problem

A user with the Train2Go bridge connected opens **Settings → Profile → Data Flows** and sees the empty-state banner *"Connect a bridge to start syncing data with kaiord"* — with no groups and no way to add a flow, even though a bridge is already connected.

Root cause (shipped in #695): `DataFlowsSection` keyed its zero-state on `hasAny` (does any `IntegrationPolicy` exist?), not on bridge presence. A fresh profile has no policies, so:

1. **Misleading copy** — the banner tells you to connect a bridge you already have.
2. **Dead end** — the `+ Add source / + Add destination` buttons live inside `DataFlowsGroup`, which only renders in the `hasAny === true` branch. With no policy you can't reach the only affordance that creates the first policy. Chicken-and-egg.

There is no auto-seeding of policies on bridge connect; creation is fully manual via the Add dialog — which was unreachable from the zero-state.

## Fix

Key the zero-state on **bridge discovery** instead of policy count:

- `allBridges.length > 0` → render the data-type groups (Add buttons reachable), regardless of whether any policy exists yet.
- No bridge discovered → show the banner (now accurate: there genuinely is no bridge).

## Tests

`DataFlowsSection.test.tsx` rewritten for the new semantics, including a regression guard: **groups render when a bridge is connected even with zero policies**.

- ✅ 3/3 tests pass
- ✅ tsc / eslint / prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the "Data Flows" tab zero-state behavior to remain functional when a bridge is connected but no integration policies exist yet. Users can now access the controls to add sources and destinations immediately after connecting a bridge, eliminating the previous dead-end scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pablo-albaladejo/kaiord/pull/701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->