### PR TITLE
fix(spa-editor): compute "today" in local timezone, not UTC (#747)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/ScheduleDateDialog/ScheduleDateDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/ScheduleDateDialog/ScheduleDateDialog.tsx
@@ -8,6 +8,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { Calendar, X } from "lucide-react";
 import { useState } from "react";
 
+import { todayIsoDate } from "../../../utils/today-iso-date";
 import { Button } from "../../atoms/Button/Button";
 
 type ScheduleDateDialogProps = {
@@ -23,10 +24,7 @@ export function ScheduleDateDialog({
   onConfirm,
   onCancel,
 }: ScheduleDateDialogProps) {
-  const [date, setDate] = useState(() => {
-    const d = new Date();
-    return d.toISOString().slice(0, 10);
-  });
+  const [date, setDate] = useState(() => todayIsoDate());
 
   return (
     <Dialog.Root open={open} onOpenChange={(o) => !o && onCancel()}>

--- a/packages/workout-spa-editor/src/components/pages/CalendarPageView.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPageView.tsx
@@ -1,4 +1,5 @@
 import { ROUTE_HEADING_ATTR } from "../../routing/constants";
+import { todayIsoDate } from "../../utils/today-iso-date";
 import { AutoMatchBanner } from "../organisms/AutoMatchBanner/AutoMatchBanner";
 import { CalendarAddEntryDialogs } from "./CalendarAddEntryDialogs";
 import { CalendarBodyView } from "./CalendarBodyView";
@@ -18,7 +19,7 @@ export function CalendarPageView({
   bannerActions,
   wellnessByDay,
 }: CalendarPageReadyState) {
-  const todayDate = new Date().toISOString().slice(0, 10);
+  const todayDate = todayIsoDate();
   return (
     <div className="space-y-4" data-testid="calendar-page">
       <h1 tabIndex={-1} {...{ [ROUTE_HEADING_ATTR]: "" }} className="sr-only">

--- a/packages/workout-spa-editor/src/utils/today-iso-date.test.ts
+++ b/packages/workout-spa-editor/src/utils/today-iso-date.test.ts
@@ -3,16 +3,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { todayIsoDate } from "./today-iso-date";
 
 describe("todayIsoDate", () => {
+  const prevTz = process.env.TZ;
+
   beforeEach(() => {
     vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    process.env.TZ = prevTz;
   });
 
-  it("should return the current UTC date as YYYY-MM-DD", () => {
+  it("should return the current local date as YYYY-MM-DD", () => {
     // Arrange
+    process.env.TZ = "UTC";
     vi.setSystemTime(new Date("2026-06-05T10:30:00Z"));
 
     // Act
@@ -22,14 +26,31 @@ describe("todayIsoDate", () => {
     expect(result).toBe("2026-06-05");
   });
 
-  it("should use the UTC calendar day across midnight boundaries", () => {
+  it("should use the local calendar day near a non-UTC midnight boundary", () => {
     // Arrange
-    vi.setSystemTime(new Date("2026-06-05T23:59:59Z"));
+    // 23:30 local on Jun 15 in New York is 03:30Z on Jun 16; the local day
+    // (Jun 15) must win, not the UTC day (Jun 16). Regression for #747.
+    process.env.TZ = "America/New_York";
+    vi.setSystemTime(new Date("2026-06-16T03:30:00Z"));
 
     // Act
     const result = todayIsoDate();
 
     // Assert
-    expect(result).toBe("2026-06-05");
+    expect(result).toBe("2026-06-15");
+  });
+
+  it("should use the local calendar day for an early-morning far-east time", () => {
+    // Arrange
+    // 06:00 local on Jun 16 in Tokyo is 21:00Z on Jun 15; the local day
+    // (Jun 16) must win, not the UTC day (Jun 15).
+    process.env.TZ = "Asia/Tokyo";
+    vi.setSystemTime(new Date("2026-06-15T21:00:00Z"));
+
+    // Act
+    const result = todayIsoDate();
+
+    // Assert
+    expect(result).toBe("2026-06-16");
   });
 });

--- a/packages/workout-spa-editor/src/utils/today-iso-date.ts
+++ b/packages/workout-spa-editor/src/utils/today-iso-date.ts
@@ -1,4 +1,18 @@
-/** Today's calendar date as `YYYY-MM-DD` (UTC, repo-wide convention). */
+const PAD = 2;
+
+/**
+ * Today's calendar date as `YYYY-MM-DD` in the user's LOCAL timezone.
+ *
+ * Built from local Date components (not `toISOString().slice(0, 10)`,
+ * which yields the UTC day and is off by one near midnight in non-UTC
+ * timezones — see #747). This matches the local-day convention used by
+ * the calendar / coaching / Daily surfaces (`toIsoDate` / `isoToLocalDate`
+ * in Today/today-dates.ts) so a workout scheduled "today" lands on the
+ * day the user actually sees.
+ */
 export function todayIsoDate(): string {
-  return new Date().toISOString().slice(0, 10);
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(PAD, "0");
+  const day = String(now.getDate()).padStart(PAD, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
 }


### PR DESCRIPTION
Closes #747 (latent timezone inconsistency from the Daily/calendar work).

## Confirmed bug (reproduced)
`todayIsoDate()` returned the **UTC** day (`new Date().toISOString().slice(0,10)`), but all its consumers (workout schedule date, scratch-editor default, chat "today"/week-start) and the calendar/coaching/Daily layer use the **local-day** convention (`toIsoDate` / `isoToLocalDate`). Near midnight in a non-UTC timezone they disagree:

> New York, 23:30 local Jun 15 (= 03:30Z Jun 16): `todayIsoDate()` → `2026-06-16`, local calendar day → `2026-06-15`.

So a workout scheduled "today" landed on the wrong calendar day, and the Daily/calendar "today" highlight was off by one.

## Decision
Per the audit, **standardize on the local day** (the calendar/coaching UI is inherently local; all `todayIsoDate()` consumers are local-day contexts). The "UTC repo-wide convention" was itself the latent bug.

## Changes
- `todayIsoDate()` now builds the date from **local** Date components.
- Routed the two remaining inline UTC date-slices through it: `CalendarPageView` today-highlight and `ScheduleDateDialog` default.
- **Left unchanged (TZ-stable by design):** `week-utils` (ISO-week math via `Date.UTC`, covered by the Kiritimati test) and `is-valid-calendar-date` (noon-UTC validation).

## Tests
- `today-iso-date.test.ts` now asserts the **local** day, with non-UTC boundary regressions (New York 23:30 → prior day; Tokyo 06:00 → next day).
- **Full frontend suite green: 4706 tests** (no consumer assumed UTC).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed timezone handling in date selection and calendar operations. Dates now correctly reflect the user's local timezone, preventing potential date discrepancies that could occur near midnight in non-UTC regions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->