### PR TITLE
feat(spa-editor): functional Units + Notifications settings (#716)

### DIFF
--- a/.changeset/settings-units-notifications.md
+++ b/.changeset/settings-units-notifications.md
@@ -1,0 +1,13 @@
+---
+"@kaiord/workout-spa-editor": minor
+---
+
+Make the Settings "Units" and "Notifications" rows functional (previously
+display-only). A new Preferences tab persists a per-profile `units`
+(metric/imperial) preference and a browser-notification toggle.
+
+Units are display-only — canonical data stays in SI. Choosing imperial
+relabels workout step-target pace (min/km → min/mi), athlete threshold pace and
+zones (running min/mi, swimming /100yd), and weight surfaces (kg → lb) in the
+weight history and health trends. The Notifications toggle drives the real
+browser Notification permission rather than being a dead control.

--- a/packages/workout-spa-editor/src/application/set-user-preference-fields.ts
+++ b/packages/workout-spa-editor/src/application/set-user-preference-fields.ts
@@ -17,7 +17,12 @@ import type { UserPreferences } from "../types/user-preferences";
 export type UserPreferenceFieldsPatch = Partial<
   Pick<
     UserPreferences,
-    "calendarView" | "lastScratchSport" | "activeSport" | "aiBannerExpanded"
+    | "calendarView"
+    | "lastScratchSport"
+    | "activeSport"
+    | "aiBannerExpanded"
+    | "units"
+    | "notificationsEnabled"
   >
 >;
 
@@ -47,6 +52,8 @@ export async function setUserPreferenceFields(
     lastScratchSport: existing?.lastScratchSport,
     activeSport: existing?.activeSport,
     aiBannerExpanded: existing?.aiBannerExpanded,
+    units: existing?.units,
+    notificationsEnabled: existing?.notificationsEnabled,
     ...input.patch,
     updatedAt: deps.clock(),
   };

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/StepDetails.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/StepDetails.tsx
@@ -1,3 +1,4 @@
+import { useUnits } from "../../../contexts/units-context";
 import type { WorkoutStep } from "../../../types/krd";
 import { Icon } from "../../atoms/Icon/Icon";
 import { formatDuration } from "./format-duration";
@@ -9,6 +10,7 @@ type StepDetailsProps = {
 };
 
 export const StepDetails = ({ step }: StepDetailsProps) => {
+  const units = useUnits();
   const targetIcon = getTargetIcon(step.targetType);
   const durationIcon = getDurationIcon(step.durationType);
 
@@ -24,7 +26,7 @@ export const StepDetails = ({ step }: StepDetailsProps) => {
       <div className="flex items-center gap-2 mb-2">
         <Icon icon={targetIcon} size="sm" color="secondary" />
         <span className="text-sm text-gray-700 dark:text-gray-300">
-          {formatTarget(step)}
+          {formatTarget(step, units)}
         </span>
       </div>
     </>

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/format-target.test.ts
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/format-target.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 
+import type { WorkoutStep } from "../../../types/krd";
 import {
   formatCadenceTarget,
   formatHeartRateTarget,
   formatPaceTarget,
   formatPowerTarget,
+  formatTarget,
 } from "./format-target";
 
 const NUMERIC_NON_OBJECT_INPUT = 42;
@@ -181,5 +183,32 @@ describe("formatPaceTarget", () => {
 
     // Assert
     expect(actual).toBe(expected);
+  });
+
+  it("should format mps pace as min/mi for imperial units", () => {
+    // Arrange
+    const value = { unit: "mps", value: 3.5 };
+
+    // Act
+    const actual = formatPaceTarget(value, "imperial");
+
+    // Assert
+    expect(actual).toBe("7:40 min/mi");
+  });
+});
+
+describe("formatTarget", () => {
+  it("should apply the imperial unit when formatting a pace step", () => {
+    // Arrange
+    const step = {
+      targetType: "pace",
+      target: { value: { unit: "mps", value: 3.5 } },
+    } as unknown as WorkoutStep;
+
+    // Act
+    const actual = formatTarget(step, "imperial");
+
+    // Assert
+    expect(actual).toBe("7:40 min/mi");
   });
 });

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/format-target.ts
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/format-target.ts
@@ -1,18 +1,13 @@
+import {
+  formatPaceFromMps,
+  runPaceLabel,
+  type Units,
+} from "../../../lib/units/units";
 import type { WorkoutStep } from "../../../types/krd";
 
 /** Finite-number predicate used by every target formatter below. */
 const isValidNumber = (value: unknown): value is number =>
   typeof value === "number" && Number.isFinite(value);
-
-/** Convert meters per second to a `m:ss min/km` pace string. */
-const mpsToMinPerKm = (mps: number): string => {
-  if (mps <= 0 || !isFinite(mps)) return "--:--";
-  const minPerKm = 1000 / (mps * 60);
-  const minutes = Math.floor(minPerKm);
-  const seconds = Math.round((minPerKm - minutes) * 60);
-  if (seconds === 60) return `${minutes + 1}:00`;
-  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
-};
 
 type TargetValue = Record<string, unknown>;
 
@@ -52,20 +47,27 @@ export const formatCadenceTarget = (value: unknown): string => {
   return "Cadence";
 };
 
-export const formatPaceTarget = (value: unknown): string => {
+export const formatPaceTarget = (
+  value: unknown,
+  units: Units = "metric"
+): string => {
   const v = asRecord(value);
   if (!v || !("unit" in v)) return "Pace";
+  const label = runPaceLabel(units);
   if (v.unit === "mps" && isValidNumber(v.value))
-    return `${mpsToMinPerKm(v.value)} min/km`;
+    return `${formatPaceFromMps(v.value, units)} ${label}`;
   if (v.unit === "zone" && isValidNumber(v.value)) return `Zone ${v.value}`;
   if (v.unit === "range" && isValidNumber(v.min) && isValidNumber(v.max))
     // In pace, lower m/s = slower (higher min/km); show faster-slower.
-    return `${mpsToMinPerKm(v.max)}-${mpsToMinPerKm(v.min)} min/km`;
+    return `${formatPaceFromMps(v.max, units)}-${formatPaceFromMps(v.min, units)} ${label}`;
   return "Pace";
 };
 
 /** Top-level target formatter used by StepCard. */
-export const formatTarget = (step: WorkoutStep): string => {
+export const formatTarget = (
+  step: WorkoutStep,
+  units: Units = "metric"
+): string => {
   const { target, targetType } = step;
   if (targetType === "open") return "Open";
   if (!("value" in target)) return targetType.replace(/_/g, " ");
@@ -78,7 +80,7 @@ export const formatTarget = (step: WorkoutStep): string => {
     case "cadence":
       return formatCadenceTarget(value);
     case "pace":
-      return formatPaceTarget(value);
+      return formatPaceTarget(value, units);
     default:
       return targetType.replace(/_/g, " ");
   }

--- a/packages/workout-spa-editor/src/components/molecules/StepCard/format-target.ts
+++ b/packages/workout-spa-editor/src/components/molecules/StepCard/format-target.ts
@@ -1,8 +1,5 @@
-import {
-  formatPaceFromMps,
-  runPaceLabel,
-  type Units,
-} from "../../../lib/units/units";
+import type { Units } from "../../../lib/units/units";
+import { formatPaceFromMps, runPaceLabel } from "../../../lib/units/units";
 import type { WorkoutStep } from "../../../types/krd";
 
 /** Finite-number predicate used by every target formatter below. */

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/NotificationsRow.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/NotificationsRow.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { NotificationsRow } from "./NotificationsRow";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("NotificationsRow", () => {
+  it("should show an unsupported message when the API is absent", () => {
+    // Arrange
+    vi.stubGlobal("Notification", undefined);
+
+    // Act
+    render(<NotificationsRow enabled={false} onChange={vi.fn()} />);
+
+    // Assert
+    expect(screen.queryByRole("switch")).toBeNull();
+    expect(screen.getByText(/aren.t supported/i)).toBeInTheDocument();
+  });
+
+  it("should request permission and enable when granted", async () => {
+    // Arrange
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    vi.stubGlobal("Notification", { permission: "default", requestPermission });
+    const onChange = vi.fn();
+    render(<NotificationsRow enabled={false} onChange={onChange} />);
+
+    // Act
+    fireEvent.click(
+      screen.getByRole("switch", { name: /enable notifications/i })
+    );
+
+    // Assert
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(true));
+    expect(requestPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it("should disable without requesting permission when toggled off", () => {
+    // Arrange
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    vi.stubGlobal("Notification", { permission: "granted", requestPermission });
+    const onChange = vi.fn();
+    render(<NotificationsRow enabled onChange={onChange} />);
+
+    // Act
+    fireEvent.click(
+      screen.getByRole("switch", { name: /enable notifications/i })
+    );
+
+    // Assert
+    expect(onChange).toHaveBeenCalledWith(false);
+    expect(requestPermission).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/NotificationsRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/NotificationsRow.tsx
@@ -1,0 +1,52 @@
+import { Toggle } from "../../atoms/Toggle";
+import { useNotificationPermission } from "./use-notification-permission";
+
+export type NotificationsRowProps = {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+};
+
+export const NotificationsRow = ({
+  enabled,
+  onChange,
+}: NotificationsRowProps) => {
+  const { permission, request } = useNotificationPermission();
+  const checked = enabled && permission === "granted";
+
+  const handleChange = async (next: boolean) => {
+    if (!next) {
+      onChange(false);
+      return;
+    }
+    const result = await request();
+    onChange(result === "granted");
+  };
+
+  if (permission === "unsupported") {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        Notifications aren&apos;t supported in this browser.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm text-gray-900 dark:text-white">
+          Enable notifications
+        </span>
+        <Toggle
+          checked={checked}
+          onCheckedChange={(next) => void handleChange(next)}
+          aria-label="Enable notifications"
+        />
+      </div>
+      {permission === "denied" && (
+        <p className="text-sm text-amber-600 dark:text-amber-400">
+          Notifications are blocked in your browser settings.
+        </p>
+      )}
+    </div>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PreferencesTab.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PreferencesTab.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PreferencesTab } from "./PreferencesTab";
+
+const setPrefs = vi.fn().mockResolvedValue(undefined);
+const prefsMock = vi.hoisted(() => ({ value: undefined as unknown }));
+
+vi.mock("../../../hooks/use-active-profile-live", () => ({
+  useActiveProfileLive: () => ({ id: "p1", profile: null }),
+}));
+
+vi.mock("../../../hooks/use-user-preferences", () => ({
+  useUserPreferences: () => prefsMock.value,
+}));
+
+vi.mock("../../../hooks/use-set-user-preference-fields", () => ({
+  useSetUserPreferenceFields: () => setPrefs,
+}));
+
+describe("PreferencesTab", () => {
+  it("should reflect the persisted metric units as the active segment", () => {
+    // Arrange
+    prefsMock.value = {
+      profileId: "p1",
+      calendarView: "grid",
+      units: "metric",
+    };
+
+    // Act
+    render(<PreferencesTab />);
+
+    // Assert
+    expect(screen.getByRole("radio", { name: "Metric" })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+
+  it("should persist the imperial units selection on change", () => {
+    // Arrange
+    setPrefs.mockClear();
+    prefsMock.value = {
+      profileId: "p1",
+      calendarView: "grid",
+      units: "metric",
+    };
+    render(<PreferencesTab />);
+
+    // Act
+    fireEvent.click(screen.getByRole("radio", { name: "Imperial" }));
+
+    // Assert
+    expect(setPrefs).toHaveBeenCalledWith({ units: "imperial" });
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PreferencesTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PreferencesTab.tsx
@@ -1,0 +1,54 @@
+import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useSetUserPreferenceFields } from "../../../hooks/use-set-user-preference-fields";
+import { useUserPreferences } from "../../../hooks/use-user-preferences";
+import type { Units } from "../../../types/user-preferences";
+import { logger } from "../../../utils/logger";
+import { Segmented, type SegmentedOption } from "../../atoms/Segmented";
+import { SectionHead } from "../../molecules/SectionHead";
+import { NotificationsRow } from "./NotificationsRow";
+
+const UNIT_OPTIONS: SegmentedOption<Units>[] = [
+  { value: "metric", label: "Metric" },
+  { value: "imperial", label: "Imperial" },
+];
+
+export const PreferencesTab: React.FC = () => {
+  const active = useActiveProfileLive();
+  const profileId = active?.id ?? null;
+  const prefs = useUserPreferences({ profileId, defaultView: "grid" });
+  const setPrefs = useSetUserPreferenceFields(profileId);
+  const units: Units = prefs?.units ?? "metric";
+
+  const handleUnits = (next: Units) => {
+    void setPrefs({ units: next }).catch((error: unknown) => {
+      logger.warn("Failed to persist units preference", { error });
+    });
+  };
+
+  const handleNotifications = (next: boolean) => {
+    void setPrefs({ notificationsEnabled: next }).catch((error: unknown) => {
+      logger.warn("Failed to persist notifications preference", { error });
+    });
+  };
+
+  return (
+    <div className="space-y-6" data-testid="settings-preferences">
+      <section>
+        <SectionHead title="Units" />
+        <Segmented
+          options={UNIT_OPTIONS}
+          value={units}
+          onChange={handleUnits}
+          ariaLabel="Units"
+        />
+      </section>
+      <section>
+        <SectionHead title="Notifications" />
+        <NotificationsRow
+          enabled={prefs?.notificationsEnabled ?? false}
+          onChange={handleNotifications}
+        />
+      </section>
+    </div>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/types.ts
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/types.ts
@@ -1,1 +1,7 @@
-export type SettingsTab = "ai" | "sync" | "extensions" | "usage" | "privacy";
+export type SettingsTab =
+  | "ai"
+  | "sync"
+  | "extensions"
+  | "usage"
+  | "privacy"
+  | "preferences";

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/use-notification-permission.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/use-notification-permission.test.ts
@@ -1,0 +1,38 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useNotificationPermission } from "./use-notification-permission";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("useNotificationPermission", () => {
+  it("should report unsupported when the Notification API is absent", () => {
+    // Arrange
+    vi.stubGlobal("Notification", undefined);
+
+    // Act
+    const { result } = renderHook(() => useNotificationPermission());
+
+    // Assert
+    expect(result.current.permission).toBe("unsupported");
+  });
+
+  it("should reflect the granted permission after a request", async () => {
+    // Arrange
+    const requestPermission = vi.fn().mockResolvedValue("granted");
+    vi.stubGlobal("Notification", { permission: "default", requestPermission });
+    const { result } = renderHook(() => useNotificationPermission());
+
+    // Act
+    let returned: string | undefined;
+    await act(async () => {
+      returned = await result.current.request();
+    });
+
+    // Assert
+    expect(returned).toBe("granted");
+    expect(result.current.permission).toBe("granted");
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/use-notification-permission.ts
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/use-notification-permission.ts
@@ -1,0 +1,33 @@
+/**
+ * useNotificationPermission — thin wrapper over the browser Notification
+ * permission. There is no in-app notification scheduler yet; this exists so
+ * the Settings "Notifications" toggle controls a real surface (the browser
+ * permission) instead of being a dead control. `unsupported` covers
+ * non-browser/test environments where `Notification` is absent.
+ */
+
+import { useCallback, useState } from "react";
+
+export type NotificationPermissionState =
+  | "unsupported"
+  | "default"
+  | "granted"
+  | "denied";
+
+const readPermission = (): NotificationPermissionState =>
+  typeof Notification === "undefined" ? "unsupported" : Notification.permission;
+
+export const useNotificationPermission = () => {
+  const [permission, setPermission] =
+    useState<NotificationPermissionState>(readPermission);
+
+  const request =
+    useCallback(async (): Promise<NotificationPermissionState> => {
+      if (typeof Notification === "undefined") return "unsupported";
+      const result = await Notification.requestPermission();
+      setPermission(result);
+      return result;
+    }, []);
+
+  return { permission, request };
+};

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ThresholdCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ThresholdCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useUnits } from "../../../contexts/units-context";
 import { type ActiveSport, deriveThresholdMetrics } from "../../../lib/athlete";
 import type { Profile } from "../../../types/profile";
 import { Button } from "../../atoms/Button";
@@ -24,7 +25,8 @@ export function ThresholdCard({
 }: ThresholdCardProps) {
   const [auto, setAuto] = useState(true);
   const [editing, setEditing] = useState(false);
-  const metrics = deriveThresholdMetrics(profile, sport);
+  const units = useUnits();
+  const metrics = deriveThresholdMetrics(profile, sport, units);
 
   return (
     <Card className="rounded-[20px] border border-slate-700/60 bg-surface p-4">

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ZoneMapCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ZoneMapCard.tsx
@@ -1,3 +1,4 @@
+import { useUnits } from "../../../contexts/units-context";
 import { type ActiveSport, deriveZoneMap } from "../../../lib/athlete";
 import type { Profile } from "../../../types/profile";
 import { Card } from "../../atoms/Card";
@@ -15,7 +16,8 @@ type ZoneMapCardProps = {
 };
 
 export function ZoneMapCard({ profile, sport, sportLabel }: ZoneMapCardProps) {
-  const zones = deriveZoneMap(profile, sport);
+  const units = useUnits();
+  const zones = deriveZoneMap(profile, sport, units);
 
   return (
     <div>

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsPage.test.tsx
@@ -108,15 +108,18 @@ describe("SettingsPage", () => {
       });
     });
 
-    it("should render Units as a non-navigating row", () => {
+    it("should navigate to the preferences tab from the Units row", async () => {
       // Arrange
+      const user = userEvent.setup();
+      const { memory } = renderAtPath("/settings");
 
       // Act
-      renderAtPath("/settings");
+      await user.click(screen.getByTestId("settings-row-Units"));
 
       // Assert
-      const row = screen.getByTestId("settings-row-Units");
-      expect(row.tagName).not.toBe("BUTTON");
+      await waitFor(() => {
+        expect(memory.history.at(-1)).toBe("/settings/preferences");
+      });
     });
   });
 

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-groups.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-groups.ts
@@ -36,8 +36,8 @@ export const SETTINGS_GROUPS: ReadonlyArray<SettingsGroupDef> = [
   {
     eyebrow: "Preferences",
     rows: [
-      { icon: "target", label: "Units" },
-      { icon: "bell", label: "Notifications" },
+      { icon: "target", label: "Units", to: "/settings/preferences" },
+      { icon: "bell", label: "Notifications", to: "/settings/preferences" },
     ],
   },
   {

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-tab-views.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-tab-views.tsx
@@ -1,5 +1,6 @@
 import { AiTab } from "../../organisms/SettingsPanel/AiTab";
 import { ExtensionsTab } from "../../organisms/SettingsPanel/ExtensionsTab";
+import { PreferencesTab } from "../../organisms/SettingsPanel/PreferencesTab";
 import { PrivacyTab } from "../../organisms/SettingsPanel/PrivacyTab";
 import { SyncTab } from "../../organisms/SettingsPanel/SyncTab";
 import type { SettingsTab } from "../../organisms/SettingsPanel/types";
@@ -11,6 +12,7 @@ const TAB_ORDER: ReadonlyArray<SettingsTab> = [
   "extensions",
   "usage",
   "privacy",
+  "preferences",
 ];
 
 const TAB_LABELS: Record<SettingsTab, string> = {
@@ -19,6 +21,7 @@ const TAB_LABELS: Record<SettingsTab, string> = {
   extensions: "Extensions",
   usage: "Usage",
   privacy: "Privacy",
+  preferences: "Preferences",
 };
 
 const TAB_VIEWS: Record<SettingsTab, React.FC> = {
@@ -27,6 +30,7 @@ const TAB_VIEWS: Record<SettingsTab, React.FC> = {
   extensions: ExtensionsTab,
   usage: UsageTab,
   privacy: PrivacyTab,
+  preferences: PreferencesTab,
 };
 
 export const SETTINGS_TAB_LABELS = TAB_LABELS;

--- a/packages/workout-spa-editor/src/components/pages/health/HealthWeightPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/HealthWeightPage.tsx
@@ -2,9 +2,11 @@
  * /health/weight — last 90 days of weight measurements (+ latest body
  * composition if available).
  */
+import { useUnits } from "../../../contexts/units-context";
 import { useHealthBodyCompositionLatestLive } from "../../../hooks/health/use-health-body-composition-latest-live";
 import { useHealthWeightHistoryLive } from "../../../hooks/health/use-health-weight-history-live";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { formatWeightKg } from "../../../lib/units/units";
 import { lastNinetyDays } from "./health-date-windows";
 import { HealthPageHeader } from "./HealthPageHeader";
 
@@ -13,6 +15,7 @@ const EMPTY_MSG = "No weight records yet for the last 90 days.";
 export default function HealthWeightPage() {
   // Computed per render so the window stays current across day rollovers.
   const range = lastNinetyDays();
+  const units = useUnits();
   const active = useActiveProfileLive();
   const profileId = active?.id;
   const records = useHealthWeightHistoryLive(profileId ?? "", range);
@@ -44,7 +47,9 @@ export default function HealthWeightPage() {
               className="flex justify-between rounded border border-gray-200 p-2 text-sm dark:border-slate-800"
             >
               <span>{r.date}</span>
-              <span className="font-mono">{r.krd.weightKilograms} kg</span>
+              <span className="font-mono">
+                {formatWeightKg(r.krd.weightKilograms, units)}
+              </span>
             </li>
           ))}
         </ul>

--- a/packages/workout-spa-editor/src/components/pages/health/trends/TrendSingleChartCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/trends/TrendSingleChartCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 
+import { useUnits } from "../../../../contexts/units-context";
 import {
   buildTrendChartData,
   type PerMetricPoints,
@@ -31,6 +32,7 @@ export const TrendSingleChartCard = ({
   series,
   rangeDays,
 }: TrendSingleChartCardProps) => {
+  const units = useUnits();
   const selectedKeys = TREND_METRICS.map((m) => m.key).filter((k) =>
     selected.has(k)
   );
@@ -46,7 +48,10 @@ export const TrendSingleChartCard = ({
     for (const k of presentKeys) obj[k] = series[k].points;
     return obj;
   }, [presentKeys, series]);
-  const options = useMemo(() => buildTrendChartOptions(metrics), [metrics]);
+  const options = useMemo(
+    () => buildTrendChartOptions(metrics, units),
+    [metrics, units]
+  );
   const data = useMemo(
     () => buildTrendChartData(presentKeys, seriesByKey),
     [presentKeys, seriesByKey]

--- a/packages/workout-spa-editor/src/components/pages/health/trends/build-trend-chart-options.ts
+++ b/packages/workout-spa-editor/src/components/pages/health/trends/build-trend-chart-options.ts
@@ -1,22 +1,24 @@
 import type uPlot from "uplot";
 
+import type { Units } from "../../../../lib/units/units";
 import { formatPaneValue } from "./format-pane-value";
 import type { TrendMetricDef } from "./trend-metrics";
 
 const STROKE = "#2563eb";
 
 const tickFormatter =
-  (metric: TrendMetricDef) =>
+  (metric: TrendMetricDef, units: Units) =>
   (_u: uPlot, splits: number[]): string[] =>
-    splits.map((v) => formatPaneValue(metric, v));
+    splits.map((v) => formatPaneValue(metric, v, units));
 
 const legendFormatter =
-  (metric: TrendMetricDef) =>
+  (metric: TrendMetricDef, units: Units) =>
   (_u: uPlot, v: number | null | undefined): string =>
-    formatPaneValue(metric, v);
+    formatPaneValue(metric, v, units);
 
 export const buildTrendChartOptions = (
-  metrics: ReadonlyArray<TrendMetricDef>
+  metrics: ReadonlyArray<TrendMetricDef>,
+  units: Units = "metric"
 ): uPlot.Options => {
   const scales: uPlot.Scales = { x: { time: true } };
   for (const m of metrics) scales[m.key] = { auto: true };
@@ -27,7 +29,7 @@ export const buildTrendChartOptions = (
       scale: m.key,
       side: 1,
       label: m.label,
-      values: tickFormatter(m),
+      values: tickFormatter(m, units),
     });
 
   const series: uPlot.Series[] = [{}];
@@ -36,7 +38,7 @@ export const buildTrendChartOptions = (
       label: m.label,
       scale: m.key,
       stroke: STROKE,
-      value: legendFormatter(m),
+      value: legendFormatter(m, units),
     });
 
   return {

--- a/packages/workout-spa-editor/src/components/pages/health/trends/format-pane-value.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/health/trends/format-pane-value.test.ts
@@ -27,6 +27,17 @@ describe("formatPaneValue", () => {
     expect(out).toBe("72.3 kg");
   });
 
+  it("should format weight values in pounds for imperial units", () => {
+    // Arrange
+    const metric = byKey("weight");
+
+    // Act
+    const out = formatPaneValue(metric, WEIGHT_KG, "imperial");
+
+    // Assert
+    expect(out).toBe("159.5 lb");
+  });
+
   it("should format HRV values as integer milliseconds", () => {
     // Arrange
     const metric = byKey("hrv");

--- a/packages/workout-spa-editor/src/components/pages/health/trends/format-pane-value.ts
+++ b/packages/workout-spa-editor/src/components/pages/health/trends/format-pane-value.ts
@@ -2,7 +2,8 @@
 // to toast()/console.* without re-evaluating the static-source rule
 // (scripts/check-no-pii-leakage.mjs walks components/hooks/lib).
 
-import { formatWeightKg, type Units } from "../../../../lib/units/units";
+import type { Units } from "../../../../lib/units/units";
+import { formatWeightKg } from "../../../../lib/units/units";
 import type { TrendMetricDef, TrendMetricKey } from "./trend-metrics";
 
 const EMPTY = "—";

--- a/packages/workout-spa-editor/src/components/pages/health/trends/format-pane-value.ts
+++ b/packages/workout-spa-editor/src/components/pages/health/trends/format-pane-value.ts
@@ -2,6 +2,7 @@
 // to toast()/console.* without re-evaluating the static-source rule
 // (scripts/check-no-pii-leakage.mjs walks components/hooks/lib).
 
+import { formatWeightKg, type Units } from "../../../../lib/units/units";
 import type { TrendMetricDef, TrendMetricKey } from "./trend-metrics";
 
 const EMPTY = "—";
@@ -19,8 +20,11 @@ const FORMATTERS: Record<TrendMetricKey, Formatter> = {
 
 export const formatPaneValue = (
   metric: TrendMetricDef,
-  v: number | null | undefined
+  v: number | null | undefined,
+  units: Units = "metric"
 ): string => {
   if (v === null || v === undefined || !Number.isFinite(v)) return EMPTY;
+  // Weight values are stored in kilograms; relabel in the active units.
+  if (metric.key === "weight") return formatWeightKg(v, units);
   return FORMATTERS[metric.key](v);
 };

--- a/packages/workout-spa-editor/src/contexts/units-context.test.tsx
+++ b/packages/workout-spa-editor/src/contexts/units-context.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { UnitsProvider, useUnits } from "./units-context";
+
+vi.mock("../hooks/use-active-profile-live", () => ({
+  useActiveProfileLive: () => ({ id: "p1", profile: null }),
+}));
+
+const prefsMock = vi.hoisted(() => ({ value: undefined as unknown }));
+
+vi.mock("../hooks/use-user-preferences", () => ({
+  useUserPreferences: () => prefsMock.value,
+}));
+
+const Probe = () => <span data-testid="units">{useUnits()}</span>;
+
+describe("useUnits", () => {
+  it("should default to metric outside a provider", () => {
+    // Arrange
+    prefsMock.value = undefined;
+
+    // Act
+    render(<Probe />);
+
+    // Assert
+    expect(screen.getByTestId("units")).toHaveTextContent("metric");
+  });
+
+  it("should default to metric when the preference is absent", () => {
+    // Arrange
+    prefsMock.value = { profileId: "p1", calendarView: "grid" };
+
+    // Act
+    render(
+      <UnitsProvider>
+        <Probe />
+      </UnitsProvider>
+    );
+
+    // Assert
+    expect(screen.getByTestId("units")).toHaveTextContent("metric");
+  });
+
+  it("should expose the persisted imperial preference", () => {
+    // Arrange
+    prefsMock.value = {
+      profileId: "p1",
+      calendarView: "grid",
+      units: "imperial",
+    };
+
+    // Act
+    render(
+      <UnitsProvider>
+        <Probe />
+      </UnitsProvider>
+    );
+
+    // Assert
+    expect(screen.getByTestId("units")).toHaveTextContent("imperial");
+  });
+});

--- a/packages/workout-spa-editor/src/contexts/units-context.tsx
+++ b/packages/workout-spa-editor/src/contexts/units-context.tsx
@@ -1,0 +1,33 @@
+/**
+ * UnitsContext — single source of the active profile's measurement system
+ * for display. Reads the per-profile `units` preference once at the root so
+ * the many render-time formatters (step cards, thresholds, weight) do not
+ * each open a Dexie live query. Absent preference (or no provider) defaults
+ * to `metric`, matching the display-only conversion contract.
+ */
+
+import { createContext, type ReactNode, useContext } from "react";
+
+import { useActiveProfileLive } from "../hooks/use-active-profile-live";
+import { useUserPreferences } from "../hooks/use-user-preferences";
+import type { Units } from "../types/user-preferences";
+
+export type { Units };
+
+const UnitsContext = createContext<Units | undefined>(undefined);
+
+export const UnitsProvider = ({ children }: { children: ReactNode }) => {
+  const active = useActiveProfileLive();
+  const prefs = useUserPreferences({
+    profileId: active?.id ?? null,
+    defaultView: "grid",
+  });
+  const units: Units = prefs?.units ?? "metric";
+
+  return (
+    <UnitsContext.Provider value={units}>{children}</UnitsContext.Provider>
+  );
+};
+
+/** Active measurement system; defaults to `metric` outside a provider. */
+export const useUnits = (): Units => useContext(UnitsContext) ?? "metric";

--- a/packages/workout-spa-editor/src/lib/athlete/derive-thresholds.test.ts
+++ b/packages/workout-spa-editor/src/lib/athlete/derive-thresholds.test.ts
@@ -52,6 +52,38 @@ describe("deriveThresholdMetrics", () => {
     });
   });
 
+  it("should convert running threshold pace to min/mi for imperial units", () => {
+    // Arrange
+    const profile = profileWith("running", {
+      thresholdPace: 245,
+      paceUnit: "min_per_km",
+    });
+
+    // Act
+    const metrics = deriveThresholdMetrics(profile, "running", "imperial");
+
+    // Assert
+    expect(metrics[0]).toMatchObject({
+      value: "6:34",
+      unit: "/mi",
+      label: "Threshold pace",
+    });
+  });
+
+  it("should convert swimming CSS pace to 100yd for imperial units", () => {
+    // Arrange
+    const profile = profileWith("swimming", {
+      thresholdPace: SWIM_CSS_PACE,
+      paceUnit: "min_per_100m",
+    });
+
+    // Act
+    const metrics = deriveThresholdMetrics(profile, "swimming", "imperial");
+
+    // Assert
+    expect(metrics[0]).toMatchObject({ value: "1:30", unit: "/100yd" });
+  });
+
   it("should omit unset metrics and accent the first present one", () => {
     // Arrange
     const profile = profileWith("cycling", { lthr: LTHR });

--- a/packages/workout-spa-editor/src/lib/athlete/derive-thresholds.ts
+++ b/packages/workout-spa-editor/src/lib/athlete/derive-thresholds.ts
@@ -1,4 +1,5 @@
 import type { Profile } from "../../types/profile";
+import type { Units } from "../units/units";
 import type { ActiveSport } from "./sports";
 import { thresholdCandidates } from "./threshold-candidates";
 
@@ -14,10 +15,11 @@ export type ThresholdMetric = {
     is rendered in the accent color (per the design). */
 export function deriveThresholdMetrics(
   profile: Profile,
-  sport: ActiveSport
+  sport: ActiveSport,
+  units: Units = "metric"
 ): ThresholdMetric[] {
   const thresholds = profile.sportZones[sport]?.thresholds;
-  return thresholdCandidates(sport, thresholds, profile.maxHeartRate)
+  return thresholdCandidates(sport, thresholds, profile.maxHeartRate, units)
     .filter(
       (
         candidate

--- a/packages/workout-spa-editor/src/lib/athlete/derive-zone-map.test.ts
+++ b/packages/workout-spa-editor/src/lib/athlete/derive-zone-map.test.ts
@@ -59,6 +59,21 @@ describe("deriveZoneMap", () => {
     expect(map?.[ZONE_5].range).toBe("< 4:00 /km");
   });
 
+  it("should label the running pace view in min/mi for imperial units", () => {
+    // Arrange
+    const profile = profileWith("running", {
+      thresholdPace: THRESHOLD_PACE_KM,
+      paceUnit: "min_per_km",
+    });
+
+    // Act
+    const map = deriveZoneMap(profile, "running", "imperial");
+
+    // Assert
+    expect(map?.[ZONE_1].range.endsWith("/mi")).toBe(true);
+    expect(map?.[ZONE_5].range.endsWith("/mi")).toBe(true);
+  });
+
   it("should return null when the sport has no usable threshold", () => {
     // Arrange
     const profile = profileWith("cycling", {});

--- a/packages/workout-spa-editor/src/lib/athlete/derive-zone-map.ts
+++ b/packages/workout-spa-editor/src/lib/athlete/derive-zone-map.ts
@@ -1,10 +1,7 @@
 import type { ZoneMapEntry } from "../../components/organisms/ZoneMap";
 import type { Profile } from "../../types/profile";
-import {
-  paceSecondsFactor,
-  paceUnitLabelFor,
-  type Units,
-} from "../units/units";
+import type { Units } from "../units/units";
+import { paceSecondsFactor, paceUnitLabelFor } from "../units/units";
 import type { ActiveSport } from "./sports";
 import { buildZoneMap } from "./zone-bands";
 import { HR_MODEL, PACE_MODEL, POWER_MODEL } from "./zone-models";

--- a/packages/workout-spa-editor/src/lib/athlete/derive-zone-map.ts
+++ b/packages/workout-spa-editor/src/lib/athlete/derive-zone-map.ts
@@ -1,61 +1,13 @@
 import type { ZoneMapEntry } from "../../components/organisms/ZoneMap";
 import type { Profile } from "../../types/profile";
-import type { ZoneNumber } from "../zone-colors";
-import { formatPace, paceUnitLabel } from "./format";
-import type { ActiveSport } from "./sports";
 import {
-  HR_MODEL,
-  PACE_MODEL,
-  POWER_MODEL,
-  ZONE_WEIGHTS,
-  type ZoneBandModel,
-} from "./zone-models";
-
-type Bands = readonly [number, number, number, number];
-
-function ascendingRanges(threshold: number, bounds: Bands, suffix: string) {
-  const [a, b, c, d] = bounds.map((fraction) =>
-    Math.round(threshold * fraction)
-  );
-  return [
-    `< ${a}${suffix}`,
-    `${a}–${b}${suffix}`,
-    `${b}–${c}${suffix}`,
-    `${c}–${d}${suffix}`,
-    `> ${d}${suffix}`,
-  ] as const;
-}
-
-function paceRanges(threshold: number, bounds: Bands, suffix: string) {
-  const [a, b, c, d] = bounds.map((fraction) =>
-    formatPace(threshold / fraction)
-  );
-  return [
-    `> ${a}${suffix}`,
-    `${b}–${a}${suffix}`,
-    `${c}–${b}${suffix}`,
-    `${d}–${c}${suffix}`,
-    `< ${d}${suffix}`,
-  ] as const;
-}
-
-function buildZoneMap(
-  model: ZoneBandModel,
-  threshold: number,
-  suffix: string
-): ZoneMapEntry[] {
-  const ranges =
-    model.kind === "pace"
-      ? paceRanges(threshold, model.bounds, suffix)
-      : ascendingRanges(threshold, model.bounds, suffix);
-  return model.names.map((name, i) => ({
-    n: (i + 1) as ZoneNumber,
-    name,
-    range: ranges[i]!,
-    pct: model.pcts[i]!,
-    w: ZONE_WEIGHTS[i]!,
-  }));
-}
+  paceSecondsFactor,
+  paceUnitLabelFor,
+  type Units,
+} from "../units/units";
+import type { ActiveSport } from "./sports";
+import { buildZoneMap } from "./zone-bands";
+import { HR_MODEL, PACE_MODEL, POWER_MODEL } from "./zone-models";
 
 /** Derives the canonical 5-zone map for a sport from its stored threshold.
     Primary metric: cycling→power, running/swimming→pace; falls back to HR
@@ -63,7 +15,8 @@ function buildZoneMap(
     threshold exists for the sport. */
 export function deriveZoneMap(
   profile: Profile,
-  sport: ActiveSport
+  sport: ActiveSport,
+  units: Units = "metric"
 ): ZoneMapEntry[] | null {
   const thresholds = profile.sportZones[sport]?.thresholds;
   if (!thresholds) return null;
@@ -72,13 +25,13 @@ export function deriveZoneMap(
     return buildZoneMap(POWER_MODEL, thresholds.ftp, " W");
   }
   if (sport !== "cycling" && thresholds.thresholdPace) {
-    const unit =
+    const base =
       thresholds.paceUnit ??
       (sport === "swimming" ? "min_per_100m" : "min_per_km");
     return buildZoneMap(
       PACE_MODEL,
-      thresholds.thresholdPace,
-      ` ${paceUnitLabel(unit)}`
+      thresholds.thresholdPace * paceSecondsFactor(base, units),
+      ` ${paceUnitLabelFor(base, units)}`
     );
   }
   if (thresholds.lthr) return buildZoneMap(HR_MODEL, thresholds.lthr, " bpm");

--- a/packages/workout-spa-editor/src/lib/athlete/threshold-candidates.ts
+++ b/packages/workout-spa-editor/src/lib/athlete/threshold-candidates.ts
@@ -1,9 +1,6 @@
 import type { SportThresholds } from "../../types/sport-zones";
-import {
-  paceSecondsFactor,
-  paceUnitLabelFor,
-  type Units,
-} from "../units/units";
+import type { Units } from "../units/units";
+import { paceSecondsFactor, paceUnitLabelFor } from "../units/units";
 import { formatPace } from "./format";
 import type { ActiveSport } from "./sports";
 

--- a/packages/workout-spa-editor/src/lib/athlete/threshold-candidates.ts
+++ b/packages/workout-spa-editor/src/lib/athlete/threshold-candidates.ts
@@ -1,5 +1,10 @@
 import type { SportThresholds } from "../../types/sport-zones";
-import { formatPace, paceUnitLabel } from "./format";
+import {
+  paceSecondsFactor,
+  paceUnitLabelFor,
+  type Units,
+} from "../units/units";
+import { formatPace } from "./format";
 import type { ActiveSport } from "./sports";
 
 export type ThresholdCandidate = {
@@ -29,13 +34,17 @@ function hrCandidates(
 function paceCandidate(
   thresholds: SportThresholds | undefined,
   fallbackUnit: SportThresholds["paceUnit"],
-  label: string
+  label: string,
+  units: Units
 ): ThresholdCandidate {
   const pace = thresholds?.thresholdPace;
-  const unit = thresholds?.paceUnit ?? fallbackUnit ?? "min_per_km";
+  const base = thresholds?.paceUnit ?? fallbackUnit ?? "min_per_km";
   return {
-    value: pace === undefined ? undefined : formatPace(pace),
-    unit: paceUnitLabel(unit),
+    value:
+      pace === undefined
+        ? undefined
+        : formatPace(pace * paceSecondsFactor(base, units)),
+    unit: paceUnitLabelFor(base, units),
     label,
   };
 }
@@ -44,7 +53,8 @@ function paceCandidate(
 export function thresholdCandidates(
   sport: ActiveSport,
   thresholds: SportThresholds | undefined,
-  maxHeartRate: number | undefined
+  maxHeartRate: number | undefined,
+  units: Units = "metric"
 ): ThresholdCandidate[] {
   if (sport === "cycling") {
     return [
@@ -54,12 +64,12 @@ export function thresholdCandidates(
   }
   if (sport === "running") {
     return [
-      paceCandidate(thresholds, "min_per_km", "Threshold pace"),
+      paceCandidate(thresholds, "min_per_km", "Threshold pace", units),
       ...hrCandidates(thresholds, maxHeartRate, true),
     ];
   }
   return [
-    paceCandidate(thresholds, "min_per_100m", "CSS pace"),
+    paceCandidate(thresholds, "min_per_100m", "CSS pace", units),
     ...hrCandidates(thresholds, maxHeartRate, false),
   ];
 }

--- a/packages/workout-spa-editor/src/lib/athlete/zone-bands.ts
+++ b/packages/workout-spa-editor/src/lib/athlete/zone-bands.ts
@@ -1,0 +1,51 @@
+import type { ZoneMapEntry } from "../../components/organisms/ZoneMap";
+import type { ZoneNumber } from "../zone-colors";
+import { formatPace } from "./format";
+import { ZONE_WEIGHTS, type ZoneBandModel } from "./zone-models";
+
+type Bands = readonly [number, number, number, number];
+
+function ascendingRanges(threshold: number, bounds: Bands, suffix: string) {
+  const [a, b, c, d] = bounds.map((fraction) =>
+    Math.round(threshold * fraction)
+  );
+  return [
+    `< ${a}${suffix}`,
+    `${a}–${b}${suffix}`,
+    `${b}–${c}${suffix}`,
+    `${c}–${d}${suffix}`,
+    `> ${d}${suffix}`,
+  ] as const;
+}
+
+function paceRanges(threshold: number, bounds: Bands, suffix: string) {
+  const [a, b, c, d] = bounds.map((fraction) =>
+    formatPace(threshold / fraction)
+  );
+  return [
+    `> ${a}${suffix}`,
+    `${b}–${a}${suffix}`,
+    `${c}–${b}${suffix}`,
+    `${d}–${c}${suffix}`,
+    `< ${d}${suffix}`,
+  ] as const;
+}
+
+/** Builds the 5 zone-map entries from a model, threshold value and suffix. */
+export function buildZoneMap(
+  model: ZoneBandModel,
+  threshold: number,
+  suffix: string
+): ZoneMapEntry[] {
+  const ranges =
+    model.kind === "pace"
+      ? paceRanges(threshold, model.bounds, suffix)
+      : ascendingRanges(threshold, model.bounds, suffix);
+  return model.names.map((name, i) => ({
+    n: (i + 1) as ZoneNumber,
+    name,
+    range: ranges[i]!,
+    pct: model.pcts[i]!,
+    w: ZONE_WEIGHTS[i]!,
+  }));
+}

--- a/packages/workout-spa-editor/src/lib/units/units.test.ts
+++ b/packages/workout-spa-editor/src/lib/units/units.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  convertKg,
+  formatMinutesSeconds,
+  formatPaceFromMps,
+  formatWeightKg,
+  paceSecondsFactor,
+  paceUnitLabelFor,
+  runPaceLabel,
+  weightUnitLabel,
+} from "./units";
+
+const METERS_PER_KM = 1000;
+const PACE_MINUTES = 4.5;
+const SECONDS_PER_MINUTE = 60;
+const KM_PER_MILE = 1.609344;
+const YARD_PER_METER = 0.9144;
+const FACTOR_PRECISION = 6;
+const SAMPLE_KG = 72;
+const SAMPLE_LB = 158.73;
+const LB_PRECISION = 2;
+const MPS_AT_4_30 = METERS_PER_KM / (PACE_MINUTES * SECONDS_PER_MINUTE);
+
+describe("formatMinutesSeconds", () => {
+  it("should format whole seconds as m:ss", () => {
+    // Arrange
+    const seconds = 245;
+
+    // Act
+    const result = formatMinutesSeconds(seconds);
+
+    // Assert
+    expect(result).toBe("4:05");
+  });
+
+  it("should roll 60 rounded seconds up to the next minute", () => {
+    // Arrange
+    const seconds = 119.6;
+
+    // Act
+    const result = formatMinutesSeconds(seconds);
+
+    // Assert
+    expect(result).toBe("2:00");
+  });
+
+  it("should return a placeholder for non-positive input", () => {
+    // Arrange
+    const seconds = 0;
+
+    // Act
+    const result = formatMinutesSeconds(seconds);
+
+    // Assert
+    expect(result).toBe("--:--");
+  });
+});
+
+describe("formatPaceFromMps", () => {
+  it("should format metric pace as min per km", () => {
+    // Arrange
+    const mps = MPS_AT_4_30;
+
+    // Act
+    const result = formatPaceFromMps(mps, "metric");
+
+    // Assert
+    expect(result).toBe("4:30");
+  });
+
+  it("should format imperial pace as min per mile", () => {
+    // Arrange
+    const mps = MPS_AT_4_30;
+
+    // Act
+    const result = formatPaceFromMps(mps, "imperial");
+
+    // Assert
+    expect(result).toBe("7:15");
+  });
+
+  it("should return a placeholder for a non-positive speed", () => {
+    // Arrange
+    const mps = 0;
+
+    // Act
+    const result = formatPaceFromMps(mps, "imperial");
+
+    // Assert
+    expect(result).toBe("--:--");
+  });
+});
+
+describe("runPaceLabel", () => {
+  it("should label metric pace as min/km", () => {
+    // Arrange
+    const units = "metric" as const;
+
+    // Act
+    const result = runPaceLabel(units);
+
+    // Assert
+    expect(result).toBe("min/km");
+  });
+
+  it("should label imperial pace as min/mi", () => {
+    // Arrange
+    const units = "imperial" as const;
+
+    // Act
+    const result = runPaceLabel(units);
+
+    // Assert
+    expect(result).toBe("min/mi");
+  });
+});
+
+describe("paceSecondsFactor", () => {
+  it("should leave metric pace unscaled", () => {
+    // Arrange
+    const base = "min_per_km" as const;
+
+    // Act
+    const result = paceSecondsFactor(base, "metric");
+
+    // Assert
+    expect(result).toBe(1);
+  });
+
+  it("should scale per-km pace to per-mile for imperial", () => {
+    // Arrange
+    const base = "min_per_km" as const;
+
+    // Act
+    const result = paceSecondsFactor(base, "imperial");
+
+    // Assert
+    expect(result).toBeCloseTo(KM_PER_MILE, FACTOR_PRECISION);
+  });
+
+  it("should scale per-100m pace to per-100yd for imperial", () => {
+    // Arrange
+    const base = "min_per_100m" as const;
+
+    // Act
+    const result = paceSecondsFactor(base, "imperial");
+
+    // Assert
+    expect(result).toBeCloseTo(YARD_PER_METER, FACTOR_PRECISION);
+  });
+});
+
+describe("paceUnitLabelFor", () => {
+  it("should keep metric km and 100m suffixes", () => {
+    // Arrange
+    const units = "metric" as const;
+
+    // Act
+    const km = paceUnitLabelFor("min_per_km", units);
+    const swim = paceUnitLabelFor("min_per_100m", units);
+
+    // Assert
+    expect(km).toBe("/km");
+    expect(swim).toBe("/100m");
+  });
+
+  it("should map to mile and 100yd suffixes for imperial", () => {
+    // Arrange
+    const units = "imperial" as const;
+
+    // Act
+    const run = paceUnitLabelFor("min_per_km", units);
+    const swim = paceUnitLabelFor("min_per_100m", units);
+
+    // Assert
+    expect(run).toBe("/mi");
+    expect(swim).toBe("/100yd");
+  });
+});
+
+describe("weight conversion", () => {
+  it("should leave kilograms unchanged for metric", () => {
+    // Arrange
+    const kg = SAMPLE_KG;
+
+    // Act
+    const value = convertKg(kg, "metric");
+    const label = weightUnitLabel("metric");
+
+    // Assert
+    expect(value).toBe(SAMPLE_KG);
+    expect(label).toBe("kg");
+  });
+
+  it("should convert kilograms to pounds for imperial", () => {
+    // Arrange
+    const kg = SAMPLE_KG;
+
+    // Act
+    const result = convertKg(kg, "imperial");
+
+    // Assert
+    expect(result).toBeCloseTo(SAMPLE_LB, LB_PRECISION);
+  });
+
+  it("should format weight with the active unit suffix", () => {
+    // Arrange
+    const kg = SAMPLE_KG;
+
+    // Act
+    const metric = formatWeightKg(kg, "metric");
+    const imperial = formatWeightKg(kg, "imperial");
+
+    // Assert
+    expect(metric).toBe("72.0 kg");
+    expect(imperial).toBe("158.7 lb");
+  });
+});

--- a/packages/workout-spa-editor/src/lib/units/units.ts
+++ b/packages/workout-spa-editor/src/lib/units/units.ts
@@ -1,0 +1,66 @@
+/**
+ * Display-only unit conversion. The canonical domain stays in SI
+ * (m/s for pace, kilograms for weight); these helpers convert ONLY for
+ * rendering. Callers default to `metric` so existing call sites are
+ * unaffected until they opt into the active `units` preference.
+ */
+
+import type { Units } from "../../types/user-preferences";
+
+export type { Units };
+
+/** Pace base unit as stored on athlete thresholds. */
+export type PaceBase = "min_per_km" | "min_per_100m";
+
+const KM_PER_MILE = 1.609344;
+const LB_PER_KG = 2.2046226218487757;
+// 100 yards = 91.44 m, so seconds per 100yd = seconds per 100m × 0.9144.
+const YARD_PER_METER = 0.9144;
+
+const SECONDS_PER_MINUTE = 60;
+
+/** Formats a non-negative seconds value as "m:ss" (e.g. 245 → "4:05"). */
+export const formatMinutesSeconds = (totalSeconds: number): string => {
+  if (!Number.isFinite(totalSeconds) || totalSeconds <= 0) return "--:--";
+  const minutes = Math.floor(totalSeconds / SECONDS_PER_MINUTE);
+  const seconds = Math.round(totalSeconds - minutes * SECONDS_PER_MINUTE);
+  if (seconds === SECONDS_PER_MINUTE) return `${minutes + 1}:00`;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+};
+
+/** Pace unit suffix for the m/s-based running pace (workout step targets). */
+export const runPaceLabel = (units: Units): string =>
+  units === "imperial" ? "min/mi" : "min/km";
+
+/** Formats a m/s speed as an "m:ss" running pace in the active units. */
+export const formatPaceFromMps = (mps: number, units: Units): string => {
+  if (!Number.isFinite(mps) || mps <= 0) return "--:--";
+  const secondsPerKm = 1000 / mps;
+  const seconds =
+    units === "imperial" ? secondsPerKm * KM_PER_MILE : secondsPerKm;
+  return formatMinutesSeconds(seconds);
+};
+
+/** Multiplier applied to a stored pace (seconds per base unit) for display. */
+export const paceSecondsFactor = (base: PaceBase, units: Units): number => {
+  if (units === "metric") return 1;
+  return base === "min_per_100m" ? YARD_PER_METER : KM_PER_MILE;
+};
+
+/** Pace suffix for an athlete threshold pace in the active units. */
+export const paceUnitLabelFor = (base: PaceBase, units: Units): string => {
+  if (base === "min_per_100m") return units === "imperial" ? "/100yd" : "/100m";
+  return units === "imperial" ? "/mi" : "/km";
+};
+
+/** Weight unit suffix in the active units. */
+export const weightUnitLabel = (units: Units): string =>
+  units === "imperial" ? "lb" : "kg";
+
+/** Converts a kilogram value to the active units (kg or pounds). */
+export const convertKg = (kg: number, units: Units): number =>
+  units === "imperial" ? kg * LB_PER_KG : kg;
+
+/** Formats a kilogram value with its unit suffix in the active units. */
+export const formatWeightKg = (kg: number, units: Units, digits = 1): string =>
+  `${convertKg(kg, units).toFixed(digits)} ${weightUnitLabel(units)}`;

--- a/packages/workout-spa-editor/src/main.tsx
+++ b/packages/workout-spa-editor/src/main.tsx
@@ -19,6 +19,7 @@ import {
 import { CoachingRegistryBootstrap } from "./contexts/coaching-registry-bootstrap";
 import { PersistenceProvider } from "./contexts/persistence-context";
 import { SyncProvider } from "./contexts/sync-context";
+import { UnitsProvider } from "./contexts/units-context";
 import { reloadOnceForChunkError } from "./lib/chunk-reload";
 import { getDeviceId } from "./lib/cloud-sync/device-id";
 import { getSyncPassphrase } from "./lib/cloud-sync/encryption-runtime";
@@ -58,9 +59,11 @@ createRoot(document.getElementById("root")!).render(
           <ThemeProvider defaultTheme="dark">
             <GarminBridgeProvider>
               <CoachingRegistryBootstrap>
-                <Router base={routerBase}>
-                  <App />
-                </Router>
+                <UnitsProvider>
+                  <Router base={routerBase}>
+                    <App />
+                  </Router>
+                </UnitsProvider>
               </CoachingRegistryBootstrap>
             </GarminBridgeProvider>
           </ThemeProvider>

--- a/packages/workout-spa-editor/src/types/user-preferences.ts
+++ b/packages/workout-spa-editor/src/types/user-preferences.ts
@@ -15,6 +15,10 @@ export const calendarViewSchema = z.enum(["grid", "list"]);
 
 export type CalendarView = z.infer<typeof calendarViewSchema>;
 
+export const unitsSchema = z.enum(["metric", "imperial"]);
+
+export type Units = z.infer<typeof unitsSchema>;
+
 export const userPreferencesSchema = z.object({
   profileId: z.string().min(1),
   calendarView: calendarViewSchema,
@@ -24,6 +28,10 @@ export const userPreferencesSchema = z.object({
   /** Sport last selected on the Athlete page; absent until first chosen. */
   activeSport: sportSchema.optional(),
   aiBannerExpanded: z.boolean().optional(),
+  /** Measurement system for display only; absent defaults to metric. */
+  units: unitsSchema.optional(),
+  /** User intent to enable browser notifications; absent defaults to off. */
+  notificationsEnabled: z.boolean().optional(),
   updatedAt: z.iso.datetime(),
 });
 


### PR DESCRIPTION
Closes #716.

The flattened Settings showed **Units** and **Notifications** as display-only rows with no persisted setting behind them. This adds a **Preferences** tab that persists a per-profile preference and wires both rows to it.

## Units (metric / imperial) — display-only
Canonical data stays in SI (m/s, kg); only rendering is relabeled. A new `lib/units` module of pure converters + a `UnitsProvider` context (single root read — no per-card live query) drive it:

- **Step-target pace**: `min/km ↔ min/mi` in `StepCard` and the workout review.
- **Athlete thresholds + zone map**: running `min/mi`, swimming `/100yd`.
- **Weight**: `kg ↔ lb` in the weight history list and health trends (chart series stays in kg; axis/legend relabel at the same physical points).

Inputs and stored values are untouched. Workout-review raw `m/s` is left as-is (SI, identical in both systems).

## Notifications
The toggle drives the **real browser Notification permission** (`requestPermission()`), reflecting granted/denied/default and showing an "unsupported" message where the API is absent — so it controls a real surface instead of being a dead control.

## Notes
- No Dexie migration: `userPreferences` is a plain per-profile object; new fields are optional and default to `metric` / off.
- Extracted `derive-zone-map` range builders into `zone-bands.ts` to stay under the 80-line cap.

## Tests / verification
- New: `lib/units` math, `units-context`, `PreferencesTab`, `NotificationsRow`, `use-notification-permission`; imperial-path cases added to pace/threshold/zone-map/trends formatters.
- Full package suite green (4751 tests), `tsc` + ESLint + Prettier clean, production build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Preferences Tab**: Added a new Preferences tab in Settings where users can select measurement units (metric or imperial) and toggle browser notifications.
* **Unit Display Options**: Workout paces, weights, athlete thresholds, and zones now display in the selected unit system across the app.
* **Notification Control**: Users can enable/disable browser notifications with automatic permission handling.
* **Persisted Settings**: Unit and notification preferences are saved per profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->