### PR TITLE
feat(spa-editor): matched-sessions read-model port + read-cast cleanup + tcx restore-honesty (closes #758)

### DIFF
--- a/.changeset/code-semantics-followups.md
+++ b/.changeset/code-semantics-followups.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/tcx": patch
+---
+
+fix(tcx): validate restored `kaiord:` duration thresholds are positive and finite. A present-but-invalid heart-rate / power / calorie attribute (0, negative, NaN, or Infinity) now warns and degrades instead of silently restoring a physiologically meaningless duration.

--- a/packages/tcx/src/adapters/duration/duration-kaiord-restorer.test.ts
+++ b/packages/tcx/src/adapters/duration/duration-kaiord-restorer.test.ts
@@ -186,4 +186,54 @@ describe("restoreKaiordDuration", () => {
     // Assert
     expect(result).toBeNull();
   });
+
+  it("should warn and drop a restored threshold that is zero or negative", () => {
+    // Arrange
+    const logger = createMockLogger();
+    const tcxDuration = {
+      "@_kaiord:originalDurationType": "power_less_than",
+      "@_kaiord:originalDurationWatts": 0,
+    };
+
+    // Act
+    const result = restoreKaiordDuration(tcxDuration, logger);
+
+    // Assert
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "Lossy conversion: kaiord power_less_than watts attribute is not a positive finite number, dropping",
+      { value: 0 }
+    );
+  });
+
+  it("should warn and drop a restored threshold that is not finite", () => {
+    // Arrange
+    const logger = createMockLogger();
+    const tcxDuration = {
+      "@_kaiord:originalDurationType": "calories",
+      "@_kaiord:originalDurationCalories": Number.POSITIVE_INFINITY,
+    };
+
+    // Act
+    const result = restoreKaiordDuration(tcxDuration, logger);
+
+    // Assert
+    expect(result).toBeNull();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("should not warn when the attribute is simply absent", () => {
+    // Arrange
+    const logger = createMockLogger();
+    const tcxDuration = {
+      "@_kaiord:originalDurationType": "heart_rate_less_than",
+    };
+
+    // Act
+    const result = restoreKaiordDuration(tcxDuration, logger);
+
+    // Assert
+    expect(result).toBeNull();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
 });

--- a/packages/tcx/src/adapters/duration/duration-kaiord-restorer.ts
+++ b/packages/tcx/src/adapters/duration/duration-kaiord-restorer.ts
@@ -5,66 +5,88 @@
 import type { Duration } from "@kaiord/core";
 import type { Logger } from "@kaiord/core";
 
+/**
+ * Reads a restored numeric `kaiord:` attribute. Returns the value only when it
+ * is a positive, finite number — a bpm / watts / calorie threshold of 0,
+ * negative, NaN, or Infinity is physiologically meaningless, so a present but
+ * invalid attribute degrades loudly (warn + null) rather than restoring a
+ * corrupt duration. A non-number (attribute absent for this concept) returns
+ * null silently.
+ */
+const readRestoredThreshold = (
+  value: unknown,
+  conceptLabel: string,
+  logger: Logger
+): number | null => {
+  if (typeof value !== "number") return null;
+  if (!Number.isFinite(value) || value <= 0) {
+    logger.warn(
+      `Lossy conversion: kaiord ${conceptLabel} attribute is not a positive finite number, dropping`,
+      { value }
+    );
+    return null;
+  }
+  return value;
+};
+
 const restoreHeartRateLessThan = (
   tcxDuration: Record<string, unknown>,
   logger: Logger
 ): Duration | null => {
-  const bpm = tcxDuration["@_kaiord:originalDurationBpm"] as number | undefined;
-  if (typeof bpm === "number") {
-    logger.debug("Restoring heart_rate_less_than from kaiord attributes", {
-      bpm,
-    });
-    return { type: "heart_rate_less_than", bpm };
-  }
-  return null;
+  const bpm = readRestoredThreshold(
+    tcxDuration["@_kaiord:originalDurationBpm"],
+    "heart_rate_less_than bpm",
+    logger
+  );
+  if (bpm === null) return null;
+  logger.debug("Restoring heart_rate_less_than from kaiord attributes", {
+    bpm,
+  });
+  return { type: "heart_rate_less_than", bpm };
 };
 
 const restorePowerLessThan = (
   tcxDuration: Record<string, unknown>,
   logger: Logger
 ): Duration | null => {
-  const watts = tcxDuration["@_kaiord:originalDurationWatts"] as
-    | number
-    | undefined;
-  if (typeof watts === "number") {
-    logger.debug("Restoring power_less_than from kaiord attributes", {
-      watts,
-    });
-    return { type: "power_less_than", watts };
-  }
-  return null;
+  const watts = readRestoredThreshold(
+    tcxDuration["@_kaiord:originalDurationWatts"],
+    "power_less_than watts",
+    logger
+  );
+  if (watts === null) return null;
+  logger.debug("Restoring power_less_than from kaiord attributes", { watts });
+  return { type: "power_less_than", watts };
 };
 
 const restorePowerGreaterThan = (
   tcxDuration: Record<string, unknown>,
   logger: Logger
 ): Duration | null => {
-  const watts = tcxDuration["@_kaiord:originalDurationWatts"] as
-    | number
-    | undefined;
-  if (typeof watts === "number") {
-    logger.debug("Restoring power_greater_than from kaiord attributes", {
-      watts,
-    });
-    return { type: "power_greater_than", watts };
-  }
-  return null;
+  const watts = readRestoredThreshold(
+    tcxDuration["@_kaiord:originalDurationWatts"],
+    "power_greater_than watts",
+    logger
+  );
+  if (watts === null) return null;
+  logger.debug("Restoring power_greater_than from kaiord attributes", {
+    watts,
+  });
+  return { type: "power_greater_than", watts };
 };
 
 const restoreCalories = (
   tcxDuration: Record<string, unknown>,
   logger: Logger
 ): Duration | null => {
-  const calories = tcxDuration["@_kaiord:originalDurationCalories"] as
-    | number
-    | undefined;
-  if (typeof calories === "number") {
-    logger.debug("Restoring calories from kaiord attributes", {
-      calories,
-    });
-    return { type: "calories", calories };
-  }
-  return null;
+  const calories = readRestoredThreshold(
+    tcxDuration["@_kaiord:originalDurationCalories"],
+    "calories",
+    logger
+  );
+  if (calories === null) return null;
+  logger.debug("Restoring calories from kaiord attributes", { calories });
+  return { type: "calories", calories };
 };
 
 export const restoreKaiordDuration = (

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-matched-sessions-read-model.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-matched-sessions-read-model.test.ts
@@ -1,0 +1,132 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { WorkoutRecord } from "../../types/calendar-record";
+import type { CoachingActivityRecord } from "../../types/coaching-activity-record";
+import type { SessionMatch } from "../../types/session-match";
+import { db } from "./dexie-database";
+import { createDexieMatchedSessionsReadModel } from "./dexie-matched-sessions-read-model";
+
+const readModel = createDexieMatchedSessionsReadModel(db);
+
+const PROFILE = "p1";
+const COMPOSITE = "p1:train2go:1";
+const DATE = "2026-04-29";
+
+const seedActivity = (): CoachingActivityRecord => ({
+  id: COMPOSITE,
+  profileId: PROFILE,
+  source: "train2go",
+  sourceId: "1",
+  date: DATE,
+  sport: "cycling",
+  title: "FTP test",
+  duration: "60 min",
+  status: "pending",
+  fetchedAt: "2026-04-28T10:00:00.000Z",
+});
+
+const seedWorkout = (id: string): WorkoutRecord =>
+  ({
+    id,
+    date: DATE,
+    sport: "cycling",
+    source: "train2go",
+    state: "ready",
+    raw: { duration: { value: 3600, unit: "s" } },
+  }) as unknown as WorkoutRecord;
+
+const seedMatch = (overrides: Partial<SessionMatch> = {}): SessionMatch => ({
+  id: "m-1",
+  profileId: PROFILE,
+  coachingActivityId: COMPOSITE,
+  workoutId: "w-1",
+  date: DATE,
+  createdAt: "2026-04-28T10:00:00.000Z",
+  source: "manual",
+  executedWorkoutIds: [],
+  ...overrides,
+});
+
+const clearAll = (): Promise<unknown> =>
+  Promise.all([
+    db.table("sessionMatches").clear(),
+    db.table("coachingActivities").clear(),
+    db.table("workouts").clear(),
+  ]);
+
+describe("dexie matched-sessions read-model", () => {
+  beforeEach(clearAll);
+  afterEach(clearAll);
+
+  describe("loadJoinSources", () => {
+    it("should key present activities and workouts by id and omit missing ids", async () => {
+      // Arrange
+      await db.table("coachingActivities").put(seedActivity());
+      await db.table("workouts").put(seedWorkout("w-1"));
+
+      // Act
+      const { activitiesById, workoutsById } = await readModel.loadJoinSources(
+        [COMPOSITE, "missing-activity"],
+        ["w-1", "missing-workout"]
+      );
+
+      // Assert
+      expect(activitiesById.get(COMPOSITE)?.id).toBe(COMPOSITE);
+      expect(activitiesById.has("missing-activity")).toBe(false);
+      expect(workoutsById.get("w-1")?.id).toBe("w-1");
+      expect(workoutsById.has("missing-workout")).toBe(false);
+    });
+
+    it("should return empty maps for empty id sets", async () => {
+      // Arrange
+
+      // Act
+      const { activitiesById, workoutsById } = await readModel.loadJoinSources(
+        [],
+        []
+      );
+
+      // Assert
+      expect(activitiesById.size).toBe(0);
+      expect(workoutsById.size).toBe(0);
+    });
+  });
+
+  describe("findActivityMatch", () => {
+    it("should return the match id and workout for a matched activity", async () => {
+      // Arrange
+      await db.table("workouts").put(seedWorkout("w-1"));
+      await db.table("sessionMatches").put(seedMatch());
+
+      // Act
+      const result = await readModel.findActivityMatch(PROFILE, COMPOSITE);
+
+      // Assert
+      expect(result).toEqual({ matchId: "m-1", workout: expect.anything() });
+      expect(result?.workout.id).toBe("w-1");
+    });
+
+    it("should return null when no match exists for the activity", async () => {
+      // Arrange
+
+      // Act
+      const result = await readModel.findActivityMatch(PROFILE, COMPOSITE);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+
+    it("should return null when the matched workout is a dangling ref", async () => {
+      // Arrange
+      await db.table("sessionMatches").put(seedMatch({ workoutId: "w-gone" }));
+
+      // Act
+      const result = await readModel.findActivityMatch(PROFILE, COMPOSITE);
+
+      // Assert
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-matched-sessions-read-model.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-matched-sessions-read-model.ts
@@ -1,0 +1,56 @@
+/**
+ * Dexie MatchedSessionsReadModel
+ *
+ * IndexedDB-backed read-model for the matched-sessions calendar projections.
+ * Issues the same observable Dexie queries the two hooks used to inline, so
+ * `useLiveQuery` reactivity is preserved when the hooks read through the port.
+ */
+
+import type { MatchedSessionsReadModel } from "../../ports/matched-sessions-read-model";
+import type { WorkoutRecord } from "../../types/calendar-record";
+import type { CoachingActivityRecord } from "../../types/coaching-activity-record";
+import type { SessionMatch } from "../../types/session-match";
+import type { KaiordDatabase } from "./dexie-database";
+
+export function createDexieMatchedSessionsReadModel(
+  db: KaiordDatabase
+): MatchedSessionsReadModel {
+  const activities = () =>
+    db.table<CoachingActivityRecord>("coachingActivities");
+  const workouts = () => db.table<WorkoutRecord>("workouts");
+  const sessionMatches = () => db.table<SessionMatch>("sessionMatches");
+
+  return {
+    loadJoinSources: async (activityIds, workoutIds) => {
+      const [activityRows, workoutRows] = await Promise.all([
+        activities()
+          .where("id")
+          .anyOf([...activityIds])
+          .toArray(),
+        workouts()
+          .where("id")
+          .anyOf([...workoutIds])
+          .toArray(),
+      ]);
+      return {
+        activitiesById: new Map(activityRows.map((a) => [a.id, a])),
+        workoutsById: new Map(workoutRows.map((w) => [w.id, w])),
+      };
+    },
+
+    findActivityMatch: async (profileId, persistedCoachingActivityId) => {
+      const match = await sessionMatches()
+        .where("[profileId+coachingActivityId]")
+        .equals([profileId, persistedCoachingActivityId])
+        .first();
+      if (!match) return null;
+
+      const workout = await workouts().get(match.workoutId);
+      // Dangling-ref tolerance: the match exists but the workout is gone
+      // (mid-cascade race). Callers treat null as solo.
+      if (!workout) return null;
+
+      return { matchId: match.id, workout };
+    },
+  };
+}

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-persistence-adapter.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-persistence-adapter.ts
@@ -21,6 +21,7 @@ import { db as defaultDb, type KaiordDatabase } from "./dexie-database";
 import { createDexieHealthCleanupRepository } from "./dexie-health-cleanup-repository";
 import { createDexieHealthRecordRepository } from "./dexie-health-record-repository";
 import { createDexieIntegrationPolicyRepository } from "./dexie-integration-policy-repository";
+import { createDexieMatchedSessionsReadModel } from "./dexie-matched-sessions-read-model";
 import { createDexieProfileRepository } from "./dexie-profile-repository";
 import { createDexieSessionMatchRepository } from "./dexie-session-match-repository";
 import { createDexieSyncStateRepository } from "./dexie-sync-state-repository";
@@ -45,6 +46,7 @@ export function createDexiePersistence(
     coachingSyncState: createDexieCoachingSyncStateRepository(database),
     integrationPolicy: createDexieIntegrationPolicyRepository(database),
     sessionMatch: createDexieSessionMatchRepository(database),
+    matchedSessionsReadModel: createDexieMatchedSessionsReadModel(database),
     autoMatchDismissal: createDexieAutoMatchDismissalRepository(database),
     userPreferences: createDexieUserPreferencesRepository(database),
     healthCleanup: createDexieHealthCleanupRepository(database),

--- a/packages/workout-spa-editor/src/components/pages/use-back-handler.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-back-handler.ts
@@ -4,9 +4,9 @@ import { useLocation } from "wouter";
 import type { BackOrigin } from "../../routing/back-origin";
 import { buildPickerHref } from "../../routing/picker-href";
 import { resolveBackTarget } from "../../routing/resolve-back-target";
+import { extractStructuredWorkout } from "../../store/actions/_helpers/extract-workout";
 import { useClearWorkout } from "../../store/selectors/workout-selectors";
 import { useWorkoutStore } from "../../store/workout-store";
-import type { Workout } from "../../types/krd";
 import type { NewWorkoutMode } from "./render-new-workout-surface";
 import { useDiscardConfirmation } from "./WorkoutSection/use-discard-confirmation";
 
@@ -32,9 +32,7 @@ export function useBackHandler(
   const [, navigate] = useLocation();
   const clearWorkout = useClearWorkout();
   const stepsLength = useWorkoutStore(
-    (s) =>
-      (s.currentWorkout?.extensions?.structured_workout as Workout | undefined)
-        ?.steps?.length ?? 0
+    (s) => extractStructuredWorkout(s.currentWorkout)?.steps?.length ?? 0
   );
 
   const isInPicker =

--- a/packages/workout-spa-editor/src/hooks/use-activity-match-state.ts
+++ b/packages/workout-spa-editor/src/hooks/use-activity-match-state.ts
@@ -17,10 +17,9 @@
 
 import { useLiveQuery } from "dexie-react-hooks";
 
-import { db } from "../adapters/dexie/dexie-database";
+import { usePersistence } from "../contexts/persistence-context";
 import type { WorkoutRecord } from "../types/calendar-record";
 import { toPersistedCoachingActivityId } from "../types/coaching-activity-record";
-import type { SessionMatch } from "../types/session-match";
 
 export type ActivityMatchState =
   | { kind: "solo" }
@@ -30,39 +29,32 @@ export type ActivityMatchState =
  * @param activityViewModelId the in-memory `CoachingActivity.id`
  *   (SHORT form `"${source}:${sourceId}"`). The hook composes the
  *   canonical COMPOSITE persisted shape via `toPersistedCoachingActivityId`
- *   before querying `sessionMatches.[profileId+coachingActivityId]`,
+ *   before asking the read-model for `sessionMatches.[profileId+coachingActivityId]`,
  *   matching the COMPOSITE shape every writer persists. See
  *   `.omc/autopilot/bug-trace.md` §H7 for the original divergence.
+ *
+ * Reads go through `matchedSessionsReadModel` (not `db` directly); its Dexie
+ * adapter issues the same observable queries, so `useLiveQuery` reactivity is
+ * preserved while the persistence boundary stays behind the port.
  */
 export function useActivityMatchState(
   profileId: string | null,
   activityViewModelId: string | null
 ): ActivityMatchState | undefined {
+  const { matchedSessionsReadModel } = usePersistence();
   return useLiveQuery<ActivityMatchState>(async () => {
     if (!profileId || !activityViewModelId) return { kind: "solo" };
 
-    const match = await db
-      .table<SessionMatch>("sessionMatches")
-      .where("[profileId+coachingActivityId]")
-      .equals([
-        profileId,
-        toPersistedCoachingActivityId(profileId, activityViewModelId),
-      ])
-      .first();
+    // Dangling-ref tolerance lives in the read-model: a missing workout
+    // (mid-cascade race) returns null, which we render as solo so the dialog
+    // shows the manual-match affordances until the cascade hooks reconcile.
+    const match = await matchedSessionsReadModel.findActivityMatch(
+      profileId,
+      toPersistedCoachingActivityId(profileId, activityViewModelId)
+    );
 
     if (!match) return { kind: "solo" };
 
-    const workout = await db
-      .table<WorkoutRecord>("workouts")
-      .get(match.workoutId);
-
-    if (!workout) {
-      // Dangling-ref tolerance: the match exists but the workout is
-      // gone (mid-cascade race). Treat as solo so the dialog re-renders
-      // the manual-match affordances; the cascade hooks will reconcile.
-      return { kind: "solo" };
-    }
-
-    return { kind: "matched", matchId: match.id, workout };
-  }, [profileId, activityViewModelId]);
+    return { kind: "matched", matchId: match.matchId, workout: match.workout };
+  }, [profileId, activityViewModelId, matchedSessionsReadModel]);
 }

--- a/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync-helpers.ts
+++ b/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync-helpers.ts
@@ -15,6 +15,14 @@ export const isStale = (
   return now - t > STALENESS_MS;
 };
 
+/**
+ * Per-source result of an auto-sync attempt. `skipped` means the staleness
+ * gate was closed; `synced` a clean run; `failed` an error surfaced on the
+ * source or thrown. Returned so the loop can record a `{ source, outcome }`
+ * trail for observability without changing the silent-auto-sync behavior.
+ */
+export type SourceSyncOutcome = "skipped" | "synced" | "failed";
+
 export const runSourceSync = async (
   src: CoachingSyncState,
   profileId: string,
@@ -23,13 +31,13 @@ export const runSourceSync = async (
   now: number,
   persistence: PersistencePort,
   analytics: Analytics
-): Promise<void> => {
+): Promise<SourceSyncOutcome> => {
   try {
     const row = await persistence.coachingSyncState.getBySourceAndProfile(
       src.id,
       profileId
     );
-    if (!isStale(row?.lastSyncedAt, now)) return;
+    if (!isStale(row?.lastSyncedAt, now)) return "skipped";
     analytics.event("coaching.sync.invoked", {
       source: src.id,
       profileId,
@@ -43,7 +51,9 @@ export const runSourceSync = async (
         errorKind: "transport-error",
         isAutoSync: true,
       });
+      return "failed";
     }
+    return "synced";
   } catch {
     // Silent; raw exception text never reaches telemetry.
     analytics.event("coaching.sync.failure", {
@@ -52,5 +62,6 @@ export const runSourceSync = async (
       errorKind: "transport-error",
       isAutoSync: true,
     });
+    return "failed";
   }
 };

--- a/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync.ts
+++ b/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync.ts
@@ -19,7 +19,10 @@ import { useAnalytics } from "../contexts";
 import { usePersistence } from "../contexts/persistence-context";
 import { useActiveProfileLive } from "./use-active-profile-live";
 import type { CoachingSyncState } from "./use-coaching-activities";
-import { runSourceSync } from "./use-coaching-auto-sync-helpers";
+import {
+  runSourceSync,
+  type SourceSyncOutcome,
+} from "./use-coaching-auto-sync-helpers";
 
 export const useCoachingAutoSync = (
   syncSources: CoachingSyncState[],
@@ -48,8 +51,9 @@ export const useCoachingAutoSync = (
     if (targets.length === 0) return;
 
     void (async () => {
+      const outcomes: { source: string; outcome: SourceSyncOutcome }[] = [];
       for (const src of targets) {
-        await runSourceSync(
+        const outcome = await runSourceSync(
           src,
           activeProfileId,
           weekStart,
@@ -58,7 +62,16 @@ export const useCoachingAutoSync = (
           persistence,
           analytics
         );
+        outcomes.push({ source: src.id, outcome });
       }
+      // Low-cardinality completion summary so the silent auto-sync loop is
+      // observable in telemetry (counts only — never per-source error text).
+      analytics.event("coaching.autosync.completed", {
+        trigger,
+        synced: outcomes.filter((o) => o.outcome === "synced").length,
+        skipped: outcomes.filter((o) => o.outcome === "skipped").length,
+        failed: outcomes.filter((o) => o.outcome === "failed").length,
+      });
     })();
   }, [
     activeProfileId,

--- a/packages/workout-spa-editor/src/hooks/use-matched-sessions-hydrate.test.ts
+++ b/packages/workout-spa-editor/src/hooks/use-matched-sessions-hydrate.test.ts
@@ -3,6 +3,7 @@ import "fake-indexeddb/auto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { db } from "../adapters/dexie/dexie-database";
+import { createDexieMatchedSessionsReadModel } from "../adapters/dexie/dexie-matched-sessions-read-model";
 import type { WorkoutRecord } from "../types/calendar-record";
 import {
   buildCoachingActivityId,
@@ -11,6 +12,8 @@ import {
 } from "../types/coaching-activity-record";
 import type { SessionMatch } from "../types/session-match";
 import { hydrateMatchedSessions } from "./use-matched-sessions-hydrate";
+
+const readModel = createDexieMatchedSessionsReadModel(db);
 
 const PROFILE = "p1";
 const SOURCE = "train2go";
@@ -83,7 +86,7 @@ describe("hydrateMatchedSessions", () => {
     const match = seedMatch();
 
     // Act
-    const result = await hydrateMatchedSessions([match]);
+    const result = await hydrateMatchedSessions([match], readModel);
 
     // Assert
     expect(result.matched).toHaveLength(1);
@@ -101,7 +104,7 @@ describe("hydrateMatchedSessions", () => {
     const orphan = seedMatch({ coachingActivityId: SHORT });
 
     // Act
-    const result = await hydrateMatchedSessions([orphan]);
+    const result = await hydrateMatchedSessions([orphan], readModel);
 
     // Assert
     expect(result.matched).toEqual([]);
@@ -130,7 +133,7 @@ describe("hydrateMatchedSessions", () => {
     });
 
     // Act
-    const result = await hydrateMatchedSessions([orphan]);
+    const result = await hydrateMatchedSessions([orphan], readModel);
 
     // Assert
     expect(result.matched).toEqual([]);
@@ -151,7 +154,7 @@ describe("hydrateMatchedSessions", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     // Act
-    const result = await hydrateMatchedSessions([good, orphan]);
+    const result = await hydrateMatchedSessions([good, orphan], readModel);
 
     // Assert
     expect(result.matched.map((m) => m.match.id)).toEqual(["m-1"]);

--- a/packages/workout-spa-editor/src/hooks/use-matched-sessions-hydrate.ts
+++ b/packages/workout-spa-editor/src/hooks/use-matched-sessions-hydrate.ts
@@ -9,13 +9,11 @@
  * `.omc/autopilot/bug-trace.md` §H8 for the original symptom.
  */
 
-import { db } from "../adapters/dexie/dexie-database";
 import { toCoachingActivity } from "../adapters/train2go/coaching-record-to-activity.converter";
 import { computeComplianceScore } from "../application/compute-compliance-score";
 import { parseCoachingDuration } from "../application/parse-coaching-duration";
 import type { MatchedSession } from "../components/molecules/MatchedSessionCard/MatchedSessionCard";
-import type { WorkoutRecord } from "../types/calendar-record";
-import type { CoachingActivityRecord } from "../types/coaching-activity-record";
+import type { MatchedSessionsReadModel } from "../ports/matched-sessions-read-model";
 import type { SessionMatch } from "../types/session-match";
 import { logger } from "../utils/logger";
 import type { DanglingMatch } from "./use-matched-sessions-heal";
@@ -30,37 +28,18 @@ export type MatchedSessionWithMetadata = MatchedSession & {
 
 const DROP_WARN = "[matched-sessions] dropping match — dangling ref";
 
-const fetchById = async (
-  matches: SessionMatch[]
-): Promise<{
-  aById: Map<string, CoachingActivityRecord>;
-  wById: Map<string, WorkoutRecord>;
-}> => {
-  const [activities, workouts] = await Promise.all([
-    db
-      .table<CoachingActivityRecord>("coachingActivities")
-      .where("id")
-      .anyOf(matches.map((m) => m.coachingActivityId))
-      .toArray(),
-    db
-      .table<WorkoutRecord>("workouts")
-      .where("id")
-      .anyOf(collectWorkoutIds(matches))
-      .toArray(),
-  ]);
-  return {
-    aById: new Map(activities.map((a) => [a.id, a])),
-    wById: new Map(workouts.map((w) => [w.id, w])),
-  };
-};
-
 export const hydrateMatchedSessions = async (
-  matches: SessionMatch[]
+  matches: SessionMatch[],
+  readModel: MatchedSessionsReadModel
 ): Promise<{
   matched: MatchedSessionWithMetadata[];
   dangling: DanglingMatch[];
 }> => {
-  const { aById, wById } = await fetchById(matches);
+  const { activitiesById: aById, workoutsById: wById } =
+    await readModel.loadJoinSources(
+      matches.map((m) => m.coachingActivityId),
+      collectWorkoutIds(matches)
+    );
   const matched: MatchedSessionWithMetadata[] = [];
   const dangling: DanglingMatch[] = [];
   for (const match of matches) {

--- a/packages/workout-spa-editor/src/hooks/use-matched-sessions.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/use-matched-sessions.test.tsx
@@ -5,15 +5,17 @@ import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { db } from "../adapters/dexie/dexie-database";
+import { createDexiePersistence } from "../adapters/dexie/dexie-persistence-adapter";
 import { PersistenceProvider } from "../contexts/persistence-context";
-import { createInMemoryPersistence } from "../test-utils/in-memory-persistence";
 import type { WorkoutRecord } from "../types/calendar-record";
 import type { CoachingActivityRecord } from "../types/coaching-activity-record";
 import type { SessionMatch } from "../types/session-match";
 import { useMatchedSessions } from "./use-matched-sessions";
 
+// Dexie-backed so the read-model and `queryMatchesForWeek` observe the same
+// `db` the test seeds (the hook reads matches and join sources from one store).
 const wrap = ({ children }: { children: ReactNode }) => (
-  <PersistenceProvider persistence={createInMemoryPersistence()}>
+  <PersistenceProvider persistence={createDexiePersistence(db)}>
     {children}
   </PersistenceProvider>
 );

--- a/packages/workout-spa-editor/src/hooks/use-matched-sessions.ts
+++ b/packages/workout-spa-editor/src/hooks/use-matched-sessions.ts
@@ -25,6 +25,7 @@
 import { useLiveQuery } from "dexie-react-hooks";
 
 import type { MatchedSession } from "../components/molecules/MatchedSessionCard/MatchedSessionCard";
+import { usePersistence } from "../contexts/persistence-context";
 import type { SessionMatch } from "../types/session-match";
 import {
   type DanglingMatch,
@@ -54,17 +55,18 @@ export function useMatchedSessions(
   profileId: string | null,
   days: string[]
 ): MatchedSessionWithMetadata[] | undefined {
+  const { matchedSessionsReadModel } = usePersistence();
   const result = useLiveQuery<HydrateResult>(async () => {
     markUseMatchedSessionsStart();
     try {
       if (!profileId || days.length === 0) return EMPTY;
       const matches = await queryMatchesForWeek(profileId, days);
       if (matches.length === 0) return EMPTY;
-      return await hydrateMatchedSessions(matches);
+      return await hydrateMatchedSessions(matches, matchedSessionsReadModel);
     } finally {
       markUseMatchedSessionsEnd();
     }
-  }, [profileId, days.join(",")]);
+  }, [profileId, days.join(","), matchedSessionsReadModel]);
 
   useMatchedSessionsHeal(result?.dangling ?? null);
 

--- a/packages/workout-spa-editor/src/ports/matched-sessions-read-model.ts
+++ b/packages/workout-spa-editor/src/ports/matched-sessions-read-model.ts
@@ -1,0 +1,48 @@
+/**
+ * MatchedSessionsReadModel — the read-only (CQRS query) surface the
+ * matched-sessions calendar projections need. Lets the two reactive hooks
+ * (`useActivityMatchState`, `useMatchedSessions`) read their join data through
+ * the persistence port instead of importing `db` directly, while preserving
+ * `useLiveQuery` reactivity: the Dexie adapter issues the same observable table
+ * queries the hooks used to inline.
+ *
+ * The write surface for matches lives on `SessionMatchRepository`; this port is
+ * intentionally read-only.
+ */
+
+import type { WorkoutRecord } from "../types/calendar-record";
+import type { CoachingActivityRecord } from "../types/coaching-activity-record";
+
+/** Coaching-activity and workout lookups, keyed by id, for the calendar join. */
+export type MatchedSessionJoinSources = {
+  activitiesById: Map<string, CoachingActivityRecord>;
+  workoutsById: Map<string, WorkoutRecord>;
+};
+
+/** One coaching activity's current match plus its executed workout. */
+export type ActivityMatch = {
+  matchId: string;
+  workout: WorkoutRecord;
+};
+
+export type MatchedSessionsReadModel = {
+  /**
+   * Batch-load the coaching activities and workouts referenced by a set of
+   * matches, keyed by id. The caller supplies the id sets (gathered from the
+   * matches, including executed-workout ids) so all match-shaped logic stays
+   * in the application layer and this port remains a pure fetcher.
+   */
+  loadJoinSources: (
+    activityIds: readonly string[],
+    workoutIds: readonly string[]
+  ) => Promise<MatchedSessionJoinSources>;
+  /**
+   * The activity's current match + its executed workout, or `null` when no
+   * match exists or the referenced workout is a dangling ref (treated as solo
+   * by callers).
+   */
+  findActivityMatch: (
+    profileId: string,
+    persistedCoachingActivityId: string
+  ) => Promise<ActivityMatch | null>;
+};

--- a/packages/workout-spa-editor/src/ports/persistence-port.ts
+++ b/packages/workout-spa-editor/src/ports/persistence-port.ts
@@ -21,6 +21,7 @@ import type {
 } from "./coaching-repositories";
 import type { HealthCleanupRepository } from "./health-cleanup-repository";
 import type { HealthRecordRepository } from "./health-record-repository";
+import type { MatchedSessionsReadModel } from "./matched-sessions-read-model";
 import type { SessionMatchRepository } from "./session-match-repository";
 import type {
   AiProviderRepository,
@@ -43,6 +44,11 @@ export type {
   HealthRecord,
   HealthRecordRepository,
 } from "./health-record-repository";
+export type {
+  ActivityMatch,
+  MatchedSessionJoinSources,
+  MatchedSessionsReadModel,
+} from "./matched-sessions-read-model";
 export type { SessionMatchRepository } from "./session-match-repository";
 export type {
   AiProviderRepository,
@@ -72,6 +78,10 @@ export type PersistencePort = {
   // outer `transaction` opens, so a different PersistencePort backed by
   // a different db cannot accidentally split writes.
   sessionMatch: SessionMatchRepository;
+  // Read-only (CQRS) query surface for the matched-sessions calendar
+  // projections. Lets the reactive hooks read their join data through the
+  // port instead of importing `db`, preserving useLiveQuery observability.
+  matchedSessionsReadModel: MatchedSessionsReadModel;
   autoMatchDismissal: AutoMatchDismissalRepository;
   userPreferences: UserPreferencesRepository;
   // Cross-table cleanup for the six v16 health-domain stores —

--- a/packages/workout-spa-editor/src/store/actions/_helpers/extract-workout.ts
+++ b/packages/workout-spa-editor/src/store/actions/_helpers/extract-workout.ts
@@ -1,15 +1,20 @@
 /**
  * Extracts the structured-workout payload from a KRD document, or
- * returns `null` when the document is not structured (no
+ * returns `null` when the document is absent or not structured (no
  * `extensions.structured_workout`). Centralizes the early-return guard
  * shared by every repetition-block / step mutation action — they all
- * must no-op on non-structured input.
+ * must no-op on non-structured input — and the read-side projections
+ * (history, hydrate, back-handler) that previously cast inline. Accepts
+ * `null`/`undefined` so optional-chained read sites can route through it
+ * without a bespoke guard.
  */
 
 import type { KRD, Workout } from "../../../types/krd";
 
-export const extractStructuredWorkout = (krd: KRD): Workout | null => {
-  if (!krd.extensions?.structured_workout) {
+export const extractStructuredWorkout = (
+  krd: KRD | null | undefined
+): Workout | null => {
+  if (!krd?.extensions?.structured_workout) {
     return null;
   }
   return krd.extensions.structured_workout as Workout;

--- a/packages/workout-spa-editor/src/store/actions/history-actions.ts
+++ b/packages/workout-spa-editor/src/store/actions/history-actions.ts
@@ -4,16 +4,15 @@
  * Action creators for undo/redo functionality.
  */
 
-import type { Workout } from "../../types/krd";
 import { findById } from "../find-by-id";
 import type { FocusTarget } from "../focus/focus-target.types";
 import { focusItem } from "../focus/focus-target.types";
 import { preservedSelectionTarget } from "../focus-rules";
 import type { WorkoutState } from "../workout-actions";
+import { extractStructuredWorkout } from "./_helpers/extract-workout";
 
 const currentSelectionMainListIndex = (state: WorkoutState): number => {
-  const currentWorkout = state.currentWorkout?.extensions
-    ?.structured_workout as Workout | undefined;
+  const currentWorkout = extractStructuredWorkout(state.currentWorkout);
   const steps = currentWorkout?.steps ?? [];
   const currentId = state.selectedStepId;
   if (!currentId) return 0;
@@ -28,9 +27,7 @@ const focusForHistoryIndex = (
   newIndex: number
 ): ReturnType<typeof preservedSelectionTarget> => {
   const entry = state.undoHistory[newIndex]!;
-  const workout = entry?.workout?.extensions?.structured_workout as
-    | Workout
-    | undefined;
+  const workout = extractStructuredWorkout(entry?.workout) ?? undefined;
   const priorSelection = entry?.selection ?? null;
   const fallbackIndex = currentSelectionMainListIndex(state);
   return preservedSelectionTarget(workout, priorSelection, fallbackIndex);
@@ -41,8 +38,8 @@ const focusForUndo = (state: WorkoutState, newIndex: number): FocusTarget => {
   // Check whether the selection recorded at mutation time exists there — if it
   // does, restore focus directly to it (instead of falling back to position 0).
   const currentEntry = state.undoHistory[state.historyIndex];
-  const restoredWorkout = state.undoHistory[newIndex]?.workout?.extensions
-    ?.structured_workout as Workout | undefined;
+  const restoredWorkout =
+    extractStructuredWorkout(state.undoHistory[newIndex]?.workout) ?? undefined;
   if (
     currentEntry?.selection &&
     findById(restoredWorkout, currentEntry.selection)

--- a/packages/workout-spa-editor/src/store/hydrate-ui-workout.ts
+++ b/packages/workout-spa-editor/src/store/hydrate-ui-workout.ts
@@ -1,6 +1,7 @@
-import type { KRD, RepetitionBlock, Workout, WorkoutStep } from "../types/krd";
+import type { KRD, RepetitionBlock, WorkoutStep } from "../types/krd";
 import { isWorkoutStep } from "../types/krd";
 import type { UIWorkout } from "../types/krd-ui";
+import { extractStructuredWorkout } from "./actions/_helpers/extract-workout";
 import type { IdProvider } from "./providers/id-provider";
 import { defaultIdProvider } from "./providers/id-provider";
 import type { ItemId } from "./providers/item-id";
@@ -56,7 +57,7 @@ export const hydrateUIWorkout = (
 ): UIWorkout => {
   const idProvider = options.idProvider ?? defaultIdProvider;
   const preserve = options.preserveExistingIds ?? false;
-  const workout = krd.extensions?.structured_workout as Workout | undefined;
+  const workout = extractStructuredWorkout(krd);
 
   if (!workout) return krd as UIWorkout;
 

--- a/packages/workout-spa-editor/src/test-utils/in-memory-matched-sessions-read-model.ts
+++ b/packages/workout-spa-editor/src/test-utils/in-memory-matched-sessions-read-model.ts
@@ -1,0 +1,43 @@
+import type { MatchedSessionsReadModel } from "../ports/matched-sessions-read-model";
+import type { WorkoutRecord } from "../types/calendar-record";
+import type { CoachingActivityRecord } from "../types/coaching-activity-record";
+import type { SessionMatch } from "../types/session-match";
+
+const collectInto = <T extends { id: string }>(
+  store: Map<string, T>,
+  ids: readonly string[]
+): Map<string, T> => {
+  const out = new Map<string, T>();
+  for (const id of ids) {
+    const row = store.get(id);
+    if (row) out.set(id, row);
+  }
+  return out;
+};
+
+export function createInMemoryMatchedSessionsReadModel(
+  coaching: Map<string, CoachingActivityRecord>,
+  workouts: Map<string, WorkoutRecord>,
+  sessionMatch: Map<string, SessionMatch>
+): MatchedSessionsReadModel {
+  return {
+    loadJoinSources: async (activityIds, workoutIds) => ({
+      activitiesById: collectInto(coaching, activityIds),
+      workoutsById: collectInto(workouts, workoutIds),
+    }),
+
+    findActivityMatch: async (profileId, persistedCoachingActivityId) => {
+      const match = [...sessionMatch.values()].find(
+        (m) =>
+          m.profileId === profileId &&
+          m.coachingActivityId === persistedCoachingActivityId
+      );
+      if (!match) return null;
+
+      const workout = workouts.get(match.workoutId);
+      if (!workout) return null;
+
+      return { matchId: match.id, workout };
+    },
+  };
+}

--- a/packages/workout-spa-editor/src/test-utils/in-memory-persistence.ts
+++ b/packages/workout-spa-editor/src/test-utils/in-memory-persistence.ts
@@ -18,6 +18,7 @@ import { createInMemoryCoachingRepository } from "./in-memory-coaching-repositor
 import { createInMemoryCoachingSyncStateRepository } from "./in-memory-coaching-sync-state-repository";
 import { createInMemoryHealthRecordRepository } from "./in-memory-health-record-repository";
 import { createInMemoryIntegrationPolicyRepository } from "./in-memory-integration-policy-repository";
+import { createInMemoryMatchedSessionsReadModel } from "./in-memory-matched-sessions-read-model";
 import {
   captureSnapshot,
   restoreSnapshot,
@@ -81,6 +82,11 @@ export function createInMemoryPersistence(): PersistencePort {
       stores.integrationPolicies
     ),
     sessionMatch: createInMemorySessionMatchRepository(stores.sessionMatch),
+    matchedSessionsReadModel: createInMemoryMatchedSessionsReadModel(
+      stores.coaching,
+      stores.workouts,
+      stores.sessionMatch
+    ),
     autoMatchDismissal: createInMemoryAutoMatchDismissalRepository(
       stores.autoMatchDismissal
     ),


### PR DESCRIPTION
Implements the three deferred follow-ups from the `code-semantics-hardening` change (#756), tracked in #758. All SUGGESTION-severity items from the semantic audit, scoped out then to keep the architectural work unrushed.

## Task 5.5 — `MatchedSessionsReadModel` port
Introduces a `MatchedSessionsReadModel` port that owns the two matched-session join projections previously inlined as raw `db.table(...)` access in the calendar hooks:
- `loadJoinSources(activityIds, workoutIds)` — the bulk activity/workout join for `use-matched-sessions-hydrate.ts`
- `findActivityMatch(profileId, persistedCoachingActivityId)` — the single-activity lookup for `use-activity-match-state.ts`

Dexie adapter (`createDexieMatchedSessionsReadModel`) issues the **same observable queries** on the same singleton `db`, so `useLiveQuery` reactivity is preserved; an in-memory adapter backs the test path. Wired through the existing `usePersistence()` provider next to `sessionMatch`. The two hooks no longer import `db` directly. `use-coaching-auto-sync.ts` now accumulates a `{ source, outcome }[]` per-source result and emits a low-cardinality `coaching.autosync.completed` analytics event (synced/skipped/failed counts only — never per-source error text).

New `dexie-matched-sessions-read-model.test.ts` covers `loadJoinSources` (present/missing/empty) and `findActivityMatch` (match / no-match / dangling-workout), closing the previously-uncovered `findActivityMatch` + dangling branch.

## Task 5.2 — remaining read-pattern `as Workout` casts
Widened `extractStructuredWorkout` to accept `KRD | null | undefined`, then migrated the three optional-chained read projections off the inline cast: `history-actions.ts` (2 sites), `hydrate-ui-workout.ts`, `use-back-handler.ts`. The `structured_workout as Workout` cast now appears **only** inside the helper.

## TCX restore-honesty (CodeRabbit follow-up from #756)
A present-but-invalid restored `kaiord:` threshold (0, negative, NaN, or Infinity) now warns and degrades instead of silently restoring a physiologically meaningless duration. A shared `readRestoredThreshold` validator routes all four restore helpers (heart-rate / power-less / power-greater / calories), parallelling the zwo restore-honesty fix already shipped. Patch changeset for `@kaiord/tcx`.

## Verification
- `pnpm lint && pnpm -r build` — green
- `pnpm -r test` — all packages pass (tcx 231, spa-editor 4563, full monorepo green)
- SPA mechanical guards (zustand-writethrough, session-match-id-shape, barrel) pass

Closes #758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
