### PR TITLE
test(spa-editor): drop 54 redundant ?source=scratch gotos before import seed

### DIFF
--- a/packages/workout-spa-editor/e2e/accessibility.spec.ts
+++ b/packages/workout-spa-editor/e2e/accessibility.spec.ts
@@ -252,8 +252,6 @@ test.describe("Accessibility", () => {
   });
 
   test("should maintain color contrast for accessibility", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with different intensity levels
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');
@@ -392,8 +390,6 @@ test.describe("Accessibility", () => {
 
   test("should apply theme to all UI elements", async ({ page, isMobile }) => {
     // Requirement 13: Theme applies to entire application
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout to have more UI elements
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');

--- a/packages/workout-spa-editor/e2e/advanced-workouts.spec.ts
+++ b/packages/workout-spa-editor/e2e/advanced-workouts.spec.ts
@@ -26,8 +26,6 @@ test.describe("Advanced Workout Features", () => {
       page,
     }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       // Load a swimming workout
       await seedEmptyWorkout(page);
       const fileInput = page.locator('input[type="file"]');
@@ -103,8 +101,6 @@ test.describe("Advanced Workout Features", () => {
       page,
     }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       const swimmingWorkout = {
         version: "1.0",
         type: "structured_workout",
@@ -161,8 +157,6 @@ test.describe("Advanced Workout Features", () => {
   test.describe("Advanced Duration Types", () => {
     test("should handle calorie-based duration", async ({ page }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       const calorieWorkout = {
         version: "1.0",
         type: "structured_workout",
@@ -214,8 +208,6 @@ test.describe("Advanced Workout Features", () => {
 
     test("should handle power threshold duration", async ({ page }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       const powerThresholdWorkout = {
         version: "1.0",
         type: "structured_workout",
@@ -264,8 +256,6 @@ test.describe("Advanced Workout Features", () => {
 
     test("should handle heart rate threshold duration", async ({ page }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       const hrThresholdWorkout = {
         version: "1.0",
         type: "structured_workout",
@@ -314,8 +304,6 @@ test.describe("Advanced Workout Features", () => {
 
     test("should handle repeat until conditions", async ({ page }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       const repeatWorkout = {
         version: "1.0",
         type: "structured_workout",
@@ -372,8 +360,6 @@ test.describe("Advanced Workout Features", () => {
   test.describe("Workout Notes", () => {
     test("should display step notes when present", async ({ page }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       const workoutWithNotes = {
         version: "1.0",
         type: "structured_workout",
@@ -443,8 +429,6 @@ test.describe("Advanced Workout Features", () => {
 
     test("should handle steps without notes", async ({ page }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       const workoutWithoutNotes = {
         version: "1.0",
         type: "structured_workout",
@@ -495,8 +479,6 @@ test.describe("Advanced Workout Features", () => {
   test.describe("Workout Metadata Editing", () => {
     test("should edit workout name via metadata editor", async ({ page }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       const testWorkout = {
         version: "1.0",
         type: "structured_workout",
@@ -569,8 +551,6 @@ test.describe("Advanced Workout Features", () => {
 
     test("should edit workout sport via metadata editor", async ({ page }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       const testWorkout = {
         version: "1.0",
         type: "structured_workout",
@@ -642,8 +622,6 @@ test.describe("Advanced Workout Features", () => {
 
     test("should cancel metadata editing without saving", async ({ page }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       const testWorkout = {
         version: "1.0",
         type: "structured_workout",
@@ -718,8 +696,6 @@ test.describe("Advanced Workout Features", () => {
       page,
     }) => {
       // Arrange
-      await page.goto("/workout/new?source=scratch");
-
       // Create a workout with PERF_STEP_COUNT steps
       const steps = Array.from({ length: PERF_STEP_COUNT }, (_, i) => ({
         stepIndex: i,

--- a/packages/workout-spa-editor/e2e/drag-drop-reordering.spec.ts
+++ b/packages/workout-spa-editor/e2e/drag-drop-reordering.spec.ts
@@ -656,8 +656,6 @@ test.describe("Drag-and-Drop Mobile Touch", () => {
   });
 
   test("should support touch drag on mobile", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load workout
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');

--- a/packages/workout-spa-editor/e2e/error-handling.spec.ts
+++ b/packages/workout-spa-editor/e2e/error-handling.spec.ts
@@ -403,8 +403,6 @@ test.describe("Error Handling - Mobile", () => {
 
   test("should handle error recovery on mobile", async ({ page }) => {
     // Arrange
-    await page.goto("/workout/new?source=scratch");
-
     const validWorkout = {
       version: "1.0",
       type: "structured_workout",

--- a/packages/workout-spa-editor/e2e/import-export-formats.spec.ts
+++ b/packages/workout-spa-editor/e2e/import-export-formats.spec.ts
@@ -480,8 +480,6 @@ test.describe("Import/Export Mobile Flow", () => {
 
   test("should handle format selection on mobile", async ({ page }) => {
     // Arrange
-    await page.goto("/workout/new?source=scratch");
-
     const testWorkout = {
       version: "1.0",
       type: "structured_workout",

--- a/packages/workout-spa-editor/e2e/mobile-responsive.spec.ts
+++ b/packages/workout-spa-editor/e2e/mobile-responsive.spec.ts
@@ -42,8 +42,6 @@ test.describe("Mobile Responsive Design", () => {
   });
 
   test("should support touch gestures for navigation", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');
@@ -97,8 +95,6 @@ test.describe("Mobile Responsive Design", () => {
   });
 
   test("should scroll smoothly on mobile", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with multiple steps instead of creating one
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');
@@ -324,7 +320,6 @@ test.describe("Workout Actions Overflow", () => {
   };
 
   async function loadWorkout(page: Page) {
-    await page.goto("/workout/new?source=scratch");
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');
     await fileInput.setInputFiles({

--- a/packages/workout-spa-editor/e2e/repetition-blocks.spec.ts
+++ b/packages/workout-spa-editor/e2e/repetition-blocks.spec.ts
@@ -14,8 +14,6 @@ test.describe("Repetition Blocks", () => {
   test("should create repetition block from selected steps", async ({
     page,
   }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with multiple steps
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -152,8 +150,6 @@ test.describe("Repetition Blocks", () => {
   });
 
   test("should edit repeat count", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -229,8 +225,6 @@ test.describe("Repetition Blocks", () => {
   });
 
   test("should expand and collapse repetition block", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -309,8 +303,6 @@ test.describe("Repetition Blocks", () => {
   test("should calculate stats correctly with repetition blocks", async ({
     page,
   }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with repetition blocks
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');
@@ -404,8 +396,6 @@ test.describe("Repetition Blocks", () => {
   });
 
   test("should add step within repetition block", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -466,8 +456,6 @@ test.describe("Repetition Blocks", () => {
   });
 
   test("should handle undo/redo with repetition blocks", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');
@@ -595,8 +583,6 @@ test.describe("Repetition Blocks", () => {
 
 test.describe("Repetition Blocks - Ungroup", () => {
   test("should ungroup repetition block via context menu", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -688,8 +674,6 @@ test.describe("Repetition Blocks - Ungroup", () => {
 
 test.describe("Repetition Blocks - Keyboard Shortcuts", () => {
   test("should create block with Ctrl+G", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with multiple steps
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -798,8 +782,6 @@ test.describe("Repetition Blocks - Keyboard Shortcuts", () => {
   });
 
   test("should ungroup block with Ctrl+Shift+G", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -867,8 +849,6 @@ test.describe("Repetition Blocks - Keyboard Shortcuts", () => {
   });
 
   test("should select all steps with Ctrl+A", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with multiple steps
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -951,8 +931,6 @@ test.describe("Repetition Blocks - Keyboard Shortcuts", () => {
   });
 
   test("should clear selection with Escape", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with multiple steps
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -1059,8 +1037,6 @@ test.describe("Repetition Blocks - Context Menu Actions", () => {
   test("should open inline editor via Edit Count menu item", async ({
     page,
   }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -1131,8 +1107,6 @@ test.describe("Repetition Blocks - Context Menu Actions", () => {
   });
 
   test("should add step via context menu", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -1204,8 +1178,6 @@ test.describe("Repetition Blocks - Context Menu Actions", () => {
     page,
   }) => {
     // Requirements: 1.1, 1.2, 1.3
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -1320,8 +1292,6 @@ test.describe("Repetition Blocks - Block Operations (Task 11)", () => {
     page,
   }) => {
     // Requirements: 1.1, 1.6 - Verify blocks from selected steps preserve steps (no default added)
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with steps
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -1433,8 +1403,6 @@ test.describe("Repetition Blocks - Block Operations (Task 11)", () => {
 
   test("should delete block via delete button", async ({ page }) => {
     // Requirements: 2.1, 3.2
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -1558,8 +1526,6 @@ test.describe("Repetition Blocks - Block Operations (Task 11)", () => {
 
   test("should restore block after undo", async ({ page }) => {
     // Requirements: 2.3, 2.4
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -1667,8 +1633,6 @@ test.describe("Repetition Blocks - Block Operations (Task 11)", () => {
 
   test("should delete block via keyboard shortcut", async ({ page }) => {
     // Requirements: 4.1, 4.4
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with multiple blocks
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -1784,8 +1748,6 @@ test.describe("Repetition Blocks - Block Operations (Task 11)", () => {
     page,
   }) => {
     // Requirements: 4.1, 4.2, 4.3, 4.4
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with a repetition block
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -1934,8 +1896,6 @@ test.describe("Repetition Blocks - Correct Block Deletion (Task 15)", () => {
     page,
   }) => {
     // Requirements: 1.1, 1.2, 1.3, 1.4, 4.1, 4.2
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with 3 repetition blocks with identifiable content
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -2098,8 +2058,6 @@ test.describe("Repetition Blocks - Multiple Block Deletion (Task 17)", () => {
     page,
   }) => {
     // Requirements: 1.1, 1.2, 1.3, 3.3, 3.4
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with 5 repetition blocks with unique identifiable content
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -2451,8 +2409,6 @@ test.describe("Repetition Blocks - Performance", () => {
   test("should render large repetition blocks efficiently", async ({
     page,
   }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Create a workout with a large repetition block (25 steps)
     const LARGE_BLOCK_STEP_COUNT = 25;
     const steps = Array.from({ length: LARGE_BLOCK_STEP_COUNT }, (_, i) => ({
@@ -2529,8 +2485,6 @@ test.describe("Repetition Blocks - Performance", () => {
   });
 
   test("should handle deeply nested repetitions", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Note: Current implementation doesn't support nested repetition blocks
     // This test documents the expected behavior for future implementation
 
@@ -2599,8 +2553,6 @@ test.describe("Repetition Blocks - Button Styling Consistency (Task 18)", () => 
     page,
   }) => {
     // Requirements: 5.1, 5.2, 5.3, 5.4, 5.5
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with both regular steps and repetition blocks
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");

--- a/packages/workout-spa-editor/e2e/step-selection.spec.ts
+++ b/packages/workout-spa-editor/e2e/step-selection.spec.ts
@@ -27,8 +27,6 @@ test.describe("Step Selection - Unique IDs", () => {
     page,
   }) => {
     // Requirement 4.1: Test selecting main workout step
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with steps that have duplicate stepIndex values
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -140,8 +138,6 @@ test.describe("Step Selection - Unique IDs", () => {
     page,
   }) => {
     // Requirement 4.2: Test selecting step in repetition block
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with repetition blocks
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -247,8 +243,6 @@ test.describe("Step Selection - Unique IDs", () => {
     // (rather than extend it) so `selectedStepIds` always shares one
     // parent. This test previously asserted the old (extend) behavior;
     // it now asserts the new (replace) behavior.
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with multiple repetition blocks
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -417,8 +411,6 @@ test.describe("Step Selection - Unique IDs", () => {
     page,
   }) => {
     // Requirement 4.4: Verify steps with same stepIndex are independently selectable
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout where multiple contexts have steps with stepIndex: 1
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
@@ -558,8 +550,6 @@ test.describe("Step Selection - Unique IDs", () => {
     page,
   }) => {
     // Requirement 4.4: Verify selection behavior with duplicate stepIndex values
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout with multiple blocks and duplicate stepIndex values
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");

--- a/packages/workout-spa-editor/e2e/workout-creation.spec.ts
+++ b/packages/workout-spa-editor/e2e/workout-creation.spec.ts
@@ -21,8 +21,6 @@ const ISO_DATE_LENGTH = 10;
  */
 test.describe("Step Management Flow", () => {
   test("should create, duplicate, and delete steps", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a minimal workout file
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');
@@ -106,8 +104,6 @@ test.describe("Step Management Flow", () => {
   });
 
   test("should support undo/redo for step operations", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');
@@ -167,8 +163,6 @@ test.describe("Step Management Flow", () => {
   });
 
   test("should save workout with keyboard shortcut", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     // Load a workout
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');

--- a/packages/workout-spa-editor/e2e/workout-load-edit-save.spec.ts
+++ b/packages/workout-spa-editor/e2e/workout-load-edit-save.spec.ts
@@ -145,8 +145,6 @@ test.describe("Workout Load, Edit, and Save Flow", () => {
   test("should validate KRD file and show errors for invalid format", async ({
     page,
   }) => {
-    await page.goto("/workout/new?source=scratch");
-
     await seedEmptyWorkout(page);
     const fileInput = page.locator('input[type="file"]');
 
@@ -172,8 +170,6 @@ test.describe("Workout Load, Edit, and Save Flow", () => {
   });
 
   test("should handle file parsing errors gracefully", async ({ page }) => {
-    await page.goto("/workout/new?source=scratch");
-
     await seedEmptyWorkout(page);
     const fileInput = page.getByTestId("file-upload-input");
 


### PR DESCRIPTION
Follow-up cleanup to the WebKit hardening (#776, #777).

## What
54 specs across 10 files did `await page.goto("/workout/new?source=scratch")` immediately before `await seedEmptyWorkout(page)` — but that helper (import mode) navigates straight to `?action=import`, so the scratch navigation was **always discarded**. Dead code, and each wasted `goto` was an extra opportunity for the transient WebKit "internal error" crash + needless wall-clock.

## How (conservative)
Removed a goto **only** when `seedEmptyWorkout(page)` is the *first awaited call* after it (data-only `const {...}` blocks in between are fine — they don't touch the page). Kept every goto followed by real scratch-page usage: `waitForLoadState`, assertions, `evaluate`, `dismissTutorial`, interactions, etc. (77 such sites untouched).

Removal counts: repetition-blocks 24, advanced-workouts 12, step-selection 5, mobile-responsive 3, workout-creation 3, accessibility 2, workout-load-edit-save 2, drag-drop-reordering/error-handling/import-export 1 each.

## Verification (behavior-neutral)
- **104/104 on chromium** across all 10 changed files.
- **28/28 on WebKit** for the most-affected (repetition-blocks, workout-creation).
- ESLint + Prettier clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed redundant page navigation steps from end-to-end tests across multiple test suites to streamline test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->