### PR TITLE
perf(spa-editor): index-backed auto-push change token (#725)

### DIFF
--- a/.changeset/sync-change-token-perf.md
+++ b/.changeset/sync-change-token-perf.md
@@ -1,0 +1,12 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Cross-device sync: make the auto-push change token cheap. It previously
+`toArray()`-ed every synced table and scanned every row's timestamps on each
+Dexie write (O(all rows) per change). It now reads each table's row `count`
+plus the max of an indexed timestamp (`updatedAt` for workouts/templates/
+profiles via a new Dexie v23 index, `createdAt`/`deletedAt` elsewhere) — O(tables)
+per change. In-place-edit correctness is preserved: an edit sets `updatedAt`
+to now, advancing the per-table max. The v23 migration is index-only
+(non-destructive, no data transform).

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-schemas-early.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-schemas-early.ts
@@ -1,0 +1,48 @@
+/**
+ * Early Dexie schema versions (v1–v13). Split out of `dexie-schemas.ts` so
+ * that file stays under the per-file line cap as the migration history grows;
+ * `dexie-schemas.ts` imports these and assembles the public `SCHEMAS` map.
+ */
+
+export const CORE_V1 = {
+  workouts: "id, date, [date+state], [source+sourceId], sport, *tags",
+  templates: "id, sport, *tags",
+  profiles: "id",
+  aiProviders: "id",
+  syncState: "source",
+  usage: "yearMonth",
+  meta: "key",
+};
+export const CORE_V2 = { ...CORE_V1, bridges: "extensionId, status, lastSeen" };
+export const CORE_V4 = {
+  ...CORE_V2,
+  coachingActivities:
+    "id, [profileId+date], [profileId+source+sourceId], [profileId+source]",
+  coachingSyncState: "[source+profileId], source, profileId",
+};
+export const CORE_V5 = {
+  ...CORE_V4,
+  // PK is `id` (nanoid). Indexes support all spec-mandated queries:
+  //   - [profileId+coachingActivityId] / [profileId+workoutId]: uniqueness
+  //   - [profileId+date]: weekly listByProfileAndWeek
+  //   - coachingActivityId / workoutId: cascade hooks
+  //   - profileId: profile-delete cascade
+  sessionMatches:
+    "id, [profileId+coachingActivityId], [profileId+workoutId], [profileId+date], coachingActivityId, workoutId, profileId",
+  // PK is `profileId` (one row per profile, lazy creation).
+  userPreferences: "profileId",
+  // PK is composite `[profileId+weekStart]`; index on profileId for cascade.
+  autoMatchDismissals: "[profileId+weekStart], profileId",
+};
+// v8 — AI provider insertion-order index. `createdAt` becomes a Dexie
+// index so the repository's getAll can `orderBy("createdAt")` cheaply.
+export const CORE_V8 = { ...CORE_V5, aiProviders: "id, createdAt" };
+// v13 — workouts gain `profileId` so each workout is profile-scoped 1–1.
+// Adds `profileId` and `[profileId+date]` indexes so the calendar's
+// per-profile + date-range query hits an index, and the cascade auto-
+// discovery (`isPerProfileTable`) picks the table up at delete time.
+export const CORE_V13 = {
+  ...CORE_V8,
+  workouts:
+    "id, profileId, [profileId+date], date, [date+state], [source+sourceId], sport, *tags",
+};

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-schemas.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-schemas.test.ts
@@ -91,3 +91,41 @@ describe("SCHEMAS.v21 (chat transcript store)", () => {
     }
   });
 });
+
+describe("SCHEMAS.v23 (auto-push updatedAt indexes)", () => {
+  it("should index updatedAt on the workouts/templates/profiles stores", () => {
+    // Arrange
+    const stores = SCHEMAS.v23 as Record<string, string>;
+
+    // Act
+
+    // Assert
+    for (const name of ["workouts", "templates", "profiles"]) {
+      expect(stores[name].split(", ")).toContain("updatedAt");
+    }
+  });
+
+  it("should add no new stores on top of v22 (index-only change)", () => {
+    // Arrange
+    const v22Keys = new Set(Object.keys(SCHEMAS.v22));
+    const v23Keys = new Set(Object.keys(SCHEMAS.v23));
+
+    // Act
+    const added = [...v23Keys].filter((k) => !v22Keys.has(k));
+
+    // Assert
+    expect(added).toEqual([]);
+  });
+
+  it("should change only workouts/templates/profiles from v22", () => {
+    // Arrange
+    const v22 = SCHEMAS.v22 as Record<string, string>;
+    const v23 = SCHEMAS.v23 as Record<string, string>;
+
+    // Act
+    const changed = Object.keys(v22).filter((k) => v23[k] !== v22[k]);
+
+    // Assert
+    expect(changed.sort()).toEqual(["profiles", "templates", "workouts"]);
+  });
+});

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-schemas.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-schemas.ts
@@ -3,51 +3,18 @@
  *
  * Per-version `stores()` configs for the Kaiord IndexedDB schema.
  * Co-located with `dexie-database.ts` but split out so the database
