### PR TITLE
feat(spa-editor): defer coaching create until Save (+ AI sport fix + junk cleanup)

### DIFF
--- a/.changeset/defer-coaching-create-until-save.md
+++ b/.changeset/defer-coaching-create-until-save.md
@@ -1,0 +1,22 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+Coaching "Edit manually" defers persistence until Save (+ AI sport fix + junk cleanup)
+
+Clicking "Edit manually" on a coaching activity no longer eagerly persists a
+workout: it opens a store-only draft editor (`/workout/new?coaching=…`, mirroring
+the scratch flow) and the workout + its SessionMatch are written only on an
+explicit Save. Leaving without saving persists nothing. If a workout already
+exists for the activity, the existing one opens instead (idempotency).
+
+Also: the AI "expand with AI" path now resolves the Train2Go sport before
+prompting the model and force-sets the resolved sport/subSport, so both
+`record.sport` and the KRD sport carry the real sport (cycling/training/…) instead
+of collapsing to `generic`. The shared builder now sets `record.sport` from the
+resolved sport for the manual path too.
+
+A one-time, guarded maintenance pass removes the untouched 1-step template
+workouts (and their orphaned session matches) left behind by earlier eager
+"Edit manually" clicks, matched by step shape + `modifiedAt===null` +
+`createdAt===updatedAt` so no user-edited workout is ever removed.

--- a/packages/workout-spa-editor/e2e/coaching-dialog-redesign.spec.ts
+++ b/packages/workout-spa-editor/e2e/coaching-dialog-redesign.spec.ts
@@ -13,8 +13,10 @@
  *       on the second attempt (D3, no-persist-on-failure).
  *   (c) AI failure → static error toast fires and prevents state mutation
  *       (C2 / R-PIIInterpolation).
- *   (d) Edit manually → editor renders template KRD + coaching sidebar;
- *       a `session_match` row is written alongside the workout (D1, D4).
+ *   (d) Edit manually → opens a store-only draft editor (template KRD +
+ *       coaching sidebar); nothing is persisted until the explicit Save,
+ *       which then writes the workout + `session_match` row (D1, D4,
+ *       defer-coaching-create).
  *   (e) Auto-heal → a converted-but-not-matched workout (legacy state)
  *       is silently linked when the dialog opens (D8 belt-and-braces).
  *   (f) Process with AI from matched raw → transitions raw to structured
@@ -244,7 +246,7 @@ test.describe("Coaching activity dialog redesign", () => {
     await disableOnboardingTutorial(page);
   });
 
