### PR TITLE
feat(spa-editor): Daily WeekStrip presence/intensity mark + Planned open-in-place

### DIFF
--- a/.changeset/daily-weekstrip-presence-and-open-in-place.md
+++ b/.changeset/daily-weekstrip-presence-and-open-in-place.md
@@ -1,0 +1,15 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+Daily WeekStrip shows per-day presence + intensity; Planned entries open in place
+
+The Daily page's WeekStrip no longer shows a flat workout-only load bar (which
+rendered an identical dash on coaching-only days). Each day now shows a
+presence + coarse intensity mark across all sources (workouts, coaching, matched
+sessions): an empty day is a faint hairline; a day with entries shows an
+intensity-tinted dot (filled for measured TSS, outline for estimated coaching
+effort) plus a count when 2+ entries; the real today is marked with a circled
+day number. Tapping a "Planned" entry now opens it in place — a coaching
+activity opens its dialog, a ready workout opens the editor, a raw/skipped
+workout opens its process dialog — instead of bouncing to the calendar.

--- a/packages/workout-spa-editor/src/components/pages/CalendarDialogs.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarDialogs.tsx
@@ -19,6 +19,8 @@ export type CalendarDialogsProps = {
   onCloseCoaching?: () => void;
   expandActivity: (activity: CoachingActivity) => void;
   onOpenExecuted?: (workout: WorkoutRecord) => void;
+  /** Override the "Process" target (Daily passes a `daily`-origin builder). */
+  buildProcessHref?: (id: string) => string;
 };
 
 export function CalendarDialogs({
@@ -28,9 +30,10 @@ export function CalendarDialogs({
   onCloseCoaching = () => {},
   expandActivity,
   onOpenExecuted,
+  buildProcessHref,
 }: CalendarDialogsProps) {
   const { handleProcess, handleSkip, handleUnskip, isSubmitting } =
-    useDialogHandlers(selectedWorkout, onCloseWorkout);
+    useDialogHandlers(selectedWorkout, onCloseWorkout, buildProcessHref);
 
   return (
     <>

--- a/packages/workout-spa-editor/src/components/pages/Today/Daily.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/Daily.tsx
@@ -1,14 +1,9 @@
-import { useCallback } from "react";
-import { useLocation } from "wouter";
-
-import { calendarWeekHref } from "../../../routing/calendar-week-href";
-import { withOrigin } from "../../../routing/with-origin";
-import type { WorkoutRecord } from "../../../types/calendar-record";
-import type { CoachingActivity } from "../../../types/coaching-activity";
+import { CalendarDialogs } from "../CalendarDialogs";
 import { DailyHeader } from "./DailyHeader";
 import { PlannedSession } from "./PlannedSession";
 import { ReadinessCard } from "./ReadinessCard";
 import { TrendsCard } from "./TrendsCard";
+import { useDailyEntryOpen } from "./use-daily-entry-open";
 import { useTodayData } from "./use-today-data";
 import { useTodayFocusNav } from "./use-today-focus-nav";
 import { useTodayRouteParams } from "./use-today-route-params";
@@ -16,33 +11,17 @@ import { WeekStrip } from "./WeekStrip";
 
 export default function Daily() {
   const { focusDate, focusIso, realTodayIso } = useTodayRouteParams();
-  const { profile, days, weekWorkouts, planned, readiness, isFocusToday } =
-    useTodayData(focusDate, realTodayIso);
+  const {
+    days,
+    weekSummary,
+    planned,
+    readiness,
+    isFocusToday,
+    expandActivity,
+    coachingByDay,
+  } = useTodayData(focusDate, realTodayIso);
   const nav = useTodayFocusNav(focusIso, realTodayIso);
-  const [, navigate] = useLocation();
-
-  const handleWorkoutClick = useCallback(
-    (workout: WorkoutRecord) => {
-      // Mirror the calendar: ready workouts open their editor (origin "daily",
-      // carrying the focused day so Back returns here); raw/skipped open in the
-      // calendar week where the processing affordances live.
-      if (workout.state === "raw" || workout.state === "skipped") {
-        navigate(calendarWeekHref(workout.date));
-      } else {
-        navigate(
-          withOrigin(`/workout/${workout.id}`, "daily", {
-            date: isFocusToday ? undefined : focusIso,
-          })
-        );
-      }
-    },
-    [navigate, isFocusToday, focusIso]
-  );
-
-  const handleActivityClick = useCallback(
-    (activity: CoachingActivity) => navigate(calendarWeekHref(activity.date)),
-    [navigate]
-  );
+  const open = useDailyEntryOpen(coachingByDay, focusIso, realTodayIso);
 
   return (
     <div className="space-y-6 px-4 pb-8" data-testid="daily-page">
@@ -54,8 +33,7 @@ export default function Daily() {
       <ReadinessCard readiness={readiness} />
       <WeekStrip
         days={days}
-        workouts={weekWorkouts}
-        profile={profile}
+        weekSummary={weekSummary}
         onSelectDay={nav.selectDay}
         onPrev={nav.goPrev}
         onNext={nav.goNext}
@@ -63,8 +41,17 @@ export default function Daily() {
       <TrendsCard />
       <PlannedSession
         buckets={planned}
-        onWorkoutClick={handleWorkoutClick}
-        onActivityClick={handleActivityClick}
+        onWorkoutClick={open.handleWorkoutClick}
+        onActivityClick={open.handleActivityClick}
+      />
+      <CalendarDialogs
+        selectedWorkout={open.selectedWorkout}
+        selectedCoachingActivity={open.selectedActivity}
+        onCloseWorkout={open.closeWorkout}
+        onCloseCoaching={open.closeActivity}
+        expandActivity={expandActivity}
+        onOpenExecuted={open.handleWorkoutClick}
+        buildProcessHref={open.buildProcessHref}
       />
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/Today/WeekStrip.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/WeekStrip.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 
+import type { WeekSummary } from "./build-week-summary";
 import type { WeekDay } from "./today-dates";
 import { weekDays } from "./today-dates";
 import { WeekStrip } from "./WeekStrip";
@@ -14,6 +15,12 @@ const JAN = 0;
 const TENTH = 10;
 const ANCHOR = new Date(Y, JAN, TENTH);
 const REAL_ISO = "2024-01-10";
+
+function emptySummary(days: WeekDay[]): WeekSummary {
+  return Object.fromEntries(
+    days.map((d) => [d.iso, { count: 0, intensity: null, estimated: false }])
+  );
+}
 
 function renderStrip(
   days: WeekDay[],
@@ -31,8 +38,7 @@ function renderStrip(
       <Router hook={hook}>
         <WeekStrip
           days={days}
-          workouts={[]}
-          profile={null}
+          weekSummary={overrides.weekSummary ?? emptySummary(days)}
           onSelectDay={onSelectDay}
           onPrev={onPrev}
           onNext={onNext}

--- a/packages/workout-spa-editor/src/components/pages/Today/WeekStrip.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/WeekStrip.tsx
@@ -1,17 +1,14 @@
 import { Link } from "wouter";
 
 import { calendarWeekHref } from "../../../routing/calendar-week-href";
-import type { WorkoutRecord } from "../../../types/calendar-record";
-import type { Profile } from "../../../types/profile";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
+import type { DaySummary, WeekSummary } from "./build-week-summary";
 import type { WeekDay } from "./today-dates";
-import { weekLoadFractions } from "./today-load";
 import { WeekStripColumn } from "./WeekStripColumn";
 
 export type WeekStripProps = {
   days: WeekDay[];
-  workouts: WorkoutRecord[] | undefined;
-  profile: Profile | null;
+  weekSummary: WeekSummary;
   onSelectDay: (iso: string) => void;
   onPrev: () => void;
   onNext: () => void;
@@ -20,13 +17,10 @@ export type WeekStripProps = {
 const ARROW =
   "flex h-8 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-slate-800";
 
+const EMPTY: DaySummary = { count: 0, intensity: null, estimated: false };
+
 export function WeekStrip(props: WeekStripProps) {
-  const { days, workouts, profile, onSelectDay } = props;
-  const fractions = weekLoadFractions(
-    days.map((d) => d.iso),
-    workouts ?? [],
-    profile
-  );
+  const { days, weekSummary, onSelectDay } = props;
   const calendarHref =
     days.length > 0 ? calendarWeekHref(days[0].iso) : "/calendar";
 
@@ -44,11 +38,11 @@ export function WeekStrip(props: WeekStripProps) {
         >
           <Icon icon={ICON_MAP.chevL} size="sm" color="inherit" />
         </button>
-        {days.map((day, index) => (
+        {days.map((day) => (
           <WeekStripColumn
             key={day.iso}
             day={day}
-            fraction={fractions[index]}
+            summary={weekSummary[day.iso] ?? EMPTY}
             onSelect={onSelectDay}
           />
         ))}

--- a/packages/workout-spa-editor/src/components/pages/Today/WeekStripColumn.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/WeekStripColumn.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { DaySummary } from "./build-week-summary";
+import type { WeekDay } from "./today-dates";
+import { WeekStripColumn } from "./WeekStripColumn";
+
+const DAY: WeekDay = {
+  iso: "2026-04-29",
+  letter: "W",
+  dayNumber: 29,
+  isFocused: false,
+  isRealToday: false,
+};
+
+const summary = (o: Partial<DaySummary> = {}): DaySummary => ({
+  count: 1,
+  intensity: "moderate",
+  estimated: false,
+  ...o,
+});
+
+function renderColumn(day: WeekDay, s: DaySummary) {
+  return render(<WeekStripColumn day={day} summary={s} onSelect={vi.fn()} />);
+}
+
+describe("WeekStripColumn", () => {
+  it("should render a hairline when the day is empty", () => {
+    // Arrange
+    const s = summary({ count: 0, intensity: null });
+
+    // Act
+    renderColumn(DAY, s);
+
+    // Assert
+    expect(screen.getByTestId("weekstrip-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("weekstrip-dot")).not.toBeInTheDocument();
+  });
+
+  it("should render a filled dot for a measured intensity", () => {
+    // Arrange
+    const s = summary({ intensity: "hard", estimated: false });
+
+    // Act
+    renderColumn(DAY, s);
+
+    // Assert
+    const dot = screen.getByTestId("weekstrip-dot");
+    expect(dot.className).toContain("bg-sky-400");
+  });
+
+  it("should render an outline dot for an estimated intensity", () => {
+    // Arrange
+    const s = summary({ intensity: "hard", estimated: true });
+
+    // Act
+    renderColumn(DAY, s);
+
+    // Assert
+    const dot = screen.getByTestId("weekstrip-dot");
+    expect(dot.className).toContain("border");
+  });
+
+  it("should show the count when a day has two or more entries", () => {
+    // Arrange
+    const s = summary({ count: 3 });
+
+    // Act
+    renderColumn(DAY, s);
+
+    // Assert
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("should mark the real today with aria-current date", () => {
+    // Arrange
+    const today: WeekDay = { ...DAY, isRealToday: true };
+
+    // Act
+    renderColumn(today, summary());
+
+    // Assert
+    expect(screen.getByRole("button")).toHaveAttribute("aria-current", "date");
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/Today/WeekStripColumn.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/WeekStripColumn.tsx
@@ -1,29 +1,35 @@
+import type { DaySummary } from "./build-week-summary";
 import type { WeekDay } from "./today-dates";
+import { WeekStripMark } from "./weekstrip-mark";
 
 export type WeekStripColumnProps = {
   day: WeekDay;
-  fraction: number;
+  summary: DaySummary;
   onSelect: (iso: string) => void;
 };
 
-const BAR_TRACK_HEIGHT = 40;
-const MIN_BAR_PX = 3;
-const PERCENT = 100;
+function ariaLabel(day: WeekDay, summary: DaySummary): string {
+  const today = day.isRealToday ? " (today)" : "";
+  if (summary.count === 0) {
+    return `Focus ${day.letter} ${day.dayNumber}${today}, nothing planned`;
+  }
+  const intensity = summary.intensity
+    ? `, ${summary.intensity}${summary.estimated ? " estimated" : ""}`
+    : "";
+  return `Focus ${day.letter} ${day.dayNumber}${today}, ${summary.count} planned${intensity}`;
+}
 
 export function WeekStripColumn({
   day,
-  fraction,
+  summary,
   onSelect,
 }: WeekStripColumnProps) {
-  const barHeight = Math.max(
-    MIN_BAR_PX,
-    Math.round(fraction * BAR_TRACK_HEIGHT)
-  );
   const column = day.isFocused
     ? "bg-sky-500/15 border border-sky-500 text-sky-400"
     : "text-slate-500";
-  const bar = day.isFocused ? "bg-sky-400" : "bg-slate-600";
-  const label = `Focus ${day.letter} ${day.dayNumber}${day.isRealToday ? " (today)" : ""}`;
+  const number = day.isRealToday
+    ? "flex h-5 w-5 items-center justify-center rounded-full border border-sky-400 text-sky-400"
+    : "";
 
   return (
     <button
@@ -31,26 +37,16 @@ export function WeekStripColumn({
       onClick={() => onSelect(day.iso)}
       aria-pressed={day.isFocused}
       aria-current={day.isRealToday ? "date" : undefined}
-      aria-label={label}
+      aria-label={ariaLabel(day, summary)}
       className={`flex flex-1 flex-col items-center gap-1 rounded-md py-1.5 transition-colors hover:bg-slate-800 ${column}`}
     >
       <span className="text-[11px] font-semibold">{day.letter}</span>
-      <span className="text-[13px] font-bold tabular-nums">
+      <span className={`text-[13px] font-bold tabular-nums ${number}`}>
         {day.dayNumber}
       </span>
-      <span
-        aria-hidden="true"
-        className={`h-1 w-1 rounded-full ${day.isRealToday ? "bg-sky-400" : "bg-transparent"}`}
-      />
-      <div
-        className="flex w-full items-end justify-center"
-        style={{ height: BAR_TRACK_HEIGHT }}
-      >
-        <div
-          className={`w-1.5 rounded-full ${bar}`}
-          style={{ height: `${(barHeight / BAR_TRACK_HEIGHT) * PERCENT}%` }}
-        />
-      </div>
+      <span className="flex h-3 items-center justify-center">
+        <WeekStripMark summary={summary} />
+      </span>
     </button>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/Today/build-week-summary.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/build-week-summary.test.ts
@@ -1,0 +1,179 @@
+import { createWorkoutKRD } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import type { MatchedSessionWithMetadata } from "../../../hooks/use-matched-sessions";
+import { profileWith } from "../../../lib/athlete/test-profile";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import { buildWeekSummary } from "./build-week-summary";
+
+const DAY = "2026-04-29";
+const DAYS = ["2026-04-28", DAY, "2026-04-30"];
+const STEP_SECONDS = 600;
+const FTP_PERCENT = 60;
+const FTP_WATTS = 250;
+const PROFILE = profileWith("cycling", { ftp: FTP_WATTS });
+
+const activity = (o: Partial<CoachingActivity> = {}): CoachingActivity => ({
+  id: "a-1",
+  source: "train2go",
+  sourceBadge: "T2G",
+  date: DAY,
+  sport: { label: "Cycling", icon: "bike" },
+  title: "Session",
+  status: "pending",
+  ...o,
+});
+
+const rawWorkout = (o: Partial<WorkoutRecord> = {}): WorkoutRecord =>
+  ({
+    id: "w-raw",
+    date: DAY,
+    sport: "cycling",
+    source: "manual",
+    state: "raw",
+    krd: null,
+    raw: { title: "Ride" },
+    ...o,
+  }) as WorkoutRecord;
+
+const krdWorkout = (o: Partial<WorkoutRecord> = {}): WorkoutRecord =>
+  ({
+    ...rawWorkout(),
+    id: "w-krd",
+    state: "structured",
+    krd: createWorkoutKRD({
+      sport: "cycling",
+      steps: [
+        {
+          stepIndex: 0,
+          durationType: "time",
+          duration: { type: "time", seconds: STEP_SECONDS },
+          targetType: "power",
+          target: {
+            type: "power",
+            value: { unit: "percent_ftp", value: FTP_PERCENT },
+          },
+        },
+      ],
+    }),
+    ...o,
+  }) as WorkoutRecord;
+
+const NO_MATCHED: MatchedSessionWithMetadata[] = [];
+
+describe("buildWeekSummary", () => {
+  it("should bucket a coaching effort as an estimated intensity", () => {
+    // Arrange
+    const coachingByDay = { [DAY]: [activity({ effort: 4 })] };
+
+    // Act
+    const summary = buildWeekSummary({
+      dayIsos: DAYS,
+      weekWorkouts: [],
+      coachingByDay,
+      matched: NO_MATCHED,
+      profile: PROFILE,
+    });
+
+    // Assert
+    expect(summary[DAY]).toEqual({
+      count: 1,
+      intensity: "hard",
+      estimated: true,
+    });
+  });
+
+  it("should map a low coaching effort to easy", () => {
+    // Arrange
+    const coachingByDay = { [DAY]: [activity({ effort: 1 })] };
+
+    // Act
+    const summary = buildWeekSummary({
+      dayIsos: DAYS,
+      weekWorkouts: [],
+      coachingByDay,
+      matched: NO_MATCHED,
+      profile: PROFILE,
+    });
+
+    // Assert
+    expect(summary[DAY].intensity).toBe("easy");
+  });
+
+  it("should count multiple entries on a day", () => {
+    // Arrange
+    const coachingByDay = {
+      [DAY]: [activity({ id: "a-1" }), activity({ id: "a-2" })],
+    };
+
+    // Act
+    const summary = buildWeekSummary({
+      dayIsos: DAYS,
+      weekWorkouts: [],
+      coachingByDay,
+      matched: NO_MATCHED,
+      profile: PROFILE,
+    });
+
+    // Assert
+    expect(summary[DAY].count).toBe(2);
+  });
+
+  it("should mark a KRD workout as measured (not estimated)", () => {
+    // Arrange
+
+    // Act
+    const summary = buildWeekSummary({
+      dayIsos: DAYS,
+      weekWorkouts: [krdWorkout()],
+      coachingByDay: {},
+      matched: NO_MATCHED,
+      profile: PROFILE,
+    });
+
+    // Assert
+    expect(summary[DAY].estimated).toBe(false);
+    expect(summary[DAY].intensity).not.toBeNull();
+  });
+
+  it("should leave a raw KRD-less workout presence-only", () => {
+    // Arrange
+
+    // Act
+    const summary = buildWeekSummary({
+      dayIsos: DAYS,
+      weekWorkouts: [rawWorkout()],
+      coachingByDay: {},
+      matched: NO_MATCHED,
+      profile: PROFILE,
+    });
+
+    // Assert
+    expect(summary[DAY]).toEqual({
+      count: 1,
+      intensity: null,
+      estimated: false,
+    });
+  });
+
+  it("should report an empty day as count 0 with no intensity", () => {
+    // Arrange
+
+    // Act
+    const summary = buildWeekSummary({
+      dayIsos: DAYS,
+      weekWorkouts: [],
+      coachingByDay: {},
+      matched: NO_MATCHED,
+      profile: PROFILE,
+    });
+
+    // Assert
+    expect(summary["2026-04-30"]).toEqual({
+      count: 0,
+      intensity: null,
+      estimated: false,
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/Today/build-week-summary.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/build-week-summary.ts
@@ -1,0 +1,78 @@
+/**
+ * Per-day summary for the Daily WeekStrip: presence (count) + a coarse,
+ * honest intensity bucket per day across all sources. Measured TSS (workouts
+ * with a KRD) is bucketed and flagged `estimated:false`; coaching `effort`
+ * (1-5) is bucketed and flagged `estimated:true`; a day with only KRD-less
+ * (raw) workouts and no coaching effort is presence-only (`intensity: null`).
+ * No continuous/estimated load magnitude is produced.
+ */
+import type { MatchedSessionWithMetadata } from "../../../hooks/use-matched-sessions";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import type { Profile } from "../../../types/profile";
+import { buildCalendarBuckets } from "../calendar-buckets";
+import { groupWorkoutsByDay } from "../calendar-utils";
+import { estimatedBucket, measuredBucket } from "./day-intensity";
+import type { IntensityBucket } from "./intensity-bucket";
+
+export type { IntensityBucket };
+
+export type DaySummary = {
+  count: number;
+  intensity: IntensityBucket | null;
+  estimated: boolean;
+};
+
+export type WeekSummary = Record<string, DaySummary>;
+
+export type BuildWeekSummaryArgs = {
+  dayIsos: string[];
+  weekWorkouts: WorkoutRecord[] | undefined;
+  coachingByDay: Record<string, CoachingActivity[]>;
+  matched: MatchedSessionWithMetadata[];
+  profile: Profile | null;
+};
+
+export function buildWeekSummary({
+  dayIsos,
+  weekWorkouts,
+  coachingByDay,
+  matched,
+  profile,
+}: BuildWeekSummaryArgs): WeekSummary {
+  const workoutsByDay = groupWorkoutsByDay(weekWorkouts, dayIsos);
+  const { matchedByDay, soloPlansByDay, soloActualsByDay } =
+    buildCalendarBuckets({
+      days: dayIsos,
+      workoutsByDay,
+      coachingByDay,
+      matched,
+    });
+
+  const summary: WeekSummary = {};
+  for (const iso of dayIsos) {
+    const dayMatched = matchedByDay[iso] ?? [];
+    const plans = soloPlansByDay[iso] ?? [];
+    const actuals = soloActualsByDay[iso] ?? [];
+    const count = dayMatched.length + plans.length + actuals.length;
+
+    const measured = measuredBucket(
+      [...dayMatched.map((m) => m.workout), ...actuals],
+      profile
+    );
+    if (measured) {
+      summary[iso] = { count, intensity: measured, estimated: false };
+      continue;
+    }
+    const estimated = estimatedBucket([
+      ...plans,
+      ...dayMatched.map((m) => m.activity),
+    ]);
+    summary[iso] = {
+      count,
+      intensity: estimated,
+      estimated: estimated !== null,
+    };
+  }
+  return summary;
+}

--- a/packages/workout-spa-editor/src/components/pages/Today/day-intensity.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/day-intensity.ts
@@ -1,0 +1,39 @@
+/** Intensity-bucket reducers for a day's workouts (measured TSS) and coaching
+    activities (estimated effort), used by the WeekStrip per-day summary. */
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import type { Profile } from "../../../types/profile";
+import {
+  effortBucket,
+  type IntensityBucket,
+  maxBucket,
+  tssBucket,
+} from "./intensity-bucket";
+import { reviewFor } from "./today-load";
+
+export function measuredBucket(
+  workouts: WorkoutRecord[],
+  profile: Profile | null
+): IntensityBucket | null {
+  let bucket: IntensityBucket | null = null;
+  for (const w of workouts) {
+    const tss = reviewFor(w, profile)?.tss;
+    if (typeof tss === "number") {
+      bucket = bucket ? maxBucket(bucket, tssBucket(tss)) : tssBucket(tss);
+    }
+  }
+  return bucket;
+}
+
+export function estimatedBucket(
+  activities: CoachingActivity[]
+): IntensityBucket | null {
+  let bucket: IntensityBucket | null = null;
+  for (const a of activities) {
+    if (a.effort) {
+      const next = effortBucket(a.effort);
+      bucket = bucket ? maxBucket(bucket, next) : next;
+    }
+  }
+  return bucket;
+}

--- a/packages/workout-spa-editor/src/components/pages/Today/intensity-bucket.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/intensity-bucket.ts
@@ -1,0 +1,17 @@
+/** Coarse, ordinal intensity buckets for the Daily WeekStrip mark. */
+export type IntensityBucket = "easy" | "moderate" | "hard";
+
+const EASY_MAX = 40;
+const MODERATE_MAX = 80;
+const RANK: Record<IntensityBucket, number> = { easy: 0, moderate: 1, hard: 2 };
+
+export const maxBucket = (
+  a: IntensityBucket,
+  b: IntensityBucket
+): IntensityBucket => (RANK[a] >= RANK[b] ? a : b);
+
+export const tssBucket = (tss: number): IntensityBucket =>
+  tss < EASY_MAX ? "easy" : tss <= MODERATE_MAX ? "moderate" : "hard";
+
+export const effortBucket = (effort: number): IntensityBucket =>
+  effort <= 2 ? "easy" : effort === 3 ? "moderate" : "hard";

--- a/packages/workout-spa-editor/src/components/pages/Today/today-load.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-load.test.ts
@@ -3,20 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import { profileWith } from "../../../lib/athlete/test-profile";
 import type { WorkoutRecord } from "../../../types/calendar-record";
-import {
-  normaliseLoads,
-  recordLoad,
-  reviewFor,
-  weekLoadFractions,
-} from "./today-load";
+import { reviewFor } from "./today-load";
 
-const RAW_FALLBACK_LOAD = 30;
-const MIN_BAR_FRACTION = 0.12;
-const FULL = 1;
-const MID_LOAD = 50;
-const PEAK_LOAD = 100;
-const HIGH_LOAD = 1000;
-const TINY_LOAD = 1;
 const STEP_SECONDS = 600;
 const FTP_PERCENT = 60;
 const FTP_WATTS = 250;
@@ -44,70 +32,6 @@ function rawWorkout(date: string): WorkoutRecord {
     updatedAt: "2026-05-27T08:00:00.000Z",
   };
 }
-
-describe("normaliseLoads", () => {
-  it("should scale loads against the week maximum", () => {
-    // Arrange
-    const loads = [0, MID_LOAD, PEAK_LOAD];
-
-    // Act
-    const fractions = normaliseLoads(loads);
-
-    // Assert
-    expect(fractions[0]).toBe(0);
-    expect(fractions[2]).toBe(FULL);
-  });
-
-  it("should return all zeros when no day has load", () => {
-    // Arrange
-    const loads = [0, 0, 0];
-
-    // Act
-    const fractions = normaliseLoads(loads);
-
-    // Assert
-    expect(fractions).toEqual([0, 0, 0]);
-  });
-
-  it("should clamp small non-zero loads to a minimum fraction", () => {
-    // Arrange
-    const loads = [TINY_LOAD, HIGH_LOAD];
-
-    // Act
-    const fractions = normaliseLoads(loads);
-
-    // Assert
-    expect(fractions[0]).toBe(MIN_BAR_FRACTION);
-  });
-});
-
-describe("recordLoad", () => {
-  it("should use the raw fallback when the record has no KRD", () => {
-    // Arrange
-    const record = rawWorkout("2026-05-27");
-
-    // Act
-    const load = recordLoad(record, null);
-
-    // Assert
-    expect(load).toBe(RAW_FALLBACK_LOAD);
-  });
-});
-
-describe("weekLoadFractions", () => {
-  it("should sum per-day loads and normalise across the week", () => {
-    // Arrange
-    const days = ["2026-05-25", "2026-05-26"];
-    const workouts = [rawWorkout("2026-05-26"), rawWorkout("2026-05-26")];
-
-    // Act
-    const fractions = weekLoadFractions(days, workouts, null);
-
-    // Assert
-    expect(fractions[0]).toBe(0);
-    expect(fractions[1]).toBe(FULL);
-  });
-});
 
 function krdWorkout(date: string): WorkoutRecord {
   return {

--- a/packages/workout-spa-editor/src/components/pages/Today/today-load.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-load.ts
@@ -1,10 +1,8 @@
 /**
- * Pure load-proxy helpers for the Today week strip.
- *
- * A day's training load is the summed TSS of its planned workouts when a KRD
- * is present; otherwise it falls back to estimated minutes so unprocessed
- * (raw) entries still register a bar. Heights are normalised to the week's
- * busiest day so the tallest bar fills the track.
+ * `reviewFor` — the review view-model (incl. measured TSS) for a workout that
+ * carries a parsed KRD, using the athlete's sport thresholds. Returns `null`
+ * for a KRD-less (raw) workout, so callers treat such days as presence-only
+ * (no fabricated load).
  */
 import { thresholdsForSport } from "../../../lib/athlete";
 import {
@@ -15,8 +13,6 @@ import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { Profile } from "../../../types/profile";
 
 const FALLBACK_TITLE = "Workout";
-const RAW_FALLBACK_LOAD = 30;
-const MIN_BAR_FRACTION = 0.12;
 
 export function reviewFor(
   record: WorkoutRecord,
@@ -25,34 +21,4 @@ export function reviewFor(
   if (!record.krd) return null;
   const thresholds = thresholdsForSport(profile, record.sport);
   return buildReviewModel(record.krd, thresholds, FALLBACK_TITLE);
-}
-
-export function recordLoad(
-  record: WorkoutRecord,
-  profile: Profile | null
-): number {
-  return reviewFor(record, profile)?.tss ?? RAW_FALLBACK_LOAD;
-}
-
-/** Maps each day's raw load to a 0..1 bar fraction against the week max. */
-export function normaliseLoads(loads: number[]): number[] {
-  const max = Math.max(0, ...loads);
-  if (max <= 0) return loads.map(() => 0);
-  return loads.map((load) =>
-    load <= 0 ? 0 : Math.max(MIN_BAR_FRACTION, load / max)
-  );
-}
-
-/** Bar fraction per ISO day, summing each day's workout loads then normalising. */
-export function weekLoadFractions(
-  dayIsos: string[],
-  workouts: WorkoutRecord[],
-  profile: Profile | null
-): number[] {
-  const raw = dayIsos.map((iso) =>
-    workouts
-      .filter((w) => w.date === iso)
-      .reduce((sum, w) => sum + recordLoad(w, profile), 0)
-  );
-  return normaliseLoads(raw);
 }

--- a/packages/workout-spa-editor/src/components/pages/Today/use-daily-entry-open.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-daily-entry-open.test.ts
@@ -73,6 +73,19 @@ describe("useDailyEntryOpen", () => {
     expect(history.at(-1)).toBe("/workout/w-1?from=daily&date=2026-06-10");
   });
 
+  it("should clear the opposite selection so dialogs never overlap", () => {
+    // Arrange
+    const { result } = setup();
+
+    // Act
+    act(() => result.current.handleActivityClick(ACTIVITY));
+    act(() => result.current.handleWorkoutClick(workout({ state: "raw" })));
+
+    // Assert
+    expect(result.current.selectedWorkout?.id).toBe("w-1");
+    expect(result.current.selectedActivity).toBeNull();
+  });
+
   it("should build a daily-origin process href carrying the focus date", () => {
     // Arrange
     const { result } = setup();

--- a/packages/workout-spa-editor/src/components/pages/Today/use-daily-entry-open.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-daily-entry-open.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import { useDailyEntryOpen } from "./use-daily-entry-open";
+
+const FOCUS = "2026-06-10";
+const REAL_TODAY = "2026-06-08";
+
+const ACTIVITY: CoachingActivity = {
+  id: "a-1",
+  source: "train2go",
+  sourceBadge: "T2G",
+  date: FOCUS,
+  sport: { label: "Cycling", icon: "bike" },
+  title: "Intervals",
+  status: "pending",
+};
+
+const workout = (o: Partial<WorkoutRecord>): WorkoutRecord =>
+  ({ id: "w-1", date: FOCUS, sport: "cycling", ...o }) as WorkoutRecord;
+
+function setup() {
+  const { hook, history } = memoryLocation({ path: "/daily", record: true });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(Router, { hook }, children);
+  const { result } = renderHook(
+    () => useDailyEntryOpen({ [FOCUS]: [ACTIVITY] }, FOCUS, REAL_TODAY),
+    { wrapper }
+  );
+  return { result, history };
+}
+
+describe("useDailyEntryOpen", () => {
+  it("should select a coaching activity instead of navigating", () => {
+    // Arrange
+    const { result, history } = setup();
+
+    // Act
+    act(() => result.current.handleActivityClick(ACTIVITY));
+
+    // Assert
+    expect(result.current.selectedActivity?.id).toBe("a-1");
+    expect(history.at(-1)).toBe("/daily");
+  });
+
+  it("should open a raw workout in the dialog (no navigation)", () => {
+    // Arrange
+    const { result, history } = setup();
+
+    // Act
+    act(() => result.current.handleWorkoutClick(workout({ state: "raw" })));
+
+    // Assert
+    expect(result.current.selectedWorkout?.id).toBe("w-1");
+    expect(history.at(-1)).toBe("/daily");
+  });
+
+  it("should navigate a ready workout to the editor with the daily origin", () => {
+    // Arrange
+    const { result, history } = setup();
+
+    // Act
+    act(() =>
+      result.current.handleWorkoutClick(workout({ state: "structured" }))
+    );
+
+    // Assert
+    expect(history.at(-1)).toBe("/workout/w-1?from=daily&date=2026-06-10");
+  });
+
+  it("should build a daily-origin process href carrying the focus date", () => {
+    // Arrange
+    const { result } = setup();
+
+    // Act
+    const href = result.current.buildProcessHref("w-9");
+
+    // Assert
+    expect(href).toBe("/workout/w-9?from=daily&date=2026-06-10");
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/Today/use-daily-entry-open.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-daily-entry-open.ts
@@ -1,0 +1,63 @@
+/**
+ * Opening Planned entries in place on the Daily page: a coaching activity opens
+ * its dialog; a ready/structured workout opens the editor (origin "daily"); a
+ * raw/skipped workout opens the raw-workout dialog. The "Process" target carries
+ * the daily origin so Back returns to /daily?date= (no calendar-origin leak).
+ */
+import { useCallback, useState } from "react";
+import { useLocation } from "wouter";
+
+import { withOrigin } from "../../../routing/with-origin";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import { useSelectedActivity } from "../use-selected-activity";
+
+export function useDailyEntryOpen(
+  coachingByDay: Record<string, CoachingActivity[]>,
+  focusIso: string,
+  realTodayIso: string
+) {
+  const [, navigate] = useLocation();
+  const { selectedActivity, setSelectedActivity } =
+    useSelectedActivity(coachingByDay);
+  const [selectedWorkout, setSelectedWorkout] = useState<WorkoutRecord | null>(
+    null
+  );
+
+  const workoutHref = useCallback(
+    (id: string) =>
+      withOrigin(`/workout/${id}`, "daily", {
+        date: focusIso === realTodayIso ? undefined : focusIso,
+      }),
+    [focusIso, realTodayIso]
+  );
+
+  const handleWorkoutClick = useCallback(
+    (workout: WorkoutRecord) => {
+      if (workout.state === "raw" || workout.state === "skipped") {
+        setSelectedWorkout(workout);
+      } else {
+        navigate(workoutHref(workout.id));
+      }
+    },
+    [navigate, workoutHref]
+  );
+
+  const handleActivityClick = useCallback(
+    (activity: CoachingActivity) => setSelectedActivity(activity),
+    [setSelectedActivity]
+  );
+
+  return {
+    handleWorkoutClick,
+    handleActivityClick,
+    selectedWorkout,
+    selectedActivity,
+    closeWorkout: useCallback(() => setSelectedWorkout(null), []),
+    closeActivity: useCallback(
+      () => setSelectedActivity(null),
+      [setSelectedActivity]
+    ),
+    buildProcessHref: workoutHref,
+  };
+}

--- a/packages/workout-spa-editor/src/components/pages/Today/use-daily-entry-open.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-daily-entry-open.ts
@@ -34,17 +34,23 @@ export function useDailyEntryOpen(
 
   const handleWorkoutClick = useCallback(
     (workout: WorkoutRecord) => {
+      // Clear the opposite selection so the two dialogs never overlap.
+      setSelectedActivity(null);
       if (workout.state === "raw" || workout.state === "skipped") {
         setSelectedWorkout(workout);
       } else {
+        setSelectedWorkout(null);
         navigate(workoutHref(workout.id));
       }
     },
-    [navigate, workoutHref]
+    [navigate, workoutHref, setSelectedActivity]
   );
 
   const handleActivityClick = useCallback(
-    (activity: CoachingActivity) => setSelectedActivity(activity),
+    (activity: CoachingActivity) => {
+      setSelectedWorkout(null);
+      setSelectedActivity(activity);
+    },
     [setSelectedActivity]
   );
 

--- a/packages/workout-spa-editor/src/components/pages/Today/use-today-data.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-today-data.ts
@@ -9,8 +9,10 @@ import { useHealthHrvHistoryLive } from "../../../hooks/health/use-health-hrv-hi
 import { useHealthSleepWeekLive } from "../../../hooks/health/use-health-sleep-week-live";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
 import type { Profile } from "../../../types/profile";
 import type { TodayBuckets } from "./build-today-buckets";
+import type { WeekSummary } from "./build-week-summary";
 import { toIsoDate, type WeekDay, weekDays } from "./today-dates";
 import { buildReadinessModel, type ReadinessModel } from "./today-readiness";
 import { useTodayPlannedBuckets } from "./use-today-planned-buckets";
@@ -24,6 +26,9 @@ export type TodayData = {
   days: WeekDay[];
   weekWorkouts: WorkoutRecord[] | undefined;
   planned: TodayBuckets;
+  weekSummary: WeekSummary;
+  coachingByDay: Record<string, CoachingActivity[]>;
+  expandActivity: (activity: CoachingActivity) => void;
   readiness: ReadinessModel;
 };
 
@@ -51,12 +56,8 @@ export function useTodayData(focusDate: Date, realTodayIso: string): TodayData {
     end: focusIso,
   });
 
-  const planned = useTodayPlannedBuckets(
-    profileId,
-    dayIsos,
-    focusIso,
-    weekWorkouts
-  );
+  const { planned, weekSummary, coachingByDay, expandActivity } =
+    useTodayPlannedBuckets(profileId, dayIsos, focusIso, weekWorkouts, profile);
   const isFocusToday = focusIso === realTodayIso;
   const readiness = buildReadinessModel(
     hrvRecords?.at(-1)?.krd,
@@ -72,6 +73,9 @@ export function useTodayData(focusDate: Date, realTodayIso: string): TodayData {
     days,
     weekWorkouts,
     planned,
+    weekSummary,
+    coachingByDay,
+    expandActivity,
     readiness,
   };
 }

--- a/packages/workout-spa-editor/src/components/pages/Today/use-today-planned-buckets.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-today-planned-buckets.ts
@@ -1,31 +1,42 @@
 /**
- * Live-query wiring for the Today planned section.
+ * Live-query wiring for the Daily planned section + WeekStrip summary.
  *
  * Mounts the same coaching + matched sources the calendar composes
- * (`useCoachingActivities`, `useMatchedSessions`), scoped to the visible week,
- * and assembles today's buckets via the pure `buildTodayBuckets`. Note:
- * `useMatchedSessions` is read-with-heal-writeback (it schedules an idempotent
- * Dexie heal); `PersistenceProvider` wraps the app root so it is safe here.
- * Auto-execute matching (`useExecutedMatchAutoForCalendar`) is intentionally
- * NOT mounted — that stays calendar-owned.
+ * (`useCoachingActivities`, `useMatchedSessions`), scoped to the visible week.
+ * Returns the focused day's buckets, the per-day week summary (presence +
+ * intensity), and the coaching `byDay` map + `expandActivity` callback so the
+ * Daily page can open a coaching activity in place. Note: `useMatchedSessions`
+ * is read-with-heal-writeback (idempotent); `useExecutedMatchAutoForCalendar`
+ * is intentionally NOT mounted — that stays calendar-owned.
  */
 import { useMemo } from "react";
 
 import { useCoachingActivities } from "../../../hooks/use-coaching-activities";
 import { useMatchedSessions } from "../../../hooks/use-matched-sessions";
 import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import type { Profile } from "../../../types/profile";
 import { buildTodayBuckets, type TodayBuckets } from "./build-today-buckets";
+import { buildWeekSummary, type WeekSummary } from "./build-week-summary";
+
+export type TodayPlanned = {
+  planned: TodayBuckets;
+  weekSummary: WeekSummary;
+  coachingByDay: Record<string, CoachingActivity[]>;
+  expandActivity: (activity: CoachingActivity) => void;
+};
 
 export function useTodayPlannedBuckets(
   profileId: string | null,
   dayIsos: string[],
   focusIso: string,
-  weekWorkouts: WorkoutRecord[] | undefined
-): TodayBuckets {
+  weekWorkouts: WorkoutRecord[] | undefined,
+  profile: Profile | null
+): TodayPlanned {
   const coaching = useCoachingActivities(dayIsos);
   const matched = useMatchedSessions(profileId, dayIsos);
 
-  return useMemo(
+  const planned = useMemo(
     () =>
       buildTodayBuckets({
         dayIsos,
@@ -36,4 +47,23 @@ export function useTodayPlannedBuckets(
       }),
     [dayIsos, focusIso, weekWorkouts, coaching.byDay, matched]
   );
+
+  const weekSummary = useMemo(
+    () =>
+      buildWeekSummary({
+        dayIsos,
+        weekWorkouts,
+        coachingByDay: coaching.byDay,
+        matched: matched ?? [],
+        profile,
+      }),
+    [dayIsos, weekWorkouts, coaching.byDay, matched, profile]
+  );
+
+  return {
+    planned,
+    weekSummary,
+    coachingByDay: coaching.byDay,
+    expandActivity: coaching.expandActivity,
+  };
 }

--- a/packages/workout-spa-editor/src/components/pages/Today/weekstrip-mark.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/weekstrip-mark.tsx
@@ -1,0 +1,49 @@
+/**
+ * Per-day mark for a WeekStrip column: a faint hairline when the day is empty,
+ * else an intensity-tinted dot — filled when the intensity is measured (TSS),
+ * outline when estimated (coaching effort), neutral when presence-only — plus a
+ * small count when the day holds 2+ entries.
+ */
+import type { DaySummary, IntensityBucket } from "./build-week-summary";
+
+const FILL: Record<IntensityBucket, string> = {
+  easy: "bg-sky-500/40",
+  moderate: "bg-sky-500/70",
+  hard: "bg-sky-400",
+};
+const RING: Record<IntensityBucket, string> = {
+  easy: "border border-sky-500/40",
+  moderate: "border border-sky-500/70",
+  hard: "border border-sky-400",
+};
+
+function dotClass(summary: DaySummary): string {
+  if (!summary.intensity) return "border border-slate-500";
+  return summary.estimated ? RING[summary.intensity] : FILL[summary.intensity];
+}
+
+export function WeekStripMark({ summary }: { summary: DaySummary }) {
+  if (summary.count === 0) {
+    return (
+      <span
+        data-testid="weekstrip-empty"
+        aria-hidden="true"
+        className="h-px w-3 rounded-full bg-slate-700"
+      />
+    );
+  }
+  return (
+    <span className="flex items-center gap-0.5">
+      <span
+        data-testid="weekstrip-dot"
+        aria-hidden="true"
+        className={`h-1.5 w-1.5 rounded-full ${dotClass(summary)}`}
+      />
+      {summary.count >= 2 && (
+        <span className="text-[9px] font-semibold leading-none text-slate-500">
+          {summary.count}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/use-dialog-handlers.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-dialog-handlers.ts
@@ -26,24 +26,28 @@ const weekIdForDate = (date: string): string => {
 
 export function useDialogHandlers(
   selectedWorkout: WorkoutRecord | null,
-  onCloseWorkout: () => void
+  onCloseWorkout: () => void,
+  // Optional href builder for the "Process" target. The default routes Back to
+  // THAT week's calendar grid; the Daily page passes a `daily`-origin builder so
+  // Back returns to /daily?date= instead of leaking the calendar origin.
+  buildProcessHref?: (id: string) => string
 ) {
   const [, navigate] = useLocation();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  // commentIndices is part of the dialog's onProcess contract but the workout
-  // route consumes no selection, so handleProcess takes only the workout id.
-  // The originating week comes from the closed-over selectedWorkout's date
-  // so Back returns to THAT week's grid.
   const handleProcess = useCallback(
     (id: string) => {
-      const week = selectedWorkout
-        ? weekIdForDate(selectedWorkout.date)
-        : undefined;
-      navigate(withOrigin(`/workout/${id}`, "calendar", { week }));
+      if (buildProcessHref) {
+        navigate(buildProcessHref(id));
+      } else {
+        const week = selectedWorkout
+          ? weekIdForDate(selectedWorkout.date)
+          : undefined;
+        navigate(withOrigin(`/workout/${id}`, "calendar", { week }));
+      }
       onCloseWorkout();
     },
-    [navigate, onCloseWorkout, selectedWorkout]
+    [navigate, onCloseWorkout, selectedWorkout, buildProcessHref]
   );
 
   const handleSkip = useCallback(


### PR DESCRIPTION
## What

Two Daily-page fixes from the user's confusion about the WeekStrip and Planned clicks.

### 1. WeekStrip per-day mark (no more flat "-")
The WeekStrip's load bar read only the `workouts` table, so coaching-only weeks rendered an identical minimum-height dash on every day. It's replaced by a **per-day presence + coarse intensity mark across all sources** (workouts + coaching + matched), decided by a 3-expert UX panel (user-confirmed):
- empty day → faint hairline;
- day with entries → an intensity-tinted dot — **filled = measured TSS**, **outline = estimated coaching effort** — plus a **count** for 2+ entries;
- **real today = a circled day number** (off the dot); focus keeps the sky highlight.
- **No fabricated continuous load:** raw/no-KRD days are presence-only; coaching `effort` (1-5) buckets as *estimated*; measured beats estimated.

### 2. Planned entries open in place
Tapping a "Planned" card no longer bounces to the calendar:
- coaching activity → its **dialog** (description/process), in place;
- ready/structured workout → the **editor** (origin `daily`);
- raw/skipped workout → its **process dialog**, in place.

The shared `CalendarDialogs`/`useDialogHandlers` gain an optional `buildProcessHref` so Daily's Process target carries the `daily` origin (no calendar-origin leak). `useSelectedActivity` is reused so `expandActivity`'s description write propagates into the open dialog.

## How
- New pure `build-week-summary` derives the per-day `{count, intensity, estimated}` from the calendar's `buildCalendarBuckets` (full week, deduped); intensity logic split into `intensity-bucket` + `day-intensity` for the size cap.
- `today-load` reduced to `reviewFor` (orphaned `weekLoadFractions`/`normaliseLoads`/`recordLoad` removed — the `RAW_FALLBACK_LOAD=30` fabrication is gone).
- Coaching intensity reads the view-model `effort` field (not the persisted `intensity`).
- `use-daily-entry-open` owns the dialog state + handlers (keeps `Daily` under the component cap).

## Tests
- `build-week-summary`: coaching effort → estimated bucket, KRD workout → measured, raw/no-KRD → presence-only, count for 2+, empty day.
- `WeekStripColumn`: hairline (empty), filled vs outline, count, circled today (aria-current).
- `use-daily-entry-open`: coaching tap → select (no nav), raw → dialog, ready → editor href, process href carries `daily`+date.
- WeekStrip + today-load tests updated. Full SPA suite **581/581** files green; tsc + eslint (incl. size caps) + mechanical guards green.

## Provenance
`/deep-dive` (3-lane trace) → **3-expert UX panel** decided the WeekStrip mark (user-confirmed) → `/plan --consensus` (Architect SOUND-WITH-CHANGES: `effort` not `intensity`, raw=presence-only, chief-risk retired; Critic APPROVED-WITH-NITS) → autopilot execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Daily WeekStrip: per-day activity indicators now display presence with coarse intensity levels (easy, moderate, hard)
  * Added visual markers for activity days—filled dots for measured intensity, outlined dots for estimated, with count badges for multiple entries
  * Improved "Planned" entry interaction: tapping now opens entries in place rather than navigating to calendar
  * Current day is visually distinguished with a circled number

<!-- end of auto-generated comment: release notes by coderabbit.ai -->