- * class stays under the per-file line cap.
+ * class stays under the per-file line cap. Early versions (v1–v13) live
+ * in `dexie-schemas-early.ts`; this file adds v16+ and assembles `SCHEMAS`.
  */
 
-const CORE_V1 = {
-  workouts: "id, date, [date+state], [source+sourceId], sport, *tags",
-  templates: "id, sport, *tags",
-  profiles: "id",
-  aiProviders: "id",
-  syncState: "source",
-  usage: "yearMonth",
-  meta: "key",
-};
-const CORE_V2 = { ...CORE_V1, bridges: "extensionId, status, lastSeen" };
-const CORE_V4 = {
-  ...CORE_V2,
-  coachingActivities:
-    "id, [profileId+date], [profileId+source+sourceId], [profileId+source]",
-  coachingSyncState: "[source+profileId], source, profileId",
-};
-const CORE_V5 = {
-  ...CORE_V4,
-  // PK is `id` (nanoid). Indexes support all spec-mandated queries:
-  //   - [profileId+coachingActivityId] / [profileId+workoutId]: uniqueness
-  //   - [profileId+date]: weekly listByProfileAndWeek
-  //   - coachingActivityId / workoutId: cascade hooks
-  //   - profileId: profile-delete cascade
-  sessionMatches:
-    "id, [profileId+coachingActivityId], [profileId+workoutId], [profileId+date], coachingActivityId, workoutId, profileId",
-  // PK is `profileId` (one row per profile, lazy creation).
-  userPreferences: "profileId",
-  // PK is composite `[profileId+weekStart]`; index on profileId for cascade.
-  autoMatchDismissals: "[profileId+weekStart], profileId",
-};
-// v8 — AI provider insertion-order index. `createdAt` becomes a Dexie
-// index so the repository's getAll can `orderBy("createdAt")` cheaply.
-const CORE_V8 = { ...CORE_V5, aiProviders: "id, createdAt" };
-// v13 — workouts gain `profileId` so each workout is profile-scoped 1–1.
-// Adds `profileId` and `[profileId+date]` indexes so the calendar's
-// per-profile + date-range query hits an index, and the cascade auto-
-// discovery (`isPerProfileTable`) picks the table up at delete time.
-const CORE_V13 = {
-  ...CORE_V8,
-  workouts:
-    "id, profileId, [profileId+date], date, [date+state], [source+sourceId], sport, *tags",
-};
+import {
+  CORE_V1,
+  CORE_V2,
+  CORE_V4,
+  CORE_V5,
+  CORE_V8,
+  CORE_V13,
+} from "./dexie-schemas-early";
 
 // v16 — six health-domain stores added (KRD v2.0). Each store keys on
 // the KRD record `id` (nanoid) and indexes `[profileId+date]` so the
@@ -122,6 +89,26 @@ const CORE_V21 = {
   chatMessages: "id, profileId, [profileId+createdAt]",
 };
 
