### PR TITLE
revert: seedEmptyWorkout webkit goto change (#774) — regressed firefox

### DIFF
--- a/packages/workout-spa-editor/e2e/helpers/seed-empty-workout.ts
+++ b/packages/workout-spa-editor/e2e/helpers/seed-empty-workout.ts
@@ -20,30 +20,14 @@ import type { Page } from "@playwright/test";
  *    and skips auto-init; `WorkoutHeader` stays in view mode (seeded
  *    workout already has sport/name).
  */
-// The editor consumes its query params on mount and rewrites the URL
-// (strips `?source=scratch` / `?action=import` back to `/workout/new`).
-// A default `goto` waits for `load`, so that client-side rewrite races
-// the navigation — WebKit aborts it ("Frame load interrupted" /
-// "interrupted by another navigation"), failing the seed. `waitUntil:
-// "commit"` resolves once the document commits, before the rewrite; the
-// explicit readiness waits below replace the dropped `load` wait.
-const READY_TIMEOUT_MS = 20000;
-
 export async function seedEmptyWorkout(
   page: Page,
   krd?: Record<string, unknown>
 ): Promise<void> {
   if (krd) {
     if (!page.url().includes("/workout/new")) {
-      await page.goto("/workout/new", { waitUntil: "commit" });
+      await page.goto("/workout/new");
     }
-    // `commit` does not wait for scripts, so the store global may not be
-    // installed yet — wait for it before seeding.
-    await page.waitForFunction(
-      () => "__KAIORD_WORKOUT_STORE__" in window,
-      undefined,
-      { timeout: READY_TIMEOUT_MS }
-    );
     await page.evaluate((seed) => {
       const w = window as unknown as {
         __KAIORD_WORKOUT_STORE__?: {
@@ -57,13 +41,13 @@ export async function seedEmptyWorkout(
       }
       w.__KAIORD_WORKOUT_STORE__.getState().loadWorkout(seed);
     }, krd);
-    await page.goto("/workout/new?source=scratch", { waitUntil: "commit" });
+    await page.goto("/workout/new?source=scratch");
     return;
   }
 
   if (!page.url().includes("action=import")) {
-    await page.goto("/workout/new?action=import", { waitUntil: "commit" });
+    await page.goto("/workout/new?action=import");
   }
   const fileInput = page.locator('input[type="file"]');
-  await fileInput.waitFor({ state: "attached", timeout: READY_TIMEOUT_MS });
+  await fileInput.waitFor({ state: "attached", timeout: 20000 });
 }


### PR DESCRIPTION
Reverts #774.

#774 changed `seedEmptyWorkout` gotos to `waitUntil: "commit"` to fix a WebKit navigation-interruption flake. Verified locally it fixed WebKit (80%→~2.5%), **but it regressed Firefox**: `workout-creation` then failed ~73%/attempt with `NS_ERROR_FAILURE` / `NS_BINDING_ABORTED` (confirmed on the post-merge run + locally). The `goto` + app-URL-rewrite race aborts differently per engine and there is no `goto`-level fix that satisfies both (swallowing the abort leaves the editor un-mounted → worse).

Reverting to restore the baseline (Firefox green; WebKit flake returns) while a proper, cross-engine-verified fix is developed. No production code involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Optimized test helper for workout initialization with improved reliability and efficiency. Enhanced readiness detection for multiple workflow paths, refined file input element detection for import operations, and streamlined timeout handling across development-mode seeding and standard import/upload workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->