### PR TITLE
feat(spa-editor): movable focus day on Today

### DIFF
--- a/.changeset/today-movable-focus-day.md
+++ b/.changeset/today-movable-focus-day.md
@@ -1,0 +1,15 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+Today's focused day is now movable
+
+The Today page's focused day can move within the visible week — tap a day in
+the WeekStrip or use the prev/next day arrows. The focused day lives in the URL
+(`/today?date=YYYY-MM-DD`), so it is deep-linkable, back-recoverable, and
+shareable; the whole dashboard (readiness, planned sessions, header) follows the
+focused day. The header shows "Today" with no reset when focus is the real
+today, otherwise the focused weekday plus a "Back to Today" control. The
+WeekStrip keeps a dedicated "open in calendar" control and marks the real today
+distinctly from the focus cursor. Focus is bounded to the visible week and the
+`?date=` param is clamped (malformed/out-of-week falls back to today).

--- a/packages/workout-spa-editor/src/components/pages/Today/Today.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/Today.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { useLocation } from "wouter";
 
 import { calendarWeekHref } from "../../../routing/calendar-week-href";
@@ -10,25 +10,33 @@ import { ReadinessCard } from "./ReadinessCard";
 import { TodayHeader } from "./TodayHeader";
 import { TrendsCard } from "./TrendsCard";
 import { useTodayData } from "./use-today-data";
