### PR TITLE
fix(spa-editor): unbreak firefox e2e on main (focusmanager.testmode)

### DIFF
--- a/packages/workout-spa-editor/playwright.config.ts
+++ b/packages/workout-spa-editor/playwright.config.ts
@@ -38,7 +38,20 @@ export default defineConfig({
     },
     {
       name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
+      use: {
+        ...devices["Desktop Firefox"],
+        launchOptions: {
+          // Headless Firefox on Linux (CI) does not treat the page as the
+          // active focus owner, so programmatic `element.focus()` in app
+          // code (e.g. useFocusOnRouteChange) is not reflected as `:focus`
+          // and `toBeFocused()` reports "inactive" — even though real
+          // headed Firefox and headless Firefox on macOS focus correctly.
+          // geckodriver/Selenium set this pref by default; Playwright does
+          // not. Enabling it aligns the test env with real-browser focus
+          // behaviour. Fixes the firefox-only library-flows focus failure.
+          firefoxUserPrefs: { "focusmanager.testmode": true },
+        },
+      },
     },
     {
       name: "webkit",


### PR DESCRIPTION
## Problem

`e2e/library-flows.spec.ts` **Test A** asserts the routed-page heading receives focus on navigation:

```ts
const heading = page.locator("h1[data-route-heading]");
await expect(heading).toBeFocused();
```

This has failed **firefox-only** on `main` for ~1 month (#635), re-detected on every push by the CI-failure bot. Chromium, WebKit, and both mobile projects pass.

## Root cause

The CI log shows the heading mounts fine but is `Received: inactive` for the full 10s (24 polls, all 3 retries) — focus is never reflected on it.

- The Library heading is focused **programmatically** by app code (`useFocusOnRouteChange` → `element.focus()`).
- The one *other* firefox `toBeFocused()` assertion that passes (`accessibility.spec.ts` theme toggle) is focused by Playwright's **real Tab/click input**, which activates the page.
- **Headless Firefox on Linux does not treat the page as the active focus owner**, so programmatic `.focus()` is not reflected as `:focus`. Real headed Firefox — and headless Firefox on macOS (verified locally, passes every time, including with the lazy chunk delayed to force the `MutationObserver` fallback) — focus correctly.
- geckodriver/Selenium enable `focusmanager.testmode` by default; Playwright does not.

The **app behaviour is correct for real users** — this is a test-environment gap, not a product bug.

## Fix

Enable `focusmanager.testmode` for the firefox Playwright project so the headless test env matches real-browser focus behaviour:

```ts
{ name: "firefox", use: { ...devices["Desktop Firefox"],
  launchOptions: { firefoxUserPrefs: { "focusmanager.testmode": true } } } }
```

Test-config only — no production code change.

## Verification

- Local firefox `Test A` passes (could not reproduce the red locally — macOS headless firefox already reflects programmatic focus; the failure is Linux-headless-specific).
- **This PR's CI firefox job is the real verification** — it runs on the same Linux runner that has been red.

Fixes #635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing environment configuration for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->