### PR TITLE
test(spa-editor): harden flaky WebKit e2e (seedEmptyWorkout goto race)

### DIFF
--- a/packages/workout-spa-editor/e2e/helpers/seed-empty-workout.ts
+++ b/packages/workout-spa-editor/e2e/helpers/seed-empty-workout.ts
@@ -20,14 +20,30 @@ import type { Page } from "@playwright/test";
  *    and skips auto-init; `WorkoutHeader` stays in view mode (seeded
  *    workout already has sport/name).
  */
+// The editor consumes its query params on mount and rewrites the URL
+// (strips `?source=scratch` / `?action=import` back to `/workout/new`).
+// A default `goto` waits for `load`, so that client-side rewrite races
+// the navigation — WebKit aborts it ("Frame load interrupted" /
+// "interrupted by another navigation"), failing the seed. `waitUntil:
+// "commit"` resolves once the document commits, before the rewrite; the
+// explicit readiness waits below replace the dropped `load` wait.
+const READY_TIMEOUT_MS = 20000;
+
 export async function seedEmptyWorkout(
   page: Page,
   krd?: Record<string, unknown>
 ): Promise<void> {
   if (krd) {
     if (!page.url().includes("/workout/new")) {
-      await page.goto("/workout/new");
+      await page.goto("/workout/new", { waitUntil: "commit" });
     }
+    // `commit` does not wait for scripts, so the store global may not be
+    // installed yet — wait for it before seeding.
+    await page.waitForFunction(
+      () => "__KAIORD_WORKOUT_STORE__" in window,
+      undefined,
+      { timeout: READY_TIMEOUT_MS }
+    );
     await page.evaluate((seed) => {
       const w = window as unknown as {
         __KAIORD_WORKOUT_STORE__?: {
@@ -41,13 +57,13 @@ export async function seedEmptyWorkout(
       }
       w.__KAIORD_WORKOUT_STORE__.getState().loadWorkout(seed);
     }, krd);
-    await page.goto("/workout/new?source=scratch");
+    await page.goto("/workout/new?source=scratch", { waitUntil: "commit" });
     return;
   }
 
   if (!page.url().includes("action=import")) {
-    await page.goto("/workout/new?action=import");
+    await page.goto("/workout/new?action=import", { waitUntil: "commit" });
   }
   const fileInput = page.locator('input[type="file"]');
-  await fileInput.waitFor({ state: "attached", timeout: 20000 });
+  await fileInput.waitFor({ state: "attached", timeout: READY_TIMEOUT_MS });
 }


### PR DESCRIPTION
## Problem
After #635 fixed Firefox, the post-merge e2e run still went red intermittently on **WebKit** (4 specs across two attempts: `workout-creation`, `button-improvements`, `repetition-blocks`, `workout-library`). All passed on a clean rerun → flaky, not a real regression.

## Root cause (reproduced locally on WebKit)
The dominant flake is the shared `seedEmptyWorkout` helper (backs ~13 specs). The editor consumes its query params on mount and **rewrites the URL** (strips `?source=scratch` / `?action=import` back to `/workout/new`). A default `page.goto` waits for the `load` event, so that client-side rewrite races the navigation and WebKit aborts it — surfaced as *"Frame load interrupted"* (WebKit) / *"interrupted by another navigation"* (Chromium/Firefox).

Measured locally: `workout-creation` failed **~80% per attempt** → `0.8³ ≈ 51%` chance of failing all 3 CI retries. That single test was the main driver of WebKit redness.

## Fix
In `seedEmptyWorkout`, use `waitUntil: "commit"` for the editor gotos (resolves once the document commits, **before** the rewrite) and add an explicit `__KAIORD_WORKOUT_STORE__` readiness wait to replace the dropped `load` wait.

Considered and rejected:
- **Global `goto` default → `commit`**: unsafe — the Dexie seeding helpers (`clearDexie`/`seedWorkouts`/`seedTemplates`) `evaluate` `__KAIORD_DB__` immediately after `goto` and rely on the `load` wait.
- **Swallowing the interruption error in the fixture**: makes it *worse* — the abort leaves the editor un-mounted (app falls back to the picker).

## Verification (WebKit, local)
- `workout-creation`: **80% → ~2.5%** failure over 40 runs (residual is a separate transient Vite dynamic-import hiccup — `"Importing a module script failed"` — covered by the existing 2 CI retries).
- `button-improvements`: **20/20**.
- Chromium regression: **6/6**, no change.

## Residual / out of scope
- `repetition-blocks` failed once via *"WebKit encountered an internal error"* (a browser crash, not a test bug) — retries mitigate.
- ~130 direct `goto("/workout/new?source=…")` call sites share the same latent race but flake far less; a safe central fix isn't available (see rejected options), so they're left to retries.

WebKit is only exercised post-merge (the suite triggers on CI success on `main`), so the post-merge run is the final confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test stability and reliability for test setup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->