### PR TITLE
fix(spa-editor): advance the Daily "today" across midnight (#748)

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/Today/use-real-today-iso.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-real-today-iso.test.tsx
@@ -1,0 +1,58 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useRealTodayIso } from "./use-real-today-iso";
+
+const PAST_MIDNIGHT_MS = 3000;
+
+describe("useRealTodayIso", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should return today's local date initially", () => {
+    // Arrange
+    vi.setSystemTime(new Date("2026-06-16T12:00:00"));
+
+    // Act
+    const { result } = renderHook(() => useRealTodayIso());
+
+    // Assert
+    expect(result.current).toBe("2026-06-16");
+  });
+
+  it("should advance to the next day at local midnight while open", () => {
+    // Arrange
+    vi.setSystemTime(new Date("2026-06-16T23:59:59"));
+    const { result } = renderHook(() => useRealTodayIso());
+    expect(result.current).toBe("2026-06-16");
+
+    // Act
+    // Cross midnight; the armed timer fires.
+    act(() => {
+      vi.advanceTimersByTime(PAST_MIDNIGHT_MS);
+    });
+
+    // Assert
+    expect(result.current).toBe("2026-06-17");
+  });
+
+  it("should re-derive today when the tab regains visibility", () => {
+    // Arrange
+    vi.setSystemTime(new Date("2026-06-16T23:59:59"));
+    const { result } = renderHook(() => useRealTodayIso());
+
+    // Act
+    // Clock crosses midnight while hidden, then the tab returns.
+    act(() => {
+      vi.setSystemTime(new Date("2026-06-17T08:00:00"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    // Assert
+    expect(result.current).toBe("2026-06-17");
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/Today/use-real-today-iso.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-real-today-iso.ts
@@ -1,0 +1,50 @@
+/**
+ * useRealTodayIso — the current LOCAL calendar day as `YYYY-MM-DD`, advancing
+ * while the app stays open instead of freezing at load (#748).
+ *
+ * It re-derives at the next local midnight (the timer is re-armed each day)
+ * and whenever the tab regains visibility or window focus — so a session left
+ * open overnight (or backgrounded across midnight) still circles the right
+ * "today" and defaults the Daily focus to it.
+ */
+import { useEffect, useState } from "react";
+
+import { toIsoDate } from "./today-dates";
+
+const PAST_MIDNIGHT_SLACK_MS = 1000;
+
+const msUntilNextMidnight = (now: Date): number => {
+  const next = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+  return next.getTime() - now.getTime() + PAST_MIDNIGHT_SLACK_MS;
+};
+
+export function useRealTodayIso(): string {
+  const [todayIso, setTodayIso] = useState(() => toIsoDate(new Date()));
+
+  useEffect(() => {
+    const sync = () =>
+      setTodayIso((prev) => {
+        const next = toIsoDate(new Date());
+        return prev === next ? prev : next;
+      });
+
+    let timer: ReturnType<typeof setTimeout>;
+    const arm = () => {
+      timer = setTimeout(() => {
+        sync();
+        arm();
+      }, msUntilNextMidnight(new Date()));
+    };
+    arm();
+
+    document.addEventListener("visibilitychange", sync);
+    window.addEventListener("focus", sync);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener("visibilitychange", sync);
+      window.removeEventListener("focus", sync);
+    };
+  }, []);
+
+  return todayIso;
+}

--- a/packages/workout-spa-editor/src/components/pages/Today/use-today-route-params.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-today-route-params.ts
@@ -3,12 +3,16 @@
  * unbounded (any past/future day); a malformed or missing param falls back to
  * the real today. Validation lives in the pure `resolveFocusIso`; the local
  * constructor (`isoToLocalDate`) avoids a UTC day-shift.
+ *
+ * `realTodayIso` comes from `useRealTodayIso`, so it advances at midnight /
+ * on tab refocus and the memo re-derives the default focus with it (#748).
  */
 import { useMemo } from "react";
 import { useSearch } from "wouter";
 
-import { isoToLocalDate, toIsoDate } from "./today-dates";
+import { isoToLocalDate } from "./today-dates";
 import { resolveFocusIso } from "./today-focus-date";
+import { useRealTodayIso } from "./use-real-today-iso";
 
 export type TodayRouteParams = {
   focusDate: Date;
@@ -18,15 +22,14 @@ export type TodayRouteParams = {
 
 export function useTodayRouteParams(): TodayRouteParams {
   const search = useSearch();
+  const realTodayIso = useRealTodayIso();
 
   return useMemo(() => {
-    const realToday = new Date();
-    const realTodayIso = toIsoDate(realToday);
     const requested = new URLSearchParams(search).get("date") ?? "";
     const focusIso = resolveFocusIso(requested, realTodayIso);
     const focusDate =
-      focusIso === realTodayIso ? realToday : isoToLocalDate(focusIso);
+      focusIso === realTodayIso ? new Date() : isoToLocalDate(focusIso);
 
     return { focusDate, focusIso, realTodayIso };
-  }, [search]);
+  }, [search, realTodayIso]);
 }


### PR DESCRIPTION
Closes #748.

## Problem
`useTodayRouteParams` computed `realTodayIso` once inside a `useMemo` keyed only on the URL search. A session left open across midnight kept circling yesterday and defaulting the Daily focus to it.

## Fix
New `useRealTodayIso` hook returns the local `YYYY-MM-DD`, advancing while open:
- re-derives at the next local midnight (timer re-armed each day),
- and on `visibilitychange` / window `focus` (covers a backgrounded tab returning after midnight).

`useTodayRouteParams` consumes it and lists it as a memo dependency, so the WeekStrip `isRealToday` and the default focus follow the wall clock.

## Tests
Fake-timer hook tests: initial day, midnight-timer advance (23:59:59 → +3s → next day), and visibility re-derivation after crossing midnight while hidden. All Today-dir tests green; tsc + lint clean.