### PR TITLE
fix(spa-editor): authenticate sync snapshot manifest via AES-GCM AAD (#724)

### DIFF
--- a/packages/workout-spa-editor/src/adapters/cloud-sync/encrypting-cloud-sync.test.ts
+++ b/packages/workout-spa-editor/src/adapters/cloud-sync/encrypting-cloud-sync.test.ts
@@ -106,6 +106,31 @@ describe("withEncryption", () => {
     await expect(attempt).rejects.toThrow(/passphrase/i);
   });
 
+  it("should reject a downgraded snapshot whose cleartext manifest carries a ciphertext", async () => {
+    // Arrange
+    const encrypted = await encryptSnapshot(makeSnapshot(), "secret");
+    const downgraded = {
+      ...encrypted,
+      manifest: { ...encrypted.manifest, encrypted: false },
+    };
+    const inner = createInMemoryCloudSyncPort({
+      authenticated: true,
+      snapshot: downgraded as unknown as Snapshot,
+      revision: "rev-0",
+      pushCount: 0,
+    });
+    const port = withEncryption(inner, {
+      isEnabled: () => true,
+      getPassphrase: () => "secret",
+    });
+
+    // Act
+    const attempt = port.pull();
+
+    // Assert
+    await expect(attempt).rejects.toThrow(/tampered/i);
+  });
+
   it("should pass through a cleartext remote snapshot unchanged on pull", async () => {
     // Arrange
     const inner = createInMemoryCloudSyncPort({

--- a/packages/workout-spa-editor/src/adapters/cloud-sync/encrypting-cloud-sync.ts
+++ b/packages/workout-spa-editor/src/adapters/cloud-sync/encrypting-cloud-sync.ts
@@ -36,6 +36,9 @@ export type EncryptionSettings = {
 const MISSING_PASSPHRASE =
   "Encrypted snapshot requires a passphrase before it can be applied";
 
+const DOWNGRADED_SNAPSHOT =
+  "Snapshot manifest is marked cleartext but carries a ciphertext (tampered)";
+
 export function withEncryption(
   inner: CloudSyncPort,
   settings: EncryptionSettings
@@ -44,7 +47,14 @@ export function withEncryption(
     const remote = await inner.pull();
     if (!remote) return null;
     const wire = remote.snapshot as unknown as WireSnapshot;
-    if (!isEncryptedSnapshot(wire)) return remote;
+    if (!isEncryptedSnapshot(wire)) {
+      // A cleartext wire must not carry a `ciphertext`. That combination
+      // is an encrypted-flag downgrade (manifest.encrypted flipped to
+      // false to skip decryption), leaving a snapshot with no readable
+      // tables/tombstones — reject it rather than process garbage.
+      if ("ciphertext" in wire) throw new Error(DOWNGRADED_SNAPSHOT);
+      return remote;
+    }
     const passphrase = settings.getPassphrase();
     if (!passphrase) throw new Error(MISSING_PASSPHRASE);
     const snapshot = await decryptSnapshot(wire, passphrase);

--- a/packages/workout-spa-editor/src/lib/cloud-sync/snapshot-cipher.test.ts
+++ b/packages/workout-spa-editor/src/lib/cloud-sync/snapshot-cipher.test.ts
@@ -73,4 +73,34 @@ describe("snapshot-cipher", () => {
     // Assert
     await expect(attempt).rejects.toThrow();
   });
+
+  it("should fail to decrypt when the cleartext manifest deviceId is tampered", async () => {
+    // Arrange
+    const encrypted = await encryptSnapshot(makeSnapshot(), "correct horse");
+    const tampered = {
+      ...encrypted,
+      manifest: { ...encrypted.manifest, deviceId: "attacker-device" },
+    };
+
+    // Act
+    const attempt = decryptSnapshot(tampered, "correct horse");
+
+    // Assert
+    await expect(attempt).rejects.toThrow();
+  });
+
+  it("should fail to decrypt when the cleartext manifest schemaVersion is tampered", async () => {
+    // Arrange
+    const encrypted = await encryptSnapshot(makeSnapshot(), "correct horse");
+    const tampered = {
+      ...encrypted,
+      manifest: { ...encrypted.manifest, schemaVersion: 99 },
+    };
+
+    // Act
+    const attempt = decryptSnapshot(tampered, "correct horse");
+
+    // Assert
+    await expect(attempt).rejects.toThrow();
+  });
 });

--- a/packages/workout-spa-editor/src/lib/cloud-sync/snapshot-cipher.ts
+++ b/packages/workout-spa-editor/src/lib/cloud-sync/snapshot-cipher.ts
@@ -5,16 +5,37 @@
  * `ciphertext` blob with a user passphrase (PBKDF2 → AES-256-GCM via the
  * shared `crypto.ts` primitives), leaving the manifest in cleartext with
  * `encrypted: true` so a receiving device can detect it before prompting.
+ * The cleartext manifest is bound to the ciphertext as AES-GCM Additional
+ * Authenticated Data (AAD), so tampering with any manifest field makes
+ * decryption fail (it stays readable but is no longer forgeable).
  * No I/O, no Drive, no Dexie — only the snapshot value and the passphrase.
  */
 
-import type { EncryptedSnapshot, Snapshot } from "../../types/snapshot";
+import type {
+  EncryptedSnapshot,
+  Snapshot,
+  SnapshotManifest,
+} from "../../types/snapshot";
 import { decrypt, encrypt } from "../crypto";
 
 type Payload = {
   tables: Snapshot["tables"];
   tombstones: Snapshot["tombstones"];
 };
+
+/**
+ * Canonical, order-stable serialization of the manifest used as AES-GCM
+ * AAD. An array (not an object) avoids JSON key-order ambiguity between
+ * encrypt and decrypt. `encrypted` is always `true` on the wire here.
+ */
+function manifestAad(manifest: SnapshotManifest): string {
+  return JSON.stringify([
+    manifest.schemaVersion,
+    manifest.deviceId,
+    manifest.exportedAt,
+    manifest.encrypted,
+  ]);
+}
 
 export async function encryptSnapshot(
   snapshot: Snapshot,
@@ -24,18 +45,24 @@ export async function encryptSnapshot(
     tables: snapshot.tables,
     tombstones: snapshot.tombstones,
   };
-  const ciphertext = await encrypt(JSON.stringify(payload), passphrase);
-  return {
-    manifest: { ...snapshot.manifest, encrypted: true },
-    ciphertext,
-  };
+  const manifest: SnapshotManifest = { ...snapshot.manifest, encrypted: true };
+  const ciphertext = await encrypt(
+    JSON.stringify(payload),
+    passphrase,
+    manifestAad(manifest)
+  );
+  return { manifest, ciphertext };
 }
 
 export async function decryptSnapshot(
   encrypted: EncryptedSnapshot,
   passphrase: string
 ): Promise<Snapshot> {
-  const plaintext = await decrypt(encrypted.ciphertext, passphrase);
+  const plaintext = await decrypt(
+    encrypted.ciphertext,
+    passphrase,
+    manifestAad(encrypted.manifest)
+  );
   const payload = JSON.parse(plaintext) as Payload;
   return {
     manifest: { ...encrypted.manifest, encrypted: false },

--- a/packages/workout-spa-editor/src/lib/crypto.test.ts
+++ b/packages/workout-spa-editor/src/lib/crypto.test.ts
@@ -71,4 +71,36 @@ describe("crypto", () => {
     // Assert
     expect(() => atob(encrypted)).not.toThrow();
   });
+
+  it("should round-trip when additionalData matches", async () => {
+    // Arrange
+    const aad = "manifest-context";
+    const encrypted = await encrypt("secret", passphrase, aad);
+
+    // Act
+    const decrypted = await decrypt(encrypted, passphrase, aad);
+
+    // Assert
+    expect(decrypted).toBe("secret");
+  });
+
+  it("should fail decryption when additionalData differs", async () => {
+    // Arrange
+    const encrypted = await encrypt("secret", passphrase, "context-a");
+
+    // Act
+
+    // Assert
+    await expect(decrypt(encrypted, passphrase, "context-b")).rejects.toThrow();
+  });
+
+  it("should fail decryption when additionalData is omitted on decrypt", async () => {
+    // Arrange
+    const encrypted = await encrypt("secret", passphrase, "context-a");
+
+    // Act
+
+    // Assert
+    await expect(decrypt(encrypted, passphrase)).rejects.toThrow();
+  });
 });

--- a/packages/workout-spa-editor/src/lib/crypto.ts
+++ b/packages/workout-spa-editor/src/lib/crypto.ts
@@ -7,14 +7,16 @@ const copyBytes = (data: Uint8Array): Uint8Array =>
     data.buffer.slice(data.byteOffset, data.byteOffset + data.byteLength)
   );
 
+const bytes = (text: string): BufferSource =>
+  copyBytes(new TextEncoder().encode(text)) as BufferSource;
+
 const deriveKey = async (
   passphrase: string,
   salt: Uint8Array
 ): Promise<CryptoKey> => {
-  const encoder = new TextEncoder();
   const keyMaterial = await crypto.subtle.importKey(
     "raw",
-    copyBytes(encoder.encode(passphrase)) as BufferSource,
+    bytes(passphrase),
     "PBKDF2",
     false,
     ["deriveKey"]
@@ -33,19 +35,30 @@ const deriveKey = async (
   );
 };
 
+// AAD: authenticated by the AES-GCM tag but not encrypted; decryption
+// fails unless the identical value is supplied. Binds cleartext metadata
+// (e.g. a snapshot manifest) to the ciphertext so tampering is detectable.
+const gcmParams = (iv: Uint8Array, additionalData?: string): AesGcmParams => ({
+  name: "AES-GCM",
+  iv: copyBytes(iv) as BufferSource,
+  ...(additionalData !== undefined && {
+    additionalData: bytes(additionalData),
+  }),
+});
+
 export const encrypt = async (
   plaintext: string,
-  passphrase: string
+  passphrase: string,
+  additionalData?: string
 ): Promise<string> => {
-  const encoder = new TextEncoder();
   const salt = crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
   const iv = crypto.getRandomValues(new Uint8Array(IV_LENGTH));
   const key = await deriveKey(passphrase, salt);
 
   const ciphertext = await crypto.subtle.encrypt(
-    { name: "AES-GCM", iv: copyBytes(iv) as BufferSource },
+    gcmParams(iv, additionalData),
     key,
-    copyBytes(encoder.encode(plaintext)) as BufferSource
+    bytes(plaintext)
   );
 
   const combined = new Uint8Array(
@@ -60,7 +73,8 @@ export const encrypt = async (
 
 export const decrypt = async (
   encoded: string,
-  passphrase: string
+  passphrase: string,
+  additionalData?: string
 ): Promise<string> => {
   const combined = Uint8Array.from(atob(encoded), (c) => c.charCodeAt(0));
   const salt = combined.slice(0, SALT_LENGTH);
@@ -69,7 +83,7 @@ export const decrypt = async (
 
   const key = await deriveKey(passphrase, salt);
   const decrypted = await crypto.subtle.decrypt(
-    { name: "AES-GCM", iv: copyBytes(iv) as BufferSource },
+    gcmParams(iv, additionalData),
     key,
     copyBytes(ciphertext) as BufferSource
   );


### PR DESCRIPTION
Closes #724 (deferred CodeRabbit finding from the cross-device-sync feature, PR #719).

## Problem
With E2E encryption enabled, `snapshot-cipher` encrypted only `tables`+`tombstones`. The cleartext manifest (`schemaVersion`, `deviceId`, `exportedAt`, `encrypted`) was **unauthenticated** — tamperable without detection (schema-version downgrade, deviceId spoof, etc.).

## Fix
Bind the manifest to the ciphertext as **AES-GCM Additional Authenticated Data**:
- `crypto.ts` `encrypt`/`decrypt` gain an optional `additionalData` param (authenticated, not encrypted). Backward-compatible — the AI-key (`secure-storage`, `dexie-ai-provider-repository`) callers pass nothing and are unchanged. Refactored the GCM-params + byte-encoding into small shared helpers to stay within the file's line budget.
- `snapshot-cipher` passes a **canonical, order-stable** serialization of the manifest (a fixed-order array, not an object, to avoid JSON key-order ambiguity) as AAD on both encrypt and decrypt.

The manifest stays cleartext (receivers still detect `encrypted: true` and prompt), but tampering with any field now makes decryption fail.

## Why it's safe
Snapshots are encrypted/decrypted **only** via the cipher module (`encrypting-cloud-sync.ts`), so the AAD is always symmetric — no raw-crypto snapshot path.

## Tests
- `crypto.test.ts`: AAD round-trip, AAD-mismatch rejection, AAD-omitted-on-decrypt rejection.
- `snapshot-cipher.test.ts`: deviceId + schemaVersion tamper rejection.
- 27/27 across crypto + cipher + snapshot-port + secure-storage; tsc + lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced encrypted snapshot integrity by binding manifest metadata to the ciphertext using cryptographic authentication. Tampering with manifest fields such as device ID or schema version will now cause decryption to fail, ensuring the authenticity and integrity of synced workout data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->