### PR TITLE
feat(spa-editor): derive Today battery from stress, not HRV score (#717)

### DIFF
--- a/.changeset/today-battery-from-stress.md
+++ b/.changeset/today-battery-from-stress.md
@@ -1,0 +1,10 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Today readiness: derive the "Battery" stat from a real, independent signal
+(the day's ingested stress episodes) instead of reusing the HRV overnight
+score. Battery now shows a daily-energy proxy — 100 − mean stress level,
+clamped 0–100 — and falls back to the em-dash empty state when no stress
+record exists for the day. Full Garmin Body Battery ingestion remains a
+follow-up.

--- a/packages/workout-spa-editor/src/components/pages/Today/readiness-metrics.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/readiness-metrics.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure per-stat derivations for the Today readiness card. Each resolves to a
+ * display string (or the em-dash placeholder when its record is absent); no
+ * values are invented.
+ */
+import type { HrvSummary, SleepRecord, StressEpisode } from "@kaiord/core";
+
+export const EM_DASH = "—";
+export const SCORE_MAX = 100;
+const SCORE_MIN = 0;
+const SECONDS_PER_HOUR = 3600;
+const HRV_TREND_THRESHOLD = 0;
+
+export function compositeScore(
+  hrv: HrvSummary | undefined,
+  sleep: SleepRecord | undefined
+): number | null {
+  const scores = [hrv?.score, sleep?.score].filter(
+    (value): value is number => typeof value === "number"
+  );
+  if (scores.length === 0) return null;
+  const sum = scores.reduce((acc, value) => acc + value, 0);
+  return Math.round(sum / scores.length);
+}
+
+export function sleepValue(sleep: SleepRecord | undefined): string {
+  if (!sleep) return EM_DASH;
+  const hours = sleep.totalDurationSeconds / SECONDS_PER_HOUR;
+  return `${hours.toFixed(1)}h`;
+}
+
+export function hrvTrend(hrv: HrvSummary | undefined): string | undefined {
+  if (!hrv?.score) return undefined;
+  return hrv.score > HRV_TREND_THRESHOLD ? "balanced" : undefined;
+}
+
+/**
+ * Daily-energy proxy from the day's stress episodes: 100 − mean(averageLevel),
+ * clamped to 0..100. Em-dash when no stress record exists for the day.
+ */
+export function batteryValue(stress: StressEpisode[] | undefined): string {
+  if (!stress || stress.length === 0) return EM_DASH;
+  const mean =
+    stress.reduce((sum, episode) => sum + episode.averageLevel, 0) /
+    stress.length;
+  const energy = Math.min(
+    SCORE_MAX,
+    Math.max(SCORE_MIN, Math.round(SCORE_MAX - mean))
+  );
+  return `${energy}`;
+}

--- a/packages/workout-spa-editor/src/components/pages/Today/today-readiness.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-readiness.test.ts
@@ -1,9 +1,10 @@
-import type { HrvSummary, SleepRecord } from "@kaiord/core";
+import type { HrvSummary, SleepRecord, StressEpisode } from "@kaiord/core";
 import { describe, expect, it } from "vitest";
 
 import { buildReadinessModel } from "./today-readiness";
 
 const EXPECTED_COMPOSITE = 75;
+const EXPECTED_BATTERY = 65;
 
 const HRV: HrvSummary = {
   kind: "hrv",
@@ -24,12 +25,32 @@ const SLEEP: SleepRecord = {
   score: 70,
 };
 
+// Mean averageLevel (30, 40) = 35 → energy = 100 − 35 = 65.
+const STRESS: StressEpisode[] = [
+  {
+    kind: "stress",
+    version: "2.0",
+    startTime: "2026-05-27T08:00:00.000Z",
+    endTime: "2026-05-27T10:00:00.000Z",
+    averageLevel: 30,
+    peakLevel: 55,
+  },
+  {
+    kind: "stress",
+    version: "2.0",
+    startTime: "2026-05-27T12:00:00.000Z",
+    endTime: "2026-05-27T14:00:00.000Z",
+    averageLevel: 40,
+    peakLevel: 60,
+  },
+];
+
 describe("buildReadinessModel", () => {
   it("should average available scores into a composite", () => {
     // Arrange
 
     // Act
-    const model = buildReadinessModel(HRV, SLEEP, true);
+    const model = buildReadinessModel(HRV, SLEEP, STRESS, true);
 
     // Assert
     expect(model.score).toBe(EXPECTED_COMPOSITE);
@@ -40,7 +61,7 @@ describe("buildReadinessModel", () => {
     // Arrange
 
     // Act
-    const model = buildReadinessModel(HRV, SLEEP, false);
+    const model = buildReadinessModel(HRV, SLEEP, STRESS, false);
 
     // Assert
     expect(model.headline).toBe("Good to push");
@@ -50,7 +71,7 @@ describe("buildReadinessModel", () => {
     // Arrange
 
     // Act
-    const model = buildReadinessModel(undefined, undefined, true);
+    const model = buildReadinessModel(undefined, undefined, undefined, true);
 
     // Assert
     expect(model.score).toBeNull();
@@ -59,15 +80,34 @@ describe("buildReadinessModel", () => {
     expect(model.battery.value).toBe("—");
   });
 
-  it("should render rounded HRV and battery values from the summary", () => {
+  it("should render the rounded HRV value from the summary", () => {
     // Arrange
 
     // Act
-    const model = buildReadinessModel(HRV, undefined, true);
+    const model = buildReadinessModel(HRV, undefined, undefined, true);
 
     // Assert
     expect(model.hrv.value).toBe("62");
-    expect(model.battery.value).toBe("80");
     expect(model.sleep.value).toBe("—");
+  });
+
+  it("should derive battery as 100 minus the mean stress level", () => {
+    // Arrange
+
+    // Act
+    const model = buildReadinessModel(undefined, undefined, STRESS, true);
+
+    // Assert
+    expect(model.battery.value).toBe(`${EXPECTED_BATTERY}`);
+  });
+
+  it("should em-dash the battery when no stress is recorded", () => {
+    // Arrange
+
+    // Act
+    const model = buildReadinessModel(HRV, SLEEP, [], true);
+
+    // Assert
+    expect(model.battery.value).toBe("—");
   });
 });

--- a/packages/workout-spa-editor/src/components/pages/Today/today-readiness.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/today-readiness.ts
@@ -1,17 +1,24 @@
 /**
  * Readiness view-model derivation for the Today page.
  *
- * Inputs are Garmin daily metrics persisted under the v16 health stores:
- * the overnight HRV summary (`rMSSD` + optional 0..100 `score`) and the
- * sleep session (`score` + duration). No values are invented — every metric
- * resolves to a string or the em-dash placeholder when its record is absent.
+ * Inputs are Garmin daily metrics persisted under the health stores: the
+ * overnight HRV summary (`rMSSD` + optional 0..100 `score`), the sleep
+ * session (`score` + duration), and the day's stress episodes. The Battery
+ * stat is a daily-energy proxy derived from stress (100 − mean stress level),
+ * an independent signal — not the HRV score. No values are invented: every
+ * metric resolves to a string or the em-dash placeholder when its record is
+ * absent.
  */
-import type { HrvSummary, SleepRecord } from "@kaiord/core";
+import type { HrvSummary, SleepRecord, StressEpisode } from "@kaiord/core";
 
-const EM_DASH = "—";
-const SECONDS_PER_HOUR = 3600;
-const HRV_TREND_THRESHOLD = 0;
-const SCORE_MAX = 100;
+import {
+  batteryValue,
+  compositeScore,
+  EM_DASH,
+  hrvTrend,
+  SCORE_MAX,
+  sleepValue,
+} from "./readiness-metrics";
 
 const HEADLINE_PUSH_TODAY = "Good to push today";
 const HEADLINE_PUSH = "Good to push";
@@ -38,32 +45,10 @@ export type ReadinessModel = {
   battery: ReadinessMetric;
 };
 
-function compositeScore(
-  hrv: HrvSummary | undefined,
-  sleep: SleepRecord | undefined
-): number | null {
-  const scores = [hrv?.score, sleep?.score].filter(
-    (value): value is number => typeof value === "number"
-  );
-  if (scores.length === 0) return null;
-  const sum = scores.reduce((acc, value) => acc + value, 0);
-  return Math.round(sum / scores.length);
-}
-
-function sleepValue(sleep: SleepRecord | undefined): string {
-  if (!sleep) return EM_DASH;
-  const hours = sleep.totalDurationSeconds / SECONDS_PER_HOUR;
-  return `${hours.toFixed(1)}h`;
-}
-
-function hrvTrend(hrv: HrvSummary | undefined): string | undefined {
-  if (!hrv?.score) return undefined;
-  return hrv.score > HRV_TREND_THRESHOLD ? "balanced" : undefined;
-}
-
 export function buildReadinessModel(
   hrv: HrvSummary | undefined,
   sleep: SleepRecord | undefined,
+  stress: StressEpisode[] | undefined,
   isFocusToday: boolean
 ): ReadinessModel {
   const score = compositeScore(hrv, sleep);
@@ -84,9 +69,6 @@ export function buildReadinessModel(
       trend: hrvTrend(hrv),
     },
     sleep: { label: "Sleep", value: sleepValue(sleep) },
-    battery: {
-      label: "Battery",
-      value: hrv?.score !== undefined ? `${hrv.score}` : EM_DASH,
-    },
+    battery: { label: "Battery", value: batteryValue(stress) },
   };
 }

--- a/packages/workout-spa-editor/src/components/pages/Today/use-today-data.ts
+++ b/packages/workout-spa-editor/src/components/pages/Today/use-today-data.ts
@@ -1,12 +1,13 @@
 /**
  * Aggregates every reactive source the Today page renders: the active
- * profile, this week's workouts, and today's Garmin health metrics (HRV +
- * sleep). View-model derivation stays in the pure `today-*` helpers.
+ * profile, this week's workouts, and today's Garmin health metrics (HRV,
+ * sleep, stress). View-model derivation stays in the pure `today-*` helpers.
  */
 import { useMemo } from "react";
 
 import { useHealthHrvHistoryLive } from "../../../hooks/health/use-health-hrv-history-live";
 import { useHealthSleepWeekLive } from "../../../hooks/health/use-health-sleep-week-live";
+import { useHealthStressDayLive } from "../../../hooks/health/use-health-stress-day-live";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { CoachingActivity } from "../../../types/coaching-activity";
@@ -55,6 +56,7 @@ export function useTodayData(focusDate: Date, realTodayIso: string): TodayData {
     start: focusIso,
     end: focusIso,
   });
+  const stressRecords = useHealthStressDayLive(profileId ?? "", focusIso);
 
   const { planned, weekSummary, coachingByDay, expandActivity } =
     useTodayPlannedBuckets(profileId, dayIsos, focusIso, weekWorkouts, profile);
@@ -62,6 +64,7 @@ export function useTodayData(focusDate: Date, realTodayIso: string): TodayData {
   const readiness = buildReadinessModel(
     hrvRecords?.at(-1)?.krd,
     sleepRecords?.at(-1)?.krd,
+    stressRecords?.map((record) => record.krd),
     isFocusToday
   );
 


### PR DESCRIPTION
Closes #717.

The Today readiness **Battery** stat reused `hrv.score` — making it redundant with the HRV stat (both HRV-derived) and mislabeling HRV as energy.

## Finding
No real Body Battery value is ingested anywhere in the app (only a FIT message-type name exists). But the day's **stress episodes are fully ingested** (`healthStress` Dexie store + `useHealthStressDayLive` + `StressEpisode` 0–100).

## Change
Battery is now a **daily-energy proxy from the real stress signal**: `100 − mean(averageLevel)`, clamped 0–100, with the em-dash empty state when no stress record exists for the day. This is a real, independent metric (per the issue's "derive… or equivalent daily-energy") and removes the HRV redundancy.

- `today-readiness.ts`: `buildReadinessModel` takes the day's stress episodes; Battery derived from them.
- `use-today-data.ts`: feeds today's stress via `useHealthStressDayLive`.
- Pure per-stat derivations extracted to `readiness-metrics.ts` (keeps `today-readiness.ts` under the 80-line cap).

## Follow-up (not in scope)
Full Garmin Body Battery ingestion (core schema + FIT/Garmin parse + Dexie store) is a multi-package epic; tracked as a follow-up.

## Verification
- New tests: battery = 100 − mean stress; em-dash when no stress; HRV stat unchanged.
- Full package suite green (4753), `tsc` + ESLint + Prettier clean, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)