### PR TITLE
test(spa-editor): fix WebKit+Firefox flake in seedEmptyWorkout (redesign)

### DIFF
--- a/packages/workout-spa-editor/e2e/helpers/seed-empty-workout.ts
+++ b/packages/workout-spa-editor/e2e/helpers/seed-empty-workout.ts
@@ -20,14 +20,28 @@ import type { Page } from "@playwright/test";
  *    and skips auto-init; `WorkoutHeader` stays in view mode (seeded
  *    workout already has sport/name).
  */
+const READY_TIMEOUT_MS = 20000;
+
 export async function seedEmptyWorkout(
   page: Page,
   krd?: Record<string, unknown>
 ): Promise<void> {
   if (krd) {
-    if (!page.url().includes("/workout/new")) {
-      await page.goto("/workout/new");
-    }
+    // Single navigation to the scratch surface. A `page.goto` is a full
+    // reload that resets the Zustand store, so the prior "land on the
+    // picker, seed, then goto ?source=scratch" sequence (a) lost the seed
+    // anyway and (b) the second goto raced the editor mount and was
+    // aborted across engines (WebKit "Frame load interrupted"; Firefox
+    // "NS_ERROR_FAILURE"/"NS_BINDING_ABORTED"), the dominant WebKit e2e
+    // flake. We navigate once, then seed AFTER mount so the workout
+    // actually persists (the editor auto-inits empty first; the seed
+    // overwrites it).
+    await page.goto("/workout/new?source=scratch");
+    await page.waitForFunction(
+      () => "__KAIORD_WORKOUT_STORE__" in window,
+      undefined,
+      { timeout: READY_TIMEOUT_MS }
+    );
     await page.evaluate((seed) => {
       const w = window as unknown as {
         __KAIORD_WORKOUT_STORE__?: {
@@ -41,7 +55,6 @@ export async function seedEmptyWorkout(
       }
       w.__KAIORD_WORKOUT_STORE__.getState().loadWorkout(seed);
     }, krd);
-    await page.goto("/workout/new?source=scratch");
     return;
   }
 
@@ -49,5 +62,5 @@ export async function seedEmptyWorkout(
     await page.goto("/workout/new?action=import");
   }
   const fileInput = page.locator('input[type="file"]');
-  await fileInput.waitFor({ state: "attached", timeout: 20000 });
+  await fileInput.waitFor({ state: "attached", timeout: READY_TIMEOUT_MS });
 }


### PR DESCRIPTION
Proper fix for the WebKit e2e flake (replaces the reverted #774; #775 reverted it).

## Root cause (verified via CI dispatch + local repro on both engines)
The scratch path did **two** navigations: `goto(/workout/new)` → seed Zustand → `goto(?source=scratch)`. Diagnosis revealed:
- A `page.goto` is a full reload that **resets Zustand**, so the seed was *lost anyway* — the editor auto-initialised an empty "Untitled workout" (the `krd` arg was effectively a no-op). The URL is **not** rewritten by the app (my earlier theory was wrong).
- The **second goto raced the editor mount** and got aborted, worded differently per engine: WebKit `Frame load interrupted`; Firefox `NS_ERROR_FAILURE` / `NS_BINDING_ABORTED`; Chromium/FF `interrupted by another navigation`.

This was the dominant WebKit flake: `workout-creation` failed **~80%/attempt** locally.

## Why earlier attempts failed (all reverted/abandoned)
- `waitUntil:"commit"` (#774): fixed WebKit but **regressed Firefox to ~73%** → reverted in #775.
- Swallowing the abort error: **worse** — the editor never mounts (falls back to picker).
- Global `commit` default: unsafe — breaks the Dexie seeding helpers that read `__KAIORD_DB__` right after `goto`.

## Fix
Collapse scratch mode to a **single navigation** and apply the seed **after** the editor mounts (so the workout genuinely persists and there's no second racing goto). Scratch mode is used by exactly **one** spec (`workout-creation`); the import path (**120** call sites) is untouched.

## Verification
- `workout-creation` ×20 on **Firefox + WebKit = 40/40** (was ~80% fail WebKit / ~73% Firefox).
- Mode-2 (import) sanity 6/6 (chromium + webkit).
- WebKit only runs post-merge, so the post-merge run is the final confirmation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test infrastructure for the workout editor initialization flow, optimizing navigation and state handling during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->