### PR TITLE
fix: resolve CodeQL alert triage findings

### DIFF
--- a/.changeset/codeql-triage-sanitization.md
+++ b/.changeset/codeql-triage-sanitization.md
@@ -1,0 +1,10 @@
+---
+"@kaiord/train2go-bridge": patch
+---
+
+Harden HTML sanitization in the Train2Go parser: entity decoding is now
+single-pass (no double-unescaping of payloads like `&amp;lt;`) and tag,
+comment, and script/style stripping repeat until stable so interleaved
+markup cannot re-form a tag after one pass. Resolves the CodeQL
+`js/double-escaping` and `js/incomplete-multi-character-sanitization`
+findings.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,8 @@ jobs:
             paths-ignore:
               - "**/*.test.ts"
               - "**/*.test.tsx"
+              - "**/*.test.js"
+              - "**/*.test.mjs"
               - "**/*.spec.ts"
               - "**/test-utils/**"
               - "**/tests/fixtures/**"

--- a/packages/docs/scripts/generate-api-docs.mjs
+++ b/packages/docs/scripts/generate-api-docs.mjs
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { mkdirSync, existsSync, writeFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -56,20 +56,24 @@ for (const pkg of packages) {
 
   const tsconfig = join(monorepoRoot, `packages/${pkg.name}/tsconfig.json`);
   try {
-    execSync(
+    // execFileSync (no shell) so paths with spaces or shell
+    // metacharacters cannot be reinterpreted as commands.
+    execFileSync(
+      join(docsRoot, "node_modules/.bin/typedoc"),
       [
-        join(docsRoot, "node_modules/.bin/typedoc"),
-        `--entryPoints ${entryPath}`,
-        "--plugin typedoc-plugin-markdown",
-        `--out ${outDir}`,
-        existsSync(tsconfig) ? `--tsconfig ${tsconfig}` : "",
-        "--readme none",
+        "--entryPoints",
+        entryPath,
+        "--plugin",
+        "typedoc-plugin-markdown",
+        "--out",
+        outDir,
+        ...(existsSync(tsconfig) ? ["--tsconfig", tsconfig] : []),
+        "--readme",
+        "none",
         "--hideGenerator",
         "--excludePrivate",
         "--excludeInternal",
-      ]
-        .filter(Boolean)
-        .join(" "),
+      ],
       {
         cwd: monorepoRoot,
         stdio: "pipe",

--- a/packages/train2go-bridge/parser.js
+++ b/packages/train2go-bridge/parser.js
@@ -5,17 +5,32 @@
  * Designed for graceful degradation: returns empty arrays on malformed HTML.
  */
 
+const NAMED_ENTITIES = { amp: "&", lt: "<", gt: ">", quot: '"' };
+
+// Single-pass decode: sequential .replace() chains double-decode
+// payloads like `&amp;lt;` (first pass yields `&lt;`, second yields
+// `<`), which is what CodeQL's js/double-escaping flags.
 const decodeEntities = (text) =>
-  text
-    .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(Number(n)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, h) =>
-      String.fromCharCode(parseInt(h, 16))
-    )
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#0?39;/g, "'");
+  text.replace(
+    /&(?:#(\d+)|#x([0-9a-f]+)|(amp|lt|gt|quot));/gi,
+    (match, dec, hex, named) => {
+      if (dec) return String.fromCharCode(Number(dec));
+      if (hex) return String.fromCharCode(parseInt(hex, 16));
+      return NAMED_ENTITIES[named.toLowerCase()];
+    }
+  );
+
+// Repeat a replacement until the string stops changing — a single pass
+// can leave new matches behind (e.g. stripping `<b>` from `<scr<b>ipt`
+// re-forms `<script`).
+const replaceUntilStable = (text, pattern, replacement) => {
+  let prev;
+  do {
+    prev = text;
+    text = text.replace(pattern, replacement);
+  } while (text !== prev);
+  return text;
+};
 
 const extractNumber = (text) => {
   const m = text?.match(/\d+/);
@@ -162,7 +177,7 @@ const extractDescription = (block) => {
   text = text.replace(/<\/(p|h[1-6]|li|ul|ol)>/gi, "\n");
   text = text.replace(/<(p|li)\b[^>]*>/gi, "\n");
   // Strip remaining HTML
-  text = text.replace(/<[^>]+>/g, "");
+  text = replaceUntilStable(text, /<[^>]+>/g, "");
   text = decodeEntities(text);
   // Clean up whitespace
   return text
@@ -190,11 +205,15 @@ const htmlToPlainText = (html) => {
   // Drop script/style blocks ENTIRE — including their text content —
   // before the tag-strip pass; otherwise the inner JS/CSS leaks into
   // the popup's textContent.
-  const noEmbedded = html.replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, "");
+  const noEmbedded = replaceUntilStable(
+    html,
+    /<(script|style)[^>]*>[\s\S]*?<\/\1>/gi,
+    ""
+  );
   const withBreaks = noEmbedded
     .replace(/<\/(p|h[1-6]|li|div)>/gi, "$&\n")
     .replace(/<br\s*\/?>/gi, "\n");
-  const stripped = withBreaks.replace(/<[^>]+>/g, "");
+  const stripped = replaceUntilStable(withBreaks, /<[^>]+>/g, "");
   const decoded = decodeEntities(stripped);
   return decoded
     .replace(/\r\n?/g, "\n")
@@ -320,7 +339,7 @@ const parseHrZonesBlock = (html) => {
   // Generic → skip fallback per D-FB1. HTML comments are stripped
   // first so prose mentions of zone class names (e.g. fixture
   // headers) cannot anchor the wrapper regex.
-  const stripped = html.replace(/<!--[\s\S]*?-->/g, "");
+  const stripped = replaceUntilStable(html, /<!--[\s\S]*?-->/g, "");
   const block = sliceBetween(
     stripped,
     /id="hrzones-\d+"/,

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/format-coaching-description.ts
@@ -25,18 +25,34 @@ const STRONG_RE =
 
 const stripTagsExceptStrong = (html: string): string => {
   // Remove every tag except <strong>...</strong> markers (the strong
-  // splitter below extracts those before this strip).
-  return html.replace(/<\/?(?!strong\b)[^>]+>/gi, "").trim();
+  // splitter below extracts those before this strip). Looped until
+  // stable: a single pass can re-form a tag from interleaved input
+  // (e.g. `<scr<b>ipt` -> `<script`).
+  let text = html;
+  let prev: string;
+  do {
+    prev = text;
+    text = text.replace(/<\/?(?!strong\b)[^>]+>/gi, "");
+  } while (text !== prev);
+  return text.trim();
 };
 
+const ENTITY_REPLACEMENTS: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&nbsp;": " ",
+};
+
+// Single-pass decode: sequential .replace() chains double-decode
+// payloads like `&amp;lt;` (first pass yields `&lt;`, second `<`).
 const decodeEntities = (s: string): string =>
-  s
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, " ");
+  s.replace(
+    /&(?:amp|lt|gt|quot|#39|nbsp);/g,
+    (entity) => ENTITY_REPLACEMENTS[entity] ?? entity
+  );
 
 const splitInlines = (paragraph: string): DescriptionInline[] => {
   const inlines: DescriptionInline[] = [];


### PR DESCRIPTION
## Summary

Triage of the 22 alerts surfaced by CodeQL's first full scan of `main` (the workflow landed in #743). Disposition: 8 fixed here, 14 dismissed as test-only.

### Fixed (8 alerts)

| Alerts | Rule | Fix |
|---|---|---|
| #3, #4 | `js/double-escaping` (high) | Entity decoding in `train2go-bridge/parser.js` and the SPA `format-coaching-description.ts` is now **single-pass** — sequential `.replace()` chains double-decoded payloads like `&amp;lt;` → `<` |
| #5–#9 | `js/incomplete-multi-character-sanitization` (high) | Tag, comment, and script/style stripping now **repeats until stable**, so interleaved markup (`<scr<b>ipt`) cannot re-form a tag after a single pass |
| #10 | `js/shell-command-injection-from-environment` (medium) | `docs/scripts/generate-api-docs.mjs` uses `execFileSync` with an argument array instead of `execSync` with an interpolated shell string |

### Dismissed (14 alerts, "used in tests")

#11–#24 — all `js/incomplete-url-substring-sanitization` in `scripts/cws-api.test.mjs`: the `url.includes("oauth2.googleapis.com")` matches are mock-fetch routing inside a test double, selecting which fake response to return. No real URL validation occurs. `codeql.yml` now ignores `*.test.js`/`*.test.mjs` alongside the existing TS test globs so test files stop generating scan noise.

## Verification

- train2go-bridge: 128/128 tests pass (parser round-trips unchanged for well-formed input)
- SPA CoachingSidebar + formatter: 13/13 tests pass, typecheck and lint clean
- docs generator: syntax-checked; exercised by the docs build job in CI
- Changeset included (`@kaiord/train2go-bridge` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened HTML parsing and sanitization to prevent double-unescaping and incomplete tag stripping issues.
  
* **Security**
  * Resolved CodeQL security findings related to HTML entity handling and incomplete sanitization patterns.

* **Chores**
  * Updated security scanning configuration and improved script execution for documentation generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->