### PR TITLE
feat(spa-editor): scale Daily WeekStrip mark by measured duration (#744)

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/Daily/WeekStrip.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/WeekStrip.test.tsx
@@ -18,7 +18,16 @@ const REAL_ISO = "2024-01-10";
 
 function emptySummary(days: WeekDay[]): WeekSummary {
   return Object.fromEntries(
-    days.map((d) => [d.iso, { count: 0, intensity: null, estimated: false }])
+    days.map((d) => [
+      d.iso,
+      {
+        count: 0,
+        intensity: null,
+        estimated: false,
+        sport: null,
+        durationSec: null,
+      },
+    ])
   );
 }
 

--- a/packages/workout-spa-editor/src/components/pages/Daily/WeekStrip.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/WeekStrip.tsx
@@ -22,6 +22,7 @@ const EMPTY: DaySummary = {
   intensity: null,
   estimated: false,
   sport: null,
+  durationSec: null,
 };
 
 export function WeekStrip(props: WeekStripProps) {

--- a/packages/workout-spa-editor/src/components/pages/Daily/WeekStripColumn.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/WeekStripColumn.test.tsx
@@ -13,10 +13,14 @@ const DAY: WeekDay = {
   isRealToday: false,
 };
 
+const SESSION_SECONDS = 2700; // 45 min
+
 const summary = (o: Partial<DaySummary> = {}): DaySummary => ({
   count: 1,
   intensity: "moderate",
   estimated: false,
+  sport: null,
+  durationSec: null,
   ...o,
 });
 
@@ -81,5 +85,18 @@ describe("WeekStripColumn", () => {
 
     // Assert
     expect(screen.getByRole("button")).toHaveAttribute("aria-current", "date");
+  });
+
+  it("should include the measured duration in the aria-label", () => {
+    // Arrange
+    const s = summary({ durationSec: SESSION_SECONDS });
+
+    // Act
+    renderColumn(DAY, s);
+
+    // Assert
+    expect(screen.getByRole("button").getAttribute("aria-label")).toContain(
+      "45m"
+    );
   });
 });

--- a/packages/workout-spa-editor/src/components/pages/Daily/WeekStripColumn.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/WeekStripColumn.tsx
@@ -1,3 +1,4 @@
+import { formatHms } from "../../../lib/workout-review";
 import type { DaySummary } from "./build-week-summary";
 import type { WeekDay } from "./today-dates";
 import { WeekStripMark } from "./WeekStripMark";
@@ -16,7 +17,9 @@ function ariaLabel(day: WeekDay, summary: DaySummary): string {
   const intensity = summary.intensity
     ? `, ${summary.intensity}${summary.estimated ? " estimated" : ""}`
     : "";
-  return `Focus ${day.letter} ${day.dayNumber}${today}, ${summary.count} planned${intensity}`;
+  const duration =
+    summary.durationSec !== null ? `, ${formatHms(summary.durationSec)}` : "";
+  return `Focus ${day.letter} ${day.dayNumber}${today}, ${summary.count} planned${intensity}${duration}`;
 }
 
 export function WeekStripColumn({

--- a/packages/workout-spa-editor/src/components/pages/Daily/WeekStripMark.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/WeekStripMark.test.tsx
@@ -4,11 +4,15 @@ import { describe, expect, it } from "vitest";
 import type { DaySummary } from "./build-week-summary";
 import { WeekStripMark } from "./WeekStripMark";
 
+const SHORT_SEC = 1200; // 20 min
+const LONG_SEC = 5400; // 90 min
+
 const summary = (o: Partial<DaySummary> = {}): DaySummary => ({
   count: 1,
   intensity: "hard",
   estimated: false,
   sport: null,
+  durationSec: null,
   ...o,
 });
 
@@ -48,5 +52,29 @@ describe("WeekStripMark", () => {
 
     // Assert
     expect(screen.getByTestId("weekstrip-empty")).toBeInTheDocument();
+  });
+
+  it("should grow the sport glyph for a long session", () => {
+    // Arrange
+    const day = summary({ sport: "\u{1F6B4}", durationSec: LONG_SEC });
+
+    // Act
+    render(<WeekStripMark summary={day} />);
+
+    // Assert
+    expect(screen.getByTestId("weekstrip-sport").className).toContain(
+      "text-[12px]"
+    );
+  });
+
+  it("should shrink the dot for a short session", () => {
+    // Arrange
+    const day = summary({ sport: null, durationSec: SHORT_SEC });
+
+    // Act
+    render(<WeekStripMark summary={day} />);
+
+    // Assert
+    expect(screen.getByTestId("weekstrip-dot").className).toContain("h-1 w-1");
   });
 });

