### PR TITLE
feat(spa-editor): count-only chat analytics events

### DIFF
--- a/.changeset/chat-analytics-events.md
+++ b/.changeset/chat-analytics-events.md
@@ -1,0 +1,8 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Emit count-only analytics for the AI chat: a `chat-message-sent` event per
+user turn and a `chat-tool-confirmed` event (with the bounded tool name) when a
+pending action is approved. No message content or API keys reach analytics,
+satisfying the spa-ai-chat usage rule.

--- a/packages/workout-spa-editor/src/hooks/use-chat-turn-types.ts
+++ b/packages/workout-spa-editor/src/hooks/use-chat-turn-types.ts
@@ -1,0 +1,30 @@
+/**
+ * Public arg + return types for `useChatTurn`, split out so the hook file
+ * stays under the per-file line cap.
+ */
+import type { PendingAction } from "@kaiord/ai";
+
+import type { LlmProviderConfig } from "../store/ai-store-types";
+import type { ChatMessageRecord } from "../types/chat/chat-message-record";
+import type { ChatTurnState } from "./chat/chat-turn-types";
+
+export type UseChatTurnArgs = {
+  profileId: string | null;
+  provider: LlmProviderConfig | null;
+  modelId: string | null;
+  generationProvider: LlmProviderConfig | null;
+  generationModelId: string | null;
+  today: string;
+  messages: ChatMessageRecord[];
+};
+
+export type UseChatTurn = {
+  state: ChatTurnState;
+  streamingText: string;
+  pendingAction: PendingAction | null;
+  error: string | null;
+  send: (text: string) => void;
+  approve: () => void;
+  deny: () => void;
+  retry: () => void;
+};

