### PR TITLE
chore(ci): raise test-frontend job timeout to 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,9 +612,11 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
-    # P95 = 334s (worst matrix shard); ceil(P95 × 1.5 / 60) = 9; capped at
-    # test-family ceiling 30.
-    timeout-minutes: 9
+    # Frontend vitest + coverage P95 drifted to ~9min as the suite grew,
+    # intermittently exceeding the old 9-min cap (timeout flake on the
+    # 22.18.0 shard). Bumped to 15 for headroom; still under the test-family
+    # ceiling of 30.
+    timeout-minutes: 15
     needs: [detect-changes, build]
     if: needs.detect-changes.outputs.should-test == 'true'
     strategy:


### PR DESCRIPTION
## What
Raises the `test-frontend` job's `timeout-minutes` from **9 → 15** in `.github/workflows/ci.yml` (and updates the calibration comment).

## Why
The frontend vitest + coverage P95 has drifted to ~9 min as the suite grew, intermittently exceeding the old 9-min cap. This trips a **timeout flake on the `test-frontend (22.18.0)` shard**: every step passes (tests + 70% coverage + Codecov upload), but the job is killed at the cap. It has now required reruns on #792, #793, #798, and **failed #799 twice** — reruns no longer reliably clear it.

15 min gives comfortable headroom and is still well under the test-family ceiling of 30. `scripts/check-workflow-timeouts.mjs` only enforces that a positive integer timeout exists (calibration is advisory), so this passes the invariant.

## Verification
- `node scripts/check-workflow-timeouts.mjs` → "every job declares timeout-minutes" ✓
- full `pnpm lint` + `tsc` green (worktree off `origin/main`); this PR's own `test-frontend` runs under the new 15-min cap
- No changeset (CI config only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)