--- a/packages/workout-spa-editor/src/components/pages/Daily/WeekStripMark.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/WeekStripMark.tsx
@@ -2,10 +2,12 @@
  * Per-day mark for a WeekStrip column: a faint hairline when the day is empty;
  * otherwise the day's sport glyph (emoji) when one is known — dimmed by
  * intensity (easy/moderate/hard, fainter when presence-only) — falling back to
- * an intensity-tinted dot when no sport is available. A small count is appended
- * when the day holds 2+ entries.
+ * an intensity-tinted dot when no sport is available. The mark grows with the
+ * day's measured duration (short/medium/long). A small count is appended when
+ * the day holds 2+ entries.
  */
 import type { DaySummary, IntensityBucket } from "./build-week-summary";
+import { DOT_SIZE, durationMarkSize, GLYPH_SIZE } from "./mark-size";
 
 const FILL: Record<IntensityBucket, string> = {
   easy: "bg-sky-500/40",
@@ -42,6 +44,7 @@ export function WeekStripMark({ summary }: { summary: DaySummary }) {
       />
     );
   }
+  const size = durationMarkSize(summary.durationSec);
   const count = summary.count >= 2 && (
     <span className="text-[9px] font-semibold leading-none text-slate-500">
       {summary.count}
@@ -51,7 +54,7 @@ export function WeekStripMark({ summary }: { summary: DaySummary }) {
     <span
       data-testid="weekstrip-sport"
       aria-hidden="true"
-      className={`text-[10px] leading-none ${glyphOpacity(summary)}`}
+      className={`${GLYPH_SIZE[size]} leading-none ${glyphOpacity(summary)}`}
     >
       {summary.sport}
     </span>
@@ -59,7 +62,7 @@ export function WeekStripMark({ summary }: { summary: DaySummary }) {
     <span
       data-testid="weekstrip-dot"
       aria-hidden="true"
-      className={`h-1.5 w-1.5 rounded-full ${dotClass(summary)}`}
+      className={`${DOT_SIZE[size]} rounded-full ${dotClass(summary)}`}
     />
   );
   return (

--- a/packages/workout-spa-editor/src/components/pages/Daily/build-week-summary.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/build-week-summary.test.ts
@@ -82,6 +82,7 @@ describe("buildWeekSummary", () => {
       intensity: "hard",
       estimated: true,
       sport: "bike",
+      durationSec: null,
     });
   });
 
@@ -156,6 +157,7 @@ describe("buildWeekSummary", () => {
       intensity: null,
       estimated: false,
       sport: "\u{1F6B4}",
+      durationSec: null,
     });
   });
 
@@ -177,6 +179,23 @@ describe("buildWeekSummary", () => {
       intensity: null,
       estimated: false,
       sport: null,
+      durationSec: null,
     });
+  });
+
+  it("should expose the measured duration of a KRD workout", () => {
+    // Arrange
+
+    // Act
+    const summary = buildWeekSummary({
+      dayIsos: DAYS,
+      weekWorkouts: [krdWorkout()],
+      coachingByDay: {},
+      matched: NO_MATCHED,
+      profile: PROFILE,
+    });
+
+    // Assert
+    expect(summary[DAY].durationSec).toBe(STEP_SECONDS);
   });
 });

