### PR TITLE
test(spa-editor): cover stepIntensityFactor branch logic

### DIFF
--- a/packages/workout-spa-editor/src/lib/workout-review/intensity-factor.test.ts
+++ b/packages/workout-spa-editor/src/lib/workout-review/intensity-factor.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+
+import type { Target } from "../../types/krd";
+import type { SportThresholds } from "../../types/sport-zones";
+import { stepIntensityFactor } from "./intensity-factor";
+
+const THRESHOLDS: SportThresholds = {
+  ftp: 250,
+  lthr: 160,
+  thresholdPace: 250,
+  paceUnit: "min_per_km",
+};
+
+const PRECISION = 5;
+const FACTOR_PERCENT_80 = 0.8;
+const FACTOR_AT_THRESHOLD = 1;
+const FACTOR_HALF = 0.5;
+const MIDPOINT_Z1 = 0.45;
+const MIDPOINT_Z3 = 0.825;
+const MIDPOINT_Z5 = 1.15;
+
+describe("stepIntensityFactor", () => {
+  it("should return the percent_ftp value as a fraction for a power target", () => {
+    // Arrange
+    const target: Target = {
+      type: "power",
+      value: { unit: "percent_ftp", value: 80 },
+    };
+
+    // Act
+    const factor = stepIntensityFactor(target, THRESHOLDS);
+
+    // Assert
+    expect(factor).toBeCloseTo(FACTOR_PERCENT_80, PRECISION);
+  });
+
+  it("should divide watts by FTP for a watts power target", () => {
+    // Arrange
+    const target: Target = {
+      type: "power",
+      value: { unit: "watts", value: 250 },
+    };
+
+    // Act
+    const factor = stepIntensityFactor(target, THRESHOLDS);
+
+    // Assert
+    expect(factor).toBeCloseTo(FACTOR_AT_THRESHOLD, PRECISION);
+  });
+
+  it("should return null for a watts power target without an FTP threshold", () => {
+    // Arrange
+    const target: Target = {
+      type: "power",
+      value: { unit: "watts", value: 250 },
+    };
+
+    // Act
+    const factor = stepIntensityFactor(target, { paceUnit: "min_per_km" });
+
+    // Assert
+    expect(factor).toBeNull();
+  });
+
+  it("should map a power zone target to its zone midpoint", () => {
+    // Arrange
+    const target: Target = { type: "power", value: { unit: "zone", value: 3 } };
+
+    // Act
+    const factor = stepIntensityFactor(target, THRESHOLDS);
+
+    // Assert
+    expect(factor).toBe(MIDPOINT_Z3);
+  });
+
+  it("should divide bpm by LTHR for a heart-rate target", () => {
+    // Arrange
+    const target: Target = {
+      type: "heart_rate",
+      value: { unit: "bpm", value: 160 },
+    };
+
+    // Act
+    const factor = stepIntensityFactor(target, THRESHOLDS);
+
+    // Assert
+    expect(factor).toBeCloseTo(FACTOR_AT_THRESHOLD, PRECISION);
+  });
+
+  it("should return null for a bpm heart-rate target without an LTHR threshold", () => {
+    // Arrange
+    const target: Target = {
+      type: "heart_rate",
+      value: { unit: "bpm", value: 160 },
+    };
+
+    // Act
+    const factor = stepIntensityFactor(target, { paceUnit: "min_per_km" });
+
+    // Assert
+    expect(factor).toBeNull();
+  });
+
+  it("should map a heart-rate zone target to its zone midpoint", () => {
+    // Arrange
+    const target: Target = {
+      type: "heart_rate",
+      value: { unit: "zone", value: 1 },
+    };
+
+    // Act
+    const factor = stepIntensityFactor(target, THRESHOLDS);
+
+    // Assert
+    expect(factor).toBe(MIDPOINT_Z1);
+  });
+
+  it("should compute the pace factor for a min_per_km threshold", () => {
+    // Arrange
+    const target: Target = { type: "pace", value: { unit: "mps", value: 4 } };
+
+    // Act
+    const factor = stepIntensityFactor(target, THRESHOLDS);
+
+    // Assert
+    expect(factor).toBeCloseTo(FACTOR_AT_THRESHOLD, PRECISION);
+  });
+
+  it("should compute the pace factor for a min_per_100m threshold", () => {
+    // Arrange
+    const target: Target = { type: "pace", value: { unit: "mps", value: 2 } };
+
+    // Act
+    const factor = stepIntensityFactor(target, {
+      thresholdPace: 25,
+      paceUnit: "min_per_100m",
+    });
+
+    // Assert
+    expect(factor).toBeCloseTo(FACTOR_HALF, PRECISION);
+  });
+
+  it("should return null for an mps pace target without a threshold pace", () => {
+    // Arrange
+    const target: Target = { type: "pace", value: { unit: "mps", value: 4 } };
+
+    // Act
+    const factor = stepIntensityFactor(target, { paceUnit: "min_per_km" });
+
+    // Assert
+    expect(factor).toBeNull();
+  });
+
+  it("should map a pace zone target to its zone midpoint", () => {
+    // Arrange
+    const target: Target = { type: "pace", value: { unit: "zone", value: 5 } };
+
+    // Act
+    const factor = stepIntensityFactor(target, THRESHOLDS);
+
+    // Assert
+    expect(factor).toBe(MIDPOINT_Z5);
+  });
+
+  it("should clamp an out-of-range zone to the nearest midpoint", () => {
+    // Arrange
+    const target: Target = { type: "power", value: { unit: "zone", value: 9 } };
+
+    // Act
+    const factor = stepIntensityFactor(target, THRESHOLDS);
+
+    // Assert
+    expect(factor).toBe(MIDPOINT_Z5);
+  });
+
+  it("should return null for a non power/heart-rate/pace target", () => {
+    // Arrange
+    const target: Target = { type: "open" };
+
+    // Act
+    const factor = stepIntensityFactor(target, THRESHOLDS);
+
+    // Assert
+    expect(factor).toBeNull();
+  });
+});


### PR DESCRIPTION
## What
`lib/workout-review/intensity-factor.ts` — the fraction-of-threshold helper that feeds the TSS approximation — had **no direct unit test** (only indirect exercise via `review-model.test.ts`). Adds full, direct branch coverage for `stepIntensityFactor`:

- **power**: `percent_ftp` fraction, `watts ÷ FTP`, `watts` without an FTP threshold → `null`, `zone` → midpoint
- **heart rate**: `bpm ÷ LTHR`, `bpm` without an LTHR threshold → `null`, `zone` → midpoint
- **pace**: `mps ÷ threshold speed` for both `min_per_km` and `min_per_100m`, `mps` without a threshold pace → `null`, `zone` → midpoint
- out-of-range zone **clamping**; non power/hr/pace target → `null`

13 cases, all pure/deterministic. **Test-only — no source change.**

## Why
Pins the sports-science branch math directly so a future refactor that breaks one unit (e.g. the pace-unit conversion) fails at the unit level with a clear message, rather than buried in the review-model integration test. Picked as safe, low-conflict work (pure `lib/` logic, no overlap with in-flight schema/dexie changes).

## Verification
- 13/13 tests pass; `eslint` + `prettier` clean; full `pnpm lint` + `tsc` green (worktree off `origin/main`)
- No changeset needed (`@kaiord/workout-spa-editor` is private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for intensity factor calculations with extensive coverage of power targets in multiple formats, heart-rate and pace zone mapping, pace factor computation for various distance units, handling of missing thresholds, boundary clamping, and unsupported target type validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->