### PR TITLE
test(spa-editor): cover mergeRefs ref-merging utility

### DIFF
--- a/packages/workout-spa-editor/src/lib/merge-refs.test.ts
+++ b/packages/workout-spa-editor/src/lib/merge-refs.test.ts
@@ -1,0 +1,67 @@
+import type { MutableRefObject, Ref } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { mergeRefs } from "./merge-refs";
+
+const NODE = "node-value";
+
+describe("mergeRefs", () => {
+  it("should assign the node to an object ref's current", () => {
+    // Arrange
+    const objectRef: MutableRefObject<string | null> = { current: null };
+
+    // Act
+    mergeRefs(objectRef)(NODE);
+
+    // Assert
+    expect(objectRef.current).toBe(NODE);
+  });
+
+  it("should call a function ref with the node", () => {
+    // Arrange
+    const fnRef = vi.fn();
+
+    // Act
+    mergeRefs<string>(fnRef)(NODE);
+
+    // Assert
+    expect(fnRef).toHaveBeenCalledWith(NODE);
+  });
+
+  it("should skip null and undefined refs without throwing", () => {
+    // Arrange
+    const refs: Array<Ref<string> | undefined> = [null, undefined];
+
+    // Act
+    const act = () => mergeRefs<string>(...refs)(NODE);
+
+    // Assert
+    expect(act).not.toThrow();
+  });
+
+  it("should fan the node out to every ref at once", () => {
+    // Arrange
+    const objectRef: MutableRefObject<string | null> = { current: null };
+    const fnRef = vi.fn();
+
+    // Act
+    mergeRefs<string>(objectRef, fnRef)(NODE);
+
+    // Assert
+    expect(objectRef.current).toBe(NODE);
+    expect(fnRef).toHaveBeenCalledWith(NODE);
+  });
+
+  it("should propagate a null node on unmount", () => {
+    // Arrange
+    const objectRef: MutableRefObject<string | null> = { current: NODE };
+    const fnRef = vi.fn();
+
+    // Act
+    mergeRefs<string>(objectRef, fnRef)(null);
+
+    // Assert
+    expect(objectRef.current).toBeNull();
+    expect(fnRef).toHaveBeenCalledWith(null);
+  });
+});


### PR DESCRIPTION
## What
`lib/merge-refs.ts` (`mergeRefs` — merges multiple React refs into one callback ref) had **no direct unit test**. Its branches (skip null/undefined, call function refs, assign object refs) aren't fully exercised by the consuming component render tests. Adds 5 direct cases:

- assigns the node to an object ref's `current`
- calls a function ref with the node
- skips `null`/`undefined` refs without throwing
- fans the node out to multiple refs at once (object + function)
- propagates a `null` node on unmount

**Test-only — no source change.** Pure utility.

## Why
Safe, low-conflict pure-logic coverage (generic `lib/` util, no overlap with in-flight schema/dexie work).

## Verification
- 5/5 pass; `eslint` + `prettier` clean; full `pnpm lint` + `tsc` green (worktree off `origin/main`)
- No changeset needed (`@kaiord/workout-spa-editor` is private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)