### PR TITLE
feat(core): activity-level NEAT factor on predicted daily expenditure (#804)

### DIFF
--- a/.changeset/energy-expenditure-activity-factor.md
+++ b/.changeset/energy-expenditure-activity-factor.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/core": minor
+---
+
+Add an activity-level NEAT factor API (`ActivityLevel`, `NEAT_FACTOR`, `DEFAULT_NEAT_FACTOR`, `neatFactorForActivityLevel`) and apply it to the predicted daily expenditure. `resolveDayExpenditure` now accepts an optional `basalActivityFactor` that scales the predicted basal (`bmrKcal × factor`), so a no-workout day reflects realistic maintenance instead of raw BMR. The factors are NEAT-only (sedentary 1.2 … very_active 1.6); scheduled-workout energy is still added separately via `expectedActivityKcal` and is never double-counted, and the measured-wellness path is unchanged.

--- a/openspec/changes/energy-expenditure-activity-factor/proposal.md
+++ b/openspec/changes/energy-expenditure-activity-factor/proposal.md
@@ -1,0 +1,49 @@
+## Why
+
+`resolveDayExpenditure`'s predicted path is `BMR + expectedActivityKcal`. On a
+no-workout day the predicted expenditure collapses to the raw BMR (e.g. 1750
+kcal for an 80 kg / 180 cm / 36 yo male), which understates real daily
+maintenance — even a fully sedentary person burns ~20% over BMR through
+Non-Exercise Activity Thermogenesis (NEAT): posture, daily movement, digestion,
+occupational activity. Profiles already capture `activityLevel`
+(`sedentary`…`very_active`), but it is never applied, so the predicted
+expenditure and the goal maintenance baseline are systematically too low.
+
+This is GitHub issue #804.
+
+## What Changes
+
+Apply an activity-level NEAT factor to the predicted basal:
+
+- **New core API** `@kaiord/core` `activity-factor`: `ActivityLevel`,
+  `NEAT_FACTOR` (`sedentary` 1.2, `light` 1.3, `moderate` 1.4, `active` 1.5,
+  `very_active` 1.6), `DEFAULT_NEAT_FACTOR` (1.2), and
+  `neatFactorForActivityLevel(level?)`. These are NEAT-only multipliers,
+  deliberately lower than classic TDEE multipliers: scheduled-workout energy is
+  added separately via `expectedActivityKcal`, so a full TDEE multiplier would
+  double-count the workout kcal.
+- **`resolveDayExpenditure`** gains an optional `basalActivityFactor` on
+  `DayExpenditureInput`. The predicted basal becomes `bmrKcal × factor`
+  (defaulting the factor to 1); `expectedActivityKcal` is still added on top. The
+  factor must be finite and `> 0` (`RangeError` otherwise). The measured path is
+  unchanged — it never reads the factor.
+- **SPA wiring**: `toExpenditureInput` passes
+  `basalActivityFactor: neatFactorForActivityLevel(profile.activityLevel)` on the
+  predicted branch; `resolveGoalMaintenance` scales its modeled maintenance by the
+  same factor so the goal target is measured against a realistic baseline. An
+  unset `activityLevel` resolves to the conservative default (1.2).
+
+## Impact
+
+- **Affected specs**: `energy-expenditure` (MODIFIED "Daily expenditure
+  resolution" requirement — the predicted basal is now `BMR × activity-level NEAT
+factor`, with scheduled-workout kcal still added separately and never
+  double-counted).
+- **Affected code**:
+  - `packages/core/src/application/energy/activity-factor.ts` (new) and its test.
+  - `packages/core/src/application/energy/expenditure.ts` (optional
+    `basalActivityFactor`, predicted-basal scaling, factor guard) and its test.
+  - `packages/core/src/index.ts` (export the new symbols).
+  - `packages/workout-spa-editor/src/application/energy/resolve-day-expenditure-inputs.ts`
+    and `resolve-goal-maintenance.ts` (apply the factor).
+- **Versioning**: `@kaiord/core` minor (additive public API).

--- a/openspec/changes/energy-expenditure-activity-factor/specs/energy-expenditure/spec.md
+++ b/openspec/changes/energy-expenditure-activity-factor/specs/energy-expenditure/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+<!-- MODIFIED FROM openspec/specs/energy-expenditure / Requirement: Daily expenditure resolution. The full prior block is reproduced below; the predicted basal is now BMR scaled by the profile's activity-level NEAT factor instead of the raw BMR. Scheduled-workout kcal are still added separately via expectedActivityKcal and MUST NOT be double-counted. The two prior scenarios are preserved; two new scenarios assert the NEAT scaling and the no-double-count invariant (issue #804). -->
+
+### Requirement: Daily expenditure resolution
+
+The system SHALL resolve a day's total energy expenditure as measured
+(`restingCalories + activeCalories`) when a connection covers that day, and as
+predicted (`BMR × activityFactor + expectedActivityKcal`) otherwise, where
+`activityFactor` is the profile's activity-level NEAT multiplier
+(`sedentary` 1.2, `light` 1.3, `moderate` 1.4, `active` 1.5, `very_active` 1.6;
+defaulting to 1.2 when the activity level is unset). These NEAT factors cover
+non-exercise daily movement only; scheduled-workout energy is added separately
+via `expectedActivityKcal` and SHALL NOT be double-counted. Each resolved value
+SHALL be labelled `measured`, `predicted`, or `mixed`. The measured path SHALL
+ignore the activity factor.
+
+#### Scenario: Measured expenditure from ingested wellness
+
+- **GIVEN** a day with a `DailyWellness` record carrying `activeCalories` and `restingCalories`
+- **WHEN** daily expenditure is resolved
+- **THEN** expenditure equals `restingCalories + activeCalories`
+- **AND** the value is labelled `measured`
+
+#### Scenario: Predicted expenditure for an uncovered future day
+
+- **GIVEN** a future day with no ingested wellness record
+- **WHEN** daily expenditure is resolved
+- **THEN** expenditure equals `BMR × activityFactor + expectedActivityKcal`
+- **AND** the value is labelled `predicted`
+
+#### Scenario: Moderate-activity rest day scales the basal by the NEAT factor
+
+- **GIVEN** a profile with `activityLevel` = `moderate` and a computed `BMR` of 1750 kcal
+- **WHEN** daily expenditure is resolved for a day with no scheduled workout (`expectedActivityKcal` = 0)
+- **THEN** the predicted expenditure equals `1750 × 1.4` = 2450 kcal, not the raw 1750 kcal
+
+#### Scenario: Scheduled workout kcal are not double-counted
+
+- **GIVEN** a profile with `activityLevel` = `moderate` and a scheduled workout estimated at 500 `expectedActivityKcal`
+- **WHEN** daily expenditure is resolved
+- **THEN** the predicted expenditure equals `BMR × 1.4 + 500` — the workout kcal are added once on top of the NEAT-scaled basal and are NOT folded into the activity factor

--- a/openspec/changes/energy-expenditure-activity-factor/tasks.md
+++ b/openspec/changes/energy-expenditure-activity-factor/tasks.md
@@ -1,0 +1,38 @@
+## 1. Core: activity-factor module
+
+- [x] 1.1 Add `packages/core/src/application/energy/activity-factor.ts` with
+      `ActivityLevel`, `NEAT_FACTOR`, `DEFAULT_NEAT_FACTOR`, and
+      `neatFactorForActivityLevel`. Document the NEAT-vs-TDEE rationale.
+- [x] 1.2 Add `activity-factor.test.ts` (each level → its factor; unset/null →
+      default).
+
+## 2. Core: expenditure scaling
+
+- [x] 2.1 Add optional `basalActivityFactor` to `DayExpenditureInput`.
+- [x] 2.2 Scale the predicted basal by the factor (default 1); guard the factor
+      as finite and `> 0` (`RangeError`). Leave the measured path unchanged.
+- [x] 2.3 Update `expenditure.test.ts`: factor scales the basal; absent factor
+      keeps `bmr × 1`; invalid factor throws; measured path unaffected.
+
+## 3. Core: exports
+
+- [x] 3.1 Export the activity-factor symbols from `packages/core/src/index.ts`.
+
+## 4. SPA wiring
+
+- [x] 4.1 `resolve-day-expenditure-inputs.ts`: pass
+      `basalActivityFactor: neatFactorForActivityLevel(profile.activityLevel)` on
+      the predicted branch.
+- [x] 4.2 `resolve-goal-maintenance.ts`: scale the modeled maintenance by the
+      activity factor.
+- [x] 4.3 Recompute any affected SPA test expectations (none required — all
+      affected assertions are relative or measured-path).
+
+## 5. Verify
+
+- [x] 5.1 `pnpm --filter @kaiord/core run build`.
+- [x] 5.2 Core energy tests green.
+- [x] 5.3 `pnpm --filter @kaiord/workout-spa-editor run build` + affected SPA
+      tests green.
+- [x] 5.4 `pnpm lint:specs`, `pnpm test:scripts`, and
+      `npx openspec validate energy-expenditure-activity-factor --strict` green.

--- a/packages/core/src/application/energy/activity-factor.test.ts
+++ b/packages/core/src/application/energy/activity-factor.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  type ActivityLevel,
+  DEFAULT_NEAT_FACTOR,
+  NEAT_FACTOR,
+  neatFactorForActivityLevel,
+} from "./activity-factor";
+
+const LEVELS = Object.keys(NEAT_FACTOR) as ActivityLevel[];
+
+describe("neatFactorForActivityLevel", () => {
+  it.each(LEVELS)("should map %s to its NEAT_FACTOR entry", (level) => {
+    // Arrange
+    const expected = NEAT_FACTOR[level];
+
+    // Act
+    const factor = neatFactorForActivityLevel(level);
+
+    // Assert
+    expect(factor).toBe(expected);
+  });
+
+  it("should rank the factors monotonically from sedentary to very_active", () => {
+    // Arrange
+    const ordered = LEVELS.map((level) => NEAT_FACTOR[level]);
+
+    // Act
+    const sorted = [...ordered].sort((a, b) => a - b);
+
+    // Assert
+    expect(ordered).toEqual(sorted);
+    expect(NEAT_FACTOR.sedentary).toBe(DEFAULT_NEAT_FACTOR);
+  });
+
+  it("should fall back to the default factor when the level is undefined", () => {
+    // Arrange
+    const level = undefined;
+
+    // Act
+    const factor = neatFactorForActivityLevel(level);
+
+    // Assert
+    expect(factor).toBe(DEFAULT_NEAT_FACTOR);
+  });
+
+  it("should fall back to the default factor when the level is null", () => {
+    // Arrange
+    const level = null;
+
+    // Act
+    const factor = neatFactorForActivityLevel(level);
+
+    // Assert
+    expect(factor).toBe(DEFAULT_NEAT_FACTOR);
+  });
+});

--- a/packages/core/src/application/energy/activity-factor.ts
+++ b/packages/core/src/application/energy/activity-factor.ts
@@ -1,0 +1,40 @@
+/**
+ * Activity-level NEAT factors applied to the predicted basal expenditure.
+ *
+ * These multipliers are deliberately LOWER than the classic TDEE activity
+ * multipliers (which run ~1.2–1.9). The predicted expenditure already adds
+ * scheduled-workout energy separately via `expectedActivityKcal`, so the factor
+ * here only covers Non-Exercise Activity Thermogenesis (NEAT) — daily movement,
+ * posture, fidgeting, occupational activity — NOT structured exercise. Using a
+ * full TDEE multiplier would double-count the workout kcal.
+ *
+ * The default (unset activity level) is `sedentary` (1.2), the most conservative
+ * assumption, so an incomplete profile never over-states maintenance.
+ */
+
+export type ActivityLevel =
+  | "sedentary"
+  | "light"
+  | "moderate"
+  | "active"
+  | "very_active";
+
+/** NEAT factor used when the profile has no `activityLevel` set. */
+export const DEFAULT_NEAT_FACTOR = 1.2;
+
+/** NEAT-only multipliers per activity level (workout kcal added separately). */
+export const NEAT_FACTOR: Record<ActivityLevel, number> = {
+  sedentary: 1.2,
+  light: 1.3,
+  moderate: 1.4,
+  active: 1.5,
+  very_active: 1.6,
+};
+
+/**
+ * Resolve the NEAT multiplier for an activity level, falling back to
+ * `DEFAULT_NEAT_FACTOR` when the level is unset (`undefined`/`null`).
+ */
+export const neatFactorForActivityLevel = (
+  level?: ActivityLevel | null
+): number => (level ? NEAT_FACTOR[level] : DEFAULT_NEAT_FACTOR);

--- a/packages/core/src/application/energy/expenditure.test.ts
+++ b/packages/core/src/application/energy/expenditure.test.ts
@@ -94,6 +94,35 @@ describe("resolveDayExpenditure (predicted)", () => {
     expect(result.source).toBe("predicted");
     expect(result.expenditureKcal).toBe(BMR_KCAL);
   });
+
+  it("should scale the basal by the activity factor when provided", () => {
+    // Arrange
+    const factor = 1.4;
+    const input: DayExpenditureInput = {
+      ...PREDICTED_INPUT,
+      basalActivityFactor: factor,
+    };
+
+    // Act
+    const result = resolveDayExpenditure(input);
+
+    // Assert
+    expect(result.basalKcal).toBe(BMR_KCAL * factor);
+    expect(result.expenditureKcal).toBe(
+      BMR_KCAL * factor + EXPECTED_ACTIVITY_KCAL
+    );
+  });
+
+  it("should keep the raw basal when no activity factor is provided", () => {
+    // Arrange
+    const input = PREDICTED_INPUT;
+
+    // Act
+    const result = resolveDayExpenditure(input);
+
+    // Assert
+    expect(result.basalKcal).toBe(BMR_KCAL);
+  });
 });
 
 describe("resolveDayExpenditure (input guards)", () => {
@@ -123,5 +152,37 @@ describe("resolveDayExpenditure (input guards)", () => {
 
     // Assert
     expect(act).toThrow(RangeError);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "should throw RangeError for an invalid activity factor %s",
+    (factor) => {
+      // Arrange
+      const input: DayExpenditureInput = {
+        ...PREDICTED_INPUT,
+        basalActivityFactor: factor,
+      };
+
+      // Act
+      const act = () => resolveDayExpenditure(input);
+
+      // Assert
+      expect(act).toThrow(RangeError);
+    }
+  );
+
+  it("should ignore the activity factor on the measured path", () => {
+    // Arrange
+    const input: DayExpenditureInput = {
+      ...MEASURED_INPUT,
+      basalActivityFactor: 1.6,
+    };
+
+    // Act
+    const result = resolveDayExpenditure(input);
+
+    // Assert
+    expect(result.source).toBe("measured");
+    expect(result.expenditureKcal).toBe(RESTING_KCAL + ACTIVE_KCAL);
   });
 });

--- a/packages/core/src/application/energy/expenditure.ts
+++ b/packages/core/src/application/energy/expenditure.ts
@@ -23,6 +23,11 @@ export type DayExpenditureInput = {
   bmrKcal: number;
   /** Estimated activity kcal for the predicted fallback (Phase 4 input). */
   expectedActivityKcal: number;
+  /**
+   * NEAT multiplier applied to BMR for the predicted basal; defaults to 1.
+   * The measured path ignores it.
+   */
+  basalActivityFactor?: number;
 };
 
 export type DayExpenditureResult = {
@@ -46,6 +51,9 @@ const assertMeasured = (measured: MeasuredWellness): void => {
   }
 };
 
+const isPositiveFinite = (value: number): boolean =>
+  Number.isFinite(value) && value > 0;
+
 const assertPredicted = (input: DayExpenditureInput): void => {
   if (
     !isNonNegativeFinite(input.bmrKcal) ||
@@ -53,6 +61,14 @@ const assertPredicted = (input: DayExpenditureInput): void => {
   ) {
     throw new RangeError(
       "Predicted expenditure requires non-negative finite bmrKcal and expectedActivityKcal."
+    );
+  }
+  if (
+    input.basalActivityFactor !== undefined &&
+    !isPositiveFinite(input.basalActivityFactor)
+  ) {
+    throw new RangeError(
+      "Predicted expenditure requires a positive finite basalActivityFactor."
     );
   }
 };
@@ -69,10 +85,12 @@ const resolveMeasured = (measured: MeasuredWellness): DayExpenditureResult => {
 
 const resolvePredicted = (input: DayExpenditureInput): DayExpenditureResult => {
   assertPredicted(input);
+  const factor = input.basalActivityFactor ?? 1;
+  const basalKcal = input.bmrKcal * factor;
   return {
-    basalKcal: input.bmrKcal,
+    basalKcal,
     activityKcal: input.expectedActivityKcal,
-    expenditureKcal: input.bmrKcal + input.expectedActivityKcal,
+    expenditureKcal: basalKcal + input.expectedActivityKcal,
     source: "predicted",
   };
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -171,6 +171,12 @@ export { fromBinary, fromText } from "./application";
 export { toBinary, toText } from "./application";
 
 // Application: Energy calculators (pure)
+export type { ActivityLevel } from "./application/energy/activity-factor";
+export {
+  DEFAULT_NEAT_FACTOR,
+  NEAT_FACTOR,
+  neatFactorForActivityLevel,
+} from "./application/energy/activity-factor";
 export type {
   AdaptiveTdeeResult,
   ComputeAdaptiveTdeeInput,

--- a/packages/workout-spa-editor/src/application/energy/resolve-day-expenditure-inputs.ts
+++ b/packages/workout-spa-editor/src/application/energy/resolve-day-expenditure-inputs.ts
@@ -7,7 +7,11 @@
  * we never show a basal-derived number we cannot honestly compute.
  */
 
-import { computeBmr, type DayExpenditureInput } from "@kaiord/core";
+import {
+  computeBmr,
+  type DayExpenditureInput,
+  neatFactorForActivityLevel,
+} from "@kaiord/core";
 
 import type { IntakeEntryRecord } from "../../types/intake-entry-record";
 import type { Profile } from "../../types/profile";
@@ -58,5 +62,9 @@ export const toExpenditureInput = (
     sex: profile.sex!,
     bodyFatFraction: toBodyFatFraction(sources.bodyComposition),
   });
-  return { bmrKcal: bmr.kcal, expectedActivityKcal };
+  return {
+    bmrKcal: bmr.kcal,
+    expectedActivityKcal,
+    basalActivityFactor: neatFactorForActivityLevel(profile.activityLevel),
+  };
 };

--- a/packages/workout-spa-editor/src/application/energy/resolve-goal-maintenance.ts
+++ b/packages/workout-spa-editor/src/application/energy/resolve-goal-maintenance.ts
@@ -3,14 +3,15 @@
  * derive its day target, independently of the measured-vs-predicted expenditure
  * path (a measured day still needs a modeled maintenance for the goal math).
  *
- * Maintenance is the BMR the goal delta is measured against; the day's expected
+ * Maintenance is the BMR scaled by the profile's activity-level NEAT factor (the
+ * goal delta is measured against this realistic baseline); the day's expected
  * activity is added separately at the periodized-target layer so it raises the
  * day target without inflating the goal delta. Returns `null` when the profile
  * lacks the physiological fields BMR estimation requires, so the use-case leaves
  * `target_kcal` null rather than inventing a number.
  */
 
-import { computeBmr } from "@kaiord/core";
+import { computeBmr, neatFactorForActivityLevel } from "@kaiord/core";
 
 import type { HealthWeightRecord } from "../../types/health/health-records";
 import type { Profile } from "../../types/profile";
@@ -59,5 +60,7 @@ export const resolveGoalMaintenance = (
     sex: profile.sex,
     bodyFatFraction: toBodyFatFraction(sources.bodyComposition),
   });
-  return { maintenanceKcal: bmr.kcal, currentWeightKg };
+  const maintenanceKcal =
+    bmr.kcal * neatFactorForActivityLevel(profile.activityLevel);
+  return { maintenanceKcal, currentWeightKg };
 };


### PR DESCRIPTION
Closes #804.

## Why
On a no-workout day the predicted expenditure collapsed to the raw BMR (e.g. 1750 kcal for an 80 kg / 180 cm / 36 yo male), which understates real daily maintenance. Even a fully sedentary person burns ~20% over BMR through **NEAT** (Non-Exercise Activity Thermogenesis): posture, daily movement, digestion, occupational activity. Profiles already capture `activityLevel` (`sedentary`…`very_active`) but it was never applied, so both the predicted expenditure and the goal maintenance baseline were systematically too low.

## What
- **New `@kaiord/core` `activity-factor` API**: `ActivityLevel`, `NEAT_FACTOR` (sedentary 1.2, light 1.3, moderate 1.4, active 1.5, very_active 1.6), `DEFAULT_NEAT_FACTOR` (1.2), `neatFactorForActivityLevel(level?)`. These are **NEAT-only** multipliers, deliberately lower than classic TDEE multipliers — scheduled-workout energy is added separately via `expectedActivityKcal`, so a full TDEE multiplier would double-count the workout kcal.
- **`resolveDayExpenditure`** gains an optional `basalActivityFactor` on `DayExpenditureInput`. Predicted basal becomes `bmrKcal × factor` (default 1); `expectedActivityKcal` is still added on top. Factor must be finite and `> 0` (`RangeError` otherwise). **Measured path is unchanged** — it never reads the factor.
- **SPA wiring**: `toExpenditureInput` passes `basalActivityFactor: neatFactorForActivityLevel(profile.activityLevel)` on the predicted branch; `resolveGoalMaintenance` scales its modeled maintenance by the same factor so the goal target is measured against a realistic baseline. Unset `activityLevel` → conservative 1.2.

## Spec
OpenSpec change `energy-expenditure-activity-factor` — MODIFIED `energy-expenditure` "Daily expenditure resolution" requirement (predicted basal now `BMR × activity-level NEAT factor`, two new scenarios for NEAT scaling + no-double-count). `openspec validate --strict` passes.

## Verification
- `@kaiord/core` build ✅ · 427 unit tests ✅ (incl. new `activity-factor.test.ts` + expanded `expenditure.test.ts`)
- SPA energy app-layer tests ✅ (9 files / 49 tests)
- `pnpm test:scripts` mechanical guards ✅ (511/511)
- `pnpm lint` (eslint + tsc + format + archive + specs) ✅
- `pnpm exec changeset` ✅ (`@kaiord/core` minor — additive public API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)