### PR TITLE
test(spa-editor): add coaching draft unit coverage (#746)

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/CoachingDraftSurface.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CoachingDraftSurface.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * CoachingDraftSurface — renders the Save button for a draft with a
+ * structured workout, wires the click to the save action, and shows the
+ * no-data state for a rest day. The draft/save hooks and heavy children are
+ * mocked so the test focuses on the surface's own branching.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CoachingDraftSurface } from "./CoachingDraftSurface";
+
+type DraftState = { activity: unknown; noStructured: boolean };
+
+let mockDraft: DraftState = { activity: { id: "a-1" }, noStructured: false };
+let mockCanSave = true;
+const mockSave = vi.fn();
+
+vi.mock("./use-coaching-draft", () => ({
+  useCoachingDraft: () => mockDraft,
+}));
+vi.mock("./use-coaching-draft-save", () => ({
+  useCoachingDraftSave: () => ({ canSave: mockCanSave, save: mockSave }),
+}));
+vi.mock("../../store/selectors/workout-selectors", () => ({
+  useCurrentWorkout: () => null,
+}));
+vi.mock("../../store/workout-store", () => ({
+  useWorkoutStore: () => undefined,
+}));
+vi.mock("../../hooks/use-app-handlers", () => ({
+  useAppHandlers: () => ({ handleStepSelect: vi.fn() }),
+}));
+vi.mock("./EditorPageHeader", () => ({
+  EditorPageHeader: () => <div data-testid="editor-header" />,
+}));
+vi.mock("./EditorLoadingState", () => ({
+  EditorNoData: () => <div data-testid="editor-no-data" />,
+}));
+vi.mock("./WorkoutSection/WorkoutSection", () => ({
+  WorkoutSection: () => <div data-testid="workout-section" />,
+}));
+vi.mock("../organisms/CoachingSidebar/CoachingSidebar", () => ({
+  CoachingSidebar: () => <div data-testid="coaching-sidebar" />,
+}));
+
+const SAVE_BUTTON = "coaching-draft-save-button";
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockDraft = { activity: { id: "a-1" }, noStructured: false };
+  mockCanSave = true;
+});
+
+describe("CoachingDraftSurface", () => {
+  it("should render the Save button for a draft with a structured workout", () => {
+    // Arrange
+    mockDraft = { activity: { id: "a-1" }, noStructured: false };
+
+    // Act
+    render(<CoachingDraftSurface coachingDraftId="a-1" />);
+
+    // Assert
+    expect(screen.getByTestId(SAVE_BUTTON)).toBeInTheDocument();
+    expect(screen.queryByTestId("editor-no-data")).toBeNull();
+  });
+
+  it("should call save when the Save button is clicked", () => {
+    // Arrange
+    mockDraft = { activity: { id: "a-1" }, noStructured: false };
+    render(<CoachingDraftSurface coachingDraftId="a-1" />);
+
+    // Act
+    fireEvent.click(screen.getByTestId(SAVE_BUTTON));
+
+    // Assert
+    expect(mockSave).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show the no-data state for a rest day", () => {
+    // Arrange
+    mockDraft = { activity: undefined, noStructured: true };
+
+    // Act
+    render(<CoachingDraftSurface coachingDraftId="a-1" />);
+
+    // Assert
+    expect(screen.getByTestId("editor-no-data")).toBeInTheDocument();
+    expect(screen.queryByTestId(SAVE_BUTTON)).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/use-coaching-draft-save.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/use-coaching-draft-save.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * useCoachingDraftSave — persists the current store KRD via
+ * `persistCoachingWorkout` and navigates to the real workout URL on success;
+ * surfaces an error toast on failure. All collaborators are mocked.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { CoachingActivityForConvert } from "../../application/coaching/convert-coaching-activity-manual-types";
+import type { KRD } from "../../types/krd";
+import { useCoachingDraftSave } from "./use-coaching-draft-save";
+
+const mockNavigate = vi.fn();
+vi.mock("wouter", () => ({
+  useLocation: () => ["/workout/new", mockNavigate],
+}));
+
+const mockPersist = vi.fn();
+vi.mock("../../application/coaching/persist-coaching-workout", () => ({
+  persistCoachingWorkout: (...args: unknown[]) => mockPersist(...args),
+}));
+
+let mockCurrentWorkout: KRD | null = null;
+vi.mock("../../store/selectors/workout-selectors", () => ({
+  useCurrentWorkout: () => mockCurrentWorkout,
+}));
+
+vi.mock("../../contexts/persistence-context", () => ({
+  usePersistence: () => ({ coaching: {}, workouts: {}, sessionMatch: {} }),
+}));
+
+vi.mock("../../contexts/analytics-context", () => ({
+  useAnalytics: () => ({ pageView: vi.fn(), event: vi.fn() }),
+}));
+
+const mockToastError = vi.fn();
+vi.mock("../../contexts/ToastContext", () => ({
+  useToastContext: () => ({ error: mockToastError }),
+}));
+
+const WORKOUT_ID = "w-123";
+
+const fakeKrd = (): KRD => ({
+  version: "1.0",
+  type: "structured_workout",
+  metadata: { created: "2026-04-01T00:00:00Z", sport: "cycling" },
+});
+
+const activity = {} as CoachingActivityForConvert;
+
+afterEach(() => {
+  vi.clearAllMocks();
+  mockCurrentWorkout = null;
+});
+
+describe("useCoachingDraftSave", () => {
+  it("should report canSave false when there is no current workout", () => {
+    // Arrange
+    mockCurrentWorkout = null;
+
+    // Act
+    const { result } = renderHook(() => useCoachingDraftSave(activity));
+
+    // Assert
+    expect(result.current.canSave).toBe(false);
+  });
+
+  it("should persist the workout and navigate on a successful save", async () => {
+    // Arrange
+    mockCurrentWorkout = fakeKrd();
+    mockPersist.mockResolvedValue({ workoutId: WORKOUT_ID });
+    const { result } = renderHook(() => useCoachingDraftSave(activity));
+
+    // Act
+    await act(async () => {
+      await result.current.save();
+    });
+
+    // Assert
+    expect(mockPersist).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith(`/workout/${WORKOUT_ID}`, {
+      replace: true,
+    });
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it("should surface an error toast when persistence fails", async () => {
+    // Arrange
+    mockCurrentWorkout = fakeKrd();
+    mockPersist.mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useCoachingDraftSave(activity));
+
+    // Act
+    await act(async () => {
+      await result.current.save();
+    });
+
+    // Assert
+    expect(mockToastError).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/use-coaching-draft.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/use-coaching-draft.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * useCoachingDraft — seeds the workout store once from the coaching activity
+ * (known sport) and marks a rest day as no-structured. Reads the shared Dexie
+ * DB via useLiveQuery (fake IndexedDB, global in test-setup); the store
+ * selectors are mocked so the seed call can be observed and the seed-once
+ * guard exercised.
+ */
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "../../adapters/dexie/dexie-database";
+import { stubActivity } from "../../application/coaching/convert-coaching-activity-with-ai.test-helpers";
+import type { KRD } from "../../types/krd";
+import { useCoachingDraft } from "./use-coaching-draft";
+
+const mockLoadWorkout = vi.fn();
+let mockCurrentWorkout: KRD | null = null;
+vi.mock("../../store/selectors/workout-selectors", () => ({
+  useLoadWorkout: () => mockLoadWorkout,
+  useCurrentWorkout: () => mockCurrentWorkout,
+}));
+
+afterEach(async () => {
+  await db.table("coachingActivities").clear();
+  vi.clearAllMocks();
+  mockCurrentWorkout = null;
+});
+
+describe("useCoachingDraft", () => {
+  it("should seed the store once from a known-sport activity", async () => {
+    // Arrange
+    const activity = stubActivity({ sport: "cycling" });
+    await db.table("coachingActivities").put(activity);
+
+    // Act
+    const { result } = renderHook(() => useCoachingDraft(activity.id));
+
+    // Assert
+    await waitFor(() => expect(result.current.activity?.id).toBe(activity.id));
+    await waitFor(() => expect(mockLoadWorkout).toHaveBeenCalledTimes(1));
+    const seeded = mockLoadWorkout.mock.calls[0]?.[0] as KRD;
+    expect(seeded.metadata.sport).toBe("cycling");
+    expect(result.current.noStructured).toBe(false);
+  });
+
+  it("should mark a rest day as no-structured and not seed the store", async () => {
+    // Arrange
+    const activity = stubActivity({ sport: "rest" });
+    await db.table("coachingActivities").put(activity);
+
+    // Act
+    const { result } = renderHook(() => useCoachingDraft(activity.id));
+
+    // Assert
+    await waitFor(() => expect(result.current.activity?.id).toBe(activity.id));
+    expect(result.current.noStructured).toBe(true);
+    expect(mockLoadWorkout).not.toHaveBeenCalled();
+  });
+
+  it("should not re-seed when the store already holds a workout", async () => {
+    // Arrange
+    mockCurrentWorkout = {
+      version: "1.0",
+      type: "structured_workout",
+      metadata: { created: "2026-04-01T00:00:00Z", sport: "cycling" },
+    };
+    const activity = stubActivity({ sport: "cycling" });
+    await db.table("coachingActivities").put(activity);
+
+    // Act
+    const { result } = renderHook(() => useCoachingDraft(activity.id));
+
+    // Assert
+    await waitFor(() => expect(result.current.activity?.id).toBe(activity.id));
+    expect(mockLoadWorkout).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #746 (follow-up to #741).

## What
The store-only coaching draft surface and its hooks were only covered by Playwright e2e (coaching flow d), so `codecov/patch/frontend` (advisory) went red. Adds vitest coverage for the three units:

- **`use-coaching-draft`** (integration, fake-indexeddb): seeds the workout store **once** from the activity (known sport), marks a **rest day** as no-structured, and honors the **seed-once guard** when the store already holds a workout. Mirrors the `useCoachingDialogState` fake-idb pattern; store selectors are mocked to observe the seed.
- **`use-coaching-draft-save`**: persists via `persistCoachingWorkout` and navigates to `/workout/:id` on success; error toast on failure; `canSave` gating.
- **`CoachingDraftSurface`**: renders the Save button for a structured draft, wires the click to `save`, and shows the no-data state for a rest day.

Test-only; no source change.

## Verification
- 3 files / 9 tests pass; `eslint` + `prettier` clean; full `pnpm lint` + `tsc` green (worktree off `origin/main`)
- No changeset needed (`@kaiord/workout-spa-editor` is private / excluded from PUBLISHABLE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the coaching draft editor surface
  * Added test suites for draft persistence and navigation workflows
  * Added test suites for draft data initialization and seeding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->