### PR TITLE
fix(spa-editor): fix 3 regressions shipped by the mobile redesign

### DIFF
--- a/packages/workout-spa-editor/e2e/calendar-navigation.spec.ts
+++ b/packages/workout-spa-editor/e2e/calendar-navigation.spec.ts
@@ -34,15 +34,16 @@ test.describe("Calendar Navigation", () => {
     expect(page.url()).toContain("/calendar");
   });
 
-  test('Header "Calendar" button navigates to /calendar from /workout/new', async ({
+  test('Header "Calendar" button navigates to the week calendar', async ({
     page,
   }) => {
     await page.goto("/workout/new?source=scratch");
     await page.getByRole("button", { name: "Go to calendar" }).click();
-    await page.waitForURL(/\/calendar$/);
-    // The header "Go to calendar" entry targets bare /calendar, which
-    // renders the Today page post-redesign.
-    await expect(page.getByTestId("today-page")).toBeVisible();
+    // The Calendar entry targets the current week (/calendar/:weekId) so
+    // the week calendar is reachable from the header (bare /calendar is
+    // now the Today page).
+    await page.waitForURL(/\/calendar\/\d{4}-W\d{2}$/);
+    await expect(page.getByTestId("week-navigation")).toBeVisible();
   });
 
   test("Kaiord logo navigates to /calendar (SPA, no reload)", async ({

--- a/packages/workout-spa-editor/e2e/garmin-push-via-policy.spec.ts
+++ b/packages/workout-spa-editor/e2e/garmin-push-via-policy.spec.ts
@@ -93,22 +93,53 @@ test.describe("GarminPushButton resolver gating (AC-5)", () => {
     await page.reload();
     await page.waitForURL(/\/workout/, { timeout: 10_000 });
 
-    // Assert — no GarminPushButton rendered
-    // The button uses aria-label containing "garmin" or data-testid
-    await expect(page.getByRole("button", { name: /push to garmin/i }))
-      .not.toBeVisible({ timeout: 3_000 })
-      .catch(() => undefined);
+    // Assert — no editor GarminPushButton rendered (no enabled policy).
+    await expect(
+      page.getByRole("button", { name: /push to garmin/i })
+    ).toHaveCount(0);
+  });
+
+  test("should show the editor push button when an enabled export policy exists", async ({
+    page,
+  }) => {
+    // Verifies AC-5 is enforced again in the editor: with the active
+    // profile's enabled workout-export policy resolved (profileId wired
+    // into the editor GarminPushButton), the gated button renders.
+    const WORKOUT_ID = "garmin-push-editor-workout";
+    await installGarminBridgeStub(page);
+    await page.goto("/calendar");
+    await page.waitForFunction(
+      () =>
+        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
+      { timeout: 10_000 }
+    );
+    await seedProfileBase(page, PROFILE_ID);
+    await addExportPolicy(page, PROFILE_ID, GARMIN_BRIDGE_ID);
+    await seedWorkouts(page, [
+      makeWorkout({
+        id: WORKOUT_ID,
+        profileId: PROFILE_ID,
+        date: getWeekDates()[0],
+        state: "ready",
+      }),
+    ]);
+
+    // Act — open the workout in the editor.
+    await page.goto(`/workout/${WORKOUT_ID}`);
+
+    // Assert — the policy-gated editor push button renders.
+    await expect(
+      page.getByRole("button", { name: /push to garmin/i })
+    ).toBeVisible({ timeout: 8_000 });
   });
 
   test("should show the Push to Garmin button on the workout detail page", async ({
     page,
   }) => {
-    // NOTE: post-redesign the canonical Garmin push moved to the read-only
-    // WorkoutDetail page (/workout/view/:id), where the footer always
-    // renders "Push to Garmin". The editor's policy-gated GarminPushButton
-    // is no longer wired with a profileId, so resolver-gating (AC-5) is no
-    // longer enforced — flagged in the e2e redesign report. This test now
-    // asserts the shipped push surface.
+    // The redesign added a read-only WorkoutDetail page
+    // (/workout/view/:id) whose footer always renders "Push to Garmin"
+    // (ungated by design for that surface). This asserts that surface;
+    // the editor's policy-gated button is covered by the test above.
     const WORKOUT_ID = "garmin-push-detail-workout";
     await installGarminBridgeStub(page);
     await page.goto("/calendar");

--- a/packages/workout-spa-editor/e2e/library-flows.spec.ts
+++ b/packages/workout-spa-editor/e2e/library-flows.spec.ts
@@ -37,14 +37,6 @@ test.describe("Library flows", () => {
   test("Test A: header Library navigates to /library (no modal)", async ({
     page,
   }) => {
-    // NOTE: the original assertion that the routed `[data-route-heading]`
-    // H1 receives focus no longer holds. The redesigned StatusHeader nav
-    // entries are `<button onClick={navigate(...)}>` (programmatic wouter
-    // navigation) rather than `<Link>` anchors, so the clicked button
-    // retains focus and `useFocusOnRouteChange` does not move focus to the
-    // Library H1. This is an a11y regression in the shipped redesign —
-    // flagged in the e2e redesign report. The surface-classification
-    // contract (navigate, do not open a modal) is still asserted here.
     await page.goto("/calendar");
 
     // Use the mobile-aware helper so the test works on mobile
@@ -53,8 +45,11 @@ test.describe("Library flows", () => {
     await page.waitForURL(/\/library$/);
 
     await expect(page.getByTestId("library-page")).toBeVisible();
-    // The routed page owns a single `[data-route-heading]` H1.
-    await expect(page.locator("h1[data-route-heading]")).toHaveText("Library");
+    // The routed page owns a single `[data-route-heading]` H1, which
+    // receives focus on navigation via useFocusOnRouteChange.
+    const heading = page.locator("h1[data-route-heading]");
+    await expect(heading).toHaveText("Library");
+    await expect(heading).toBeFocused();
     // No dialog should have mounted as a side-effect of the click.
     await expect(page.getByRole("dialog")).toHaveCount(0);
 

--- a/packages/workout-spa-editor/src/components/molecules/StatusHeader/StatusEntryButtons.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StatusHeader/StatusEntryButtons.tsx
@@ -4,7 +4,7 @@ import { useLocation } from "wouter";
 import { Button } from "../../atoms/Button/Button";
 import { ProfileEntryButton } from "./ProfileEntryButton";
 import type { EntryDef } from "./status-entry-defs";
-import { ENTRY_DEFS } from "./status-entry-defs";
+import { ENTRY_DEFS, resolveEntryHref } from "./status-entry-defs";
 import { StatusIndicators } from "./StatusIndicators";
 
 type StatusEntryButtonsProps = {
@@ -46,7 +46,7 @@ export function StatusEntryButtons({ onHelpClick }: StatusEntryButtonsProps) {
         <EntryButton
           key={entry.id}
           entry={entry}
-          onClick={() => navigate(entry.to)}
+          onClick={() => navigate(resolveEntryHref(entry))}
         />
       ))}
       <span

--- a/packages/workout-spa-editor/src/components/molecules/StatusHeader/status-entry-defs.ts
+++ b/packages/workout-spa-editor/src/components/molecules/StatusHeader/status-entry-defs.ts
@@ -1,6 +1,8 @@
 import { Activity, Calendar, Library, Plus, Settings } from "lucide-react";
 import type { ComponentType } from "react";
 
+import { getCurrentWeekId } from "../../../utils/week-utils";
+
 export type EntryDef = {
   id: string;
   icon: ComponentType<{ className?: string }>;
@@ -47,3 +49,11 @@ export const ENTRY_DEFS: ReadonlyArray<EntryDef> = [
     to: "/settings/ai",
   },
 ];
+
+/** Resolves an entry's navigation target. The bare `/calendar` route now
+    renders the Today page, so the Calendar entry points at the current
+    week (`/calendar/:weekId`) — otherwise the week calendar would only be
+    reachable by deep-link. */
+export function resolveEntryHref(entry: EntryDef): string {
+  return entry.id === "calendar" ? `/calendar/${getCurrentWeekId()}` : entry.to;
+}

--- a/packages/workout-spa-editor/src/components/pages/Library/LibraryContent.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Library/LibraryContent.tsx
@@ -5,7 +5,6 @@ import type { WorkoutTemplate } from "../../../types/workout-library";
 import { ConfirmationModal } from "../../molecules/ConfirmationModal";
 import { filterTemplates, type SportFilter } from "./library-filter";
 import { LibraryEmpty } from "./LibraryEmpty";
-import { LibraryHeader } from "./LibraryHeader";
 import { LibraryListRow } from "./LibraryListRow";
 import { LibrarySearchField } from "./LibrarySearchField";
 import { LibrarySportChips } from "./LibrarySportChips";
@@ -45,7 +44,6 @@ export function LibraryContent({
 
   return (
     <div className="space-y-4">
-      <LibraryHeader count={templates.length} />
       <LibrarySearchField value={query} onChange={setQuery} />
       <LibrarySportChips active={sport} onChange={setSport} />
       {filtered.length === 0 ? (

--- a/packages/workout-spa-editor/src/components/pages/LibraryPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/LibraryPage.tsx
@@ -80,13 +80,14 @@ export default function LibraryPage() {
 
   return (
     <div className="space-y-4 p-4" data-testid="library-page">
+      {/* Render the route heading once (a stable element) so the focus
+          set by useFocusOnRouteChange survives the loading→loaded swap;
+          a per-branch header would unmount and drop focus to <body>. */}
+      <LibraryHeader count={templates?.length ?? 0} />
       {templates === undefined ? (
-        <>
-          <LibraryHeader count={0} />
-          <div className="flex items-center justify-center p-8 text-slate-400">
-            Loading library...
-          </div>
-        </>
+        <div className="flex items-center justify-center p-8 text-slate-400">
+          Loading library...
+        </div>
       ) : (
         <>
           <LibraryContent

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutActions.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutActions.tsx
@@ -1,5 +1,6 @@
 import { Trash2 } from "lucide-react";
 
+import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import type { KRD } from "../../../types/krd";
 import { Button } from "../../atoms/Button/Button";
 import { GarminPushButton } from "../../molecules/GarminPushButton";
@@ -24,6 +25,10 @@ export function WorkoutActions({
   onRedo,
   onDiscard,
 }: WorkoutActionsProps) {
+  // Restore the policy-gated push: GarminPushButton resolves export
+  // policies by profile, so without the active profile id it always
+  // renders null (AC-5 gating was dead after the redesign).
+  const activeProfileId = useActiveProfileLive()?.id ?? undefined;
   return (
     <div className="flex flex-wrap items-start gap-3">
       <UndoRedoButtons
@@ -34,7 +39,7 @@ export function WorkoutActions({
       />
       <SaveButton workout={krd} />
       <SaveToLibraryButton workout={krd} />
-      <GarminPushButton />
+      <GarminPushButton profileId={activeProfileId} />
       <Button
         variant="tertiary"
         onClick={onDiscard}


### PR DESCRIPTION
## Summary

Fixes three regressions introduced by the mobile-first redesign of the workout SPA editor (#702–#705). Scoped to the editor UI only; no domain/adapter changes.

Touched areas:
- **StatusHeader** — `StatusEntryButtons.tsx` + `status-entry-defs.ts`
- **Library** — `LibraryPage.tsx` + `LibraryContent.tsx`
- **WorkoutSection** — `WorkoutActions.tsx`
- **e2e specs** — `calendar-navigation`, `garmin-push-via-policy`, `library-flows` updated to match the corrected behavior

## Verification

- `pnpm --filter @kaiord/workout-spa-editor build` — exit 0
- `pnpm --filter @kaiord/workout-spa-editor test` — 534 files / 4329 tests passing

## Note

This change was split out of the cross-device-sync branch (#719) into its own PR; it is independent of that feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)