+// v22 — additive `aiModelBindings` store for per-profile model bindings.
+// Composite PK `[profileId+purpose]` keeps one row per purpose per profile;
+// the `profileId` index drives the cascade and makes the table a cascade
+// target (also auto-discovered by `isPerProfileTable`).
+const CORE_V22 = {
+  ...CORE_V21,
+  aiModelBindings: "[profileId+purpose], profileId",
+};
+
+// v23 — index `updatedAt` on the auto-push synced tables (#725) so the cloud
+// change token reads `count` + `max(updatedAt)` per table via an index instead
+// of `toArray()`-ing every row. Index-only addition: Dexie rebuilds the
+// indexes on upgrade, no data transform and existing tables are untouched.
+const CORE_V23 = {
+  ...CORE_V22,
+  workouts: `${CORE_V13.workouts}, updatedAt`,
+  templates: `${CORE_V1.templates}, updatedAt`,
+  profiles: `${CORE_V1.profiles}, updatedAt`,
+};
+
 export const SCHEMAS = {
   v1: CORE_V1,
   v2: CORE_V2,
@@ -135,9 +122,6 @@ export const SCHEMAS = {
   v19: CORE_V19,
   v20: CORE_V20,
   v21: CORE_V21,
-  // v22 — additive `aiModelBindings` store for per-profile model bindings.
-  // Composite PK `[profileId+purpose]` keeps one row per purpose per profile;
-  // the `profileId` index drives the cascade and makes the table a cascade
-  // target (also auto-discovered by `isPerProfileTable`).
-  v22: { ...CORE_V21, aiModelBindings: "[profileId+purpose], profileId" },
+  v22: CORE_V22,
+  v23: CORE_V23,
 } as const;

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-snapshot-port.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-snapshot-port.test.ts
@@ -19,7 +19,7 @@ const dbName = () => `kaiord-test-snapshot-${Date.now()}-${Math.random()}`;
 const PASSPHRASE = "kaiord-spa-v1";
 // Current head version KaiordDatabase opens at; v20 added coachingDayNotes
 // (train2go-links-and-day-comments), v21 added chatMessages (this change).
-const SCHEMA_HEAD = 22;
+const SCHEMA_HEAD = 23;
 
 describe("createDexieSnapshotPort", () => {
   let name: string;

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v17-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v17-migration.test.ts
@@ -15,7 +15,7 @@ const dbName = (suffix: string) =>
 const SCHEMA_V16 = 16;
 // Current head version KaiordDatabase opens at; v20 added coachingDayNotes,
 // v21 added chatMessages (this change).
-const SCHEMA_HEAD = 22;
+const SCHEMA_HEAD = 23;
 const STORES_V16 = {
   profiles: "id",
   linkedAccounts: "id",

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v19-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v19-migration.test.ts
@@ -17,7 +17,7 @@ const SCHEMA_V18 = 18;
 // Opening KaiordDatabase always migrates to the latest registered version,
 // so a seeded v18 db lands at the current head (v20 coachingDayNotes,
 // v21 chatMessages), not exactly v19.
-const SCHEMA_HEAD = 22;
+const SCHEMA_HEAD = 23;
 const STORES_V18 = {
   workouts: "id, profileId, [profileId+date], date",
   meta: "key",

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v21-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v21-migration.test.ts
@@ -15,7 +15,7 @@ const dbName = (suffix: string) =>
   `kaiord-test-v21-${suffix}-${Date.now()}-${Math.random()}`;
 
 const SCHEMA_SEED = 19;
-const SCHEMA_HEAD = 22;
+const SCHEMA_HEAD = 23;
 const STORES_SEED = {
   workouts: "id, profileId, [profileId+date], date",
   tombstones: "[table+id], table, deletedAt",

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v22-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v22-migration.test.ts
@@ -15,7 +15,7 @@ const dbName = (suffix: string) =>
   `kaiord-test-v22-${suffix}-${Date.now()}-${Math.random()}`;
 
 const SCHEMA_SEED = 19;
-const SCHEMA_HEAD = 22;
+const SCHEMA_HEAD = 23;
 const STORES_SEED = {
   profiles: "id",
   aiProviders: "id, createdAt",

--- a/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions-v10-plus.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions-v10-plus.ts
@@ -95,3 +95,10 @@ export const registerV22 = (db: DexieVersionHost): void => {
   // key↔model decoupling.
   db.version(22).stores(SCHEMAS.v22).upgrade(applyV22Upgrade);
 };
+
+export const registerV23 = (db: DexieVersionHost): void => {
+  // v23 — index `updatedAt` on workouts/templates/profiles so the auto-push
+  // change token reads max(updatedAt) via an index (#725). Index-only: Dexie
+  // rebuilds the indexes on upgrade, no data migration, tables untouched.
+  db.version(23).stores(SCHEMAS.v23);
+};

--- a/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/register-kaiord-versions.ts
@@ -26,6 +26,7 @@ import {
   registerV20,
   registerV21,
   registerV22,
+  registerV23,
 } from "./register-kaiord-versions-v10-plus";
 
 // Narrowed handle: only `version()` is needed and Dexie's full surface
@@ -92,4 +93,5 @@ export const registerKaiordVersions = (db: DexieVersionHost): void => {
   registerV20(db);
   registerV21(db);
   registerV22(db);
+  registerV23(db);
 };

--- a/packages/workout-spa-editor/src/hooks/sync-change-token.integration.test.ts
+++ b/packages/workout-spa-editor/src/hooks/sync-change-token.integration.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Integration coverage for the auto-push change signal: the v23 `updatedAt`
+ * index must let `orderBy("updatedAt").last()` read the per-table max cheaply,
+ * and that max must advance when a row is edited in place (an edit sets
+ * `updatedAt` to now). Runs against fake-indexeddb.
+ */
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { KaiordDatabase } from "../adapters/dexie/dexie-database";
+
+const dbName = () => `kaiord-test-sync-token-${Date.now()}-${Math.random()}`;
+
+describe("auto-push change signal (v23 updatedAt index)", () => {
+  let db: KaiordDatabase;
+
+  beforeEach(async () => {
+    db = new KaiordDatabase(dbName());
+    await db.open();
+  });
+
+  afterEach(async () => {
+    db.close();
+    await db.delete();
+  });
+
+  it("should read the latest workout updatedAt via the index", async () => {
+    // Arrange
+    await db.table("workouts").bulkPut([
+      { id: "w-1", updatedAt: "2026-05-01T00:00:00.000Z" },
+      { id: "w-2", updatedAt: "2026-05-03T00:00:00.000Z" },
+    ]);
+
+    // Act
+    const last = await db.table("workouts").orderBy("updatedAt").last();
+
+    // Assert
+    expect(last?.updatedAt).toBe("2026-05-03T00:00:00.000Z");
+  });
+
+  it("should advance the indexed max when a workout is edited in place", async () => {
+    // Arrange
+    await db.table("workouts").bulkPut([
+      { id: "w-1", updatedAt: "2026-05-01T00:00:00.000Z" },
+      { id: "w-2", updatedAt: "2026-05-03T00:00:00.000Z" },
+    ]);
+
+    // Act
+    await db
+      .table("workouts")
+      .update("w-1", { updatedAt: "2026-05-09T00:00:00.000Z" });
+    const last = await db.table("workouts").orderBy("updatedAt").last();
+
+    // Assert
+    expect(last?.updatedAt).toBe("2026-05-09T00:00:00.000Z");
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/sync-change-token.test.ts
+++ b/packages/workout-spa-editor/src/hooks/sync-change-token.test.ts
@@ -1,55 +1,52 @@
 /**
  * buildChangeToken — the cloud auto-push change token must advance on
- * creates, deletes, and in-place edits (not just row-count changes).
+ * creates, deletes, and in-place edits (not just row-count changes). It is
+ * assembled from per-table { count, latest } signals read via an index.
  */
 import { describe, expect, it } from "vitest";
 
-import { buildChangeToken } from "./sync-change-token";
+import { buildChangeToken, type TableSignal } from "./sync-change-token";
 
 describe("buildChangeToken", () => {
-  it("should combine the total row count with the latest timestamp", () => {
+  it("should join each table's count and latest timestamp", () => {
     // Arrange
-    const tables = {
-      workouts: [{ id: "w-1", updatedAt: "2026-05-01T00:00:00.000Z" }],
-      templates: [{ id: "t-1", createdAt: "2026-05-02T00:00:00.000Z" }],
-    };
+    const signals: TableSignal[] = [
+      { count: 2, latest: "2026-05-02T00:00:00.000Z" },
+      { count: 1, latest: "2026-05-01T00:00:00.000Z" },
+    ];
 
     // Act
-    const token = buildChangeToken(tables);
+    const token = buildChangeToken(signals);
 
     // Assert
-    expect(token).toBe("2:2026-05-02T00:00:00.000Z");
+    expect(token).toBe("2:2026-05-02T00:00:00.000Z|1:2026-05-01T00:00:00.000Z");
   });
 
   it("should change the token on an in-place edit even when the count is unchanged", () => {
     // Arrange
-    const before = buildChangeToken({
-      workouts: [{ id: "w-1", updatedAt: "2026-05-01T00:00:00.000Z" }],
-    });
+    const before = buildChangeToken([
+      { count: 1, latest: "2026-05-01T00:00:00.000Z" },
+    ]);
 
     // Act
-    const after = buildChangeToken({
-      workouts: [{ id: "w-1", updatedAt: "2026-05-09T00:00:00.000Z" }],
-    });
+    const after = buildChangeToken([
+      { count: 1, latest: "2026-05-09T00:00:00.000Z" },
+    ]);
 
     // Assert
     expect(after).not.toBe(before);
   });
 
-  it("should advance the token when a tombstone records a deletion", () => {
+  it("should advance the token when a row count changes", () => {
     // Arrange
-    const before = buildChangeToken({
-      workouts: [{ id: "w-1", updatedAt: "2026-05-01T00:00:00.000Z" }],
-      tombstones: [],
-    });
+    const before = buildChangeToken([
+      { count: 1, latest: "2026-05-01T00:00:00.000Z" },
+    ]);
 
     // Act
-    const after = buildChangeToken({
-      workouts: [{ id: "w-1", updatedAt: "2026-05-01T00:00:00.000Z" }],
-      tombstones: [
-        { table: "workouts", id: "w-9", deletedAt: "2026-05-10T00:00:00.000Z" },
-      ],
-    });
+    const after = buildChangeToken([
+      { count: 2, latest: "2026-05-01T00:00:00.000Z" },
+    ]);
 
     // Assert
     expect(after).not.toBe(before);
@@ -57,12 +54,15 @@ describe("buildChangeToken", () => {
 
   it("should return a zero-count token for an empty database", () => {
     // Arrange
-    const tables = { workouts: [], templates: [] };
+    const signals: TableSignal[] = [
+      { count: 0, latest: "" },
+      { count: 0, latest: "" },
+    ];
 
     // Act
-    const token = buildChangeToken(tables);
+    const token = buildChangeToken(signals);
 
     // Assert
-    expect(token).toBe("0:");
+    expect(token).toBe("0:|0:");
   });
 });

--- a/packages/workout-spa-editor/src/hooks/sync-change-token.ts
+++ b/packages/workout-spa-editor/src/hooks/sync-change-token.ts
@@ -1,32 +1,19 @@
 /**
  * Pure change-token builder for cloud auto-push.
  *
- * Combines the total row count with the latest timestamp across the synced
- * tables, so the token advances on creates, deletes, AND in-place edits
- * (an edit bumps updatedAt/modifiedAt). ISO-8601 timestamps sort
- * chronologically as plain strings, so a lexical max is a chronological max.
+ * Each synced table contributes a cheap signal: its row `count` plus the
+ * `latest` value of an indexed timestamp column. The token changes whenever
+ * any table gains/loses a row (count) or any row is touched in place (an edit
+ * sets `updatedAt` to now, advancing the per-table max). ISO-8601 timestamps
+ * sort chronologically as plain strings, so a lexical max is a chronological
+ * max. Reading the max via an index keeps this O(tables), not O(all rows).
  */
 
-const TIMESTAMP_FIELDS = [
-  "updatedAt",
-  "modifiedAt",
-  "createdAt",
-  "deletedAt",
-] as const;
+export type TableSignal = {
+  count: number;
+  latest: string;
+};
 
-export function buildChangeToken(
-  tables: Record<string, ReadonlyArray<Record<string, unknown>>>
-): string {
-  let count = 0;
-  let latest = "";
-  for (const rows of Object.values(tables)) {
-    count += rows.length;
-    for (const row of rows) {
-      for (const field of TIMESTAMP_FIELDS) {
-        const value = row[field];
-        if (typeof value === "string" && value > latest) latest = value;
-      }
-    }
-  }
-  return `${count}:${latest}`;
+export function buildChangeToken(signals: ReadonlyArray<TableSignal>): string {
+  return signals.map((signal) => `${signal.count}:${signal.latest}`).join("|");
 }

--- a/packages/workout-spa-editor/src/hooks/use-sync-auto-push.ts
+++ b/packages/workout-spa-editor/src/hooks/use-sync-auto-push.ts
@@ -1,45 +1,54 @@
 /**
  * useSyncAutoPush — drive a debounced cloud push from live Dexie changes.
  *
- * Observes the synced tables via `useLiveQuery` and builds a change token
- * (row count + latest timestamp) that advances on creates, deletes, AND
- * in-place edits — so editing an existing workout arms the push, not only
- * adding/removing rows. Whenever the token changes it asks the sync engine
- * for a debounced push, so a burst of edits collapses to a single Drive
- * write. This lives in a hook (not a Zustand store), so it does not violate
- * the no-write-through guards.
+ * Observes the synced tables via `useLiveQuery` and builds a change token from
+ * each table's row `count` plus the max of an indexed timestamp column. The
+ * token advances on creates, deletes, AND in-place edits (an edit sets
+ * `updatedAt` to now, advancing the max) — so editing an existing workout arms
+ * the push, not only adding/removing rows. Reading the max via an index keeps
+ * the query O(tables) instead of scanning every row on every change. Whenever
+ * the token changes it asks the sync engine for a debounced push, so a burst
+ * of edits collapses to a single Drive write. This lives in a hook (not a
+ * Zustand store), so it does not violate the no-write-through guards.
  */
 
 import { useLiveQuery } from "dexie-react-hooks";
 
 import { db } from "../adapters/dexie/dexie-database";
 import { useSync } from "../contexts/sync-context";
-import { buildChangeToken } from "./sync-change-token";
+import { buildChangeToken, type TableSignal } from "./sync-change-token";
 import { useAutoPush } from "./use-auto-push";
 
-const SYNCED_TABLES = [
-  "workouts",
-  "templates",
-  "profiles",
-  "aiProviders",
-  "tombstones",
-] as const;
+// [table, indexed timestamp column]. workouts/templates/profiles index
+// `updatedAt` (Dexie v23); aiProviders has an indexed numeric `createdAt`
+// (insertion order) and tombstones an indexed `deletedAt`.
+const SYNCED_TABLES: ReadonlyArray<readonly [string, string]> = [
+  ["workouts", "updatedAt"],
+  ["templates", "updatedAt"],
+  ["profiles", "updatedAt"],
+  ["aiProviders", "createdAt"],
+  ["tombstones", "deletedAt"],
+];
 
 // Real tokens always contain ":", so an empty string is a safe sentinel for
 // "loading / disconnected" that never collides with a genuine change token.
 const DISCONNECTED = "";
 
+async function tableSignal(name: string, field: string): Promise<TableSignal> {
+  const table = db.table(name);
+  const [count, last] = await Promise.all([
+    table.count(),
+    table.orderBy(field).last(),
+  ]);
+  const latest = (last as Record<string, unknown> | undefined)?.[field];
+  return { count, latest: latest == null ? "" : String(latest) };
+}
+
 async function syncedChangeToken(): Promise<string> {
-  const entries = await Promise.all(
-    SYNCED_TABLES.map(
-      async (name) =>
-        [
-          name,
-          (await db.table(name).toArray()) as Record<string, unknown>[],
-        ] as const
-    )
+  const signals = await Promise.all(
+    SYNCED_TABLES.map(([name, field]) => tableSignal(name, field))
   );
-  return buildChangeToken(Object.fromEntries(entries));
+  return buildChangeToken(signals);
 }
 
 export function useSyncAutoPush(): void {


### PR DESCRIPTION
Closes #725. Follow-up from the cross-device-sync feature (deferred CodeRabbit finding in #719).

## Problem
`useSyncAutoPush` built its debounce change token by `toArray()`-ing **every** synced table and scanning each row's timestamps via `buildChangeToken` — O(all rows) on every Dexie write (it re-runs through `useLiveQuery`).

## Fix
Read a cheap per-table signal instead: row `count()` + the max of an **indexed** timestamp column. O(tables) per change.

- **Dexie v23** (index-only): index `updatedAt` on `workouts` / `templates` / `profiles`. Non-destructive `.stores()` change — Dexie rebuilds the indexes on upgrade, no data transform, no `.upgrade()` callback. `aiProviders` (`createdAt`) and `tombstones` (`deletedAt`) are already indexed.
- `sync-change-token.ts`: now a pure `buildChangeToken(signals)` over `{ count, latest }[]`.
- `use-sync-auto-push.ts`: `count()` + `orderBy(field).last()` per table.

## Correctness preserved
The deliberate in-place-edit property (commit `fd977b68`) holds: every edit sets `updatedAt` to *now*, so the per-table indexed max advances — equivalent to the prior full-scan max, just without the scan. `count()` still catches creates/deletes.

## Notes
- Split the early schema versions into `dexie-schemas-early.ts` to keep both schema files under the line cap.
- Bumped the per-test `SCHEMA_HEAD` constant 22 → 23.

## Verification
- New: per-table token unit tests + a fake-indexeddb integration test proving the v23 index reads the max and advances on in-place edit; v23 schema-declaration tests (index added, no new stores, only the 3 tables changed).
- Full package suite green (4758), `tsc` + ESLint + Prettier clean, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Performance Improvements**
- Optimized cross-device sync performance by improving change token generation through indexed timestamp queries instead of loading entire datasets, resulting in significantly faster synchronization and reduced database overhead during synchronization operations.
- Enhanced change detection accuracy for in-place edits through improved timestamp tracking and indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->