### PR TITLE
feat(spa-editor): persist Athlete active sport per profile (#715)

### DIFF
--- a/packages/workout-spa-editor/src/application/set-user-preference-fields.test.ts
+++ b/packages/workout-spa-editor/src/application/set-user-preference-fields.test.ts
@@ -89,6 +89,42 @@ describe("setUserPreferenceFields", () => {
     });
   });
 
+  it("should persist activeSport on first call", async () => {
+    // Arrange
+    const repository = createInMemoryUserPreferencesRepository();
+    const profileRepository = stubProfileRepo([stubProfile()]);
+
+    // Act
+    await setUserPreferenceFields(
+      { profileId: "p1", patch: { activeSport: "running" } },
+      { clock: fixedClock, repository, profileRepository }
+    );
+
+    // Assert
+    expect((await repository.get("p1"))?.activeSport).toBe("running");
+  });
+
+  it("should preserve activeSport when a later patch changes another field", async () => {
+    // Arrange
+    const repository = createInMemoryUserPreferencesRepository();
+    const profileRepository = stubProfileRepo([stubProfile()]);
+    await setUserPreferenceFields(
+      { profileId: "p1", patch: { activeSport: "swimming" } },
+      { clock: fixedClock, repository, profileRepository }
+    );
+
+    // Act
+    await setUserPreferenceFields(
+      { profileId: "p1", patch: { calendarView: "list" } },
+      { clock: fixedClock, repository, profileRepository }
+    );
+
+    // Assert
+    const row = await repository.get("p1");
+    expect(row?.activeSport).toBe("swimming");
+    expect(row?.calendarView).toBe("list");
+  });
+
   it("should throw ProfileNotFoundError when profile is missing", async () => {
     // Arrange
     const repository = createInMemoryUserPreferencesRepository();

--- a/packages/workout-spa-editor/src/application/set-user-preference-fields.ts
+++ b/packages/workout-spa-editor/src/application/set-user-preference-fields.ts
@@ -17,7 +17,7 @@ import type { UserPreferences } from "../types/user-preferences";
 export type UserPreferenceFieldsPatch = Partial<
   Pick<
     UserPreferences,
-    "calendarView" | "lastScratchSport" | "aiBannerExpanded"
+    "calendarView" | "lastScratchSport" | "activeSport" | "aiBannerExpanded"
   >
 >;
 
@@ -45,6 +45,7 @@ export async function setUserPreferenceFields(
     profileId: input.profileId,
     calendarView: existing?.calendarView ?? "grid",
     lastScratchSport: existing?.lastScratchSport,
+    activeSport: existing?.activeSport,
     aiBannerExpanded: existing?.aiBannerExpanded,
     ...input.patch,
     updatedAt: deps.clock(),

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/AthletePageBody.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/AthletePageBody.tsx
@@ -8,6 +8,7 @@ import {
   isActiveSport,
 } from "../../../lib/athlete";
 import type { Profile } from "../../../types/profile";
+import { logger } from "../../../utils/logger";
 import { Segmented } from "../../atoms/Segmented";
 import { AthleteConnections } from "../../organisms/AthleteConnections";
 import { AthleteIdentity } from "./AthleteIdentity";
@@ -34,7 +35,11 @@ export function AthletePageBody({ profileId, profile }: AthletePageBodyProps) {
 
   const handleSportChange = (next: ActiveSport) => {
     setSport(next);
-    void setPrefs({ activeSport: next });
+    // Best-effort persist; a failed preference write must not surface as an
+    // unhandled rejection (the optimistic local state already updated).
+    void setPrefs({ activeSport: next }).catch((error: unknown) => {
+      logger.warn("Failed to persist active sport", { error });
+    });
   };
 
   const sportLabel =

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/AthletePageBody.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/AthletePageBody.tsx
@@ -1,6 +1,12 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-import { type ActiveSport, ATHLETE_SPORTS } from "../../../lib/athlete";
+import { useSetUserPreferenceFields } from "../../../hooks/use-set-user-preference-fields";
+import { useUserPreferences } from "../../../hooks/use-user-preferences";
+import {
+  type ActiveSport,
+  ATHLETE_SPORTS,
+  isActiveSport,
+} from "../../../lib/athlete";
 import type { Profile } from "../../../types/profile";
 import { Segmented } from "../../atoms/Segmented";
 import { AthleteConnections } from "../../organisms/AthleteConnections";
@@ -15,7 +21,22 @@ type AthletePageBodyProps = {
 };
 
 export function AthletePageBody({ profileId, profile }: AthletePageBodyProps) {
+  const prefs = useUserPreferences({ profileId, defaultView: "grid" });
+  const setPrefs = useSetUserPreferenceFields(profileId);
   const [sport, setSport] = useState<ActiveSport>(() => defaultSport(profile));
+
+  // Seed from the persisted active sport once preferences load, so the
+  // selection survives a reload (local state alone reset on every mount).
+  useEffect(() => {
+    const persisted = prefs?.activeSport;
+    if (isActiveSport(persisted)) setSport(persisted);
+  }, [prefs?.activeSport]);
+
+  const handleSportChange = (next: ActiveSport) => {
+    setSport(next);
+    void setPrefs({ activeSport: next });
+  };
+
   const sportLabel =
     ATHLETE_SPORTS.find((option) => option.value === sport)?.label ?? "";
 
@@ -25,7 +46,7 @@ export function AthletePageBody({ profileId, profile }: AthletePageBodyProps) {
       <Segmented
         options={[...ATHLETE_SPORTS]}
         value={sport}
-        onChange={setSport}
+        onChange={handleSportChange}
         ariaLabel="Sport"
       />
       <ThresholdCard

--- a/packages/workout-spa-editor/src/types/user-preferences.ts
+++ b/packages/workout-spa-editor/src/types/user-preferences.ts
@@ -21,6 +21,8 @@ export const userPreferencesSchema = z.object({
   // Optional: pre-v15 rows lack these fields. The Dexie v15 migration is
   // data-only; absence remains a valid state until the user first writes.
   lastScratchSport: sportSchema.optional(),
+  /** Sport last selected on the Athlete page; absent until first chosen. */
+  activeSport: sportSchema.optional(),
   aiBannerExpanded: z.boolean().optional(),
   updatedAt: z.iso.datetime(),
 });


### PR DESCRIPTION
Refs #715.

## Problem
The Athlete page sport selector was local `useState`, so the selection reset on every reload.

## Fix
- Add optional `userPreferences.activeSport` (additive — no index/migration; mirrors `lastScratchSport`).
- `AthletePageBody` seeds the selector from the persisted value on mount (via `useUserPreferences`, narrowed with `isActiveSport`) and persists on change (via `useSetUserPreferenceFields`). The ThresholdCard / ZoneMapCard that read `sport` therefore also reflect the persisted choice.
- `setUserPreferenceFields` rebuilds the row field-by-field, so `activeSport` is added to the patch type **and** carried over in the merge — otherwise a `calendarView`/`aiBanner` write would silently wipe it.

## Tests
- New use-case tests: persist `activeSport`, and **preserve it when a later patch changes another field** (regression guard for the field-by-field merge).
- Affected suites green (set-user-preference-fields, use-user-preferences, schema, AthletePage); tsc + lint clean.

## Out of scope (follow-up)
The second acceptance sub-item — AI workout generation defaulting to the active sport — touches the chat AI sport-derivation flow and is left as a separate change, so this **refs** rather than closes #715.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sport selection on the Athlete page is now automatically saved as a user preference and restored when you return to the page.

* **Tests**
  * Added test coverage for sport preference persistence and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->