### PR TITLE
test(spa-editor): cover getDeviceId persistence and fallback

### DIFF
--- a/packages/workout-spa-editor/src/lib/cloud-sync/device-id.test.ts
+++ b/packages/workout-spa-editor/src/lib/cloud-sync/device-id.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getDeviceId } from "./device-id";
+
+const DEVICE_ID_KEY = "kaiord-sync-device-id";
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getDeviceId", () => {
+  it("should return the existing id already stored in localStorage", () => {
+    // Arrange
+    const stored = "11111111-1111-4111-8111-111111111111";
+    localStorage.setItem(DEVICE_ID_KEY, stored);
+
+    // Act
+    const id = getDeviceId();
+
+    // Assert
+    expect(id).toBe(stored);
+  });
+
+  it("should create and persist a new id when none is stored", () => {
+    // Arrange
+
+    // Act
+    const id = getDeviceId();
+
+    // Assert
+    expect(id).toMatch(UUID_RE);
+    expect(localStorage.getItem(DEVICE_ID_KEY)).toBe(id);
+  });
+
+  it("should return the same id on subsequent calls", () => {
+    // Arrange
+    const first = getDeviceId();
+
+    // Act
+    const second = getDeviceId();
+
+    // Assert
+    expect(second).toBe(first);
+  });
+
+  it("should fall back to an ephemeral id when storage is unavailable", () => {
+    // Arrange
+    vi.spyOn(window.localStorage, "getItem").mockImplementation(() => {
+      throw new Error("storage blocked");
+    });
+
+    // Act
+    const id = getDeviceId();
+
+    // Assert
+    expect(id).toMatch(UUID_RE);
+  });
+});


### PR DESCRIPTION
## What
`lib/cloud-sync/device-id.ts` (`getDeviceId` — stable per-device id for sync manifests) had **no test**. Adds 4 cases:

- returns the existing id already stored in localStorage
- creates **and persists** a new uuid when none is stored
- returns the same id on subsequent calls (stability across reloads)
- returns an ephemeral uuid when localStorage is unavailable (private mode / SSR) — the `catch` branch

**Test-only — no source change.**

## Why
Pins the persistence contract and the private-mode resilience branch (which a happy-path render would never hit). Safe, low-conflict pure-logic coverage (cloud-sync util, no overlap with in-flight schema/dexie work).

## Verification
- 4/4 pass; `eslint` + `prettier` clean; full `pnpm lint` + `tsc` green (worktree off `origin/main`)
- No changeset needed (`@kaiord/workout-spa-editor` is private)

🤖 Generated with [Claude Code](https://claude.com/claude-code)