-  test("flow (d): Edit manually creates a structured workout + match and navigates to editor", async ({
+  test("flow (d): Edit manually opens a draft and persists only on Save", async ({
     page,
   }) => {
     // Arrange — boot SPA, clear Dexie, seed profile + activity
@@ -276,22 +278,34 @@ test.describe("Coaching activity dialog redesign", () => {
     await expect(page.getByTestId("coaching-activity-dialog")).toBeVisible();
     await page.getByTestId("coaching-dialog-edit-manually").click();
 
-    // Assert — navigated to editor + session_match row written (per the
-    // auto-match invariant D1). The sidebar visibility is covered by
-    // unit tests (`CoachingSidebar.test.tsx`); here we focus on the
-    // end-to-end persistence contract.
-    await expect(page).toHaveURL(/\/workout\//, { timeout: 10_000 });
-    const matchCount = await page.evaluate(async (profileId) => {
-      const db = (window as unknown as Record<string, unknown>)
-        .__KAIORD_DB__ as {
-        table: (n: string) => {
-          toArray: () => Promise<{ profileId: string }[]>;
+    const countMatches = (profileId: string) =>
+      page.evaluate(async (id) => {
+        const db = (window as unknown as Record<string, unknown>)
+          .__KAIORD_DB__ as {
+          table: (n: string) => {
+            toArray: () => Promise<{ profileId: string }[]>;
+          };
         };
-      };
-      const all = await db.table("sessionMatches").toArray();
-      return all.filter((m) => m.profileId === profileId).length;
-    }, PROFILE_ID);
-    expect(matchCount).toBeGreaterThan(0);
+        const all = await db.table("sessionMatches").toArray();
+        return all.filter((m) => m.profileId === id).length;
+      }, profileId);
+
+    // Assert — opens the store-only DRAFT editor and persists NOTHING yet
+    // (defer-coaching-create): no session_match until the explicit Save.
+    await expect(page).toHaveURL(/\/workout\/new\?coaching=/, {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("coaching-draft-save-button")).toBeVisible();
+    expect(await countMatches(PROFILE_ID)).toBe(0);
+
+    // Act — explicit Save persists the workout + match and lands on /workout/:id
+    await page.getByTestId("coaching-draft-save-button").click();
+
+    // Assert — navigated to the persisted record + session_match written
+    await expect(page).toHaveURL(/\/workout\/[0-9a-f-]{16,}/, {
+      timeout: 10_000,
+    });
+    expect(await countMatches(PROFILE_ID)).toBeGreaterThan(0);
   });
 
   test("flow (e): converted-without-match → dialog auto-heals to matched state", async ({

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
@@ -9,6 +9,7 @@ import Dexie from "dexie";
 
 import { createDexieAiProviderRepository } from "./dexie-ai-provider-repository";
 import { installExportLedgerCascade } from "./dexie-export-ledger-cascade";
+import { runJunkCleanupOnce } from "./dexie-junk-cleanup";
 import { registerKaiordVersions } from "./register-kaiord-versions";
 
 export {
@@ -26,6 +27,7 @@ export class KaiordDatabase extends Dexie {
 
 export const db = new KaiordDatabase();
 installExportLedgerCascade(db);
+db.on("ready", () => runJunkCleanupOnce(db));
 
 // Expose for e2e test seeding (dev mode only). The `typeof window` guard
 // matches the symmetric `__KAIORD_WORKOUT_STORE__` exposure in

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-database.ts
@@ -27,7 +27,12 @@ export class KaiordDatabase extends Dexie {
 
 export const db = new KaiordDatabase();
 installExportLedgerCascade(db);
-db.on("ready", () => runJunkCleanupOnce(db));
+// Fire-and-forget: returning the promise from a `ready` handler would make
+// Dexie block DB readiness (and all queued queries) until the cleanup scan
+// completes. `runJunkCleanupOnce` swallows its own errors, so voiding it is safe.
+db.on("ready", () => {
+  void runJunkCleanupOnce(db);
+});
 
 // Expose for e2e test seeding (dev mode only). The `typeof window` guard
 // matches the symmetric `__KAIORD_WORKOUT_STORE__` exposure in

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-junk-cleanup.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-junk-cleanup.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Integration tests for the one-time guarded junk cleanup.
+ *
+ * Verifies:
+ *  - removes an untouched coaching template + its session match on first run
+ *  - second run is a no-op (meta flag prevents re-execution)
+ *  - non-junk workouts survive
+ *  - errors do not propagate (never blocks app start)
+ */
+import "fake-indexeddb/auto";
+
+import Dexie from "dexie";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { KaiordDatabase } from "./dexie-database";
+import { runJunkCleanupOnce } from "./dexie-junk-cleanup";
+
+const dbName = (suffix: string) =>
+  `kaiord-test-junk-cleanup-${suffix}-${Date.now()}-${Math.random()}`;
+
+const NOW = "2026-01-01T10:00:00.000Z";
+
+const WARMUP_STEP = {
+  stepIndex: 0,
+  name: "Warmup",
+  durationType: "time",
+  duration: { type: "time", seconds: 600 },
+  targetType: "heart_rate",
+  target: { type: "heart_rate", value: { unit: "zone", value: 1 } },
+  intensity: "warmup",
+};
+
+const makeTemplateWorkout = (id = "w-junk") => ({
+  id,
+  profileId: "p-1",
+  date: "2026-01-01",
+  sport: "cycling",
+  source: "train2go",
+  sourceId: "ns:42",
+  planId: null,
+  state: "structured",
+  raw: null,
+  krd: {
+    type: "structured_workout",
+    sport: "cycling",
+    extensions: {
+      structured_workout: {
+        name: "My Ride",
+        sport: "cycling",
+        steps: [WARMUP_STEP],
+      },
+    },
+  },
+  lastProcessingError: null,
+  feedback: null,
+  aiMeta: null,
+  garminPushId: null,
+  tags: [],
+  previousState: null,
+  createdAt: NOW,
+  modifiedAt: null,
+  updatedAt: NOW,
+});
+
+const makeSessionMatch = (workoutId: string, id = "sm-1") => ({
+  id,
+  profileId: "p-1",
+  coachingActivityId: "ca-1",
+  workoutId,
+  date: "2026-01-01",
+  source: "manual-coaching",
+  createdAt: NOW,
+  updatedAt: NOW,
+});
+
+describe("runJunkCleanupOnce", () => {
+  let name: string;
+  let db: KaiordDatabase;
+
+  beforeEach(() => {
+    name = dbName("apply");
+    db = new KaiordDatabase(name);
+  });
+
+  afterEach(async () => {
+    db.close();
+    await Dexie.delete(name);
+  });
+
+  it("should remove an untouched coaching template and its session match on first run", async () => {
+    // Arrange
+    await db.open();
+    await db.table("workouts").add(makeTemplateWorkout("w-junk"));
+    await db.table("sessionMatches").add(makeSessionMatch("w-junk"));
+
+    // Act
+    await runJunkCleanupOnce(db);
+
+    // Assert
+    const workout = await db.table("workouts").get("w-junk");
+    const match = await db.table("sessionMatches").get("sm-1");
+    expect(workout).toBeUndefined();
+    expect(match).toBeUndefined();
+  });
+
+  it("should set the meta flag after running so a second run is a no-op", async () => {
+    // Arrange
+    await db.open();
+    await db.table("workouts").add(makeTemplateWorkout("w-junk"));
+
+    // Act
+    await runJunkCleanupOnce(db);
+    await db.table("workouts").add(makeTemplateWorkout("w-junk2"));
+    await runJunkCleanupOnce(db);
+
+    // Assert
+    const second = await db.table("workouts").get("w-junk2");
+    expect(second).toBeDefined();
+  });
+
+  it("should not remove a user-edited coaching workout (updatedAt > createdAt)", async () => {
+    // Arrange
+    await db.open();
+    const edited = {
+      ...makeTemplateWorkout("w-edited"),
+      updatedAt: "2026-01-02T10:00:00.000Z",
+    };
+    await db.table("workouts").add(edited);
+
+    // Act
+    await runJunkCleanupOnce(db);
+
+    // Assert
+    const workout = await db.table("workouts").get("w-edited");
+    expect(workout).toBeDefined();
+  });
+
+  it("should not throw when an error occurs inside the cleanup", async () => {
+    // Arrange
+    await db.open();
+    // Force a failure by making meta table throw
+    const origGet = db.table("meta").get.bind(db.table("meta"));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.table("meta") as any).get = async () => {
+      throw new Error("simulated failure");
+    };
+
+    // Act
+    let threw = false;
+    try {
+      await runJunkCleanupOnce(db);
+    } catch {
+      threw = true;
+    }
+
+    // Assert
+    expect(threw).toBe(false);
+    // restore
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (db.table("meta") as any).get = origGet;
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-junk-cleanup.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-junk-cleanup.ts
@@ -1,0 +1,32 @@
+/**
+ * One-time guarded junk cleanup for untouched coaching template workouts.
+ *
+ * Uses the `meta` table as a flag so this runs AT MOST ONCE per browser
+ * profile. The guard key is checked before doing any work; if the key
+ * already exists the function returns immediately. On completion the key
+ * is written so subsequent app opens skip the work entirely.
+ *
+ * Error handling: any failure is caught and logged; the function NEVER
+ * throws so it cannot block app startup.
+ */
+import { removeUntouchedCoachingTemplates } from "../../application/coaching/remove-untouched-coaching-templates";
+import type { KaiordDatabase } from "./dexie-database";
+import { createDexieSessionMatchRepository } from "./dexie-session-match-repository";
+import { createDexieWorkoutRepository } from "./dexie-workout-repository";
+
+const META_KEY = "junk-cleanup-v1";
+
+export const runJunkCleanupOnce = async (db: KaiordDatabase): Promise<void> => {
+  try {
+    const already = await db.table("meta").get(META_KEY);
+    if (already !== undefined) return;
+
+    const workouts = createDexieWorkoutRepository(db);
+    const sessionMatch = createDexieSessionMatchRepository(db);
+    await removeUntouchedCoachingTemplates(workouts, sessionMatch);
+
+    await db.table("meta").put({ key: META_KEY, value: true });
+  } catch (err) {
+    console.warn("[junk-cleanup] failed, skipping:", err);
+  }
+};

--- a/packages/workout-spa-editor/src/application/coaching/build-coaching-draft-krd.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/build-coaching-draft-krd.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { buildCoachingDraftKrd } from "./build-coaching-draft-krd";
+import { stubActivity } from "./convert-coaching-activity-with-ai.test-helpers";
+
+describe("buildCoachingDraftKrd", () => {
+  it("should resolve a known sport and return a seeded template KRD", () => {
+    // Arrange
+    const activity = stubActivity({ sport: "cycling" });
+
+    // Act
+    const draft = buildCoachingDraftKrd(activity);
+
+    // Assert
+    expect(draft?.sport).toBe("cycling");
+    expect(draft?.krd.metadata.sport).toBe("cycling");
+  });
+
+  it("should map a Train2Go sport to its KRD sport and subSport", () => {
+    // Arrange
+    const activity = stubActivity({ sport: "stretching" });
+
+    // Act
+    const draft = buildCoachingDraftKrd(activity);
+
+    // Assert
+    expect(draft?.sport).toBe("training");
+    expect(draft?.subSport).toBe("flexibility_training");
+  });
+
+  it("should return null for a rest day (no trainable workout)", () => {
+    // Arrange
+    const activity = stubActivity({ sport: "rest" });
+
+    // Act
+    const draft = buildCoachingDraftKrd(activity);
+
+    // Assert
+    expect(draft).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/application/coaching/build-coaching-draft-krd.ts
+++ b/packages/workout-spa-editor/src/application/coaching/build-coaching-draft-krd.ts
@@ -1,0 +1,38 @@
+/**
+ * buildCoachingDraftKrd — derive the seed KRD for a coaching draft.
+ *
+ * Resolves the Train2Go sport and materialises the 1-step warmup
+ * template KRD used to seed the editor at draft ENTRY (mirrors the
+ * scratch flow's `createEmptyWorkout`). Returns `null` for a rest day
+ * or unknown sport (`resolveT2GSport === null`) so the caller can show
+ * the no-structured-workout state instead of a misleading template.
+ *
+ * The resolved sport/subSport are also returned so the Save path can
+ * persist a deterministic `record.sport` via `buildStructuredCoachingWorkout`.
+ */
+import { resolveT2GSport } from "../../adapters/train2go/train2go-krd-sport";
+import type { Sport, SubSport } from "../../types/schemas";
+import { buildCoachingTemplateKrd } from "./coaching-template";
+import type { CoachingActivityForConvert } from "./convert-coaching-activity-manual-types";
+
+export type CoachingDraft = {
+  krd: ReturnType<typeof buildCoachingTemplateKrd>;
+  sport: Sport;
+  subSport?: SubSport;
+};
+
+export const buildCoachingDraftKrd = (
+  activity: CoachingActivityForConvert
+): CoachingDraft | null => {
+  const resolved = resolveT2GSport(activity.sport);
+  if (!resolved) return null;
+  return {
+    krd: buildCoachingTemplateKrd(
+      resolved.sport,
+      activity.title,
+      resolved.subSport
+    ),
+    sport: resolved.sport,
+    subSport: resolved.subSport,
+  };
+};

--- a/packages/workout-spa-editor/src/application/coaching/coaching-krd-sport.ts
+++ b/packages/workout-spa-editor/src/application/coaching/coaching-krd-sport.ts
@@ -1,0 +1,53 @@
+/**
+ * Deterministic sport override for coaching-derived KRDs.
+ *
+ * The LLM convert path may return `generic` even when the source Train2Go
+ * sport is known. Once the raw key is resolved to a KRD sport, this stamps
+ * it onto both the KRD metadata and the embedded workout so the persisted
+ * KRD never carries the model's guess for a known coaching sport.
+ */
+import type { KRD, Sport, SubSport } from "../../types/schemas";
+
+export type ResolvedSport = { sport: Sport; subSport?: SubSport };
+
+export const forceKrdSport = (krd: KRD, resolved: ResolvedSport): KRD => {
+  const workout = krd.extensions?.structured_workout as
+    | Record<string, unknown>
+    | undefined;
+  return {
+    ...krd,
+    metadata: {
+      ...krd.metadata,
+      sport: resolved.sport,
+      ...(resolved.subSport
+        ? { subSport: resolved.subSport }
+        : { subSport: undefined }),
+    },
+    ...(workout
+      ? {
+          extensions: {
+            ...krd.extensions,
+            structured_workout: {
+              ...workout,
+              sport: resolved.sport,
+              ...(resolved.subSport ? { subSport: resolved.subSport } : {}),
+            },
+          },
+        }
+      : {}),
+  };
+};
+
+/**
+ * Bundle the deterministic sport for a coaching workout: the force-set KRD
+ * plus the record `sport`/`subSport`. When the raw key is unmapped
+ * (`resolved === null`) the KRD and the raw key pass through unchanged.
+ */
+export const coachingSportArgs = (
+  krd: KRD,
+  resolved: ResolvedSport | null,
+  rawSport: string
+): { krd: KRD; sport: Sport; subSport?: SubSport } =>
+  resolved
+    ? { krd: forceKrdSport(krd, resolved), ...resolved }
+    : { krd, sport: rawSport as Sport };

--- a/packages/workout-spa-editor/src/application/coaching/coaching-workout-builder.ts
+++ b/packages/workout-spa-editor/src/application/coaching/coaching-workout-builder.ts
@@ -11,7 +11,7 @@
 import type { AiMeta } from "../../types/calendar-fragments";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { CoachingActivityRecord } from "../../types/coaching-activity-record";
-import type { KRD } from "../../types/schemas";
+import type { KRD, Sport, SubSport } from "../../types/schemas";
 
 const buildRaw = (activity: CoachingActivityRecord): WorkoutRecord["raw"] => ({
   title: activity.title,
@@ -30,6 +30,11 @@ export type StructuredCoachingWorkoutInput = {
   krd: KRD;
   aiMeta: AiMeta | null;
   now: string;
+  // Resolved KRD sport (NOT the raw Train2Go key on activity.sport) so the
+  // record carries the same sport as its KRD instead of collapsing to a raw
+  // key the calendar/filters cannot interpret.
+  sport: Sport;
+  subSport?: SubSport;
 };
 
 export const buildStructuredCoachingWorkout = (
@@ -38,7 +43,7 @@ export const buildStructuredCoachingWorkout = (
   id: input.id,
   profileId: input.activity.profileId,
   date: input.activity.date,
-  sport: input.activity.sport,
+  sport: input.sport,
   source: input.activity.source,
   sourceId: input.namespacedSourceId,
   planId: null,

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-error-mapper.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-error-mapper.ts
@@ -12,6 +12,7 @@
  *   inline error banner without having to special-case provider
  *   adapters)
  */
+import type { Analytics } from "@kaiord/core";
 import { KrdValidationError } from "@kaiord/core";
 
 export type AiFailureReason =
@@ -53,4 +54,27 @@ export const classifyAiFailure = (err: unknown): AiFailureReason => {
   if (isInvalidKrd(err)) return "ai-invalid-krd";
   if (isTransport(err)) return "transport-error";
   return "ai-error";
+};
+
+/**
+ * Emit the convert-with-ai failure/cancel analytics event and shape the
+ * failure result. Shared by both AI persist branches so the telemetry
+ * names and the error payload stay identical.
+ */
+export const buildAiFailure = (
+  analytics: Analytics,
+  err: unknown
+): { ok: false; reason: AiFailureReason; error: string } => {
+  const reason = classifyAiFailure(err);
+  analytics.event(
+    reason === "ai-cancelled"
+      ? "coaching.convert_with_ai.cancelled"
+      : "coaching.convert_with_ai.failure",
+    { reason }
+  );
+  return {
+    ok: false,
+    reason,
+    error: err instanceof Error ? err.message : String(err),
+  };
 };

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.test.ts
@@ -164,6 +164,37 @@ describe("convertCoachingActivityManual", () => {
     expect(stored?.updatedAt).toBe(NOW);
   });
 
+  it("should set record and KRD sport from the resolved key for stationarybike", async () => {
+    // Arrange
+    const activity = stubActivity({ sport: "stationarybike" });
+    const deps = buildDeps({ coaching: buildStubCoachingRepo([activity]) });
+
+    // Act
+    await convertCoachingActivityManual({ activityId: activity.id }, deps);
+
+    // Assert
+    const stored = await deps.workouts.getById("w-new");
+    expect(stored?.sport).toBe("cycling");
+    expect(stored?.krd?.metadata.sport).toBe("cycling");
+    expect(stored?.krd?.metadata.subSport).toBe("indoor_cycling");
+  });
+
+  it("should set record and KRD sport to training for stretching, never generic", async () => {
+    // Arrange
+    const activity = stubActivity({ sport: "stretching" });
+    const deps = buildDeps({ coaching: buildStubCoachingRepo([activity]) });
+
+    // Act
+    await convertCoachingActivityManual({ activityId: activity.id }, deps);
+
+    // Assert
+    const stored = await deps.workouts.getById("w-new");
+    expect(stored?.sport).toBe("training");
+    expect(stored?.sport).not.toBe("generic");
+    expect(stored?.krd?.metadata.sport).toBe("training");
+    expect(stored?.krd?.metadata.subSport).toBe("flexibility_training");
+  });
+
   it("should emit invoked + success analytics events", async () => {
     // Arrange
     const activity = stubActivity();

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-manual.ts
@@ -10,13 +10,9 @@
  * The coach description is mirrored into `raw.description` so the
  * EditorPage sidebar can render it alongside the KRD step list.
  */
-import { resolveT2GSport } from "../../adapters/train2go/train2go-krd-sport";
 import { namespaceSourceId } from "../../types/coaching-activity-record";
-import { buildCoachingTemplateKrd } from "./coaching-template";
-import {
-  buildRawCoachingWorkout,
-  buildStructuredCoachingWorkout,
-} from "./coaching-workout-builder";
+import { buildCoachingDraftKrd } from "./build-coaching-draft-krd";
+import { buildRawCoachingWorkout } from "./coaching-workout-builder";
 import {
   handleExistingManualWorkout,
   manualMatchSource,
@@ -28,6 +24,7 @@ import type {
   ConvertManualResult,
 } from "./convert-coaching-activity-manual-types";
 import { ensureSessionMatch } from "./ensure-session-match";
+import { persistCoachingWorkout } from "./persist-coaching-workout";
 
 export type {
   ConvertManualDeps,
@@ -35,33 +32,19 @@ export type {
   ConvertManualResult,
 } from "./convert-coaching-activity-manual-types";
 
-const createNewWorkout = async (
+const createRawRestDay = async (
   deps: ConvertManualDeps,
   activity: CoachingActivityForConvert,
   ns: string
 ): Promise<ConvertManualResult> => {
-  const resolved = resolveT2GSport(activity.sport);
   // A rest day (or unknown sport) is not a trainable workout: persist a
   // raw-only record so the activity still surfaces, without a KRD.
-  const workout = resolved
-    ? buildStructuredCoachingWorkout({
-        id: deps.newWorkoutId(),
-        activity,
-        namespacedSourceId: ns,
-        krd: buildCoachingTemplateKrd(
-          resolved.sport,
-          activity.title,
-          resolved.subSport
-        ),
-        aiMeta: null,
-        now: deps.clock(),
-      })
-    : buildRawCoachingWorkout({
-        id: deps.newWorkoutId(),
-        activity,
-        namespacedSourceId: ns,
-        now: deps.clock(),
-      });
+  const workout = buildRawCoachingWorkout({
+    id: deps.newWorkoutId(),
+    activity,
+    namespacedSourceId: ns,
+    now: deps.clock(),
+  });
   await deps.workouts.put(workout);
   await ensureSessionMatch(deps.sessionMatches, {
     profileId: activity.profileId,
@@ -74,6 +57,18 @@ const createNewWorkout = async (
   });
   deps.analytics.event("coaching.convert_manual.success", { created: true });
   return { workoutId: workout.id, created: true };
+};
+
+const createNewWorkout = async (
+  deps: ConvertManualDeps,
+  activity: CoachingActivityForConvert,
+  ns: string
+): Promise<ConvertManualResult> => {
+  const draft = buildCoachingDraftKrd(activity);
+  if (!draft) return createRawRestDay(deps, activity, ns);
+  // Compose the split: build the template KRD (entry) then persist it
+  // (Save), preserving the one-shot behaviour for any other caller.
+  return persistCoachingWorkout({ krd: draft.krd, activity }, deps);
 };
 
 export const convertCoachingActivityManual = async (

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai-helpers.ts
@@ -1,13 +1,14 @@
 /**
  * Internal helpers for `convertCoachingActivityWithAi`. Split from the
- * use-case file to keep the orchestrator under per-file/per-function
- * line caps; not part of the public application API.
+ * use-case file to keep it under the line caps; not public API.
  */
+import { resolveT2GSport } from "../../adapters/train2go/train2go-krd-sport";
 import type { AiMeta } from "../../types/calendar-fragments";
 import type { CoachingActivityRecord } from "../../types/coaching-activity-record";
 import type { KRD } from "../../types/schemas";
+import { coachingSportArgs, type ResolvedSport } from "./coaching-krd-sport";
 import { buildStructuredCoachingWorkout } from "./coaching-workout-builder";
-import { classifyAiFailure } from "./convert-coaching-activity-error-mapper";
+import { buildAiFailure } from "./convert-coaching-activity-error-mapper";
 import type {
   ConvertWithAiDeps,
   ConvertWithAiResult,
@@ -23,15 +24,16 @@ const persistFreshWorkout = async (
   deps: ConvertWithAiDeps,
   activity: CoachingActivityRecord,
   nsSourceId: string,
-  generated: { krd: KRD; aiMeta: AiMeta }
+  generated: { krd: KRD; aiMeta: AiMeta },
+  resolved: ResolvedSport | null
 ): Promise<string> => {
   const workout = buildStructuredCoachingWorkout({
     id: deps.newWorkoutId(),
     activity,
     namespacedSourceId: nsSourceId,
-    krd: generated.krd,
     aiMeta: generated.aiMeta,
     now: deps.clock(),
+    ...coachingSportArgs(generated.krd, resolved, activity.sport),
   });
   await deps.workouts.put(workout);
   await ensureSessionMatch(deps.sessionMatches, {
@@ -53,31 +55,25 @@ export const performAiCreation = async (
   text: string,
   abortSignal: AbortSignal | undefined
 ): Promise<ConvertWithAiResult> => {
+  const resolved = resolveT2GSport(activity.sport);
   let generated: { krd: KRD; aiMeta: AiMeta };
   try {
     generated = await deps.generateKrd({
       text,
-      sport: activity.sport,
+      // Resolved KRD sport hint; raw Train2Go keys make the LLM guess
+      // `generic`. Raw key kept only for unmapped sports.
+      sport: resolved?.sport ?? activity.sport,
       abortSignal,
     });
   } catch (err) {
-    const reason = classifyAiFailure(err);
-    const eventName =
-      reason === "ai-cancelled"
-        ? "coaching.convert_with_ai.cancelled"
-        : "coaching.convert_with_ai.failure";
-    deps.analytics.event(eventName, { reason });
-    return {
-      ok: false,
-      reason,
-      error: err instanceof Error ? err.message : String(err),
-    };
+    return buildAiFailure(deps.analytics, err);
   }
   const workoutId = await persistFreshWorkout(
     deps,
     activity,
     nsSourceId,
-    generated
+    generated,
+    resolved
   );
   deps.analytics.event("coaching.convert_with_ai.success", { created: true });
   return { ok: true, workoutId, created: true };

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai-idempotency.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai-idempotency.ts
@@ -16,10 +16,11 @@
  *     of the coaching-dialog redesign is observable through the same
  *     route-mock surface as flow (a, c).
  */
+import { resolveT2GSport } from "../../adapters/train2go/train2go-krd-sport";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { CoachingActivityRecord } from "../../types/coaching-activity-record";
 import { transitionToStructured } from "../workout-transitions";
-import { classifyAiFailure } from "./convert-coaching-activity-error-mapper";
+import { buildAiFailure } from "./convert-coaching-activity-error-mapper";
 import { resolvePromptText } from "./convert-coaching-activity-with-ai-helpers";
 import type {
   ConvertWithAiDeps,
@@ -52,10 +53,13 @@ export const processExistingRawInPlace = async (
   abortSignal?: AbortSignal
 ): Promise<ConvertWithAiResult> => {
   const text = resolvePromptText(activity);
+  const resolved = resolveT2GSport(activity.sport);
   try {
     const generated = await deps.generateKrd({
       text,
-      sport: activity.sport,
+      // Resolved KRD sport hint (raw Train2Go keys make the LLM guess
+      // `generic`); raw key kept only for unmapped sports.
+      sport: resolved?.sport ?? activity.sport,
       abortSignal,
     });
     const updated = transitionToStructured(existingWorkout, generated.krd, {
@@ -70,16 +74,6 @@ export const processExistingRawInPlace = async (
     });
     return { ok: true, workoutId: updated.id, created: false };
   } catch (err) {
-    const reason = classifyAiFailure(err);
-    const eventName =
-      reason === "ai-cancelled"
-        ? "coaching.convert_with_ai.cancelled"
-        : "coaching.convert_with_ai.failure";
-    deps.analytics.event(eventName, { reason });
-    return {
-      ok: false,
-      reason,
-      error: err instanceof Error ? err.message : String(err),
-    };
+    return buildAiFailure(deps.analytics, err);
   }
 };

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai-idempotency.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai-idempotency.ts
@@ -20,6 +20,7 @@ import { resolveT2GSport } from "../../adapters/train2go/train2go-krd-sport";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { CoachingActivityRecord } from "../../types/coaching-activity-record";
 import { transitionToStructured } from "../workout-transitions";
+import { forceKrdSport } from "./coaching-krd-sport";
 import { buildAiFailure } from "./convert-coaching-activity-error-mapper";
 import { resolvePromptText } from "./convert-coaching-activity-with-ai-helpers";
 import type {
@@ -62,7 +63,12 @@ export const processExistingRawInPlace = async (
       sport: resolved?.sport ?? activity.sport,
       abortSignal,
     });
-    const updated = transitionToStructured(existingWorkout, generated.krd, {
+    // Force the resolved sport onto the KRD too (not just the LLM hint) so a
+    // known Train2Go sport is never persisted as the model's `generic` guess.
+    const krd = resolved
+      ? forceKrdSport(generated.krd, resolved)
+      : generated.krd;
+    const updated = transitionToStructured(existingWorkout, krd, {
       provider: generated.aiMeta.provider,
       model: generated.aiMeta.model,
       promptVersion: generated.aiMeta.promptVersion,

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai.test-helpers.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai.test-helpers.ts
@@ -41,6 +41,8 @@ export const buildStubAnalytics = (): Analytics => ({
   event: vi.fn(),
 });
 export const fakeKrd = (): KRD => buildCoachingTemplateKrd("cycling");
+/** Simulates the LLM collapsing an unrecognised hint to `generic`. */
+export const fakeGenericKrd = (): KRD => buildCoachingTemplateKrd("generic");
 export const fakeAiMeta = (): AiMeta => ({
   promptVersion: "test",
   model: "test-model",

--- a/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/convert-coaching-activity-with-ai.test.ts
@@ -14,6 +14,7 @@ import {
   buildStubCoachingRepo,
   buildStubWorkoutRepo,
   fakeAiMeta,
+  fakeGenericKrd,
   fakeKrd,
   stubActivity,
 } from "./convert-coaching-activity-with-ai.test-helpers";
@@ -374,6 +375,52 @@ describe("convertCoachingActivityWithAi", () => {
     expect(call.text).toBe(`${empty.title} (${empty.sport})`);
     expect(call.text).not.toContain("undefined");
     expect(call.text).not.toContain("null");
+  });
+
+  it("should force record and KRD sport from the resolved Train2Go key for stationarybike", async () => {
+    // Arrange
+    const bike = stubActivity({ sport: "stationarybike" });
+    const generateKrd: GenerateKrdPort = vi
+      .fn()
+      .mockResolvedValue({ krd: fakeGenericKrd(), aiMeta: fakeAiMeta() });
+    const deps = buildDeps({
+      coaching: buildStubCoachingRepo([bike]),
+      generateKrd,
+    });
+
+    // Act
+    await convertCoachingActivityWithAi({ activityId: bike.id }, deps);
+
+    // Assert
+    const stored = await deps.workouts.getById("w-new");
+    expect(stored?.sport).toBe("cycling");
+    expect(stored?.krd?.metadata.sport).toBe("cycling");
+    expect(stored?.krd?.metadata.subSport).toBe("indoor_cycling");
+    const hint = (generateKrd as ReturnType<typeof vi.fn>).mock.calls[0][0]
+      .sport;
+    expect(hint).toBe("cycling");
+  });
+
+  it("should force record and KRD sport to training for stretching, never generic", async () => {
+    // Arrange
+    const stretch = stubActivity({ sport: "stretching" });
+    const generateKrd: GenerateKrdPort = vi
+      .fn()
+      .mockResolvedValue({ krd: fakeGenericKrd(), aiMeta: fakeAiMeta() });
+    const deps = buildDeps({
+      coaching: buildStubCoachingRepo([stretch]),
+      generateKrd,
+    });
+
+    // Act
+    await convertCoachingActivityWithAi({ activityId: stretch.id }, deps);
+
+    // Assert
+    const stored = await deps.workouts.getById("w-new");
+    expect(stored?.sport).toBe("training");
+    expect(stored?.sport).not.toBe("generic");
+    expect(stored?.krd?.metadata.sport).toBe("training");
+    expect(stored?.krd?.metadata.subSport).toBe("flexibility_training");
   });
 
   it("should not call the LLM when ensureMatchForExisting is invoked on an already-matched workout", async () => {

--- a/packages/workout-spa-editor/src/application/coaching/persist-coaching-workout.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/persist-coaching-workout.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { createInMemorySessionMatchRepository } from "../../test-utils/in-memory-session-match-repository";
+import { buildCoachingTemplateKrd } from "./coaching-template";
+import type { ConvertManualDeps } from "./convert-coaching-activity-manual-types";
+import {
+  buildStubAnalytics,
+  buildStubCoachingRepo,
+  buildStubWorkoutRepo,
+  stubActivity,
+} from "./convert-coaching-activity-with-ai.test-helpers";
+import { persistCoachingWorkout } from "./persist-coaching-workout";
+
+const NOW = "2026-05-04T10:00:00.000Z";
+
+const buildDeps = (
+  overrides: Partial<ConvertManualDeps> = {}
+): ConvertManualDeps => ({
+  coaching: buildStubCoachingRepo([]),
+  workouts: buildStubWorkoutRepo(),
+  sessionMatches: createInMemorySessionMatchRepository(),
+  analytics: buildStubAnalytics(),
+  newWorkoutId: () => "w-new",
+  newMatchId: () => "M-new",
+  clock: () => NOW,
+  ...overrides,
+});
+
+describe("persistCoachingWorkout", () => {
+  it("should persist the given (edited) KRD, not a rebuilt template", async () => {
+    // Arrange
+    const activity = stubActivity({ sport: "cycling" });
+    const deps = buildDeps();
+    const editedKrd = buildCoachingTemplateKrd("cycling", "EDITED TITLE");
+
+    // Act
+    const result = await persistCoachingWorkout(
+      { krd: editedKrd, activity },
+      deps
+    );
+
+    // Assert
+    expect(result).toEqual({ workoutId: "w-new", created: true });
+    const stored = await deps.workouts.getById("w-new");
+    const workout = stored?.krd?.extensions?.structured_workout as {
+      name?: string;
+    };
+    expect(workout.name).toBe("EDITED TITLE");
+    expect(stored?.sport).toBe("cycling");
+  });
+
+  it("should write a SessionMatch pointing to the new workout", async () => {
+    // Arrange
+    const activity = stubActivity({ sport: "cycling" });
+    const deps = buildDeps();
+    const krd = buildCoachingTemplateKrd("cycling", activity.title);
+
+    // Act
+    await persistCoachingWorkout({ krd, activity }, deps);
+
+    // Assert
+    const match = await deps.sessionMatches.getByActivityId("p1", activity.id);
+    expect(match?.workoutId).toBe("w-new");
+  });
+
+  it("should be idempotent and return the existing workout without re-creating", async () => {
+    // Arrange
+    const activity = stubActivity({ sport: "cycling" });
+    const workouts = buildStubWorkoutRepo();
+    workouts.setSourceLookup({
+      id: "w-existing",
+      krd: buildCoachingTemplateKrd("cycling", activity.title),
+    } as never);
+    const deps = buildDeps({ workouts });
+    const krd = buildCoachingTemplateKrd("cycling", activity.title);
+
+    // Act
+    const result = await persistCoachingWorkout({ krd, activity }, deps);
+
+    // Assert
+    expect(result.created).toBe(false);
+    expect(result.workoutId).toBe("w-existing");
+  });
+});

--- a/packages/workout-spa-editor/src/application/coaching/persist-coaching-workout.ts
+++ b/packages/workout-spa-editor/src/application/coaching/persist-coaching-workout.ts
@@ -1,0 +1,72 @@
+/**
+ * persistCoachingWorkout — INSERT a coaching-derived workout from a
+ * GIVEN (store) KRD plus its SessionMatch, used at SAVE.
+ *
+ * Unlike the entry-time `buildCoachingDraftKrd`, this persists the KRD
+ * the user actually edited rather than rebuilding the template, so user
+ * edits are carried through to the persisted record. The resolved sport
+ * (from `buildCoachingDraftKrd`) sets a deterministic `record.sport`.
+ *
+ * Keeps the same `getBySourceId(source, namespaceSourceId(...))`
+ * existence guard as the one-shot path (idempotency): if a workout
+ * already exists for this activity it heals the match and returns it
+ * instead of double-creating.
+ */
+import { namespaceSourceId } from "../../types/coaching-activity-record";
+import type { KRD } from "../../types/krd";
+import { buildCoachingDraftKrd } from "./build-coaching-draft-krd";
+import { buildStructuredCoachingWorkout } from "./coaching-workout-builder";
+import {
+  handleExistingManualWorkout,
+  manualMatchSource,
+} from "./convert-coaching-activity-manual-helpers";
+import type {
+  CoachingActivityForConvert,
+  ConvertManualDeps,
+  ConvertManualResult,
+} from "./convert-coaching-activity-manual-types";
+import { ensureSessionMatch } from "./ensure-session-match";
+
+export type PersistCoachingInput = {
+  krd: KRD;
+  activity: CoachingActivityForConvert;
+};
+
+export const persistCoachingWorkout = async (
+  input: PersistCoachingInput,
+  deps: ConvertManualDeps
+): Promise<ConvertManualResult> => {
+  const { activity } = input;
+  const ns = namespaceSourceId(activity.profileId, activity.sourceId);
+  const existing = await deps.workouts.getBySourceId(activity.source, ns);
+  if (existing) return handleExistingManualWorkout(deps, activity, existing.id);
+
+  const draft = buildCoachingDraftKrd(activity);
+  if (!draft)
+    throw new Error(
+      `Cannot persist coaching workout for non-trainable activity: ${activity.id}`
+    );
+
+  const workout = buildStructuredCoachingWorkout({
+    id: deps.newWorkoutId(),
+    activity,
+    namespacedSourceId: ns,
+    krd: input.krd,
+    aiMeta: null,
+    now: deps.clock(),
+    sport: draft.sport,
+    subSport: draft.subSport,
+  });
+  await deps.workouts.put(workout);
+  await ensureSessionMatch(deps.sessionMatches, {
+    profileId: activity.profileId,
+    coachingActivityId: activity.id,
+    workoutId: workout.id,
+    date: activity.date,
+    source: manualMatchSource,
+    newId: deps.newMatchId,
+    clock: deps.clock,
+  });
+  deps.analytics.event("coaching.convert_manual.success", { created: true });
+  return { workoutId: workout.id, created: true };
+};

--- a/packages/workout-spa-editor/src/application/coaching/remove-untouched-coaching-templates.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/remove-untouched-coaching-templates.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Tests for isUntouchedCoachingTemplate predicate and
+ * removeUntouchedCoachingTemplates use case.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionMatchRepository } from "../../ports/session-match-repository";
+import type { WorkoutRepository } from "../../ports/workout-repository";
+import type { WorkoutRecord } from "../../types/calendar-record";
+import {
+  isUntouchedCoachingTemplate,
+  removeUntouchedCoachingTemplates,
+} from "./remove-untouched-coaching-templates";
+
+const NOW = "2026-01-01T10:00:00.000Z";
+
+const WARMUP_STEP = {
+  stepIndex: 0,
+  name: "Warmup",
+  durationType: "time",
+  duration: { type: "time", seconds: 600 },
+  targetType: "heart_rate",
+  target: { type: "heart_rate", value: { unit: "zone", value: 1 } },
+  intensity: "warmup",
+};
+
+const makeTemplateKrd = () => ({
+  type: "structured_workout" as const,
+  sport: "cycling",
+  extensions: {
+    structured_workout: {
+      name: "My Workout",
+      sport: "cycling",
+      steps: [WARMUP_STEP],
+    },
+  },
+});
+
+const makeRecord = (overrides: Partial<WorkoutRecord> = {}): WorkoutRecord => ({
+  id: "w-1",
+  profileId: "p-1",
+  date: "2026-01-01",
+  sport: "cycling",
+  source: "train2go",
+  sourceId: "ns:42",
+  planId: null,
+  state: "structured",
+  raw: null,
+  krd: makeTemplateKrd() as WorkoutRecord["krd"],
+  lastProcessingError: null,
+  feedback: null,
+  aiMeta: null,
+  garminPushId: null,
+  tags: [],
+  previousState: null,
+  createdAt: NOW,
+  modifiedAt: null,
+  updatedAt: NOW,
+  ...overrides,
+});
+
+describe("isUntouchedCoachingTemplate", () => {
+  it("should return true for an untouched coaching template record", () => {
+    // Arrange
+    const record = makeRecord();
+
+    // Act
+    const result = isUntouchedCoachingTemplate(record);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("should return false when state is not structured", () => {
+    // Arrange
+    const record = makeRecord({ state: "raw" });
+
+    // Act
+    const result = isUntouchedCoachingTemplate(record);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("should return false for a non-coaching (non-train2go) source", () => {
+    // Arrange
+    const record = makeRecord({ source: "manual" });
+
+    // Act
+    const result = isUntouchedCoachingTemplate(record);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("should return false when modifiedAt is set (user explicitly saved)", () => {
+    // Arrange
+    const record = makeRecord({ modifiedAt: "2026-01-02T10:00:00.000Z" });
+
+    // Act
+    const result = isUntouchedCoachingTemplate(record);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("should return false when updatedAt differs from createdAt (user-edited)", () => {
+    // Arrange
+    const record = makeRecord({ updatedAt: "2026-01-02T10:00:00.000Z" });
+
+    // Act
+    const result = isUntouchedCoachingTemplate(record);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("should return false for a multi-step workout", () => {
+    // Arrange
+    const krd = makeTemplateKrd();
+    const multiStep = {
+      ...krd,
+      extensions: {
+        structured_workout: {
+          ...krd.extensions.structured_workout,
+          steps: [WARMUP_STEP, { ...WARMUP_STEP, stepIndex: 1, name: "Main" }],
+        },
+      },
+    };
+    const record = makeRecord({ krd: multiStep as WorkoutRecord["krd"] });
+
+    // Act
+    const result = isUntouchedCoachingTemplate(record);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("should return false when the single step has been modified (different duration)", () => {
+    // Arrange
+    const krd = makeTemplateKrd();
+    const editedKrd = {
+      ...krd,
+      extensions: {
+        structured_workout: {
+          ...krd.extensions.structured_workout,
+          steps: [
+            { ...WARMUP_STEP, duration: { type: "time", seconds: 1200 } },
+          ],
+        },
+      },
+    };
+    const record = makeRecord({ krd: editedKrd as WorkoutRecord["krd"] });
+
+    // Act
+    const result = isUntouchedCoachingTemplate(record);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("should return false when the step name differs (user renamed step)", () => {
+    // Arrange
+    const krd = makeTemplateKrd();
+    const editedKrd = {
+      ...krd,
+      extensions: {
+        structured_workout: {
+          ...krd.extensions.structured_workout,
+          steps: [{ ...WARMUP_STEP, name: "Custom" }],
+        },
+      },
+    };
+    const record = makeRecord({ krd: editedKrd as WorkoutRecord["krd"] });
+
+    // Act
+    const result = isUntouchedCoachingTemplate(record);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("should return false when krd is null", () => {
+    // Arrange
+    const record = makeRecord({ krd: null });
+
+    // Act
+    const result = isUntouchedCoachingTemplate(record);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe("removeUntouchedCoachingTemplates", () => {
+  const makeRepos = (records: WorkoutRecord[]) => {
+    const store = new Map(records.map((r) => [r.id, r]));
+    const workouts: Pick<WorkoutRepository, "getByState" | "delete"> = {
+      getByState: async (state) =>
+        [...store.values()].filter((r) => r.state === state),
+      delete: vi.fn(async (id: string) => {
+        store.delete(id);
+      }),
+    };
+    const sessionMatch: Pick<SessionMatchRepository, "deleteByWorkoutId"> = {
+      deleteByWorkoutId: vi.fn(async () => {}),
+    };
+    return { workouts, sessionMatch, store };
+  };
+
+  it("should remove an untouched template and its session match", async () => {
+    // Arrange
+    const record = makeRecord({ id: "w-junk" });
+    const { workouts, sessionMatch } = makeRepos([record]);
+
+    // Act
+    const result = await removeUntouchedCoachingTemplates(
+      workouts,
+      sessionMatch
+    );
+
+    // Assert
+    expect(result.removed).toBe(1);
+    expect(sessionMatch.deleteByWorkoutId).toHaveBeenCalledWith("w-junk");
+    expect(workouts.delete).toHaveBeenCalledWith("w-junk");
+  });
+
+  it("should not remove a user-edited workout (updatedAt > createdAt)", async () => {
+    // Arrange
+    const record = makeRecord({
+      id: "w-edited",
+      updatedAt: "2026-01-02T10:00:00.000Z",
+    });
+    const { workouts, sessionMatch } = makeRepos([record]);
+
+    // Act
+    const result = await removeUntouchedCoachingTemplates(
+      workouts,
+      sessionMatch
+    );
+
+    // Assert
+    expect(result.removed).toBe(0);
+    expect(workouts.delete).not.toHaveBeenCalled();
+    expect(sessionMatch.deleteByWorkoutId).not.toHaveBeenCalled();
+  });
+
+  it("should not remove a user-edited workout (modifiedAt set)", async () => {
+    // Arrange
+    const record = makeRecord({
+      id: "w-modified",
+      modifiedAt: "2026-01-02T10:00:00.000Z",
+    });
+    const { workouts, sessionMatch } = makeRepos([record]);
+
+    // Act
+    const result = await removeUntouchedCoachingTemplates(
+      workouts,
+      sessionMatch
+    );
+
+    // Assert
+    expect(result.removed).toBe(0);
+    expect(workouts.delete).not.toHaveBeenCalled();
+  });
+
+  it("should not remove a non-coaching (scratch) workout", async () => {
+    // Arrange
+    const record = makeRecord({ id: "w-scratch", source: "scratch" });
+    const { workouts, sessionMatch } = makeRepos([record]);
+
+    // Act
+    const result = await removeUntouchedCoachingTemplates(
+      workouts,
+      sessionMatch
+    );
+
+    // Assert
+    expect(result.removed).toBe(0);
+    expect(workouts.delete).not.toHaveBeenCalled();
+    expect(sessionMatch.deleteByWorkoutId).not.toHaveBeenCalled();
+  });
+
+  it("should not remove a multi-step coaching workout", async () => {
+    // Arrange
+    const krd = makeTemplateKrd();
+    const multiKrd = {
+      ...krd,
+      extensions: {
+        structured_workout: {
+          ...krd.extensions.structured_workout,
+          steps: [WARMUP_STEP, { ...WARMUP_STEP, stepIndex: 1, name: "Main" }],
+        },
+      },
+    };
+    const record = makeRecord({
+      id: "w-multi",
+      krd: multiKrd as WorkoutRecord["krd"],
+    });
+    const { workouts, sessionMatch } = makeRepos([record]);
+
+    // Act
+    const result = await removeUntouchedCoachingTemplates(
+      workouts,
+      sessionMatch
+    );
+
+    // Assert
+    expect(result.removed).toBe(0);
+    expect(workouts.delete).not.toHaveBeenCalled();
+  });
+
+  it("should be idempotent — second run is a no-op when store is empty", async () => {
+    // Arrange
+    const record = makeRecord({ id: "w-once" });
+    const { workouts, sessionMatch } = makeRepos([record]);
+
+    // Act
+    await removeUntouchedCoachingTemplates(workouts, sessionMatch);
+    const second = await removeUntouchedCoachingTemplates(
+      workouts,
+      sessionMatch
+    );
+
+    // Assert
+    expect(second.removed).toBe(0);
+    expect(workouts.delete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/workout-spa-editor/src/application/coaching/remove-untouched-coaching-templates.ts
+++ b/packages/workout-spa-editor/src/application/coaching/remove-untouched-coaching-templates.ts
@@ -1,0 +1,83 @@
+/**
+ * Removes coaching workouts that are still the untouched 1-step warmup
+ * template seeded at "Edit manually" creation time — junk left by eager
+ * clicks before the defer-coaching-create change shipped.
+ *
+ * Safety guards (ALL must hold to delete):
+ *   - state === "structured"
+ *   - source === "train2go" (coaching source)
+ *   - modifiedAt === null (never explicitly saved in the editor)
+ *   - createdAt === updatedAt (never written back after initial persist)
+ *   - KRD matches the 1-step warmup template by STEP SHAPE:
+ *       exactly 1 step, name "Warmup", duration.seconds 600,
+ *       target heart_rate zone 1, intensity "warmup"
+ *
+ * Idempotent: safe to call repeatedly. Does NOT throw on error — logs and
+ * returns so it never blocks app start.
+ */
+import type { SessionMatchRepository } from "../../ports/session-match-repository";
+import type { WorkoutRepository } from "../../ports/workout-repository";
+import type { WorkoutRecord } from "../../types/calendar-record";
+
+const TRAIN2GO_SOURCE = "train2go";
+const TEMPLATE_STEP_NAME = "Warmup";
+const TEMPLATE_DURATION_SECONDS = 600;
+const TEMPLATE_HR_ZONE = 1;
+const TEMPLATE_INTENSITY = "warmup";
+
+type Step = {
+  name?: unknown;
+  intensity?: unknown;
+  duration?: { type?: unknown; seconds?: unknown };
+  target?: { type?: unknown; value?: { unit?: unknown; value?: unknown } };
+};
+
+const isTemplateStep = (step: unknown): boolean => {
+  const s = step as Step;
+  return (
+    s.name === TEMPLATE_STEP_NAME &&
+    s.intensity === TEMPLATE_INTENSITY &&
+    s.duration?.seconds === TEMPLATE_DURATION_SECONDS &&
+    s.target?.type === "heart_rate" &&
+    s.target?.value?.unit === "zone" &&
+    s.target?.value?.value === TEMPLATE_HR_ZONE
+  );
+};
+
+export const isUntouchedCoachingTemplate = (record: WorkoutRecord): boolean => {
+  if (record.state !== "structured") return false;
+  if (record.source !== TRAIN2GO_SOURCE) return false;
+  if (record.modifiedAt !== null) return false;
+  if (record.createdAt !== record.updatedAt) return false;
+
+  const ext = record.krd?.extensions?.structured_workout as
+    | { steps?: unknown[] }
+    | undefined;
+  const steps = ext?.steps;
+  if (!Array.isArray(steps) || steps.length !== 1) return false;
+  return isTemplateStep(steps[0]);
+};
+
+export type RemoveResult = { removed: number };
+
+export const removeUntouchedCoachingTemplates = async (
+  workouts: Pick<WorkoutRepository, "getByState" | "delete">,
+  sessionMatch: Pick<SessionMatchRepository, "deleteByWorkoutId">
+): Promise<RemoveResult> => {
+  const structured = await workouts.getByState("structured");
+  const junk = structured.filter(isUntouchedCoachingTemplate);
+
+  for (const record of junk) {
+    await sessionMatch.deleteByWorkoutId(record.id);
+    await workouts.delete(record.id);
+  }
+
+  if (junk.length > 0) {
+    console.info(
+      "[junk-cleanup] removed untouched coaching templates:",
+      junk.map((r) => r.id)
+    );
+  }
+
+  return { removed: junk.length };
+};

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.test.tsx
@@ -1,7 +1,8 @@
 /**
- * Tests for `useCoachingManual` — covers the manual-create happy path
- * (workout + session match persisted, navigates to editor) and the
- * re-entry guard added per CodeRabbit feedback.
+ * Tests for `useCoachingManual` (defer-coaching-create): "Edit manually"
+ * no longer persists on click — it navigates to a store-only draft editor
+ * (`/workout/new?coaching=`) and persistence happens only on Save. If a
+ * workout already exists for the activity it opens that instead (idempotency).
  */
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -10,28 +11,16 @@ import { describe, expect, it, vi } from "vitest";
 import { AnalyticsProvider } from "../../../contexts/analytics-context";
 import { PersistenceProvider } from "../../../contexts/persistence-context";
 import { createInMemoryPersistence } from "../../../test-utils/in-memory-persistence";
+import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 import type { CoachingActivityRecord } from "../../../types/coaching-activity-record";
+import { namespaceSourceId } from "../../../types/coaching-activity-record";
 import { useCoachingManual } from "./use-coaching-manual-handler";
 
 const navigateMock = vi.fn();
-const mockShowSuccess = vi.fn();
 
 vi.mock("wouter", () => ({
   useLocation: () => ["/calendar", navigateMock],
-}));
-
-vi.mock("../../../contexts/ToastContext", () => ({
-  useToastContext: () => ({
-    error: vi.fn(),
-    success: mockShowSuccess,
-    toast: vi.fn(),
-    warning: vi.fn(),
-    info: vi.fn(),
-    toasts: [],
-    dismiss: vi.fn(),
-    dismissAll: vi.fn(),
-  }),
 }));
 
 const activity: CoachingActivity = {
@@ -50,7 +39,7 @@ const activity: CoachingActivity = {
 const seedActivity = async (
   persistence: ReturnType<typeof createInMemoryPersistence>
 ) => {
-  const record: CoachingActivityRecord = {
+  const record = {
     id: `profile-1:${activity.id}`,
     profileId: "profile-1",
     source: "train2go",
@@ -82,10 +71,9 @@ const wrap = (
 };
 
 describe("useCoachingManual", () => {
-  it("should persist a workout and navigate to the editor on success", async () => {
+  it("should navigate to the draft route without persisting when no workout exists", async () => {
     // Arrange
     navigateMock.mockClear();
-    mockShowSuccess.mockClear();
     const persistence = createInMemoryPersistence();
     await seedActivity(persistence);
     const onClose = vi.fn();
@@ -101,17 +89,30 @@ describe("useCoachingManual", () => {
 
     // Assert
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+    // The composite id is percent-encoded in the URL (decoded on read).
     expect(navigateMock).toHaveBeenCalledWith(
-      expect.stringMatching(/^\/workout\//)
+      expect.stringContaining("/workout/new?coaching=")
     );
+    const persisted = await persistence.workouts.getByDateRange(
+      activity.date,
+      activity.date
+    );
+    expect(persisted).toHaveLength(0);
   });
 
-  it("should fire a success toast with static title before closing the dialog", async () => {
+  it("should open the existing workout instead of a fresh draft", async () => {
     // Arrange
     navigateMock.mockClear();
-    mockShowSuccess.mockClear();
     const persistence = createInMemoryPersistence();
     await seedActivity(persistence);
+    const ns = namespaceSourceId("profile-1", "abc");
+    await persistence.workouts.put({
+      id: "w-existing",
+      source: "train2go",
+      sourceId: ns,
+      date: activity.date,
+      state: "structured",
+    } as unknown as WorkoutRecord);
     const onClose = vi.fn();
     const { result } = renderHook(
       () => useCoachingManual(activity, "profile-1", onClose),
@@ -124,17 +125,13 @@ describe("useCoachingManual", () => {
     });
 
     // Assert
-    await waitFor(() => expect(mockShowSuccess).toHaveBeenCalledTimes(1));
-    expect(mockShowSuccess).toHaveBeenCalledWith(
-      "Workout matched",
-      activity.title,
-      { duration: 3000 }
+    await waitFor(() => expect(navigateMock).toHaveBeenCalled());
+    expect(navigateMock).toHaveBeenCalledWith(
+      expect.stringContaining("/workout/w-existing")
     );
-    // Toast fires BEFORE onClose so the success signal is committed
-    // even though AppToastProvider lives above the dialog tree.
-    const successOrder = mockShowSuccess.mock.invocationCallOrder[0];
-    const onCloseOrder = onClose.mock.invocationCallOrder[0];
-    expect(successOrder).toBeLessThan(onCloseOrder);
+    expect(navigateMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("new?coaching")
+    );
   });
 
   it("should no-op when activity or profileId is missing", async () => {

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.ts
@@ -1,21 +1,20 @@
 /**
  * Manual-create handler for the coaching dialog (per design D4).
  *
- * "Edit manually" creates a workout in `state="structured"` with a
- * 1-step warmup KRD template, persists the auto-match invariant (D1),
- * and navigates to the editor. The KRD is intentionally minimal — the
- * user fills in steps from the read-only coach description sidebar
- * (rendered in EditorPage from PR 3).
+ * "Edit manually" NO LONGER persists on click (defer-coaching-create):
+ * it navigates to a store-only draft editor and persistence happens only
+ * on an explicit Save (mirroring the scratch flow). First it checks for
+ * an already-matched workout with the SAME idempotency key as the persist
+ * path; if one exists it opens that `/workout/:id`, otherwise it opens a
+ * fresh draft at `/workout/new?coaching=<profileId>:<activity.id>`.
  */
 import { useCallback, useRef, useState } from "react";
 import { useLocation } from "wouter";
 
-import { convertCoachingActivityManual } from "../../../application/coaching/convert-coaching-activity-manual";
-import { useAnalytics } from "../../../contexts/analytics-context";
 import { usePersistence } from "../../../contexts/persistence-context";
-import { useToastContext } from "../../../contexts/ToastContext";
 import { withOrigin } from "../../../routing/with-origin";
 import type { CoachingActivity } from "../../../types/coaching-activity";
+import { namespaceSourceId } from "../../../types/coaching-activity-record";
 
 export type UseCoachingManual = {
   creating: boolean;
@@ -30,8 +29,6 @@ export const useCoachingManual = (
   onClose: () => void
 ): UseCoachingManual => {
   const persistence = usePersistence();
-  const analytics = useAnalytics();
-  const { success: showSuccess } = useToastContext();
   const [, navigate] = useLocation();
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -43,42 +40,37 @@ export const useCoachingManual = (
     setError(null);
     setCreating(true);
     try {
-      // The view-model `activity.id` is `${source}:${sourceId}`; the
-      // persistence record id (what `coaching.getById` keys on) is the
-      // composite `${profileId}:${source}:${sourceId}` — see
-      // `buildCoachingActivityId`.
-      const result = await convertCoachingActivityManual(
-        { activityId: `${profileId}:${activity.id}` },
-        {
-          coaching: persistence.coaching,
-          workouts: persistence.workouts,
-          sessionMatches: persistence.sessionMatch,
-          analytics,
-          newWorkoutId: () => crypto.randomUUID(),
-          newMatchId: () => crypto.randomUUID(),
-          clock: () => new Date().toISOString(),
-        }
+      // Idempotency: if a workout already exists for this activity (same
+      // key the Save path guards on), open it instead of a fresh draft.
+      // `activity.id` is the SHORT `${source}:${sourceId}`; the raw
+      // sourceId is its second segment.
+      const sourceId = activity.id.split(":")[1] ?? "";
+      const ns = namespaceSourceId(profileId, sourceId);
+      const existing = await persistence.workouts.getBySourceId(
+        activity.source,
+        ns
       );
-      // Fire toast BEFORE onClose() to keep the success signal visible
-      // even though the AppToastProvider lives above the dialog tree.
-      showSuccess("Workout matched", activity.title, { duration: 3000 });
       onClose();
-      navigate(withOrigin(`/workout/${result.workoutId}`, "coaching"));
+      if (existing) {
+        navigate(withOrigin(`/workout/${existing.id}`, "coaching"));
+        return;
+      }
+      // The draft route carries the composite id `coaching.getById` keys
+      // on (`${profileId}:${source}:${sourceId}`); `activity.id` is the
+      // SHORT form so prefix the profileId once.
+      navigate(
+        withOrigin(
+          `/workout/new?coaching=${profileId}:${activity.id}`,
+          "coaching"
+        )
+      );
     } catch (err) {
       setError(err instanceof Error ? err.message : "Manual creation failed");
     } finally {
       setCreating(false);
       inFlight.current = false;
     }
-  }, [
-    activity,
-    profileId,
-    persistence,
-    analytics,
-    navigate,
-    onClose,
-    showSuccess,
-  ]);
+  }, [activity, profileId, persistence, navigate, onClose]);
 
   return {
     creating,

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.ts
@@ -42,9 +42,9 @@ export const useCoachingManual = (
     try {
       // Idempotency: if a workout already exists for this activity (same
       // key the Save path guards on), open it instead of a fresh draft.
-      // `activity.id` is the SHORT `${source}:${sourceId}`; the raw
-      // sourceId is its second segment.
-      const sourceId = activity.id.split(":")[1] ?? "";
+      // `activity.id` is the SHORT `${source}:${sourceId}`; strip the known
+      // `${source}:` prefix (sourceId itself may contain `:`).
+      const sourceId = activity.id.slice(activity.source.length + 1);
       const ns = namespaceSourceId(profileId, sourceId);
       const existing = await persistence.workouts.getBySourceId(
         activity.source,

--- a/packages/workout-spa-editor/src/components/pages/CoachingDraftSurface.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CoachingDraftSurface.tsx
@@ -1,0 +1,78 @@
+/**
+ * Editor canvas for `/workout/new?coaching=<compositeId>` — the
+ * store-only coaching draft (defer-coaching-create). Nothing is persisted
+ * until the explicit Save click; mirrors `ScratchEditorSurface`.
+ *
+ * The sidebar is rendered directly from the draft activity record rather
+ * than through `useCoachingSidebar`/`EditorBody.sidebar`, which resolve a
+ * persisted SessionMatch that does not exist for a draft.
+ */
+import { useAppHandlers } from "../../hooks/useAppHandlers";
+import { useCurrentWorkout } from "../../store/selectors/workout-selectors";
+import { useWorkoutStore } from "../../store/workout-store";
+import type { Workout } from "../../types/krd";
+import { Button } from "../atoms/Button/Button";
+import { CoachingSidebar } from "../organisms/CoachingSidebar/CoachingSidebar";
+import { EditorNoData } from "./EditorLoadingState";
+import { EditorPageHeader } from "./EditorPageHeader";
+import { useCoachingDraft } from "./use-coaching-draft";
+import { useCoachingDraftSave } from "./use-coaching-draft-save";
+import { WorkoutSection } from "./WorkoutSection/WorkoutSection";
+
+export type CoachingDraftSurfaceProps = {
+  coachingDraftId: string;
+  onBack?: () => void;
+};
+
+export function CoachingDraftSurface({
+  coachingDraftId,
+  onBack,
+}: CoachingDraftSurfaceProps) {
+  const { activity, noStructured } = useCoachingDraft(coachingDraftId);
+  const { canSave, save } = useCoachingDraftSave(activity);
+  const currentWorkout = useCurrentWorkout();
+  const selectedStepId = useWorkoutStore((s) => s.selectedStepId);
+  const reorderStep = useWorkoutStore((s) => s.reorderStep);
+  const reorderStepsInBlock = useWorkoutStore((s) => s.reorderStepsInBlock);
+  const { handleStepSelect } = useAppHandlers();
+
+  const workout = currentWorkout?.extensions?.structured_workout as
+    | Workout
+    | undefined;
+
+  return (
+    <div className="space-y-6">
+      <EditorPageHeader mode="new" onBack={onBack} />
+      {noStructured && <EditorNoData />}
+      {!noStructured && (
+        <Button
+          variant="primary"
+          disabled={!canSave}
+          onClick={() => void save()}
+          data-testid="coaching-draft-save-button"
+        >
+          Save workout
+        </Button>
+      )}
+      {workout && currentWorkout && (
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
+          <div className="flex-1">
+            <WorkoutSection
+              workout={workout}
+              krd={currentWorkout}
+              selectedStepId={selectedStepId}
+              onStepSelect={handleStepSelect}
+              onStepReorder={reorderStep}
+              onReorderStepsInBlock={reorderStepsInBlock}
+            />
+          </div>
+          {activity && (
+            <div className="lg:w-80 lg:flex-shrink-0">
+              <CoachingSidebar activity={activity} />
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/EditorPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/EditorPage.tsx
@@ -9,29 +9,28 @@
 import { useSearch } from "wouter";
 
 import { useActiveProfileLive } from "../../hooks/use-active-profile-live";
-import { useAppHandlers } from "../../hooks/useAppHandlers";
 import { useDeleteCleanup } from "../../hooks/useDeleteCleanup";
 import { useWorkoutStore } from "../../store/workout-store";
 import type { Workout } from "../../types/krd";
 import { useCoachingSidebar } from "../organisms/CoachingSidebar/use-coaching-sidebar";
+import { CoachingDraftSurface } from "./CoachingDraftSurface";
 import { DateBanner } from "./DateBanner";
 import { parseEditorRouteParams } from "./editor-route-params";
-import { EditorBody } from "./EditorBody";
 import { EditorLoading, EditorNoData } from "./EditorLoadingState";
 import { EditorPageHeader } from "./EditorPageHeader";
+import { EditorPopulatedBody } from "./EditorPopulatedBody";
 import { EditorWorkflowBar } from "./EditorWorkflowBar";
 import { renderNewWorkoutSurface } from "./render-new-workout-surface";
 import { useBackHandler } from "./use-back-handler";
 import { useEditorActions } from "./use-editor-actions";
 import { useWorkoutRecord } from "./use-workout-record";
-import { WorkoutSection } from "./WorkoutSection/WorkoutSection";
 
 export type EditorPageProps = { id?: string };
 
 export default function EditorPage({ id }: EditorPageProps) {
   useDeleteCleanup();
   const search = useSearch();
-  const { dateParam, weekParam, origin, newWorkoutMode } =
+  const { dateParam, weekParam, origin, newWorkoutMode, coachingDraftId } =
     parseEditorRouteParams(search);
   const handleBack = useBackHandler(
     newWorkoutMode,
@@ -41,10 +40,6 @@ export default function EditorPage({ id }: EditorPageProps) {
   );
 
   const currentWorkout = useWorkoutStore((s) => s.currentWorkout);
-  const selectedStepId = useWorkoutStore((s) => s.selectedStepId);
-  const reorderStep = useWorkoutStore((s) => s.reorderStep);
-  const reorderStepsInBlock = useWorkoutStore((s) => s.reorderStepsInBlock);
-  const { handleStepSelect } = useAppHandlers();
 
   const { record, loading } = useWorkoutRecord(id);
   const { acceptWorkout, pushWorkout } = useEditorActions(record);
@@ -57,6 +52,14 @@ export default function EditorPage({ id }: EditorPageProps) {
 
   if (id && loading) return <EditorLoading />;
   if (id && record && !record.krd) return <EditorNoData />;
+
+  if (!id && coachingDraftId)
+    return (
+      <CoachingDraftSurface
+        coachingDraftId={coachingDraftId}
+        onBack={handleBack ?? undefined}
+      />
+    );
 
   const importComplete = newWorkoutMode === "import" && currentWorkout !== null;
   const showNewSurface = !id && newWorkoutMode !== undefined && !importComplete;
@@ -80,16 +83,11 @@ export default function EditorPage({ id }: EditorPageProps) {
       )}
       {showNewSurface && renderNewWorkoutSurface(newWorkoutMode, dateParam)}
       {showPopulatedBody && workout && currentWorkout && (
-        <EditorBody sidebar={sidebarData}>
-          <WorkoutSection
-            workout={workout}
-            krd={currentWorkout}
-            selectedStepId={selectedStepId}
-            onStepSelect={handleStepSelect}
-            onStepReorder={reorderStep}
-            onReorderStepsInBlock={reorderStepsInBlock}
-          />
-        </EditorBody>
+        <EditorPopulatedBody
+          workout={workout}
+          currentWorkout={currentWorkout}
+          sidebar={sidebarData}
+        />
       )}
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/EditorPopulatedBody.tsx
+++ b/packages/workout-spa-editor/src/components/pages/EditorPopulatedBody.tsx
@@ -1,0 +1,40 @@
+/**
+ * The populated editor body (sidebar + step list) for `EditorPage`. Lives
+ * in its own file so `EditorPage` stays under the per-function line cap.
+ */
+import { useAppHandlers } from "../../hooks/useAppHandlers";
+import { useWorkoutStore } from "../../store/workout-store";
+import type { KRD, Workout } from "../../types/krd";
+import type { useCoachingSidebar } from "../organisms/CoachingSidebar/use-coaching-sidebar";
+import { EditorBody } from "./EditorBody";
+import { WorkoutSection } from "./WorkoutSection/WorkoutSection";
+
+export type EditorPopulatedBodyProps = {
+  workout: Workout;
+  currentWorkout: KRD;
+  sidebar: ReturnType<typeof useCoachingSidebar>;
+};
+
+export function EditorPopulatedBody({
+  workout,
+  currentWorkout,
+  sidebar,
+}: EditorPopulatedBodyProps) {
+  const selectedStepId = useWorkoutStore((s) => s.selectedStepId);
+  const reorderStep = useWorkoutStore((s) => s.reorderStep);
+  const reorderStepsInBlock = useWorkoutStore((s) => s.reorderStepsInBlock);
+  const { handleStepSelect } = useAppHandlers();
+
+  return (
+    <EditorBody sidebar={sidebar}>
+      <WorkoutSection
+        workout={workout}
+        krd={currentWorkout}
+        selectedStepId={selectedStepId}
+        onStepSelect={handleStepSelect}
+        onStepReorder={reorderStep}
+        onReorderStepsInBlock={reorderStepsInBlock}
+      />
+    </EditorBody>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/editor-route-params.ts
+++ b/packages/workout-spa-editor/src/components/pages/editor-route-params.ts
@@ -8,10 +8,13 @@ export type EditorRouteParams = {
   weekParam: string | null;
   origin: BackOrigin | null;
   newWorkoutMode: NewWorkoutMode | undefined;
+  /** Composite coaching id (`${profileId}:${source}:${sourceId}`) when
+      `/workout/new?coaching=` opens a store-only coaching draft. */
+  coachingDraftId: string | null;
 };
 
 /** Parse the editor route's query contract (`date`, `week`, `from`,
-    `source`/`action`) from a raw search string. */
+    `source`/`action`, `coaching`) from a raw search string. */
 export function parseEditorRouteParams(search: string): EditorRouteParams {
   const params = new URLSearchParams(search);
   return {
@@ -19,5 +22,6 @@ export function parseEditorRouteParams(search: string): EditorRouteParams {
     weekParam: params.get("week"),
     origin: parseBackOrigin(params.get("from")),
     newWorkoutMode: deriveNewWorkoutMode(search),
+    coachingDraftId: params.get("coaching"),
   };
 }

--- a/packages/workout-spa-editor/src/components/pages/use-coaching-draft-save.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-coaching-draft-save.ts
@@ -1,0 +1,58 @@
+/**
+ * useCoachingDraftSave — the single persist trigger for a store-only
+ * coaching draft. Mirrors `usePersistScratch`: the explicit Save click
+ * persists the CURRENT store KRD (carrying user edits) via
+ * `persistCoachingWorkout`, then replaces the URL with the real
+ * `/workout/:id` so a reload no longer re-derives the draft.
+ */
+import { useLocation } from "wouter";
+
+import type { CoachingActivityForConvert } from "../../application/coaching/convert-coaching-activity-manual-types";
+import { persistCoachingWorkout } from "../../application/coaching/persist-coaching-workout";
+import { useAnalytics } from "../../contexts/analytics-context";
+import { usePersistence } from "../../contexts/persistence-context";
+import { useToastContext } from "../../contexts/ToastContext";
+import { useCurrentWorkout } from "../../store/selectors/workout-selectors";
+
+const SAVE_FAIL_TITLE = "Save failed";
+const SAVE_FAIL_DESC = "Could not save the workout — please retry.";
+
+export type UseCoachingDraftSave = {
+  canSave: boolean;
+  save: () => Promise<void>;
+};
+
+export function useCoachingDraftSave(
+  activity: CoachingActivityForConvert | undefined
+): UseCoachingDraftSave {
+  const currentWorkout = useCurrentWorkout();
+  const persistence = usePersistence();
+  const analytics = useAnalytics();
+  const toast = useToastContext();
+  const [, navigate] = useLocation();
+
+  const canSave = activity !== undefined && currentWorkout !== null;
+
+  const save = async (): Promise<void> => {
+    if (!activity || !currentWorkout) return;
+    try {
+      const result = await persistCoachingWorkout(
+        { krd: currentWorkout, activity },
+        {
+          coaching: persistence.coaching,
+          workouts: persistence.workouts,
+          sessionMatches: persistence.sessionMatch,
+          analytics,
+          newWorkoutId: () => crypto.randomUUID(),
+          newMatchId: () => crypto.randomUUID(),
+          clock: () => new Date().toISOString(),
+        }
+      );
+      navigate(`/workout/${result.workoutId}`, { replace: true });
+    } catch {
+      toast.error(SAVE_FAIL_TITLE, SAVE_FAIL_DESC);
+    }
+  };
+
+  return { canSave, save };
+}

--- a/packages/workout-spa-editor/src/components/pages/use-coaching-draft.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-coaching-draft.ts
@@ -1,0 +1,64 @@
+/**
+ * useCoachingDraft — store-only coaching draft for
+ * `/workout/new?coaching=<compositeId>`.
+ *
+ * Reads the coaching activity by its composite id (reactive via
+ * `useLiveQuery`, like `use-coaching-sidebar`), derives the seed KRD via
+ * `buildCoachingDraftKrd`, and seeds the workout-store ONCE (guarded like
+ * `use-workout-record` / `ScratchEditorSurface` so user edits are never
+ * clobbered by a re-seed). Nothing is persisted — Save does that.
+ *
+ * A rest day or unknown sport (`resolveT2GSport === null`) yields no
+ * draft KRD; the caller shows the no-structured-workout state while still
+ * exposing the activity for the sidebar.
+ */
+import { useLiveQuery } from "dexie-react-hooks";
+import { useEffect, useRef } from "react";
+
+import { db } from "../../adapters/dexie/dexie-database";
+import { buildCoachingDraftKrd } from "../../application/coaching/build-coaching-draft-krd";
+import { useLoadWorkout } from "../../store/selectors/workout-selectors";
+import { useCurrentWorkout } from "../../store/selectors/workout-selectors";
+import type { CoachingActivityRecord } from "../../types/coaching-activity-record";
+
+export type CoachingDraftState = {
+  activity: CoachingActivityRecord | undefined;
+  /** true once the activity row resolved but yields no trainable KRD. */
+  noStructured: boolean;
+};
+
+export function useCoachingDraft(
+  coachingDraftId: string | null
+): CoachingDraftState {
+  const activity = useLiveQuery(
+    () =>
+      coachingDraftId
+        ? db
+            .table<CoachingActivityRecord>("coachingActivities")
+            .get(coachingDraftId)
+        : undefined,
+    [coachingDraftId]
+  );
+
+  const loadWorkout = useLoadWorkout();
+  const currentWorkout = useCurrentWorkout();
+  const seededRef = useRef(false);
+
+  useEffect(() => {
+    if (!activity || seededRef.current) return;
+    // Seed-once guard: never re-seed over user edits already in the store.
+    if (currentWorkout !== null) {
+      seededRef.current = true;
+      return;
+    }
+    const draft = buildCoachingDraftKrd(activity);
+    seededRef.current = true;
+    if (!draft) return;
+    loadWorkout(draft.krd);
+  }, [activity, currentWorkout, loadWorkout]);
+
+  const noStructured =
+    activity !== undefined && buildCoachingDraftKrd(activity) === null;
+
+  return { activity, noStructured };
+}

--- a/packages/workout-spa-editor/src/new-workout-route.tsx
+++ b/packages/workout-spa-editor/src/new-workout-route.tsx
@@ -21,7 +21,8 @@ export function NewWorkoutRoute() {
   const params = new URLSearchParams(search);
   const hasAction = params.get("action") === "import";
   const hasSource = params.get("source") === "scratch";
-  if (hasAction || hasSource) return <EditorPage />;
+  const hasCoachingDraft = params.get("coaching") !== null;
+  if (hasAction || hasSource || hasCoachingDraft) return <EditorPage />;
   const date = params.get("date");
   const closeTarget = date ? buildPickerHref(date) : "/calendar";
   return (


### PR DESCRIPTION
## What

Three related fixes on the coaching → workout creation flow (one consensus plan, Architect + Critic approved).

### 1. Defer "Edit manually" persistence until Save (primary)
Clicking **Edit manually** used to eagerly persist a structured workout + SessionMatch on click, then navigate to the editor — leaving junk behind if the user never saved. Now it opens a **store-only draft** editor (`/workout/new?coaching=…`, mirroring the existing scratch flow) and persistence happens only on an explicit **Save**. Leaving without saving persists nothing. If a workout already exists for the activity, the existing one opens instead (idempotency, same `getBySourceId` key).

The manual convert use case is split into `buildCoachingDraftKrd` (entry seed) + `persistCoachingWorkout` (Save — persists the **edited** store KRD, not a rebuilt template), so user edits are carried through. The one-shot `convertCoachingActivityManual` composes both. Persistence stays in `application/` behind ports (zustand-no-writethrough safe).

### 2. AI path sport fix
"Expand with AI" passed the **raw** Train2Go key to the LLM hint (rejected → `generic`) and the shared builder copied the raw key to `record.sport`. Now the path resolves the Train2Go sport, force-sets the resolved sport/subSport on the KRD, and the shared builder sets `record.sport` from the resolved sport — fixing **both** the AI and manual paths so a known sport never lands `generic`.

### 3. Junk cleanup
A guarded, idempotent one-time pass (`db.on("ready")`, meta flag `junk-cleanup-v1`) removes the untouched 1-step template workouts left by earlier eager clicks, plus their orphaned session matches. Matched by **step shape** + `modifiedAt===null` + `createdAt===updatedAt`, so no user-edited workout is ever removed; never blocks app start.

## Notes
- **Forward-only / additive**; the calendar shows the activity un-collapsed until Save (intended — no match until persisted).
- EditorPage gains a draft branch; the populated body was extracted to `EditorPopulatedBody` to respect the per-function line cap.

## Tests
- New: `build-coaching-draft-krd`, `persist-coaching-workout` (persists edited KRD, match, idempotency), `remove-untouched-coaching-templates` (+ dexie integration), rewritten `use-coaching-manual-handler` (navigates to draft, no persist, idempotency).
- Full SPA suite **4585 passing**, mechanical guards **485 passing**, `pnpm -r build` + `pnpm lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Coaching "Edit manually" now opens a draft editor with deferred save—changes persist only on explicit save, not when navigating away
  * Existing workouts for coaching activities now open idempotently, preventing duplicates

* **Bug Fixes**
  * Train2Go sport resolution now correctly maps sports (e.g., stretching, stationarybike) instead of defaulting to generic
  * AI workout expansion now resolves actual sports before generation, ensuring accurate metadata

* **Chores**
  * One-time maintenance cleanup removes untouched coaching template workouts while preserving user-edited ones

<!-- end of auto-generated comment: release notes by coderabbit.ai -->