### PR TITLE
fix(spa-editor): auto-recover from stale lazy chunks after a deploy

### DIFF
--- a/.changeset/chunk-load-recovery.md
+++ b/.changeset/chunk-load-recovery.md
@@ -1,0 +1,12 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Recover automatically from stale lazy chunks after a deploy
+
+When a new build ships, the hashed lazy route chunks change; a browser tab still
+running the previous `index` fails to import the old chunk ("Failed to fetch
+dynamically imported module") and lands on the route error screen. The app now
+reloads once to pull the fresh build — both on Vite's `vite:preloadError` event
+and when the failure surfaces through the route error boundary — guarded by a
+sessionStorage cooldown so a genuinely-unfetchable chunk never causes a reload loop.

--- a/packages/workout-spa-editor/src/components/molecules/RouteErrorBoundary.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/RouteErrorBoundary.tsx
@@ -17,6 +17,10 @@ import type { ErrorInfo, ReactNode } from "react";
 import { Component } from "react";
 
 import { buildRouteErrorPayload } from "../../lib/build-route-error-payload";
+import {
+  isChunkLoadError,
+  reloadOnceForChunkError,
+} from "../../lib/chunk-reload";
 import { scrubAnalyticsString } from "../../lib/scrub-analytics-string";
 import { RouteErrorFallback } from "./RouteErrorFallback";
 
@@ -34,6 +38,9 @@ export class RouteErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
+    // A stale dynamic-import chunk (post-deploy) can surface here as a render
+    // error — recover by reloading once instead of showing the error screen.
+    if (isChunkLoadError(error) && reloadOnceForChunkError()) return;
     if (this.props.analytics) {
       try {
         const payload = buildRouteErrorPayload(

--- a/packages/workout-spa-editor/src/lib/chunk-reload.test.ts
+++ b/packages/workout-spa-editor/src/lib/chunk-reload.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { isChunkLoadError, reloadOnceForChunkError } from "./chunk-reload";
+import { isChunkLoadError } from "./chunk-reload";
 
 const RELOAD_AT_KEY = "kaiord:chunk-reload-at";
 
@@ -33,6 +33,13 @@ describe("isChunkLoadError", () => {
 describe("reloadOnceForChunkError", () => {
   const reload = vi.fn();
 
+  // Fresh module per test so the in-memory `reloadedThisLoad` guard resets.
+  const loadFn = async () => {
+    vi.resetModules();
+    const mod = await import("./chunk-reload");
+    return mod.reloadOnceForChunkError;
+  };
+
   beforeEach(() => {
     reload.mockClear();
     sessionStorage.clear();
@@ -43,8 +50,9 @@ describe("reloadOnceForChunkError", () => {
     vi.unstubAllGlobals();
   });
 
-  it("should reload when no recent reload is recorded", () => {
+  it("should reload when no recent reload is recorded", async () => {
     // Arrange
+    const reloadOnceForChunkError = await loadFn();
 
     // Act
     const triggered = reloadOnceForChunkError();
@@ -54,9 +62,10 @@ describe("reloadOnceForChunkError", () => {
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  it("should suppress a second reload within the cooldown window", () => {
+  it("should suppress a second reload within the cooldown window", async () => {
     // Arrange
     sessionStorage.setItem(RELOAD_AT_KEY, String(Date.now()));
+    const reloadOnceForChunkError = await loadFn();
 
     // Act
     const triggered = reloadOnceForChunkError();
@@ -64,5 +73,28 @@ describe("reloadOnceForChunkError", () => {
     // Assert
     expect(triggered).toBe(false);
     expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("should reload at most once per load when sessionStorage is unavailable", async () => {
+    // Arrange
+    vi.stubGlobal("sessionStorage", {
+      getItem: () => {
+        throw new Error("denied");
+      },
+      setItem: () => {
+        throw new Error("denied");
+      },
+      clear: () => undefined,
+    });
+    const reloadOnceForChunkError = await loadFn();
+
+    // Act
+    const first = reloadOnceForChunkError();
+    const second = reloadOnceForChunkError();
+
+    // Assert
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+    expect(reload).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/workout-spa-editor/src/lib/chunk-reload.test.ts
+++ b/packages/workout-spa-editor/src/lib/chunk-reload.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isChunkLoadError, reloadOnceForChunkError } from "./chunk-reload";
+
+const RELOAD_AT_KEY = "kaiord:chunk-reload-at";
+
+describe("isChunkLoadError", () => {
+  it("should match a failed dynamic-import message", () => {
+    // Arrange
+    const error = new Error(
+      "Failed to fetch dynamically imported module: /assets/Today-x.js"
+    );
+
+    // Act
+    const result = isChunkLoadError(error);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("should not match an unrelated error", () => {
+    // Arrange
+    const error = new Error("Cannot read properties of undefined");
+
+    // Act
+    const result = isChunkLoadError(error);
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe("reloadOnceForChunkError", () => {
+  const reload = vi.fn();
+
+  beforeEach(() => {
+    reload.mockClear();
+    sessionStorage.clear();
+    vi.stubGlobal("location", { reload });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should reload when no recent reload is recorded", () => {
+    // Arrange
+
+    // Act
+    const triggered = reloadOnceForChunkError();
+
+    // Assert
+    expect(triggered).toBe(true);
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("should suppress a second reload within the cooldown window", () => {
+    // Arrange
+    sessionStorage.setItem(RELOAD_AT_KEY, String(Date.now()));
+
+    // Act
+    const triggered = reloadOnceForChunkError();
+
+    // Assert
+    expect(triggered).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workout-spa-editor/src/lib/chunk-reload.ts
+++ b/packages/workout-spa-editor/src/lib/chunk-reload.ts
@@ -26,14 +26,22 @@ export const isChunkLoadError = (error: unknown): boolean => {
  * Reload the page once to recover from a stale chunk. Returns `true` if a
  * reload was triggered, `false` if suppressed by the cooldown (loop guard).
  */
+// In-memory guard: prevents repeated reloads within a single page load even
+// when `sessionStorage` is unavailable (private mode), so a flurry of chunk
+// errors (multiple preloadError events / boundary catches) cannot loop.
+let reloadedThisLoad = false;
+
 export const reloadOnceForChunkError = (): boolean => {
+  if (reloadedThisLoad) return false;
   try {
     const last = Number(sessionStorage.getItem(RELOAD_AT_KEY) ?? "0");
     if (Date.now() - last < RELOAD_COOLDOWN_MS) return false;
     sessionStorage.setItem(RELOAD_AT_KEY, String(Date.now()));
   } catch {
-    // sessionStorage unavailable (private mode) — still attempt one reload.
+    // sessionStorage unavailable (private mode) — the in-memory guard still
+    // ensures we reload at most once per page load.
   }
+  reloadedThisLoad = true;
   window.location.reload();
   return true;
 };

--- a/packages/workout-spa-editor/src/lib/chunk-reload.ts
+++ b/packages/workout-spa-editor/src/lib/chunk-reload.ts
@@ -1,0 +1,39 @@
+/**
+ * Recovery for stale dynamic-import chunks after a deploy.
+ *
+ * When a new build ships, hashed lazy chunks (e.g. `Today-<hash>.js`) are
+ * replaced. A tab still running the previous `index` references the old
+ * hashes and fails to import them ("Failed to fetch dynamically imported
+ * module"). The fix is a one-shot reload to pull the fresh `index` + chunks.
+ *
+ * A sessionStorage cooldown prevents a reload loop when the chunk is
+ * genuinely unfetchable (offline / persistent 404): after one reload we let
+ * the error surface to the route boundary instead of reloading again.
+ */
+const RELOAD_AT_KEY = "kaiord:chunk-reload-at";
+const RELOAD_COOLDOWN_MS = 10_000;
+
+const CHUNK_ERROR_PATTERN =
+  /failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed|dynamically imported module/i;
+
+/** True when an error looks like a stale/failed dynamic-import chunk load. */
+export const isChunkLoadError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return CHUNK_ERROR_PATTERN.test(message);
+};
+
+/**
+ * Reload the page once to recover from a stale chunk. Returns `true` if a
+ * reload was triggered, `false` if suppressed by the cooldown (loop guard).
+ */
+export const reloadOnceForChunkError = (): boolean => {
+  try {
+    const last = Number(sessionStorage.getItem(RELOAD_AT_KEY) ?? "0");
+    if (Date.now() - last < RELOAD_COOLDOWN_MS) return false;
+    sessionStorage.setItem(RELOAD_AT_KEY, String(Date.now()));
+  } catch {
+    // sessionStorage unavailable (private mode) — still attempt one reload.
+  }
+  window.location.reload();
+  return true;
+};

--- a/packages/workout-spa-editor/src/main.tsx
+++ b/packages/workout-spa-editor/src/main.tsx
@@ -19,11 +19,20 @@ import {
 import { CoachingRegistryBootstrap } from "./contexts/coaching-registry-bootstrap";
 import { PersistenceProvider } from "./contexts/persistence-context";
 import { SyncProvider } from "./contexts/sync-context";
+import { reloadOnceForChunkError } from "./lib/chunk-reload";
 import { getDeviceId } from "./lib/cloud-sync/device-id";
 import { getSyncPassphrase } from "./lib/cloud-sync/encryption-runtime";
 import { isEncryptionEnabled } from "./lib/cloud-sync/sync-encryption-pref";
 import { getCfAnalyticsToken } from "./lib/runtime-config";
 import { computeRouterBase } from "./router-base";
+
+// Recover from stale lazy chunks after a deploy: Vite fires `vite:preloadError`
+// when a hashed chunk can no longer be fetched; reload once to pull the fresh
+// build (loop-guarded). See `lib/chunk-reload`.
+window.addEventListener("vite:preloadError", (event) => {
+  event.preventDefault();
+  reloadOnceForChunkError();
+});
 
 const analytics = createCloudflareAnalytics(getCfAnalyticsToken());
 


### PR DESCRIPTION
## What

Fixes the `Failed to fetch dynamically imported module` error (route error screen) that hits open tabs after a deploy — the symptom seen live on the `Today`/Daily lazy route right after #741 shipped.

When a new build ships, the hashed lazy chunks (e.g. `Today-<hash>.js`) are replaced. A tab still running the **previous** `index` references the old hashes and fails to import them. The deploy itself is fine (index ↔ chunks are consistent); the running tab is stale.

## Fix

Reload once to pull the fresh build, on two fronts:
- **`vite:preloadError`** — Vite fires this when its preload helper can't fetch a chunk (`main.tsx`).
- **`RouteErrorBoundary`** — when the import failure surfaces as a render error (the observed case), the boundary detects a chunk-load error and reloads instead of showing the error screen.

A `sessionStorage` cooldown (`lib/chunk-reload.ts`) guards against a reload loop: if a chunk is genuinely unfetchable (offline / persistent 404), it reloads at most once, then lets the error surface.

## Tests
- `chunk-reload.test.ts`: `isChunkLoadError` matching; reload triggered on a clean session; suppressed within the cooldown window.
- tsc + eslint + build green; existing `RouteErrorBoundary` tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery from stale lazy-loaded chunk failures after app deployments. When the app encounters a chunk load error, it now attempts a single automatic page reload to fetch fresh content, with built-in protection against repeated reload loops.

* **Tests**
  * Added test coverage for chunk error detection and recovery logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->