### PR TITLE
fix(spa-editor): create flows persist and land on the calendar

### DIFF
--- a/.changeset/create-save-lands-on-calendar.md
+++ b/.changeset/create-save-lands-on-calendar.md
@@ -1,0 +1,14 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Create flows always persist and land on the calendar
+
+The scratch editor's "Save & schedule" control now renders on every entry —
+entered without a date it schedules onto today instead of leaving file export
+as the only "save". After saving, both the scratch and AI create flows land on
+the calendar week containing the saved workout (`/calendar/:weekId`) so the
+new card is visible on arrival, replacing the previous `/workout/:id` and
+dated-picker landings. The week resolution uses a local-midnight date anchor,
+fixing a latent week-shift for far-east timezones at week boundaries (the
+Today week strip now shares the same helper).

--- a/packages/workout-spa-editor/e2e/workout-creation.spec.ts
+++ b/packages/workout-spa-editor/e2e/workout-creation.spec.ts
@@ -1,8 +1,11 @@
 import { expect, test } from "./fixtures/base";
+import { buildStructuredCyclingKrd } from "./helpers/build-structured-cycling-krd";
+import { clearDexie, getWeekId } from "./helpers/seed-dexie";
 import { seedEmptyWorkout } from "./helpers/seed-empty-workout";
 
 const EXPECTED_STEP_CARDS_AFTER_DUPLICATE = 3;
 const IMMEDIATE_DELETION_GRACE_MS = 300;
