### PR TITLE
fix(spa-editor): carry coaching title + sport into generated workout KRD

### DIFF
--- a/.changeset/coaching-workout-title-and-sport.md
+++ b/.changeset/coaching-workout-title-and-sport.md
@@ -1,0 +1,13 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Coaching-derived workouts now keep their title and sport
+
+When a coaching activity was materialised into a structured workout (manual
+"create from coaching" path), the generated KRD carried neither the activity's
+title nor its sport: the editor showed "Untitled Workout" and "Sport: generic".
+The template builder now seeds the KRD workout name from the coaching activity
+title and canonicalizes the source sport onto the KRD vocabulary (e.g.
+`bike` → `cycling`, `swim` → `swimming`). Sports the KRD model does not
+represent (e.g. gym/strength) still collapse to `generic` honestly.

--- a/packages/workout-spa-editor/src/application/coaching/coaching-template.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/coaching-template.test.ts
@@ -45,12 +45,47 @@ describe("buildCoachingTemplateKrd", () => {
     expect(krd.metadata.sport).toBe("generic");
   });
 
+  it("should canonicalize a coaching sport alias onto the KRD vocabulary", () => {
+    // Arrange
+    const sport = "bike";
+
+    // Act
+    const krd = buildCoachingTemplateKrd(sport);
+
+    // Assert
+    expect(krd.metadata.sport).toBe("cycling");
+  });
+
+  it("should set the workout name from the coaching activity title", () => {
+    // Arrange
+    const title = "Endurance Ride";
+
+    // Act
+    const krd = buildCoachingTemplateKrd("cycling", title);
+
+    // Assert
+    const workout = krd.extensions!.structured_workout as { name?: string };
+    expect(workout.name).toBe(title);
+  });
+
+  it("should omit the workout name when no title is provided", () => {
+    // Arrange
+    const sport = "running";
+
+    // Act
+    const krd = buildCoachingTemplateKrd(sport);
+
+    // Assert
+    const workout = krd.extensions!.structured_workout as { name?: string };
+    expect(workout.name).toBeUndefined();
+  });
+
   it("should produce a structurally identical step for running and swimming", () => {
     // Arrange
     const sports = ["running", "swimming"] as const;
 
     // Act
-    const krds = sports.map(buildCoachingTemplateKrd);
+    const krds = sports.map((s) => buildCoachingTemplateKrd(s));
 
     // Assert
     for (const krd of krds) {

--- a/packages/workout-spa-editor/src/application/coaching/coaching-template.ts
+++ b/packages/workout-spa-editor/src/application/coaching/coaching-template.ts
@@ -15,6 +15,7 @@
  */
 import { createWorkoutKRD } from "@kaiord/core";
 
+import { canonicalizeSport } from "../../lib/canonicalize-sport";
 import type { KRD, Sport } from "../../types/schemas";
 
 const TEN_MINUTES_SECONDS = 600;
@@ -25,9 +26,19 @@ const isKnownSport = (sport: string): sport is Sport =>
   sport === "swimming" ||
   sport === "generic";
 
-export const buildCoachingTemplateKrd = (sport: string): KRD =>
+// Map a coaching source's sport string onto the KRD sport vocabulary.
+// `canonicalizeSport` resolves aliases ("bike" → "cycling", "swim" →
+// "swimming", ...); sports the KRD model does not represent (e.g. gym,
+// strength) honestly collapse to "generic".
+const toKrdSport = (sport: string): Sport => {
+  const canonical = canonicalizeSport(sport);
+  return canonical && isKnownSport(canonical) ? canonical : "generic";
+};
+
+export const buildCoachingTemplateKrd = (sport: string, name?: string): KRD =>
   createWorkoutKRD({
-    sport: isKnownSport(sport) ? sport : "generic",
+    ...(name ? { name } : {}),
+    sport: toKrdSport(sport),
     steps: [
       {
         stepIndex: 0,

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual-helpers.ts
@@ -25,7 +25,7 @@ export const handleExistingManualWorkout = async (
     await deps.workouts.put({
       ...existing,
       state: "structured",
-      krd: buildCoachingTemplateKrd(activity.sport),
+      krd: buildCoachingTemplateKrd(activity.sport, activity.title),
       updatedAt: deps.clock(),
     });
   }

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.ts
@@ -40,7 +40,7 @@ const createNewWorkout = async (
     id: deps.newWorkoutId(),
     activity,
     namespacedSourceId: ns,
-    krd: buildCoachingTemplateKrd(activity.sport),
+    krd: buildCoachingTemplateKrd(activity.sport, activity.title),
     aiMeta: null,
     now: deps.clock(),
   });

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.test.tsx
@@ -60,7 +60,7 @@ const seedActivity = async (
     duration: activity.duration,
     effort: activity.effort,
     status: "pending",
-    sport: { label: "Cycling", icon: "🚴" },
+    sport: "cycling",
     description: activity.description ?? null,
     raw: null,
     createdAt: "2026-04-13T08:00:00Z",


### PR DESCRIPTION
## What

Opening a coaching-derived workout (e.g. `/workout/<id>?from=coaching`) rendered **"Untitled Workout"** and **"Sport: generic"** even when the coaching activity had both a title and a sport.

## Root cause

The manual *create-from-coaching* path builds the seed KRD via `buildCoachingTemplateKrd(activity.sport)`, which:

1. **Dropped the title** — it never set the KRD workout `name`. The activity title only survived in `WorkoutRecord.raw.title`, which the editor heading does not read, so `workout.name || "Untitled Workout"` always showed the fallback.
2. **Did not canonicalize the sport** — it passed the raw source sport string straight to an `isKnownSport` check that only accepts `cycling|running|swimming|generic`. Any alias (`bike`, `swim`, ...) failed the check and collapsed to `generic`, even though `canonicalizeSport` already knows those aliases and is used elsewhere for matching.

## Fix

`buildCoachingTemplateKrd(sport, name?)` now:
- seeds the KRD workout `name` from the coaching activity title (omitted when absent),
- maps the source sport through `canonicalizeSport` (`bike` → `cycling`, `swim` → `swimming`, ...).

Sports the KRD vocabulary genuinely cannot represent (gym, strength, ...) still collapse to `generic` honestly — no fabricated mapping.

Both call sites (`convert-coaching-activity-manual` and the existing-workout backfill helper) now pass `activity.title`.

## Scope / notes

- **Forward-correct only.** Already-persisted coaching workouts keep their stored KRD; re-running convert does not rebuild an existing KRD. Those can be fixed in-app via the workout metadata editor (name + sport), or will be correct on next fresh conversion.
- KRD sport enum is unchanged (`cycling|running|swimming|generic`); widening it is a core-domain change with adapter ripple, out of scope here.

## Tests

- `coaching-template.test.ts`: added coverage for title propagation, the omit-when-absent case, and alias canonicalization (`bike → cycling`); fixed a latent `.map(buildCoachingTemplateKrd)` arity bug that the new `name` param would have mis-fed the index into.
- Package typecheck + lint clean; coaching conversion suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Complete redesign of Kaiord landing page with athlete and developer-focused pathways.
  * Comprehensive mobile-first redesign of the workout editor app UI with updated flows and interactions.

* **Bug Fixes**
  * Coaching-derived structured workouts now properly inherit the activity's title and canonicalize sports (e.g., "bike" → "cycling") to match the editor's vocabulary.

* **Chores**
  * Added comprehensive OpenSpec workflow skill documentation for change management and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->