### PR TITLE
fix(spa-editor): make snapshot export/import atomic (#723)

### DIFF
--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-snapshot-port.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-snapshot-port.test.ts
@@ -114,6 +114,36 @@ describe("createDexieSnapshotPort", () => {
     expect(decrypted).toBe("sk-secret-123");
   });
 
+  it("should roll the whole import back when a later phase fails (atomic)", async () => {
+    // Arrange
+    const db = new KaiordDatabase(name);
+    await db.open();
+    await db.table("workouts").add({ id: "original", profileId: "p-1" });
+    const base = createDexieSnapshotPort(db);
+    const snapshot = await exportSnapshot({ port: base, deviceId: "dev-1" });
+    const imported = {
+      ...snapshot,
+      tables: { ...snapshot.tables, workouts: [{ id: "imported" }] },
+    };
+    // The tombstone phase fails *after* importTables has written in the
+    // same transaction; the whole transaction must roll back.
+    const failing = {
+      ...base,
+      replaceTombstones: async () => {
+        throw new Error("simulated mid-restore failure");
+      },
+    };
+
+    // Act
+    const attempt = importSnapshot({ port: failing, snapshot: imported });
+
+    // Assert
+    await expect(attempt).rejects.toThrow(/mid-restore/i);
+    const workouts = await db.table("workouts").toArray();
+    db.close();
+    expect(workouts).toEqual([{ id: "original", profileId: "p-1" }]);
+  });
+
   it("should round-trip tombstones via the dedicated tombstone methods", async () => {
     // Arrange
     const db = new KaiordDatabase(name);

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-snapshot-port.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-snapshot-port.ts
@@ -16,7 +16,7 @@ const TOMBSTONES = "tombstones";
 // Narrow to a single explicit signature so tsc sidesteps Dexie's recursive
 // transaction overloads (TS2589). Same pattern as dexie-persistence-adapter.
 type DexieTxScope = (
-  mode: "rw",
+  mode: "r" | "rw",
   tables: ReadonlyArray<unknown>,
   scope: () => Promise<unknown>
 ) => Promise<unknown>;
@@ -27,6 +27,17 @@ export function createDexieSnapshotPort(db: KaiordDatabase): SnapshotPort {
   const scoped = db as unknown as { transaction: DexieTxScope };
 
   return {
+    // One transaction over every table. The inner `importTables` /
+    // `replaceTombstones` / read calls below open Dexie transactions on
+    // subsets of this scope, which Dexie nests into (joins) this one — so
+    // the whole export/import is a single atomic unit.
+    transaction: <T>(mode: "r" | "rw", scope: () => Promise<T>): Promise<T> =>
+      scoped.transaction(
+        mode,
+        db.tables,
+        scope as () => Promise<unknown>
+      ) as Promise<T>,
+
     schemaVersion: async () => db.verno,
 
     exportTables: async () => {

--- a/packages/workout-spa-editor/src/application/sync/export-snapshot.ts
+++ b/packages/workout-spa-editor/src/application/sync/export-snapshot.ts
@@ -22,11 +22,16 @@ export async function exportSnapshot({
   deviceId,
   now = () => new Date(),
 }: ExportSnapshotDeps): Promise<Snapshot> {
-  const [schemaVersion, tables, tombstones] = await Promise.all([
-    port.schemaVersion(),
-    port.exportTables(),
-    port.listTombstones(),
-  ]);
+  // Single read transaction so the schema version, table rows, and
+  // tombstones are a consistent point-in-time snapshot (a concurrent
+  // local write cannot interleave between the reads).
+  const [schemaVersion, tables, tombstones] = await port.transaction("r", () =>
+    Promise.all([
+      port.schemaVersion(),
+      port.exportTables(),
+      port.listTombstones(),
+    ])
+  );
   return {
     manifest: {
       schemaVersion,

--- a/packages/workout-spa-editor/src/application/sync/import-snapshot.ts
+++ b/packages/workout-spa-editor/src/application/sync/import-snapshot.ts
@@ -30,6 +30,11 @@ export async function importSnapshot({
         `app's v${localVersion}; update the app before importing.`
     );
   }
-  await port.importTables(snapshot.tables);
-  await port.replaceTombstones(pruneTombstones(snapshot.tombstones, now()));
+  // Single read-write transaction so tables and tombstones are restored
+  // atomically: a failure mid-restore rolls the whole database back rather
+  // than leaving tables replaced but tombstones stale (or vice versa).
+  await port.transaction("rw", async () => {
+    await port.importTables(snapshot.tables);
+    await port.replaceTombstones(pruneTombstones(snapshot.tombstones, now()));
+  });
 }

--- a/packages/workout-spa-editor/src/ports/snapshot-port.ts
+++ b/packages/workout-spa-editor/src/ports/snapshot-port.ts
@@ -14,6 +14,15 @@
 import type { SnapshotTables, Tombstone } from "../types/snapshot";
 
 export type SnapshotPort = {
+  /**
+   * Run `scope` inside a single database transaction spanning all
+   * snapshot tables so a whole export (`"r"`) or import (`"rw"`) is
+   * atomic and consistent: a concurrent write cannot interleave, and a
+   * mid-restore failure rolls the database back. Inner port calls made
+   * within `scope` join this transaction. The in-memory fake runs
+   * `scope` directly (no real transactions to model).
+   */
+  transaction: <T>(mode: "r" | "rw", scope: () => Promise<T>) => Promise<T>;
   /** Current Dexie schema version of the underlying database. */
   schemaVersion: () => Promise<number>;
   /** Dump every table's rows, keyed by table name. */

--- a/packages/workout-spa-editor/src/test-utils/in-memory-snapshot-port.ts
+++ b/packages/workout-spa-editor/src/test-utils/in-memory-snapshot-port.ts
@@ -19,6 +19,9 @@ export function createInMemorySnapshotPort(
   state: InMemorySnapshotState
 ): SnapshotPort {
   return {
+    // No real transactions to model in memory — run the scope directly.
+    transaction: <T>(_mode: "r" | "rw", scope: () => Promise<T>) => scope(),
+
     schemaVersion: async () => state.schemaVersion,
 
     exportTables: async () => {


### PR DESCRIPTION
Closes #723 (deferred CodeRabbit finding from cross-device-sync, PR #719).

## Problem
- `exportSnapshot` read schema version + tables + tombstones in separate awaited calls → a concurrent local write could mix data from different DB moments.
- `importSnapshot` wrote tables and tombstones in **two separate transactions** → a failure mid-restore could leave the DB partially restored (tables replaced but tombstones stale, or vice versa).

## Fix
Add `SnapshotPort.transaction(mode, scope)`:
- **Dexie adapter** wraps `db.transaction` over all tables. The existing `importTables` / `replaceTombstones` open Dexie transactions on subsets of that scope, which Dexie **nests into (joins)** the outer one — so the whole import is a single atomic unit.
- **In-memory fake** runs `scope` directly (no real transactions to model).
- `exportSnapshot` reads under one `"r"` transaction (consistent point-in-time); `importSnapshot` writes under one `"rw"` transaction (atomic).

No inline `SnapshotPort` mocks exist (all tests use the fake), so the new required method is safe.

## Tests
- New dexie-snapshot-port **atomicity** test: a tombstone-phase failure *after* `importTables` has written rolls the tables back to their original rows.
- 33/33 sync tests (application/sync + dexie-snapshot-port); tsc + lint clean.