+import { useTodayFocusNav } from "./use-today-focus-nav";
+import { useTodayRouteParams } from "./use-today-route-params";
 import { WeekStrip } from "./WeekStrip";
 
 export default function Today() {
-  const now = useMemo(() => new Date(), []);
-  const { profile, days, weekWorkouts, planned, readiness } = useTodayData(now);
+  const { focusDate, focusIso, realTodayIso } = useTodayRouteParams();
+  const { profile, days, weekWorkouts, planned, readiness, isFocusToday } =
+    useTodayData(focusDate, realTodayIso);
+  const nav = useTodayFocusNav(days, focusIso, realTodayIso);
   const [, navigate] = useLocation();
 
   const handleWorkoutClick = useCallback(
     (workout: WorkoutRecord) => {
-      // Mirror the calendar: ready workouts open their detail (origin "today"
-      // so Back returns here); raw/skipped open in the calendar week, where
-      // the processing affordances live.
+      // Mirror the calendar: ready workouts open their editor (origin "today",
+      // carrying the focused day so Back returns here); raw/skipped open in the
+      // calendar week where the processing affordances live.
       if (workout.state === "raw" || workout.state === "skipped") {
         navigate(calendarWeekHref(workout.date));
       } else {
-        navigate(withOrigin(`/workout/${workout.id}`, "today"));
+        navigate(
+          withOrigin(`/workout/${workout.id}`, "today", {
+            date: isFocusToday ? undefined : focusIso,
+          })
+        );
       }
     },
-    [navigate]
+    [navigate, isFocusToday, focusIso]
   );
 
   const handleActivityClick = useCallback(
@@ -38,9 +46,22 @@ export default function Today() {
 
   return (
     <div className="space-y-6 px-4 pb-8" data-testid="today-page">
-      <TodayHeader now={now} />
+      <TodayHeader
+        focusDate={focusDate}
+        isFocusToday={isFocusToday}
+        onBackToToday={nav.backToToday}
+      />
       <ReadinessCard readiness={readiness} />
-      <WeekStrip days={days} workouts={weekWorkouts} profile={profile} />
+      <WeekStrip
+        days={days}
+        workouts={weekWorkouts}
+        profile={profile}
+        onSelectDay={nav.selectDay}
+        onPrev={nav.goPrev}
+        onNext={nav.goNext}
+        canPrev={nav.canPrev}
+        canNext={nav.canNext}
+      />
       <TrendsCard />
       <PlannedSession
         buckets={planned}

--- a/packages/workout-spa-editor/src/components/pages/Today/TodayHeader.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/TodayHeader.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { TodayHeader } from "./TodayHeader";
+
+// A known Wednesday: 2026-06-10 (local).
+const Y = 2026;
+const JUN = 5;
+const TENTH = 10;
+const WED = new Date(Y, JUN, TENTH);
+
+describe("TodayHeader", () => {
+  it("should title the page Today with no reset when focus is today", () => {
+    // Arrange
+    const onBackToToday = vi.fn();
+
+    // Act
+    render(
+      <TodayHeader
+        focusDate={WED}
+        isFocusToday={true}
+        onBackToToday={onBackToToday}
+      />
+    );
+
+    // Assert
+    expect(screen.getByRole("heading")).toHaveTextContent("Today");
+    expect(
+      screen.queryByRole("button", { name: /Back to Today/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it("should show the focused weekday and a reset when focus is a past day", () => {
+    // Arrange
+    const onBackToToday = vi.fn();
+
+    // Act
+    render(
+      <TodayHeader
+        focusDate={WED}
+        isFocusToday={false}
+        onBackToToday={onBackToToday}
+      />
+    );
+    screen.getByRole("button", { name: /Back to Today/ }).click();
+
+    // Assert
+    expect(screen.getByRole("heading")).toHaveTextContent("Wednesday");
+    expect(onBackToToday).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/Today/TodayHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/TodayHeader.tsx
@@ -2,7 +2,9 @@ import { ROUTE_HEADING_ATTR } from "../../../routing/constants";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
 export type TodayHeaderProps = {
-  now: Date;
+  focusDate: Date;
+  isFocusToday: boolean;
+  onBackToToday: () => void;
 };
 
 const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
@@ -10,9 +12,17 @@ const DATE_OPTIONS: Intl.DateTimeFormatOptions = {
   month: "long",
   day: "numeric",
 };
+const TITLE_OPTIONS: Intl.DateTimeFormatOptions = { weekday: "long" };
 
-export function TodayHeader({ now }: TodayHeaderProps) {
-  const eyebrow = now.toLocaleDateString(undefined, DATE_OPTIONS);
+export function TodayHeader({
+  focusDate,
+  isFocusToday,
+  onBackToToday,
+}: TodayHeaderProps) {
+  const eyebrow = focusDate.toLocaleDateString(undefined, DATE_OPTIONS);
+  const title = isFocusToday
+    ? "Today"
+    : focusDate.toLocaleDateString(undefined, TITLE_OPTIONS);
 
   return (
     <header className="flex items-start justify-between pt-2">
@@ -25,8 +35,17 @@ export function TodayHeader({ now }: TodayHeaderProps) {
           {...{ [ROUTE_HEADING_ATTR]: "" }}
           className="text-[28px] font-bold tracking-[-0.02em] text-slate-50 m-0"
         >
-          Today
+          {title}
         </h1>
+        {!isFocusToday && (
+          <button
+            type="button"
+            onClick={onBackToToday}
+            className="mt-1 rounded-md text-[13px] font-semibold text-sky-400 transition-colors hover:text-sky-300"
+          >
+            ← Back to Today
+          </button>
+        )}
       </div>
       <button
         type="button"

--- a/packages/workout-spa-editor/src/components/pages/Today/WeekStrip.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/WeekStrip.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 
@@ -8,38 +8,85 @@ import { weekDays } from "./today-dates";
 import { WeekStrip } from "./WeekStrip";
 
 const DAYS_IN_WEEK = 7;
+// A known week: Wed 2024-01-10 (Monday of that week is 2024-01-08).
+const Y = 2024;
+const JAN = 0;
+const TENTH = 10;
+const ANCHOR = new Date(Y, JAN, TENTH);
+const REAL_ISO = "2024-01-10";
 
-function renderStrip(days: WeekDay[]) {
-  const { hook } = memoryLocation({ path: "/calendar", record: true });
-  return render(
-    <Router hook={hook}>
-      <WeekStrip days={days} workouts={[]} profile={null} />
-    </Router>
-  );
+function renderStrip(
+  days: WeekDay[],
+  overrides: Partial<Parameters<typeof WeekStrip>[0]> = {}
+) {
+  const { hook } = memoryLocation({ path: "/today", record: true });
+  const onSelectDay = overrides.onSelectDay ?? vi.fn();
+  return {
+    onSelectDay,
+    ...render(
+      <Router hook={hook}>
+        <WeekStrip
+          days={days}
+          workouts={[]}
+          profile={null}
+          onSelectDay={onSelectDay}
+          onPrev={overrides.onPrev ?? vi.fn()}
+          onNext={overrides.onNext ?? vi.fn()}
+          canPrev={overrides.canPrev ?? true}
+          canNext={overrides.canNext ?? true}
+        />
+      </Router>
+    ),
+  };
 }
 
 describe("WeekStrip", () => {
-  it("should render seven clickable day columns", () => {
+  it("should render a focus-select button per day", () => {
     // Arrange
-    const days = weekDays(new Date("2024-01-10T12:00:00"));
+    const days = weekDays(ANCHOR, REAL_ISO);
 
     // Act
     renderStrip(days);
 
     // Assert
-    expect(screen.getAllByRole("link")).toHaveLength(DAYS_IN_WEEK);
+    const dayButtons = screen
+      .getAllByRole("button")
+      .filter((b) => b.getAttribute("aria-label")?.startsWith("Focus"));
+    expect(dayButtons).toHaveLength(DAYS_IN_WEEK);
   });
 
-  it("should link each day to its calendar week route", () => {
+  it("should select a day when its column is clicked", () => {
     // Arrange
-    const days = weekDays(new Date("2024-01-10T12:00:00"));
+    const days = weekDays(ANCHOR, REAL_ISO);
+    const { onSelectDay } = renderStrip(days);
+
+    // Act
+    screen.getByRole("button", { name: /Focus M 8/ }).click();
+
+    // Assert
+    expect(onSelectDay).toHaveBeenCalledWith(days[0].iso);
+  });
+
+  it("should keep a dedicated open-in-calendar control", () => {
+    // Arrange
+    const days = weekDays(ANCHOR, REAL_ISO);
 
     // Act
     renderStrip(days);
 
     // Assert
-    for (const link of screen.getAllByRole("link")) {
-      expect(link.getAttribute("href")).toMatch(/^\/calendar\/\d{4}-W\d{2}$/);
-    }
+    const link = screen.getByRole("link", { name: "Open week in calendar" });
+    expect(link.getAttribute("href")).toMatch(/^\/calendar\/\d{4}-W\d{2}$/);
+  });
+
+  it("should disable the prev arrow when it cannot go back", () => {
+    // Arrange
+    const days = weekDays(ANCHOR, REAL_ISO);
+
+    // Act
+    renderStrip(days, { canPrev: false });
+
+    // Assert
+    expect(screen.getByRole("button", { name: "Previous day" })).toBeDisabled();
   });
 });

--- a/packages/workout-spa-editor/src/components/pages/Today/WeekStrip.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/WeekStrip.tsx
@@ -1,6 +1,9 @@
+import { Link } from "wouter";
+
 import { calendarWeekHref } from "../../../routing/calendar-week-href";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { Profile } from "../../../types/profile";
+import { Icon, ICON_MAP } from "../../atoms/Icon";
 import type { WeekDay } from "./today-dates";
 import { weekLoadFractions } from "./today-load";
 import { WeekStripColumn } from "./WeekStripColumn";
@@ -9,29 +12,69 @@ export type WeekStripProps = {
   days: WeekDay[];
   workouts: WorkoutRecord[] | undefined;
   profile: Profile | null;
+  onSelectDay: (iso: string) => void;
+  onPrev: () => void;
+  onNext: () => void;
+  canPrev: boolean;
+  canNext: boolean;
 };
 
-export function WeekStrip({ days, workouts, profile }: WeekStripProps) {
+const ARROW =
+  "flex h-8 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-800 disabled:opacity-30 disabled:hover:bg-transparent";
+
+export function WeekStrip(props: WeekStripProps) {
+  const { days, workouts, profile, onSelectDay } = props;
   const fractions = weekLoadFractions(
     days.map((d) => d.iso),
     workouts ?? [],
     profile
   );
-  const href = days.length > 0 ? calendarWeekHref(days[0].iso) : "/calendar";
+  const calendarHref =
+    days.length > 0 ? calendarWeekHref(days[0].iso) : "/calendar";
 
   return (
     <div
       data-testid="today-week-strip"
-      className="flex gap-1.5 rounded-lg bg-primary-900 border border-slate-800 p-3"
+      className="rounded-lg bg-primary-900 border border-slate-800 p-3"
     >
-      {days.map((day, index) => (
-        <WeekStripColumn
-          key={day.iso}
-          day={day}
-          fraction={fractions[index]}
-          href={href}
-        />
-      ))}
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          aria-label="Previous day"
+          disabled={!props.canPrev}
+          onClick={props.onPrev}
+          className={ARROW}
+        >
+          <Icon icon={ICON_MAP.chevL} size="sm" color="inherit" />
+        </button>
+        {days.map((day, index) => (
+          <WeekStripColumn
+            key={day.iso}
+            day={day}
+            fraction={fractions[index]}
+            onSelect={onSelectDay}
+          />
+        ))}
+        <button
+          type="button"
+          aria-label="Next day"
+          disabled={!props.canNext}
+          onClick={props.onNext}
+          className={ARROW}
+        >
+          <Icon icon={ICON_MAP.chevR} size="sm" color="inherit" />
+        </button>
+      </div>
+      <div className="mt-2 flex justify-end">
+        <Link
+          href={calendarHref}
+          aria-label="Open week in calendar"
+          className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-semibold text-slate-400 transition-colors hover:bg-slate-800"
+        >
+          <Icon icon={ICON_MAP.calendar} size="sm" color="inherit" />
+          Calendar
+        </Link>
+      </div>
     </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/Today/WeekStripColumn.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/WeekStripColumn.tsx
@@ -1,37 +1,47 @@
-import { Link } from "wouter";
-
 import type { WeekDay } from "./today-dates";
 
 export type WeekStripColumnProps = {
   day: WeekDay;
   fraction: number;
-  href: string;
+  onSelect: (iso: string) => void;
 };
 
 const BAR_TRACK_HEIGHT = 40;
 const MIN_BAR_PX = 3;
 const PERCENT = 100;
 
-export function WeekStripColumn({ day, fraction, href }: WeekStripColumnProps) {
+export function WeekStripColumn({
+  day,
+  fraction,
+  onSelect,
+}: WeekStripColumnProps) {
   const barHeight = Math.max(
     MIN_BAR_PX,
     Math.round(fraction * BAR_TRACK_HEIGHT)
   );
-  const column = day.isToday
+  const column = day.isFocused
     ? "bg-sky-500/15 border border-sky-500 text-sky-400"
     : "text-slate-500";
-  const bar = day.isToday ? "bg-sky-400" : "bg-slate-600";
+  const bar = day.isFocused ? "bg-sky-400" : "bg-slate-600";
+  const label = `Focus ${day.letter} ${day.dayNumber}${day.isRealToday ? " (today)" : ""}`;
 
   return (
-    <Link
-      href={href}
-      aria-label={`Open week of ${day.letter} ${day.dayNumber} in calendar`}
-      className={`flex flex-1 flex-col items-center gap-1.5 rounded-md py-1.5 transition-colors hover:bg-slate-800 ${column}`}
+    <button
+      type="button"
+      onClick={() => onSelect(day.iso)}
+      aria-pressed={day.isFocused}
+      aria-current={day.isRealToday ? "date" : undefined}
+      aria-label={label}
+      className={`flex flex-1 flex-col items-center gap-1 rounded-md py-1.5 transition-colors hover:bg-slate-800 ${column}`}
     >
       <span className="text-[11px] font-semibold">{day.letter}</span>
       <span className="text-[13px] font-bold tabular-nums">
         {day.dayNumber}
       </span>
+      <span
+        aria-hidden="true"
+        className={`h-1 w-1 rounded-full ${day.isRealToday ? "bg-sky-400" : "bg-transparent"}`}
+      />
       <div
         className="flex w-full items-end justify-center"
         style={{ height: BAR_TRACK_HEIGHT }}
@@ -41,6 +51,6 @@ export function WeekStripColumn({ day, fraction, href }: WeekStripColumnProps) {
           style={{ height: `${(barHeight / BAR_TRACK_HEIGHT) * PERCENT}%` }}
         />
       </div>
-    </Link>
+    </button>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/Today/build-today-buckets.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/build-today-buckets.test.ts
@@ -66,7 +66,7 @@ describe("buildTodayBuckets", () => {
     // Act
     const buckets = buildTodayBuckets({
       dayIsos: DAYS,
-      todayIso: TODAY,
+      focusIso: TODAY,
       weekWorkouts: [raw],
       coachingByDay: {},
       matched: [],
@@ -85,7 +85,7 @@ describe("buildTodayBuckets", () => {
     // Act
     const buckets = buildTodayBuckets({
       dayIsos: DAYS,
-      todayIso: TODAY,
+      focusIso: TODAY,
       weekWorkouts: [],
       coachingByDay: { [TODAY]: [swim, gym] },
       matched: [],
@@ -111,7 +111,7 @@ describe("buildTodayBuckets", () => {
     const calendar = buildCalendarBuckets(sharedArgs);
     const today = buildTodayBuckets({
       dayIsos: DAYS,
-      todayIso: TODAY,
+      focusIso: TODAY,
       weekWorkouts: [workout()],
       coachingByDay: { [TODAY]: [activity()] },
       matched: [ms],
@@ -130,7 +130,7 @@ describe("buildTodayBuckets", () => {
     // Act
     const buckets = buildTodayBuckets({
       dayIsos: DAYS,
-      todayIso: TODAY,
+      focusIso: TODAY,
       weekWorkouts: [workout()],
       coachingByDay: { [TODAY]: [activity()] },
       matched: [ms],
@@ -150,7 +150,7 @@ describe("buildTodayBuckets", () => {
     // Act
     const buckets = buildTodayBuckets({
       dayIsos: DAYS,
-      todayIso: TODAY,
+      focusIso: TODAY,
       weekWorkouts: [],
       coachingByDay: { "2026-04-27": [otherDay] },
       matched: [],

--- a/packages/workout-spa-editor/src/components/pages/Today/build-today-buckets.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/build-today-buckets.ts
@@ -21,7 +21,7 @@ export type TodayBuckets = {
 
 export type BuildTodayBucketsArgs = {
   dayIsos: string[];
-  todayIso: string;
+  focusIso: string;
   weekWorkouts: WorkoutRecord[] | undefined;
   coachingByDay: Record<string, CoachingActivity[]>;
   matched: MatchedSessionWithMetadata[];
@@ -29,7 +29,7 @@ export type BuildTodayBucketsArgs = {
 
 export function buildTodayBuckets({
   dayIsos,
-  todayIso,
+  focusIso,
   weekWorkouts,
   coachingByDay,
   matched,
@@ -43,9 +43,9 @@ export function buildTodayBuckets({
       matched,
     });
   return {
-    matchedSessions: matchedByDay[todayIso] ?? [],
-    soloPlans: soloPlansByDay[todayIso] ?? [],
-    soloActuals: soloActualsByDay[todayIso] ?? [],
+    matchedSessions: matchedByDay[focusIso] ?? [],
+    soloPlans: soloPlansByDay[focusIso] ?? [],
+    soloActuals: soloActualsByDay[focusIso] ?? [],
   };
 }
 

--- a/packages/workout-spa-editor/src/components/pages/Today/today-dates.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-dates.test.ts
@@ -29,7 +29,7 @@ describe("weekDays", () => {
     // Arrange
 
     // Act
-    const days = weekDays(WEDNESDAY);
+    const days = weekDays(WEDNESDAY, "2026-05-27");
 
     // Assert
     expect(days).toHaveLength(WEEK_LENGTH);
@@ -37,15 +37,19 @@ describe("weekDays", () => {
     expect(days[WEEK_LENGTH - 1].iso).toBe("2026-05-31");
   });
 
-  it("should flag the matching day as today", () => {
+  it("should flag the focused day and the real today distinctly", () => {
     // Arrange
+    const realTodayIso = "2026-05-25";
 
     // Act
-    const days = weekDays(WEDNESDAY);
+    const days = weekDays(WEDNESDAY, realTodayIso);
 
     // Assert
-    const todays = days.filter((d) => d.isToday);
-    expect(todays).toHaveLength(1);
-    expect(todays[0].iso).toBe("2026-05-27");
+    const focused = days.filter((d) => d.isFocused);
+    const realToday = days.filter((d) => d.isRealToday);
+    expect(focused).toHaveLength(1);
+    expect(focused[0].iso).toBe("2026-05-27");
+    expect(realToday).toHaveLength(1);
+    expect(realToday[0].iso).toBe("2026-05-25");
   });
 });

--- a/packages/workout-spa-editor/src/components/pages/Today/today-dates.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-dates.ts
@@ -2,8 +2,13 @@
  * Date helpers for the Today landing page.
  *
  * `toIsoDate` yields a local `YYYY-MM-DD` (matching how `WorkoutRecord.date`
- * is stored). `weekDays` returns the seven Monday-to-Sunday local dates of
- * the calendar week containing `today`.
+ * is stored). `weekDays` returns the seven Monday-to-Sunday local dates of the
+ * calendar week containing the focused date, flagging each as the focus cursor
+ * (`isFocused`) and/or the real calendar today (`isRealToday`).
+ *
+ * `isoToLocalDate` constructs a Date from a `YYYY-MM-DD` via the LOCAL
+ * constructor (`new Date(y, m-1, d)`), never `new Date(iso)` (which parses as
+ * UTC midnight and shifts the local day at timezone boundaries).
  */
 
 const DAYS_PER_WEEK = 7;
@@ -14,7 +19,8 @@ export type WeekDay = {
   iso: string;
   letter: string;
   dayNumber: number;
-  isToday: boolean;
+  isFocused: boolean;
+  isRealToday: boolean;
 };
 
 const WEEKDAY_LETTERS = ["M", "T", "W", "T", "F", "S", "S"] as const;
@@ -26,6 +32,11 @@ export function toIsoDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+export function isoToLocalDate(iso: string): Date {
+  const [year, month, day] = iso.split("-").map(Number);
+  return new Date(year, month - 1, day);
+}
+
 function mondayOf(date: Date): Date {
   const result = new Date(date.getFullYear(), date.getMonth(), date.getDate());
   const weekday = result.getDay();
@@ -34,9 +45,9 @@ function mondayOf(date: Date): Date {
   return result;
 }
 
-export function weekDays(today: Date): WeekDay[] {
-  const monday = mondayOf(today);
-  const todayIso = toIsoDate(today);
+export function weekDays(focus: Date, realTodayIso: string): WeekDay[] {
+  const monday = mondayOf(focus);
+  const focusIso = toIsoDate(focus);
   return Array.from({ length: DAYS_PER_WEEK }, (_, index) => {
     const date = new Date(monday);
     date.setDate(monday.getDate() + index);
@@ -45,7 +56,13 @@ export function weekDays(today: Date): WeekDay[] {
       iso,
       letter: WEEKDAY_LETTERS[index],
       dayNumber: date.getDate(),
-      isToday: iso === todayIso,
+      isFocused: iso === focusIso,
+      isRealToday: iso === realTodayIso,
     };
   });
+}
+
+/** The seven ISO day strings of the week containing `date`. */
+export function weekIsos(date: Date): string[] {
+  return weekDays(date, "").map((d) => d.iso);
 }

--- a/packages/workout-spa-editor/src/components/pages/Today/today-focus-date.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-focus-date.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+
+import { isoToLocalDate } from "./today-dates";
+import { isRealIso, resolveFocusIso } from "./today-focus-date";
+
+// Week of Mon 2026-06-08 .. Sun 2026-06-14.
+const WEEK = [
+  "2026-06-08",
+  "2026-06-09",
+  "2026-06-10",
+  "2026-06-11",
+  "2026-06-12",
+  "2026-06-13",
+  "2026-06-14",
+];
+const REAL_TODAY = "2026-06-08";
+const Y = 2026;
+const JUN_INDEX = 5;
+const FIFTH = 5;
+
+describe("isoToLocalDate", () => {
+  it("should build a local date without a UTC day shift", () => {
+    // Arrange
+    const iso = "2026-06-05";
+
+    // Act
+    const date = isoToLocalDate(iso);
+
+    // Assert
+    expect(date.getFullYear()).toBe(Y);
+    expect(date.getMonth()).toBe(JUN_INDEX);
+    expect(date.getDate()).toBe(FIFTH);
+  });
+});
+
+describe("isRealIso", () => {
+  it("should accept a real calendar date", () => {
+    // Arrange
+    const iso = "2026-06-10";
+
+    // Act
+    const ok = isRealIso(iso);
+
+    // Assert
+    expect(ok).toBe(true);
+  });
+
+  it("should reject malformed or impossible dates", () => {
+    // Arrange
+    const cases = ["", "2026-6-10", "2026-13-01", "2026-06-40", "nope"];
+
+    // Act
+    const results = cases.map(isRealIso);
+
+    // Assert
+    expect(results).toEqual([false, false, false, false, false]);
+  });
+});
+
+describe("resolveFocusIso", () => {
+  it("should keep an in-week requested day", () => {
+    // Arrange
+    const requested = "2026-06-10";
+
+    // Act
+    const focus = resolveFocusIso(requested, REAL_TODAY, WEEK);
+
+    // Assert
+    expect(focus).toBe("2026-06-10");
+  });
+
+  it("should fall back to real today for an out-of-week day", () => {
+    // Arrange
+    const requested = "2026-06-01";
+
+    // Act
+    const focus = resolveFocusIso(requested, REAL_TODAY, WEEK);
+
+    // Assert
+    expect(focus).toBe(REAL_TODAY);
+  });
+
+  it("should fall back to real today for a malformed param", () => {
+    // Arrange
+    const requested = "not-a-date";
+
+    // Act
+    const focus = resolveFocusIso(requested, REAL_TODAY, WEEK);
+
+    // Assert
+    expect(focus).toBe(REAL_TODAY);
+  });
+
+  it("should fall back to real today for a missing param", () => {
+    // Arrange
+    const requested = "";
+
+    // Act
+    const focus = resolveFocusIso(requested, REAL_TODAY, WEEK);
+
+    // Assert
+    expect(focus).toBe(REAL_TODAY);
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/Today/today-focus-date.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-focus-date.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure focus-day resolution for the Today route param. Kept separate from the
+ * `useTodayRouteParams` hook so the clamp + ISO validation (the load-bearing,
+ * timezone-sensitive logic) is unit-testable without wouter/time setup.
+ */
+import { isoToLocalDate, toIsoDate } from "./today-dates";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** True when `iso` is a real `YYYY-MM-DD` that round-trips through the LOCAL
+    constructor (rejects e.g. 2026-13-40 and UTC-shift artifacts). */
+export function isRealIso(iso: string): boolean {
+  if (!ISO_DATE.test(iso)) return false;
+  return toIsoDate(isoToLocalDate(iso)) === iso;
+}
+
+/** The focused ISO day: the requested one when it is a real date inside the
+    given week, otherwise the real today (clamp/fallback — AC8). */
+export function resolveFocusIso(
+  requested: string,
+  realTodayIso: string,
+  week: string[]
+): string {
+  if (!isRealIso(requested)) return realTodayIso;
+  if (requested < week[0] || requested > week[week.length - 1]) {
+    return realTodayIso;
+  }
+  return requested;
+}

--- a/packages/workout-spa-editor/src/components/pages/Today/today-href.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-href.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { todayHref } from "./today-href";
+
+describe("todayHref", () => {
+  it("should return the bare /today when focus is the real today", () => {
+    // Arrange
+    const iso = "2026-06-08";
+
+    // Act
+    const href = todayHref(iso, iso);
+
+    // Assert
+    expect(href).toBe("/today");
+  });
+
+  it("should carry ?date= when focus is a different day", () => {
+    // Arrange
+    const focus = "2026-06-10";
+    const realToday = "2026-06-08";
+
+    // Act
+    const href = todayHref(focus, realToday);
+
+    // Assert
+    expect(href).toBe("/today?date=2026-06-10");
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/Today/today-href.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-href.ts
@@ -1,0 +1,11 @@
+/**
+ * Canonical href for the Today page at a given focus day.
+ *
+ * The real today is the canonical, param-less `/today`; any other focused day
+ * is carried as `?date=YYYY-MM-DD`. Used at every write site (day select, day
+ * arrows, back-origin date carry) so the "no param when focus == today" rule
+ * cannot drift between callers.
+ */
+export function todayHref(focusIso: string, realTodayIso: string): string {
+  return focusIso === realTodayIso ? "/today" : `/today?date=${focusIso}`;
+}

--- a/packages/workout-spa-editor/src/components/pages/Today/today-readiness.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-readiness.test.ts
@@ -29,18 +29,28 @@ describe("buildReadinessModel", () => {
     // Arrange
 
     // Act
-    const model = buildReadinessModel(HRV, SLEEP);
+    const model = buildReadinessModel(HRV, SLEEP, true);
 
     // Assert
     expect(model.score).toBe(EXPECTED_COMPOSITE);
     expect(model.headline).toBe("Good to push today");
   });
 
+  it("should drop the present-tense today suffix when focus is a past day", () => {
+    // Arrange
+
+    // Act
+    const model = buildReadinessModel(HRV, SLEEP, false);
+
+    // Assert
+    expect(model.headline).toBe("Good to push");
+  });
+
   it("should fall back to em-dash placeholders when data is absent", () => {
     // Arrange
 
     // Act
-    const model = buildReadinessModel(undefined, undefined);
+    const model = buildReadinessModel(undefined, undefined, true);
 
     // Assert
     expect(model.score).toBeNull();
@@ -53,7 +63,7 @@ describe("buildReadinessModel", () => {
     // Arrange
 
     // Act
-    const model = buildReadinessModel(HRV, undefined);
+    const model = buildReadinessModel(HRV, undefined, true);
 
     // Assert
     expect(model.hrv.value).toBe("62");

--- a/packages/workout-spa-editor/src/components/pages/Today/today-readiness.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-readiness.ts
@@ -13,6 +13,16 @@ const SECONDS_PER_HOUR = 3600;
 const HRV_TREND_THRESHOLD = 0;
 const SCORE_MAX = 100;
 
+const HEADLINE_PUSH_TODAY = "Good to push today";
+const HEADLINE_PUSH = "Good to push";
+const HEADLINE_EASY_TODAY = "Take it easy today";
+const HEADLINE_EASY = "Take it easy";
+
+function readyHeadline(ready: boolean, isFocusToday: boolean): string {
+  if (ready) return isFocusToday ? HEADLINE_PUSH_TODAY : HEADLINE_PUSH;
+  return isFocusToday ? HEADLINE_EASY_TODAY : HEADLINE_EASY;
+}
+
 export type ReadinessMetric = {
   label: string;
   value: string;
@@ -53,7 +63,8 @@ function hrvTrend(hrv: HrvSummary | undefined): string | undefined {
 
 export function buildReadinessModel(
   hrv: HrvSummary | undefined,
-  sleep: SleepRecord | undefined
+  sleep: SleepRecord | undefined,
+  isFocusToday: boolean
 ): ReadinessModel {
   const score = compositeScore(hrv, sleep);
   const ready = score !== null && score >= SCORE_MAX / 2;
@@ -62,9 +73,7 @@ export function buildReadinessModel(
     headline:
       score === null
         ? "No readiness data yet"
-        : ready
-          ? "Good to push today"
-          : "Take it easy today",
+        : readyHeadline(ready, isFocusToday),
     rationale:
       score === null
         ? "Connect Garmin to sync HRV and sleep."

--- a/packages/workout-spa-editor/src/components/pages/Today/use-today-data.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-today-data.ts
@@ -18,48 +18,57 @@ import { useWeekWorkoutsLive } from "./use-today-workouts-live";
 
 export type TodayData = {
   profile: Profile | null;
-  todayIso: string;
+  focusIso: string;
+  realTodayIso: string;
+  isFocusToday: boolean;
   days: WeekDay[];
   weekWorkouts: WorkoutRecord[] | undefined;
   planned: TodayBuckets;
   readiness: ReadinessModel;
 };
 
-export function useTodayData(now: Date): TodayData {
+export function useTodayData(focusDate: Date, realTodayIso: string): TodayData {
   const active = useActiveProfileLive();
   const profileId = active?.id ?? null;
   const profile = active?.profile ?? null;
 
-  const days = useMemo(() => weekDays(now), [now]);
+  const days = useMemo(
+    () => weekDays(focusDate, realTodayIso),
+    [focusDate, realTodayIso]
+  );
   const dayIsos = useMemo(() => days.map((d) => d.iso), [days]);
-  const todayIso = toIsoDate(now);
+  const focusIso = toIsoDate(focusDate);
   const start = days[0].iso;
   const end = days[days.length - 1].iso;
 
   const weekWorkouts = useWeekWorkoutsLive(profileId, start, end);
   const hrvRecords = useHealthHrvHistoryLive(profileId ?? "", {
-    start: todayIso,
-    end: todayIso,
+    start: focusIso,
+    end: focusIso,
   });
   const sleepRecords = useHealthSleepWeekLive(profileId ?? "", {
-    start: todayIso,
-    end: todayIso,
+    start: focusIso,
+    end: focusIso,
   });
 
   const planned = useTodayPlannedBuckets(
     profileId,
     dayIsos,
-    todayIso,
+    focusIso,
     weekWorkouts
   );
+  const isFocusToday = focusIso === realTodayIso;
   const readiness = buildReadinessModel(
     hrvRecords?.at(-1)?.krd,
-    sleepRecords?.at(-1)?.krd
+    sleepRecords?.at(-1)?.krd,
+    isFocusToday
   );
 
   return {
     profile,
-    todayIso,
+    focusIso,
+    realTodayIso,
+    isFocusToday,
     days,
     weekWorkouts,
     planned,

--- a/packages/workout-spa-editor/src/components/pages/Today/use-today-focus-nav.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-today-focus-nav.ts
@@ -1,0 +1,45 @@
+/**
+ * Focus-day navigation for the Today page. Writes the focused day to the URL
+ * (`todayHref`) — day select, prev/next day arrows (bounded to the visible week
+ * by indexing into `days`, so the edges disable structurally), and "Back to
+ * Today" which clears the param.
+ */
+import { useCallback } from "react";
+import { useLocation } from "wouter";
+
+import type { WeekDay } from "./today-dates";
+import { todayHref } from "./today-href";
+
+export type TodayFocusNav = {
+  selectDay: (iso: string) => void;
+  goPrev: () => void;
+  goNext: () => void;
+  canPrev: boolean;
+  canNext: boolean;
+  backToToday: () => void;
+};
+
+export function useTodayFocusNav(
+  days: WeekDay[],
+  focusIso: string,
+  realTodayIso: string
+): TodayFocusNav {
+  const [, navigate] = useLocation();
+  const index = days.findIndex((d) => d.iso === focusIso);
+  const canPrev = index > 0;
+  const canNext = index >= 0 && index < days.length - 1;
+
+  const selectDay = useCallback(
+    (iso: string) => navigate(todayHref(iso, realTodayIso)),
+    [navigate, realTodayIso]
+  );
+  const goPrev = useCallback(() => {
+    if (canPrev) navigate(todayHref(days[index - 1].iso, realTodayIso));
+  }, [canPrev, days, index, navigate, realTodayIso]);
+  const goNext = useCallback(() => {
+    if (canNext) navigate(todayHref(days[index + 1].iso, realTodayIso));
+  }, [canNext, days, index, navigate, realTodayIso]);
+  const backToToday = useCallback(() => navigate("/today"), [navigate]);
+
+  return { selectDay, goPrev, goNext, canPrev, canNext, backToToday };
+}

--- a/packages/workout-spa-editor/src/components/pages/Today/use-today-planned-buckets.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-today-planned-buckets.ts
@@ -19,7 +19,7 @@ import { buildTodayBuckets, type TodayBuckets } from "./build-today-buckets";
 export function useTodayPlannedBuckets(
   profileId: string | null,
   dayIsos: string[],
-  todayIso: string,
+  focusIso: string,
   weekWorkouts: WorkoutRecord[] | undefined
 ): TodayBuckets {
   const coaching = useCoachingActivities(dayIsos);
@@ -29,11 +29,11 @@ export function useTodayPlannedBuckets(
     () =>
       buildTodayBuckets({
         dayIsos,
-        todayIso,
+        focusIso,
         weekWorkouts,
         coachingByDay: coaching.byDay,
         matched: matched ?? [],
       }),
-    [dayIsos, todayIso, weekWorkouts, coaching.byDay, matched]
+    [dayIsos, focusIso, weekWorkouts, coaching.byDay, matched]
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/Today/use-today-route-params.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-today-route-params.ts
@@ -1,0 +1,36 @@
+/**
+ * Reads the Today page's focused day from `?date=YYYY-MM-DD`, clamped into the
+ * real-today week so the WeekStrip can never render an off-week strip. A
+ * malformed, missing, or out-of-week param falls back to the real today.
+ * Validation + clamp live in the pure `resolveFocusIso`.
+ */
+import { useMemo } from "react";
+import { useSearch } from "wouter";
+
+import { isoToLocalDate, toIsoDate, weekIsos } from "./today-dates";
+import { resolveFocusIso } from "./today-focus-date";
+
+export type TodayRouteParams = {
+  focusDate: Date;
+  focusIso: string;
+  realTodayIso: string;
+};
+
+export function useTodayRouteParams(): TodayRouteParams {
+  const search = useSearch();
+
+  return useMemo(() => {
+    const realToday = new Date();
+    const realTodayIso = toIsoDate(realToday);
+    const requested = new URLSearchParams(search).get("date") ?? "";
+    const focusIso = resolveFocusIso(
+      requested,
+      realTodayIso,
+      weekIsos(realToday)
+    );
+    const focusDate =
+      focusIso === realTodayIso ? realToday : isoToLocalDate(focusIso);
+
+    return { focusDate, focusIso, realTodayIso };
+  }, [search]);
+}

--- a/packages/workout-spa-editor/src/routing/resolve-back-target.test.ts
+++ b/packages/workout-spa-editor/src/routing/resolve-back-target.test.ts
@@ -58,6 +58,17 @@ describe("resolveBackTarget", () => {
     expect(result).toBe("/today");
   });
 
+  it("should carry the focused day on a dated today origin", () => {
+    // Arrange
+    const input = { origin: "today" as const, date: "2026-06-10" };
+
+    // Act
+    const result = resolveBackTarget(input);
+
+    // Assert
+    expect(result).toBe("/today?date=2026-06-10");
+  });
+
   it("should resolve a dated calendar-day origin to the picker href", () => {
     // Arrange
     const input = { origin: "calendar-day" as const, date: "2026-06-01" };

--- a/packages/workout-spa-editor/src/routing/resolve-back-target.ts
+++ b/packages/workout-spa-editor/src/routing/resolve-back-target.ts
@@ -39,7 +39,7 @@ export function resolveBackTarget({
     case "coaching":
       return "/calendar";
     case "today":
-      return "/today";
+      return date ? `/today?date=${date}` : "/today";
     default:
       return DEFAULT_TARGET;
   }

--- a/packages/workout-spa-editor/src/routing/with-origin.test.ts
+++ b/packages/workout-spa-editor/src/routing/with-origin.test.ts
@@ -36,6 +36,17 @@ describe("withOrigin", () => {
     expect(result).toBe("/workout/new?date=2026-06-01&from=calendar-day");
   });
 
+  it("should append the focused day via the date option", () => {
+    // Arrange
+    const href = "/workout/abc";
+
+    // Act
+    const result = withOrigin(href, "today", { date: "2026-06-10" });
+
+    // Assert
+    expect(result).toBe("/workout/abc?from=today&date=2026-06-10");
+  });
+
   it("should be idempotent when applied twice", () => {
     // Arrange
     const once = withOrigin("/workout/new?source=scratch", "library");

--- a/packages/workout-spa-editor/src/routing/with-origin.ts
+++ b/packages/workout-spa-editor/src/routing/with-origin.ts
@@ -5,12 +5,13 @@
  *
  * `opts.week` carries the originating `/calendar/:weekId` so calendar
  * back-targets return to THAT week (bare `/calendar` redirects to the
- * current week since the /today split).
+ * current week since the /today split). `opts.date` carries the Today
+ * page's focused day so a `today`-origin Back returns to `/today?date=`.
  */
 
 import type { BackOrigin } from "./back-origin";
 
-export type WithOriginOpts = { week?: string };
+export type WithOriginOpts = { week?: string; date?: string };
 
 export function withOrigin(
   href: string,
@@ -21,5 +22,6 @@ export function withOrigin(
   const params = new URLSearchParams(query);
   params.set("from", origin);
   if (opts.week) params.set("week", opts.week);
+  if (opts.date) params.set("date", opts.date);
   return `${path}?${params.toString()}`;
 }


### PR DESCRIPTION
## What

The Today page's focused day is now **movable within the visible week**. Today's purpose is a single-day deep dashboard (readiness + planned + trends); that focus can now move.

- **Tap a WeekStrip day** or use **prev/next day arrows** to change focus.
- The focused day lives in the **URL** (`/today?date=YYYY-MM-DD`): deep-linkable, browser-back-recoverable, shareable.
- The **whole dashboard follows the focus** — readiness (HRV/sleep), planned sessions, and the header all reflect the focused day.

## Locked product decisions (from the deep-dive interview)
- **Readiness follows the focused day** (historical), not always real-today.
- **State in `?date=`** (query param), not a path param or ephemeral state.
- **Bounded to the visible week** — no cross-week navigation; cross-week + swipe are explicit non-goals.

## How
- `use-today-route-params` parses + **clamps** `?date=` into the real-today week via the **local-date constructor** (`new Date(y, m-1, d)`, no UTC day-shift); malformed/missing/out-of-week → real today. Pure clamp/validation in `today-focus-date` (`resolveFocusIso`/`isRealIso`).
- `weekDays` splits the conflated `isToday` into **`isFocused`** (cursor) + **`isRealToday`** (orientation marker). `use-today-data` returns distinct `focusIso` + `realTodayIso`; the bucket + readiness paths follow focus (`todayIso`→`focusIso` throughout).
- Readiness headline drops the present-tense "today" suffix when focus ≠ today.
- **WeekStrip**: columns become focus-select buttons; a **dedicated "open in calendar"** control preserves the affordance the column tap gave up; arrows **index into the week** so edges disable structurally. **Header** is focus-aware with a **"Back to Today"** reset.
- **Back-origin carries the focused day**: `withOrigin`/`resolveBackTarget` gain `date`; the round-trip flows through `EditorPage` (which already threads `dateParam`) — the detail path is untouched and `DateBanner` stays `!id`-gated.
- Shared `todayHref(focusIso, realTodayIso)` at every write site so the "no param when focus == today" rule can't drift.

## Tests
- Pure: `today-focus-date` (clamp + UTC-safe local constructor + malformed/out-of-week fallback), `today-href`, `weekDays` isFocused/isRealToday split, readiness copy variants.
- Component: WeekStrip tap-to-select + arrow-disabled + calendar control; focus-aware header + reset.
- Routing: `withOrigin(..., 'today', {date})` and `resolveBackTarget({origin:'today', date})`.
- Full SPA suite **4526/4526** green; tsc + eslint + mechanical guards green.

## Follow-ups (out of scope)
- Cross-week navigation; midnight rollover of the default focus; the latent UTC-persist vs local-query date convention.

## Provenance
`/deep-dive` (3-lane trace + interview, 3 product decisions locked) → `/plan --consensus` (Architect SOUND-WITH-CHANGES + Critic APPROVED-WITH-NITS) → autopilot execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Today page now allows navigation between days in the current week using prev/next arrow controls
  * Focused day selection is now stored in the URL as `/today?date=YYYY-MM-DD`, enabling deep-linking and sharing
  * Header dynamically displays "Today" when on the current date, or the selected weekday with a "Back to Today" button
  * Readiness data and planned sessions update to reflect the focused date

<!-- end of auto-generated comment: release notes by coderabbit.ai -->