### PR TITLE
test(spa-editor): retry page.goto on transient WebKit internal crashes

### DIFF
--- a/packages/workout-spa-editor/e2e/fixtures/base.ts
+++ b/packages/workout-spa-editor/e2e/fixtures/base.ts
@@ -10,9 +10,22 @@
  *   await page.evaluate(() => localStorage.clear());
  * });
  * ```
+ *
+ * It also retries `page.goto` on transient browser-internal crashes (see
+ * `TRANSIENT_NAV_CRASH`): WebKit on CI intermittently aborts a navigation
+ * with "WebKit encountered an internal error" (and processes can crash).
+ * These are not test failures — re-issuing the same navigation recovers —
+ * so we retry in-place a bounded number of times. Any other navigation
+ * error propagates unchanged, and the retry is narrow enough that normal
+ * navigations are untouched.
  */
 
+import type { Page } from "@playwright/test";
 import { test as base } from "@playwright/test";
+
+const TRANSIENT_NAV_CRASH =
+  /encountered an internal error|target crashed|page crashed/i;
+const GOTO_CRASH_RETRIES = 2;
 
 export const test = base.extend({
   page: async ({ page }, use) => {
@@ -21,6 +34,22 @@ export const test = base.extend({
     await page.addInitScript(() => {
       localStorage.setItem("workout-spa-onboarding-completed", "true");
     });
+
+    const originalGoto = page.goto.bind(page);
+    page.goto = (async (url, options) => {
+      let lastError: unknown;
+      for (let attempt = 0; attempt <= GOTO_CRASH_RETRIES; attempt++) {
+        try {
+          return await originalGoto(url, options);
+        } catch (error) {
+          lastError = error;
+          const transient =
+            error instanceof Error && TRANSIENT_NAV_CRASH.test(error.message);
+          if (!transient) throw error;
+        }
+      }
+      throw lastError;
+    }) as Page["goto"];
 
     await use(page);
   },


### PR DESCRIPTION
Hardens the remaining WebKit flake noted after #776: `repetition-blocks` ("delete block via keyboard shortcut") occasionally aborted `page.goto` with **"WebKit encountered an internal error"** — a transient browser-internal crash, not a test-logic bug.

## Approach
Rather than chase ~46 redundant `goto("?source=scratch")` call sites (the crash can land on *any* navigation, and some sites have non-removable follow-ups like a post-goto `localStorage` write), wrap `page.goto` once in the shared base fixture with a **bounded retry on crash signatures only** (`internal error` / `target crashed` / `page crashed`). Re-issuing the same navigation recovers from the transient crash *within the attempt*, so it no longer registers as flaky — complementing the existing test-level `retries: 2`.

Any other navigation error propagates unchanged, and normal navigations are untouched (the retry triggers only on the crash signature), so blast radius is effectively zero.

## Verification
- **Regex** matches the exact CI string `"WebKit encountered an internal error"` and does NOT match normal/race errors.
- **Retry control flow** checked deterministically: recovers after a transient crash, bounded give-up after 3 attempts, rethrows non-crash errors immediately.
- **No regression**: sample WebKit specs (repetition-blocks + workout-creation) pass.
- Honest caveat: the real-crash recovery is **not reproducible locally** (the crash is rare/CI-only), so efficacy rests on the logic + exact-string match + the fact it's strictly additive over current behavior.

## Considered & rejected
- Removing the ~46 redundant scratch gotos: reduces frequency but doesn't make the *remaining* gotos crash-proof, and several sites aren't safely removable. Left as an optional cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by implementing retry logic for navigation operations in end-to-end tests, handling transient browser-level crashes with bounded retry attempts and proper error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->