--- a/packages/workout-spa-editor/src/hooks/use-chat-turn.analytics.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/use-chat-turn.analytics.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Count-only chat analytics: a message-sent event per user turn and a
+ * tool-confirmed event per approved action. No message content reaches
+ * analytics (spa-ai-chat usage rule — count-only events).
+ */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { LlmProviderConfig } from "../store/ai-store-types";
+import { useChatTurn } from "./use-chat-turn";
+
+const mockEvent = vi.fn();
+const mockSendTurn = vi.fn();
+const mockApproveAction = vi.fn();
+
+vi.mock("../contexts/analytics-context", () => ({
+  useAnalytics: () => ({ event: mockEvent, pageView: vi.fn() }),
+}));
+vi.mock("../contexts/persistence-context", () => ({
+  usePersistence: () => ({}),
+}));
+vi.mock("./use-chat-action-ops", () => ({
+  useChatActionOps: () => ({}),
+}));
+vi.mock("./chat/chat-turn-runner", () => ({
+  sendTurn: (...args: unknown[]) => mockSendTurn(...args),
+  approveAction: (...args: unknown[]) => mockApproveAction(...args),
+  denyAction: vi.fn(),
+}));
+
+const provider: LlmProviderConfig = {
+  id: "p1",
+  type: "anthropic",
+  apiKey: "k",
+  label: "A",
+  isDefault: true,
+  createdAt: 1,
+};
+
+const args = {
+  profileId: "prof-1",
+  provider,
+  modelId: "claude-sonnet-4-6",
+  generationProvider: provider,
+  generationModelId: "claude-sonnet-4-6",
+  today: "2026-06-15",
+  messages: [],
+};
+
+describe("useChatTurn analytics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should emit a count-only chat-message-sent event on send", () => {
+    // Arrange
+    const { result } = renderHook(() => useChatTurn(args));
+
+    // Act
+    act(() => result.current.send("how far did I run last week?"));
+
+    // Assert
+    expect(mockEvent).toHaveBeenCalledWith("chat-message-sent");
+    expect(mockSendTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not emit for a blank message", () => {
+    // Arrange
+    const { result } = renderHook(() => useChatTurn(args));
+
+    // Act
+    act(() => result.current.send("   "));
+
+    // Assert
+    expect(mockEvent).not.toHaveBeenCalled();
+  });
+
+  it("should emit chat-tool-confirmed with the tool name on approval", () => {
+    // Arrange
+    mockSendTurn.mockImplementation(
+      (ctx: { set: { pendingAction: (p: unknown) => void } }) => {
+        ctx.set.pendingAction({
+          toolCallId: "tc-1",
+          toolName: "create_workout",
+          input: {},
+        });
+      }
+    );
+    const { result } = renderHook(() => useChatTurn(args));
+    act(() => result.current.send("make me a recovery ride"));
+
+    // Act
+    act(() => result.current.approve());
+
+    // Assert
+    expect(mockEvent).toHaveBeenCalledWith("chat-tool-confirmed", {
+      tool: "create_workout",
+    });
+    expect(mockApproveAction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/use-chat-turn.ts
+++ b/packages/workout-spa-editor/src/hooks/use-chat-turn.ts
@@ -9,36 +9,16 @@ import type { ChatAgent, ChatTool, PendingAction } from "@kaiord/ai";
 import type { ModelMessage } from "ai";
 import { useCallback, useMemo, useRef, useState } from "react";
 
+import { useAnalytics } from "../contexts/analytics-context";
 import { usePersistence } from "../contexts/persistence-context";
-import type { LlmProviderConfig } from "../store/ai-store-types";
-import type { ChatMessageRecord } from "../types/chat/chat-message-record";
 import { approveAction, denyAction, sendTurn } from "./chat/chat-turn-runner";
 import { type ChatTurnState, makeChatTurnCtx } from "./chat/chat-turn-types";
 import { useChatActionOps } from "./use-chat-action-ops";
-
-export type UseChatTurnArgs = {
-  profileId: string | null;
-  provider: LlmProviderConfig | null;
-  modelId: string | null;
-  generationProvider: LlmProviderConfig | null;
-  generationModelId: string | null;
-  today: string;
-  messages: ChatMessageRecord[];
-};
-
-export type UseChatTurn = {
-  state: ChatTurnState;
-  streamingText: string;
-  pendingAction: PendingAction | null;
-  error: string | null;
-  send: (text: string) => void;
-  approve: () => void;
-  deny: () => void;
-  retry: () => void;
-};
+import type { UseChatTurn, UseChatTurnArgs } from "./use-chat-turn-types";
 
 export const useChatTurn = (args: UseChatTurnArgs): UseChatTurn => {
   const persistence = usePersistence();
+  const analytics = useAnalytics();
   const ops = useChatActionOps(args.profileId, {
     provider: args.generationProvider,
     modelId: args.generationModelId,
@@ -69,13 +49,17 @@ export const useChatTurn = (args: UseChatTurnArgs): UseChatTurn => {
     (text: string) => {
       if (!ctx || state === "streaming" || !text.trim()) return;
       lastInputRef.current = text;
+      // Count-only: no message content reaches analytics (spec usage rule).
+      analytics.event("chat-message-sent");
       void sendTurn(ctx, messages, text);
     },
-    [ctx, state, messages]
+    [ctx, state, messages, analytics]
   );
   const approve = useCallback(() => {
-    if (ctx && pendingAction) void approveAction(ctx, pendingAction);
-  }, [ctx, pendingAction]);
+    if (!ctx || !pendingAction) return;
+    analytics.event("chat-tool-confirmed", { tool: pendingAction.toolName });
+    void approveAction(ctx, pendingAction);
+  }, [ctx, pendingAction, analytics]);
   const deny = useCallback(() => {
     if (ctx && pendingAction) void denyAction(ctx, pendingAction);
   }, [ctx, pendingAction]);


### PR DESCRIPTION
Implements the deferred chatbot follow-up: count-only analytics for the AI chat (satisfies the existing spa-ai-chat "analytics SHALL receive count-only events" usage rule).

- `chat-message-sent` — emitted per user turn (no message content).
- `chat-tool-confirmed` — emitted when a pending action is approved, tagged with the **bounded tool name** (not PII, already surfaced in the transcript).

Both fire from `useChatTurn`; no message content or API keys reach analytics. Extracted the hook's arg/return types into `use-chat-turn-types.ts` to stay under the file line cap.

### Verification
- tsc + eslint clean; PII guard clean; prettier clean
- New `use-chat-turn.analytics.test.tsx` (3 tests) + hooks/Chat suites green (278)

The other deferred follow-up (manual browser smoke with a real API key) needs a real key and is left for a maintainer to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)