+const ISO_DATE_LENGTH = 10;
 
 /**
  * Critical Path: Step Management (Create, Delete, Duplicate)
@@ -213,5 +216,35 @@ test.describe("Step Management Flow", () => {
     await page.keyboard.press("Control+S");
     const download = await downloadPromise;
     expect(download.suggestedFilename()).toMatch(/\.krd$/);
+  });
+});
+
+test.describe("Create → Save & schedule → calendar landing", () => {
+  test("should land on the calendar week with the new workout visible after Save & schedule", async ({
+    page,
+  }) => {
+    // Arrange — clean DB with the default active profile, starting on the calendar
+    await page.goto("/calendar");
+    await page.waitForFunction(() => "__KAIORD_DB__" in window, undefined, {
+      timeout: 10000,
+    });
+    await clearDexie(page);
+    const today = new Date().toISOString().slice(0, ISO_DATE_LENGTH);
+    const weekId = getWeekId(today);
+
+    // Act — author a scratch workout without a date (defaults to today) and save
+    await seedEmptyWorkout(
+      page,
+      buildStructuredCyclingKrd(new Date().toISOString())
+    );
+    const scheduleButton = page.getByTestId("scratch-schedule-button");
+    await expect(scheduleButton).toBeEnabled({ timeout: 10000 });
+    await scheduleButton.click();
+
+    // Assert — back on the calendar week containing today, new card visible
+    await expect(page).toHaveURL(new RegExp(`/calendar/${weekId}$`));
+    await expect(
+      page.locator('[data-testid^="workout-card-"]').first()
+    ).toBeVisible({ timeout: 10000 });
   });
 });

--- a/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchEditorSurface.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchEditorSurface.test.tsx
@@ -12,6 +12,7 @@ import { ToastContextProvider } from "../../../contexts/ToastContext";
 import { useWorkoutStore } from "../../../store/workout-store";
 import type { Profile } from "../../../types/profile";
 import type { UserPreferences } from "../../../types/user-preferences";
+import { todayIsoDate } from "../../../utils/today-iso-date";
 import { ToastProvider } from "../../atoms/Toast";
 import { ScratchEditorSurface } from "./ScratchEditorSurface";
 
@@ -284,7 +285,7 @@ describe("ScratchEditorSurface", () => {
     ).toBeInTheDocument();
   });
 
-  it("should NOT render the schedule control without a date", async () => {
+  it("should render the schedule control without a date, defaulting to today", async () => {
     // Arrange
 
     // Act
@@ -294,7 +295,27 @@ describe("ScratchEditorSurface", () => {
     await waitFor(() => {
       expect(screen.getByTestId("ai-banner")).toBeInTheDocument();
     });
-    expect(screen.queryByTestId("scratch-schedule-button")).toBeNull();
+    expect(screen.getByTestId("scratch-schedule-button")).toBeInTheDocument();
+  });
+
+  it("should persist on today's date when entered without a date", async () => {
+    // Arrange
+    const user = userEvent.setup();
+    await seedActiveProfile();
+    const put = vi.spyOn(db.table("workouts"), "put");
+
+    // Act
+    renderSurface(null);
+    const button = await screen.findByTestId("scratch-schedule-button");
+    await waitFor(() => expect(button).toBeEnabled());
+    await user.click(button);
+
+    // Assert
+    await waitFor(() => {
+      expect(put).toHaveBeenCalledWith(
+        expect.objectContaining({ date: todayIsoDate(), source: "scratch" })
+      );
+    });
   });
 
   it("should disable the schedule control when no profile is active", async () => {
@@ -307,7 +328,7 @@ describe("ScratchEditorSurface", () => {
     expect(await screen.findByTestId("scratch-schedule-button")).toBeDisabled();
   });
 
-  it("should persist on the route date and navigate to /workout/:id when scheduled", async () => {
+  it("should persist on the route date and land on its calendar week when scheduled", async () => {
     // Arrange
     const user = userEvent.setup();
     await seedActiveProfile();
@@ -326,7 +347,7 @@ describe("ScratchEditorSurface", () => {
       );
     });
     await waitFor(() => {
-      expect(location.history.at(-1)).toMatch(/^\/workout\/[0-9a-f-]+$/);
+      expect(location.history.at(-1)).toBe("/calendar/2026-W23");
     });
   });
 

--- a/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchEditorSurface.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchEditorSurface.tsx
@@ -11,6 +11,7 @@ import {
 import { useWorkoutStore } from "../../../store/workout-store";
 import type { Workout } from "../../../types/krd";
 import type { Sport } from "../../../types/krd-core";
+import { todayIsoDate } from "../../../utils/today-iso-date";
 import { AiBanner } from "../../molecules/AiBanner/AiBanner";
 import { useCoachingSidebar } from "../../organisms/CoachingSidebar/use-coaching-sidebar";
 import { EditorBody } from "../../pages/EditorBody";
@@ -86,7 +87,7 @@ export function ScratchEditorSurface({ date }: { date: string | null }) {
   return (
     <div className="space-y-6">
       <AiBanner />
-      {date && <ScratchScheduleButton date={date} />}
+      <ScratchScheduleButton date={date ?? todayIsoDate()} />
       {workout && currentWorkout && (
         <EditorBody sidebar={sidebarData}>
           <WorkoutSection

--- a/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/use-persist-scratch.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/use-persist-scratch.ts
@@ -3,6 +3,7 @@ import { useLocation } from "wouter";
 import { usePersistence } from "../../../contexts/persistence-context";
 import { useToastContext } from "../../../contexts/ToastContext";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { calendarWeekHref } from "../../../routing/calendar-week-href";
 import { useCurrentWorkout } from "../../../store/selectors/workout-selectors";
 import type { Workout } from "../../../types/krd";
 import { isValidCalendarDate } from "../../../utils/is-valid-calendar-date";
@@ -23,8 +24,9 @@ export type UsePersistScratch = {
 
 /**
  * Scratch-local "Save & schedule" wiring: persists `currentWorkout` onto
- * the route `date` as a new scratch WorkoutRecord, then navigates to the
- * id route. D6-rejects calendar-impossible dates (toast, no persist/nav).
+ * the target `date` as a new scratch WorkoutRecord, then lands on the
+ * calendar week containing it so the new card is visible on arrival.
+ * D6-rejects calendar-impossible dates (toast, no persist/nav).
  */
 export function usePersistScratch(date: string): UsePersistScratch {
   const currentWorkout = useCurrentWorkout();
@@ -46,13 +48,13 @@ export function usePersistScratch(date: string): UsePersistScratch {
       | undefined;
     const sport = workout?.sport ?? DEFAULT_SPORT;
     try {
-      const record = await persistScratchWorkout(persistence, {
+      await persistScratchWorkout(persistence, {
         krd: currentWorkout,
         date,
         profileId,
         sport,
       });
-      navigate(`/workout/${record.id}`);
+      navigate(calendarWeekHref(date));
     } catch {
       toast.error(SAVE_FAIL_TITLE, SAVE_FAIL_DESC);
     }

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateWorkout.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateWorkout.test.tsx
@@ -10,7 +10,7 @@ function renderCreate() {
   const { hook } = memoryLocation({ path: "/workout/new", record: true });
   return renderWithProviders(
     <Router hook={hook}>
-      <CreateWorkout onClose={vi.fn()} />
+      <CreateWorkout onClose={vi.fn()} onSaved={vi.fn()} />
     </Router>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateWorkout.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateWorkout.tsx
@@ -1,20 +1,24 @@
-import { useCallback } from "react";
-
 import { thresholdsForSport } from "../../../lib/athlete";
 import { buildReviewModel } from "../../../lib/workout-review";
 import { ROUTE_HEADING_ATTR } from "../../../routing/constants";
-import { buildWorkoutRecord } from "./build-workout-record";
 import { CreateGeneratingPhase } from "./CreateGeneratingPhase";
 import { CreateInputPhase } from "./CreateInputPhase";
 import { CreateResultPhase } from "./CreateResultPhase";
+import { useCreateSave } from "./use-create-save";
 import { useCreateWorkout } from "./use-create-workout";
-import { useSaveAndPush } from "./use-save-and-push";
 
 const FALLBACK_TITLE = "AI session";
 
-export type CreateWorkoutProps = { onClose: () => void };
+export type CreateWorkoutProps = {
+  onClose: () => void;
+  /** Post-save landing; receives the persisted record's calendar date. */
+  onSaved: (date: string) => void;
+};
 
-export default function CreateWorkout({ onClose }: CreateWorkoutProps) {
+export default function CreateWorkout({
+  onClose,
+  onSaved,
+}: CreateWorkoutProps) {
   const create = useCreateWorkout();
   const { phase, sport, profile, activeProfileId, generatedKrd, promptText } =
     create;
@@ -26,19 +30,15 @@ export default function CreateWorkout({ onClose }: CreateWorkoutProps) {
     : null;
   const title = model?.title ?? FALLBACK_TITLE;
 
-  const buildRecord = useCallback(() => {
-    if (!generatedKrd) throw new Error("No generated workout to save");
-    return buildWorkoutRecord({
-      profileId: activeProfileId ?? "",
-      sport,
-      prompt: promptText,
-      title,
-      krd: generatedKrd,
-      date: dateParam,
-    });
-  }, [activeProfileId, sport, promptText, title, generatedKrd, dateParam]);
-
-  const { save, saving } = useSaveAndPush({ buildRecord, onDone: onClose });
+  const { save, saving } = useCreateSave({
+    generatedKrd,
+    activeProfileId,
+    sport,
+    promptText,
+    title,
+    dateParam,
+    onSaved,
+  });
 
   return (
     <div

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/build-workout-record.ts
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/build-workout-record.ts
@@ -3,6 +3,7 @@ import type { WorkoutRaw } from "../../../types/calendar-fragments";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { KRD } from "../../../types/krd";
 import { isValidCalendarDate } from "../../../utils/is-valid-calendar-date";
+import { todayIsoDate } from "../../../utils/today-iso-date";
 
 export type BuildWorkoutRecordInput = {
   profileId: string;
@@ -13,8 +14,6 @@ export type BuildWorkoutRecordInput = {
   /** Schedule target; falls back to today when absent (non-dated entry). */
   date?: string | null;
 };
-
-const todayDate = (): string => new Date().toISOString().slice(0, 10);
 
 /** Build a persisted WorkoutRecord for an AI-generated session. */
 export async function buildWorkoutRecord(
@@ -33,7 +32,7 @@ export async function buildWorkoutRecord(
   raw.rawHash = await computeRawHash(raw);
 
   const date =
-    input.date && isValidCalendarDate(input.date) ? input.date : todayDate();
+    input.date && isValidCalendarDate(input.date) ? input.date : todayIsoDate();
 
   return {
     id: crypto.randomUUID(),

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/use-create-save.ts
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/use-create-save.ts
@@ -1,0 +1,43 @@
+import { useCallback } from "react";
+
+import type { KRD } from "../../../types/krd";
+import { buildWorkoutRecord } from "./build-workout-record";
+import { useSaveAndPush } from "./use-save-and-push";
+
+export type CreateSaveArgs = {
+  generatedKrd: KRD | null;
+  activeProfileId: string | null;
+  sport: string;
+  promptText: string;
+  title: string;
+  dateParam: string | null;
+  /** Post-save landing; receives the persisted record's calendar date. */
+  onSaved: (date: string) => void;
+};
+
+/**
+ * Save wiring for the AI create flow: builds the WorkoutRecord from the
+ * generated KRD and hands the persisted record's date to `onSaved` so the
+ * route layer can land on the matching calendar week.
+ */
+export function useCreateSave(args: CreateSaveArgs) {
+  const { generatedKrd, activeProfileId, sport, promptText } = args;
+  const { title, dateParam, onSaved } = args;
+
+  const buildRecord = useCallback(() => {
+    if (!generatedKrd) throw new Error("No generated workout to save");
+    return buildWorkoutRecord({
+      profileId: activeProfileId ?? "",
+      sport,
+      prompt: promptText,
+      title,
+      krd: generatedKrd,
+      date: dateParam,
+    });
+  }, [activeProfileId, sport, promptText, title, generatedKrd, dateParam]);
+
+  return useSaveAndPush({
+    buildRecord,
+    onDone: (record) => onSaved(record.date),
+  });
+}

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/use-save-and-push.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/use-save-and-push.test.tsx
@@ -1,0 +1,91 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "../../../adapters/dexie/dexie-database";
+import { GarminBridgeProvider } from "../../../contexts/garmin-bridge-context";
+import { ToastContextProvider } from "../../../contexts/ToastContext";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import { ToastProvider } from "../../atoms/Toast";
+import { useSaveAndPush } from "./use-save-and-push";
+
+const RECORD: WorkoutRecord = {
+  id: "11111111-1111-4111-8111-111111111111",
+  profileId: "p1",
+  date: "2026-06-01",
+  sport: "cycling",
+  source: "ai-generated",
+  sourceId: null,
+  planId: null,
+  state: "structured",
+  raw: null,
+  krd: {
+    version: "1.0",
+    type: "structured_workout",
+    metadata: { created: "2026-05-30T00:00:00.000Z", sport: "cycling" },
+    extensions: { structured_workout: { sport: "cycling", steps: [] } },
+  },
+  lastProcessingError: null,
+  feedback: null,
+  aiMeta: null,
+  garminPushId: null,
+  tags: [],
+  previousState: null,
+  createdAt: "2026-05-30T00:00:00.000Z",
+  modifiedAt: null,
+  updatedAt: "2026-05-30T00:00:00.000Z",
+};
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <GarminBridgeProvider>
+      <ToastProvider>
+        <ToastContextProvider>{children}</ToastContextProvider>
+      </ToastProvider>
+    </GarminBridgeProvider>
+  );
+}
+
+describe("useSaveAndPush", () => {
+  beforeEach(async () => {
+    await db.table("workouts").clear();
+  });
+
+  it("should persist the built record to the workouts table", async () => {
+    // Arrange
+    const buildRecord = vi.fn().mockResolvedValue(RECORD);
+    const { result } = renderHook(
+      () => useSaveAndPush({ buildRecord, onDone: vi.fn() }),
+      { wrapper }
+    );
+
+    // Act
+    await result.current.save();
+
+    // Assert
+    const stored = await db.table("workouts").get(RECORD.id);
+    expect(stored).toMatchObject({ id: RECORD.id, date: "2026-06-01" });
+  });
+
+  it("should pass the persisted record to onDone so callers can route by date", async () => {
+    // Arrange
+    const onDone = vi.fn();
+    const buildRecord = vi.fn().mockResolvedValue(RECORD);
+    const { result } = renderHook(
+      () => useSaveAndPush({ buildRecord, onDone }),
+      {
+        wrapper,
+      }
+    );
+
+    // Act
+    await result.current.save();
+
+    // Assert
+    await waitFor(() => {
+      expect(onDone).toHaveBeenCalledWith(
+        expect.objectContaining({ date: "2026-06-01" })
+      );
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/use-save-and-push.ts
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/use-save-and-push.ts
@@ -11,7 +11,8 @@ const SAVED_ONLY = "Workout saved";
 
 export type SaveAndPushInput = {
   buildRecord: () => Promise<WorkoutRecord>;
-  onDone: () => void;
+  /** Called with the just-persisted record so callers can route by date. */
+  onDone: (record: WorkoutRecord) => void;
 };
 
 /**
@@ -46,7 +47,7 @@ export function useSaveAndPush({ buildRecord, onDone }: SaveAndPushInput) {
         toast.success(SAVED_ONLY);
       }
       setSaving(false);
-      onDone();
+      onDone(record);
     })();
   }, [record, sessionActive, push, toast, onDone]);
 

--- a/packages/workout-spa-editor/src/components/pages/Today/WeekStrip.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/WeekStrip.tsx
@@ -1,6 +1,6 @@
+import { calendarWeekHref } from "../../../routing/calendar-week-href";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { Profile } from "../../../types/profile";
-import { getWeekIdForDate } from "../../../utils/week-utils";
 import type { WeekDay } from "./today-dates";
 import { weekLoadFractions } from "./today-load";
 import { WeekStripColumn } from "./WeekStripColumn";
@@ -11,18 +11,13 @@ export type WeekStripProps = {
   profile: Profile | null;
 };
 
-function weekHref(iso: string): string {
-  const [year, month, day] = iso.split("-").map(Number);
-  return `/calendar/${getWeekIdForDate(new Date(year, month - 1, day))}`;
-}
-
 export function WeekStrip({ days, workouts, profile }: WeekStripProps) {
   const fractions = weekLoadFractions(
     days.map((d) => d.iso),
     workouts ?? [],
     profile
   );
-  const href = days.length > 0 ? weekHref(days[0].iso) : "/calendar";
+  const href = days.length > 0 ? calendarWeekHref(days[0].iso) : "/calendar";
 
   return (
     <div

--- a/packages/workout-spa-editor/src/new-workout-route.tsx
+++ b/packages/workout-spa-editor/src/new-workout-route.tsx
@@ -1,6 +1,7 @@
 import { useLocation, useSearch } from "wouter";
 
 import { CreateWorkout, EditorPage } from "./lazy-pages";
+import { calendarWeekHref } from "./routing/calendar-week-href";
 import { buildPickerHref } from "./routing/picker-href";
 
 /**
@@ -10,6 +11,9 @@ import { buildPickerHref } from "./routing/picker-href";
  * `onClose` is context-aware (#5): when the route carries a `?date=` (entered
  * from a dated calendar day) it returns to the dated picker so the date is
  * preserved; otherwise it falls back to the calendar home.
+ *
+ * `onSaved` lands on the calendar week containing the saved record so the
+ * new workout is visible on arrival.
  */
 export function NewWorkoutRoute() {
   const search = useSearch();
@@ -20,5 +24,10 @@ export function NewWorkoutRoute() {
   if (hasAction || hasSource) return <EditorPage />;
   const date = params.get("date");
   const closeTarget = date ? buildPickerHref(date) : "/calendar";
-  return <CreateWorkout onClose={() => navigate(closeTarget)} />;
+  return (
+    <CreateWorkout
+      onClose={() => navigate(closeTarget)}
+      onSaved={(savedDate) => navigate(calendarWeekHref(savedDate))}
+    />
+  );
 }

--- a/packages/workout-spa-editor/src/routing/calendar-week-href.test.ts
+++ b/packages/workout-spa-editor/src/routing/calendar-week-href.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { calendarWeekHref } from "./calendar-week-href";
+
+describe("calendarWeekHref", () => {
+  it("should map a date to its ISO calendar week route", () => {
+    // Arrange
+    const date = "2026-06-01";
+
+    // Act
+    const href = calendarWeekHref(date);
+
+    // Assert
+    expect(href).toBe("/calendar/2026-W23");
+  });
+
+  it("should keep a Sunday inside the week that started the prior Monday", () => {
+    // Arrange
+    const sunday = "2026-06-07";
+
+    // Act
+    const href = calendarWeekHref(sunday);
+
+    // Assert
+    expect(href).toBe("/calendar/2026-W23");
+  });
+
+  it("should keep the week stable in far-east timezones at week boundaries", () => {
+    // Arrange
+    const previousTz = process.env.TZ;
+    process.env.TZ = "Pacific/Kiritimati";
+
+    // Act
+    const href = calendarWeekHref("2026-06-07");
+
+    // Assert
+    expect(href).toBe("/calendar/2026-W23");
+    process.env.TZ = previousTz;
+  });
+
+  it("should resolve year-boundary dates to the ISO week-numbering year", () => {
+    // Arrange
+    const date = "2026-01-01";
+
+    // Act
+    const href = calendarWeekHref(date);
+
+    // Assert
+    expect(href).toBe("/calendar/2026-W01");
+  });
+});

--- a/packages/workout-spa-editor/src/routing/calendar-week-href.test.ts
+++ b/packages/workout-spa-editor/src/routing/calendar-week-href.test.ts
@@ -30,12 +30,15 @@ describe("calendarWeekHref", () => {
     const previousTz = process.env.TZ;
     process.env.TZ = "Pacific/Kiritimati";
 
-    // Act
-    const href = calendarWeekHref("2026-06-07");
+    try {
+      // Act
+      const href = calendarWeekHref("2026-06-07");
 
-    // Assert
-    expect(href).toBe("/calendar/2026-W23");
-    process.env.TZ = previousTz;
+      // Assert
+      expect(href).toBe("/calendar/2026-W23");
+    } finally {
+      process.env.TZ = previousTz;
+    }
   });
 
   it("should resolve year-boundary dates to the ISO week-numbering year", () => {

--- a/packages/workout-spa-editor/src/routing/calendar-week-href.ts
+++ b/packages/workout-spa-editor/src/routing/calendar-week-href.ts
@@ -1,0 +1,12 @@
+import { getWeekIdForDate } from "../utils/week-utils";
+
+/**
+ * Calendar landing target for a workout date: the week route that contains
+ * `date`, so the card is visible on arrival. Local-midnight constructor —
+ * `getWeekIdForDate` reads local calendar fields, so a UTC anchor would
+ * shift the week in far-east timezones (UTC+13/+14) at week boundaries.
+ */
+export function calendarWeekHref(date: string): string {
+  const [year, month, day] = date.split("-").map(Number);
+  return `/calendar/${getWeekIdForDate(new Date(year, month - 1, day))}`;
+}

--- a/packages/workout-spa-editor/src/utils/today-iso-date.test.ts
+++ b/packages/workout-spa-editor/src/utils/today-iso-date.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { todayIsoDate } from "./today-iso-date";
+
+describe("todayIsoDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return the current UTC date as YYYY-MM-DD", () => {
+    // Arrange
+    vi.setSystemTime(new Date("2026-06-05T10:30:00Z"));
+
+    // Act
+    const result = todayIsoDate();
+
+    // Assert
+    expect(result).toBe("2026-06-05");
+  });
+
+  it("should use the UTC calendar day across midnight boundaries", () => {
+    // Arrange
+    vi.setSystemTime(new Date("2026-06-05T23:59:59Z"));
+
+    // Act
+    const result = todayIsoDate();
+
+    // Assert
+    expect(result).toBe("2026-06-05");
+  });
+});

--- a/packages/workout-spa-editor/src/utils/today-iso-date.ts
+++ b/packages/workout-spa-editor/src/utils/today-iso-date.ts
@@ -1,0 +1,4 @@
+/** Today's calendar date as `YYYY-MM-DD` (UTC, repo-wide convention). */
+export function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}


### PR DESCRIPTION
## Problem

After finishing the create-workout flow, the visible **Save** button only downloaded a file — it never persisted the workout nor added it to the calendar. Entered without `?date=`, the scratch surface had **no persist path at all** (the "Save & schedule" control only rendered on dated entries), and after a dated save the user landed on `/workout/:id` (scratch) or back on the dated picker (AI flow) instead of the calendar.

## Fix

- **Scratch surface always offers "Save & schedule"** — without `?date=` it schedules onto today (`todayIsoDate()`, extracted from `build-workout-record.ts` and now shared).
- **Post-save landing is the calendar week containing the saved date** (`/calendar/:weekId`) for both the scratch and AI create flows, so the new card is visible on arrival. New shared `calendarWeekHref()` helper; `useSaveAndPush` now passes the persisted record to `onDone`, and `CreateWorkout` gained an `onSaved(date)` prop wired in `new-workout-route.tsx` (save wiring extracted to `use-create-save.ts` to stay under the 60-line component cap).
- **Timezone correctness**: `calendarWeekHref` uses a local-midnight anchor — `getWeekIdForDate` reads local calendar fields, so the previous noon-UTC convention shifted the week in UTC+13/+14 timezones at week boundaries. The Today `WeekStrip` now imports the shared helper instead of its private copy.
- D6 invalid-date rejection and disabled-until-ready gating unchanged.

## Tests

- New unit suites: `calendar-week-href` (incl. a `Pacific/Kiritimati` week-boundary guard that fails against the old UTC anchor), `today-iso-date`, `use-save-and-push` (record forwarded to `onDone`).
- Updated `ScratchEditorSurface` specs: button renders without a date and persists on today; post-save navigation asserts `/calendar/:weekId`.
- New e2e (`workout-creation.spec.ts`): calendar → scratch create (no date) → Save & schedule → lands on `/calendar/:weekId` with the new workout card visible.
- Full package suite: 4497+ tests green; manual browser verification of the end-to-end flow.

Multi-perspective review (code-reviewer agent): APPROVE after addressing a HIGH timezone finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "Save & schedule" button now always available in the editor, regardless of date selection.
  * Workouts without a selected date automatically schedule for today when saved.
  * After saving a new workout, you're now directed to the calendar week view containing your workout instead of the individual workout page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->