--- a/packages/workout-spa-editor/src/components/pages/Daily/build-week-summary.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/build-week-summary.ts
@@ -1,10 +1,7 @@
 /**
- * Per-day summary for the Daily WeekStrip: presence (count) + a coarse,
- * honest intensity bucket per day across all sources. Measured TSS (workouts
- * with a KRD) is bucketed and flagged `estimated:false`; coaching `effort`
- * (1-5) is bucketed and flagged `estimated:true`; a day with only KRD-less
- * (raw) workouts and no coaching effort is presence-only (`intensity: null`).
- * No continuous/estimated load magnitude is produced.
+ * Per-day summaries for the Daily WeekStrip across all sources. See
+ * `summarizeDay` for the per-day rules (honest intensity + measured duration,
+ * no fabricated continuous load).
  */
 import type { MatchedSessionWithMetadata } from "../../../hooks/use-matched-sessions";
 import type { WorkoutRecord } from "../../../types/calendar-record";
@@ -12,19 +9,11 @@ import type { CoachingActivity } from "../../../types/coaching-activity";
 import type { Profile } from "../../../types/profile";
 import { buildCalendarBuckets } from "../calendar-buckets";
 import { groupWorkoutsByDay } from "../calendar-utils";
-import { estimatedBucket, measuredBucket } from "./day-intensity";
-import { representativeDaySport } from "./day-sport";
-import type { IntensityBucket } from "./intensity-bucket";
+import type { DaySummary } from "./summarize-day";
+import { summarizeDay } from "./summarize-day";
 
-export type { IntensityBucket };
-
-export type DaySummary = {
-  count: number;
-  intensity: IntensityBucket | null;
-  estimated: boolean;
-  /** Representative sport glyph (emoji) for the day, or null for a dot. */
-  sport: string | null;
-};
+export type { IntensityBucket } from "./intensity-bucket";
+export type { DaySummary };
 
 export type WeekSummary = Record<string, DaySummary>;
 
