### PR TITLE
fix(spa-editor): unbreak firefox e2e on main (#635)

### DIFF
--- a/packages/workout-spa-editor/e2e/library-flows.spec.ts
+++ b/packages/workout-spa-editor/e2e/library-flows.spec.ts
@@ -36,6 +36,7 @@ test.describe("Library flows", () => {
 
   test("Test A: header Library navigates to /library (no modal)", async ({
     page,
+    browserName,
   }) => {
     await page.goto("/daily");
 
@@ -49,7 +50,19 @@ test.describe("Library flows", () => {
     // receives focus on navigation via useFocusOnRouteChange.
     const heading = page.locator("h1[data-route-heading]");
     await expect(heading).toHaveText("Library");
-    await expect(heading).toBeFocused();
+    // Headless Firefox on Linux (CI) silently drops a programmatic
+    // element.focus() applied during the post-navigation settle window —
+    // activeElement stays on the trigger button no matter how the focus
+    // is scheduled (rAF, macrotask, MutationObserver), while a focus
+    // applied well after the window sticks. Real headed Firefox, headless
+    // Firefox on macOS, chromium and webkit all focus the heading
+    // correctly, so this is a headless-Linux-Firefox test artifact, not a
+    // user-facing regression. The focus-on-route contract is covered by
+    // the useFocusOnRouteChange unit test (jsdom) and by the chromium /
+    // webkit runs of this assertion. See #635 for the full investigation.
+    if (browserName !== "firefox") {
+      await expect(heading).toBeFocused();
+    }
     // No dialog should have mounted as a side-effect of the click.
     await expect(page.getByRole("dialog")).toHaveCount(0);
 

--- a/packages/workout-spa-editor/playwright.config.ts
+++ b/packages/workout-spa-editor/playwright.config.ts
@@ -38,20 +38,7 @@ export default defineConfig({
     },
     {
       name: "firefox",
-      use: {
-        ...devices["Desktop Firefox"],
-        launchOptions: {
-          // Headless Firefox on Linux (CI) does not treat the page as the
-          // active focus owner, so programmatic `element.focus()` in app
-          // code (e.g. useFocusOnRouteChange) is not reflected as `:focus`
-          // and `toBeFocused()` reports "inactive" — even though real
-          // headed Firefox and headless Firefox on macOS focus correctly.
-          // geckodriver/Selenium set this pref by default; Playwright does
-          // not. Enabling it aligns the test env with real-browser focus
-          // behaviour. Fixes the firefox-only library-flows focus failure.
-          firefoxUserPrefs: { "focusmanager.testmode": true },
-        },
-      },
+      use: { ...devices["Desktop Firefox"] },
     },
     {
       name: "webkit",


### PR DESCRIPTION
## Problem
`e2e/library-flows.spec.ts` **Test A** asserts the routed heading receives focus on navigation (`toBeFocused`). This failed **firefox-only** on `main` for ~1 month (#635), re-detected on every push.

## Root cause (full investigation in #635)
Verified in CI via a temporary `workflow_dispatch` diagnostic loop:
- After navigation, `document.activeElement` stays on the **trigger button** for the entire 10s; the heading never receives focus (`focusin` never fires for it).
- The *exact* `el.focus({preventScroll:true})` call the app makes **does** move focus to the heading when invoked ~1.5s later — so the element is focusable and Firefox is capable.
- **Headless Firefox on Linux silently drops a programmatic `.focus()` applied during the post-navigation settle window**, regardless of scheduling (rAF, macrotask, MutationObserver). Two earlier hypotheses were tested in CI and disproven: `focusmanager.testmode` (no effect) and swapping rAF→`setTimeout` (no effect).
- **Not reproducible** on macOS headless Firefox (focuses correctly every time), and chromium/webkit/mobile + real headed Firefox are all fine. So this is a **headless-Linux-Firefox test artifact, not a user-facing regression.**

## Fix
Skip **only** the `toBeFocused` assertion on Firefox. Every other Test A assertion (navigation, no-modal, heading text, back-nav) still runs on all browsers. The focus-on-route a11y contract remains covered by the `useFocusOnRouteChange` unit test (jsdom) and the chromium/webkit runs of this assertion.

Also reverts the no-op `focusmanager.testmode` pref added in #770 (it had no effect).

## Verification
The exact shipping state was run against the real Test A in **CI Firefox** (via a temporary dispatch job, since the firefox suite only runs post-merge): **`✓ Test A … 1 passed`**.

Fixes #635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved E2E test compatibility for Firefox on Linux environments
  * Streamlined browser testing configuration for more consistent cross-platform validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->