### PR TITLE
test(spa-editor): add v15→v16 abort-mid-flight migration test (#678)

### DIFF
--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v16-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v16-migration.test.ts
@@ -20,8 +20,18 @@ const dbName = (suffix: string) =>
   `kaiord-test-v16-${suffix}-${Date.now()}-${Math.random()}`;
 
 const SCHEMA_V15 = 15;
+const SCHEMA_V16 = 16;
 const STORES_V15 = {
   userPreferences: "profileId",
+} as const;
+const STORES_V16 = {
+  ...STORES_V15,
+  healthSleep: "id, profileId",
+  healthWeight: "id, profileId",
+  healthHrv: "id, profileId",
+  healthDaily: "id, profileId",
+  healthBodyComposition: "id, profileId",
+  healthStress: "id, profileId",
 } as const;
 
 const HEALTH_STORES = [
@@ -105,4 +115,44 @@ describe("Dexie v15 → v16 migration (health-domain stores)", () => {
       });
     }
   );
+
+  it("should leave the database at v15 when the v15→v16 upgrade aborts mid-flight", async () => {
+    // Arrange
+    await seedV15(name, [
+      {
+        profileId: PROFILE_ID,
+        calendarView: "grid",
+        updatedAt: "2026-05-08T10:00:00.000Z",
+      },
+    ]);
+    const failing = new Dexie(name);
+    failing.version(SCHEMA_V15).stores(STORES_V15);
+    failing
+      .version(SCHEMA_V16)
+      .stores(STORES_V16)
+      .upgrade(() => {
+        throw new Error("simulated mid-flight upgrade failure");
+      });
+
+    // Act
+    await expect(failing.open()).rejects.toThrow();
+    failing.close();
+
+    // Assert — the aborted transaction leaves the DB at v15: it still opens
+    // with only the v15 schema (a committed v16 would reject as VersionError),
+    // the legacy row is intact, and no health store was created.
+    const reopened = new Dexie(name);
+    reopened.version(SCHEMA_V15).stores(STORES_V15);
+    await reopened.open();
+    const verno = reopened.verno;
+    const tables = reopened.tables.map((t) => t.name);
+    const row = (await reopened.table("userPreferences").get(PROFILE_ID)) as
+      | { calendarView?: string }
+      | undefined;
+    reopened.close();
+
+    expect(verno).toBe(SCHEMA_V15);
+    expect(tables).not.toContain("healthSleep");
+    expect(row?.calendarView).toBe("grid");
+  });
 });

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-v16-migration.test.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-v16-migration.test.ts
@@ -24,14 +24,18 @@ const SCHEMA_V16 = 16;
 const STORES_V15 = {
   userPreferences: "profileId",
 } as const;
+// Mirrors the real v16 health-store contract (CORE_V16 in dexie-schemas-early):
+// `[profileId+date], date` indexes are present from v16; the provenance suffix
+// is a v17 addition and is intentionally out of scope here.
+const HEALTH_STORE_SCHEMA_V16 = "id, profileId, [profileId+date], date";
 const STORES_V16 = {
   ...STORES_V15,
-  healthSleep: "id, profileId",
-  healthWeight: "id, profileId",
-  healthHrv: "id, profileId",
-  healthDaily: "id, profileId",
-  healthBodyComposition: "id, profileId",
-  healthStress: "id, profileId",
+  healthSleep: HEALTH_STORE_SCHEMA_V16,
+  healthWeight: HEALTH_STORE_SCHEMA_V16,
+  healthHrv: HEALTH_STORE_SCHEMA_V16,
+  healthDaily: HEALTH_STORE_SCHEMA_V16,
+  healthBodyComposition: HEALTH_STORE_SCHEMA_V16,
+  healthStress: HEALTH_STORE_SCHEMA_V16,
 } as const;
 
 const HEALTH_STORES = [
@@ -138,9 +142,10 @@ describe("Dexie v15 → v16 migration (health-domain stores)", () => {
     await expect(failing.open()).rejects.toThrow();
     failing.close();
 
-    // Assert — the aborted transaction leaves the DB at v15: it still opens
-    // with only the v15 schema (a committed v16 would reject as VersionError),
-    // the legacy row is intact, and no health store was created.
+    // Assert
+    // The aborted transaction leaves the DB at v15: it still opens with only the
+    // v15 schema (a committed v16 would reject as VersionError), the legacy row
+    // is intact, and no health store was created.
     const reopened = new Dexie(name);
     reopened.version(SCHEMA_V15).stores(STORES_V15);
     await reopened.open();
@@ -152,7 +157,9 @@ describe("Dexie v15 → v16 migration (health-domain stores)", () => {
     reopened.close();
 
     expect(verno).toBe(SCHEMA_V15);
-    expect(tables).not.toContain("healthSleep");
+    for (const store of HEALTH_STORES) {
+      expect(tables).not.toContain(store);
+    }
     expect(row?.calendarView).toBe("grid");
   });
 });


### PR DESCRIPTION
Closes #678 (deferred from `add-health-metrics-to-krd` §6.5).

## What
Adds the missing **abort-mid-flight** scenario to the Dexie v15→v16 migration suite. A synthetic v16 schema whose `.upgrade()` throws is opened; the migration transaction aborts, `open()` rejects, and the test asserts the database remains at v15:
- it reopens with only the v15 schema (`verno === 15` — a committed v16 would reject with `VersionError`),
- the legacy `userPreferences` row survives intact,
- no health-domain store (`healthSleep`) was created.

This guards the atomicity of the additive migration: a failed upgrade must leave no partial v16 state behind.

## Verification
- 8/8 tests pass in `dexie-v16-migration.test.ts`
- `eslint` + `prettier` clean; full `pnpm lint` + workspace `tsc` green
- No changeset needed (test-only, no shipped behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for database migration reliability, including scenarios where upgrade operations fail to ensure database integrity is maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->