@@ -54,30 +43,12 @@ export function buildWeekSummary({
 
   const summary: WeekSummary = {};
   for (const iso of dayIsos) {
-    const dayMatched = matchedByDay[iso] ?? [];
-    const plans = soloPlansByDay[iso] ?? [];
-    const actuals = soloActualsByDay[iso] ?? [];
-    const count = dayMatched.length + plans.length + actuals.length;
-    const sport = representativeDaySport(dayMatched, plans, actuals);
-
-    const measured = measuredBucket(
-      [...dayMatched.map((m) => m.workout), ...actuals],
+    summary[iso] = summarizeDay(
+      matchedByDay[iso] ?? [],
+      soloPlansByDay[iso] ?? [],
+      soloActualsByDay[iso] ?? [],
       profile
     );
-    if (measured) {
-      summary[iso] = { count, intensity: measured, estimated: false, sport };
-      continue;
-    }
-    const estimated = estimatedBucket([
-      ...plans,
-      ...dayMatched.map((m) => m.activity),
-    ]);
-    summary[iso] = {
-      count,
-      intensity: estimated,
-      estimated: estimated !== null,
-      sport,
-    };
   }
   return summary;
 }

--- a/packages/workout-spa-editor/src/components/pages/Daily/day-duration.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/day-duration.test.ts
@@ -1,0 +1,89 @@
+import { createWorkoutKRD } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import { measuredDurationSec } from "./day-duration";
+
+const FIRST_SECONDS = 600;
+const SECOND_SECONDS = 900;
+const TOTAL_SECONDS = 1500;
+const FTP_PERCENT = 60;
+
+const krdWorkout = (seconds: number): WorkoutRecord =>
+  ({
+    id: "w-krd",
+    date: "2026-04-29",
+    sport: "cycling",
+    source: "manual",
+    state: "structured",
+    raw: null,
+    krd: createWorkoutKRD({
+      sport: "cycling",
+      steps: [
+        {
+          stepIndex: 0,
+          durationType: "time",
+          duration: { type: "time", seconds },
+          targetType: "power",
+          target: {
+            type: "power",
+            value: { unit: "percent_ftp", value: FTP_PERCENT },
+          },
+        },
+      ],
+    }),
+  }) as WorkoutRecord;
+
+const rawWorkout = (): WorkoutRecord =>
+  ({
+    ...krdWorkout(FIRST_SECONDS),
+    id: "w-raw",
+    state: "raw",
+    krd: null,
+  }) as WorkoutRecord;
+
+describe("measuredDurationSec", () => {
+  it("should return null when no workout carries a KRD", () => {
+    // Arrange
+    const workouts = [rawWorkout()];
+
+    // Act
+    const duration = measuredDurationSec(workouts);
+
+    // Assert
+    expect(duration).toBeNull();
+  });
+
+  it("should return the measured duration of a KRD workout", () => {
+    // Arrange
+    const workouts = [krdWorkout(FIRST_SECONDS)];
+
+    // Act
+    const duration = measuredDurationSec(workouts);
+
+    // Assert
+    expect(duration).toBe(FIRST_SECONDS);
+  });
+
+  it("should sum durations across multiple KRD workouts", () => {
+    // Arrange
+    const workouts = [krdWorkout(FIRST_SECONDS), krdWorkout(SECOND_SECONDS)];
+
+    // Act
+    const duration = measuredDurationSec(workouts);
+
+    // Assert
+    expect(duration).toBe(TOTAL_SECONDS);
+  });
+
+  it("should return null for an empty list", () => {
+    // Arrange
+    const workouts: WorkoutRecord[] = [];
+
+    // Act
+    const duration = measuredDurationSec(workouts);
+
+    // Assert
+    expect(duration).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/Daily/day-duration.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/day-duration.ts
@@ -1,0 +1,26 @@
+/**
+ * Measured total duration (seconds) for a WeekStrip day: the summed
+ * `totalDuration` of the day's KRD-backed workouts. Returns null when no
+ * workout yields a computable duration, so a presence-only day keeps the
+ * default mark size — no fabricated magnitude (mirrors `today-load`'s rule).
+ * Coaching `duration` is a free-text label and is deliberately not parsed.
+ */
+import { getStructuredWorkout } from "../../../lib/workout-review";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import { calculateWorkoutStats } from "../../../utils/workout-stats";
+
+export function measuredDurationSec(workouts: WorkoutRecord[]): number | null {
+  let total = 0;
+  let counted = false;
+  for (const record of workouts) {
+    if (!record.krd) continue;
+    const workout = getStructuredWorkout(record.krd);
+    if (!workout) continue;
+    const duration = calculateWorkoutStats(workout).totalDuration;
+    if (typeof duration === "number" && duration > 0) {
+      total += duration;
+      counted = true;
+    }
+  }
+  return counted ? total : null;
+}

--- a/packages/workout-spa-editor/src/components/pages/Daily/mark-size.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/mark-size.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { durationMarkSize } from "./mark-size";
+
+const SHORT_SEC = 1200; // 20 min
+const MEDIUM_SEC = 2700; // 45 min
+const LONG_SEC = 5400; // 90 min
+
+describe("durationMarkSize", () => {
+  it("should default to medium when the duration is unknown", () => {
+    // Arrange
+
+    // Act
+    const size = durationMarkSize(null);
+
+    // Assert
+    expect(size).toBe("md");
+  });
+
+  it("should size a short session small", () => {
+    // Arrange
+
+    // Act
+    const size = durationMarkSize(SHORT_SEC);
+
+    // Assert
+    expect(size).toBe("sm");
+  });
+
+  it("should size a typical session medium", () => {
+    // Arrange
+
+    // Act
+    const size = durationMarkSize(MEDIUM_SEC);
+
+    // Assert
+    expect(size).toBe("md");
+  });
+
+  it("should size a long session large", () => {
+    // Arrange
+
+    // Act
+    const size = durationMarkSize(LONG_SEC);
+
+    // Assert
+    expect(size).toBe("lg");
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/Daily/mark-size.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/mark-size.ts
@@ -1,0 +1,29 @@
+/**
+ * Duration → mark size for the WeekStrip. Short sessions render a smaller
+ * mark, long sessions a larger one; an unknown duration keeps the default
+ * medium size. Bounded to three steps so a single long day cannot dominate
+ * the strip (honest scaling, not a continuous proportional bar).
+ */
+export type MarkSize = "sm" | "md" | "lg";
+
+const SHORT_MAX_SEC = 1800; // < 30 min
+const LONG_MIN_SEC = 4500; // >= 75 min
+
+export function durationMarkSize(durationSec: number | null): MarkSize {
+  if (durationSec === null) return "md";
+  if (durationSec < SHORT_MAX_SEC) return "sm";
+  if (durationSec >= LONG_MIN_SEC) return "lg";
+  return "md";
+}
+
+export const GLYPH_SIZE: Record<MarkSize, string> = {
+  sm: "text-[9px]",
+  md: "text-[10px]",
+  lg: "text-[12px]",
+};
+
+export const DOT_SIZE: Record<MarkSize, string> = {
+  sm: "h-1 w-1",
+  md: "h-1.5 w-1.5",
+  lg: "h-2 w-2",
+};

--- a/packages/workout-spa-editor/src/components/pages/Daily/summarize-day.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/summarize-day.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-day WeekStrip summary: presence (count), an honest intensity bucket
+ * (measured TSS or estimated coaching effort), the representative sport glyph,
+ * and the measured duration in seconds (null when no KRD-backed workout yields
+ * one — no fabricated magnitude).
+ */
+import type { MatchedSessionWithMetadata } from "../../../hooks/use-matched-sessions";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import type { CoachingActivity } from "../../../types/coaching-activity";
+import type { Profile } from "../../../types/profile";
+import { measuredDurationSec } from "./day-duration";
+import { estimatedBucket, measuredBucket } from "./day-intensity";
+import { representativeDaySport } from "./day-sport";
+import type { IntensityBucket } from "./intensity-bucket";
+
+export type DaySummary = {
+  count: number;
+  intensity: IntensityBucket | null;
+  estimated: boolean;
+  /** Representative sport glyph (emoji) for the day, or null for a dot. */
+  sport: string | null;
+  /** Measured total duration in seconds, or null when unknown. */
+  durationSec: number | null;
+};
+
+export function summarizeDay(
+  dayMatched: MatchedSessionWithMetadata[],
+  plans: CoachingActivity[],
+  actuals: WorkoutRecord[],
+  profile: Profile | null
+): DaySummary {
+  const count = dayMatched.length + plans.length + actuals.length;
+  const sport = representativeDaySport(dayMatched, plans, actuals);
+  const measuredWorkouts = [...dayMatched.map((m) => m.workout), ...actuals];
+  const durationSec = measuredDurationSec(measuredWorkouts);
+  const measured = measuredBucket(measuredWorkouts, profile);
+  if (measured) {
+    return { count, intensity: measured, estimated: false, sport, durationSec };
+  }
+  const estimated = estimatedBucket([
+    ...plans,
+    ...dayMatched.map((m) => m.activity),
+  ]);
+  return {
+    count,
+    intensity: estimated,
+    estimated: estimated !== null,
+    sport,
+    durationSec,
+  };
+}


### PR DESCRIPTION
Closes #744 (follow-up to #736).

## What
The Daily WeekStrip's per-day mark now **scales with the day's measured session duration** (short / medium / long), on top of the existing sport glyph + intensity tint. The duration is also surfaced in the day column's `aria-label`.

- `day-duration.ts` — `measuredDurationSec()`: sums `totalDuration` of the day's KRD-backed workouts; returns `null` when none is computable. Coaching `duration` is a free-text label and is **deliberately not parsed** — no fabricated magnitude (mirrors the #736 "honest, no continuous load bar" decision).
- `mark-size.ts` — bounded **3-step** duration→size mapping (glyph + dot Tailwind classes); unknown duration keeps the default medium size, so one long day can't dominate the strip.
- `summarize-day.ts` — extracted the per-day summary out of `build-week-summary.ts` (keeps it under the 80-line cap) and adds `durationSec` to `DaySummary`.
- `WeekStripMark` sizes the glyph/dot; `WeekStripColumn` appends the duration (`formatHms`) to the aria-label when known.

Purely additive UI; no data-model or persistence change.

## Verification
- `tsc --noEmit` clean; `eslint` + `prettier` clean on the changed files
- Daily test suite: 19 files / 82 tests pass (new: `mark-size.test.ts`, `day-duration.test.ts`, + WeekStrip mark-size / aria-duration cases)
- No changeset needed (`@kaiord/workout-spa-editor` is private / excluded from PUBLISHABLE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workout indicators now dynamically resize based on session duration, making short, standard, and long workouts visually distinct at a glance.
  * Workout duration information is now included in accessibility labels for improved screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->