### PR TITLE
fix(spa-editor): persist profile physiology edits; real clock for goal horizon

### DIFF
--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/ProfileEditView.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/ProfileEditView.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * ProfileEditView wiring test.
+ *
+ * Regression guard for the auto-save follow-up: a Personal Data edit MUST reach
+ * the persisting `onChange` (ProfileManagerDialog auto-saves it). The tab was
+ * previously wired to a state-only setter, so physiology edits never persisted.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { renderWithProviders, screen, userEvent } from "../../../../test-utils";
+import type { ProfileFormData } from "../types";
+import { ProfileEditView } from "./ProfileEditView";
+
+const PROFILE_ID = "00000000-0000-4000-8000-0000000000a1";
+
+describe("ProfileEditView", () => {
+  it("should forward a Personal Data edit to the persisting onChange", async () => {
+    // Arrange
+    const onChange = vi.fn();
+    const formData: ProfileFormData = { name: "Athlete", bodyWeight: 70 };
+    renderWithProviders(
+      <ProfileEditView
+        profileId={PROFILE_ID}
+        formData={formData}
+        onChange={onChange}
+        onCancel={vi.fn()}
+      />
+    );
+
+    // Act
+    await userEvent.click(screen.getByRole("tab", { name: "Personal Data" }));
+    await userEvent.selectOptions(
+      screen.getByLabelText("Activity Level"),
+      "moderate"
+    );
+
+    // Assert
+    expect(onChange).toHaveBeenLastCalledWith({
+      ...formData,
+      activityLevel: "moderate",
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/ProfileEditView.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/ProfileEditView.tsx
@@ -18,14 +18,15 @@ import { ProfileTabs } from "./ProfileTabs";
 type ProfileEditViewProps = {
   profileId: string;
   formData: ProfileFormData;
-  setFormData: (data: ProfileFormData) => void;
+  /** Updates form state AND persists in place (see ProfileManagerDialog). */
+  onChange: (data: ProfileFormData) => void;
   onCancel: () => void;
 };
 
 export function ProfileEditView({
   profileId,
   formData,
-  setFormData,
+  onChange,
   onCancel,
 }: ProfileEditViewProps) {
   const [activeTab, setActiveTab] = useState<ProfileTab>("zones");
@@ -40,7 +41,7 @@ export function ProfileEditView({
       <ProfileTabs activeTab={activeTab} onTabChange={setActiveTab} />
       {activeTab === "zones" && <SportZoneEditor profileId={profileId} />}
       {activeTab === "personal" && (
-        <PersonalDataTab formData={formData} onChange={setFormData} />
+        <PersonalDataTab formData={formData} onChange={onChange} />
       )}
       {activeTab === "linked-accounts" && profile && (
         <LinkedAccountsSection profile={profile} />

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/ProfileManagerDialog.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/components/ProfileManagerDialog.tsx
@@ -6,6 +6,7 @@
 
 import { DeleteConfirmDialog } from "../DeleteConfirmDialog";
 import { ImportExportActions } from "../ImportExportActions";
+import type { ProfileFormData } from "../types";
 import { CreateProfileSection } from "./CreateProfileSection";
 import { DialogHeader } from "./DialogHeader";
 import type { ProfileManagerDialogProps } from "./profile-manager-dialog-types";
@@ -16,11 +17,16 @@ import { ProfileNotifications } from "./ProfileNotifications";
 export function ProfileManagerDialog(props: ProfileManagerDialogProps) {
   const { editingProfile, formData, setFormData, handleSave } = props;
 
-  const handleNameChange = (name: string) => {
-    const nextFormData = { ...formData, name };
-    setFormData(nextFormData);
-    if (editingProfile) handleSave(nextFormData);
+  // Single edit-mode change path: update local form state AND persist in place.
+  // Used by both the inline name field and the Personal Data tab so name and
+  // physiology edits auto-save identically (handleSave no longer exits the view).
+  const handleEditFieldChange = (next: ProfileFormData) => {
+    setFormData(next);
+    if (editingProfile) handleSave(next);
   };
+
+  const handleNameChange = (name: string) =>
+    handleEditFieldChange({ ...formData, name });
 
   return (
     <>
@@ -36,7 +42,7 @@ export function ProfileManagerDialog(props: ProfileManagerDialogProps) {
         <ProfileEditView
           profileId={editingProfile.id}
           formData={formData}
-          setFormData={setFormData}
+          onChange={handleEditFieldChange}
           onCancel={props.handleCancel}
         />
       ) : (

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileEdit.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileEdit.test.tsx
@@ -79,7 +79,7 @@ describe("useProfileEdit", () => {
   });
 
   describe("handleSave", () => {
-    it("should persist updates and clear editing state on success", async () => {
+    it("should persist updates in place without exiting edit mode", async () => {
       // Arrange
       errorSpy.mockReset();
       const persistence = createInMemoryPersistence();
@@ -111,8 +111,8 @@ describe("useProfileEdit", () => {
         expect(fresh?.name).toBe("Renamed");
         expect(fresh?.bodyWeight).toBe(75);
       });
-      expect(setEditingProfile).toHaveBeenCalledWith(null);
-      expect(setFormData).toHaveBeenCalledWith({ name: "" });
+      expect(setEditingProfile).not.toHaveBeenCalled();
+      expect(setFormData).not.toHaveBeenCalled();
       expect(errorSpy).not.toHaveBeenCalled();
     });
 

--- a/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileEdit.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ProfileManager/hooks/useProfileEdit.ts
@@ -40,6 +40,10 @@ export function useProfileEdit(params: UseProfileEditParams) {
     });
   };
 
+  // Persist in place: editing fields (name in the header, physiology in the
+  // Personal Data tab) auto-save as the user types/selects WITHOUT exiting edit
+  // mode. The edit view is left only via "Back to List" (handleCancel); by then
+  // every change is already saved, so no explicit "Save & close" is needed.
   const handleSave = (overrideData?: ProfileFormData) => {
     const data = overrideData ?? formData;
     if (!editingProfile || !data.name.trim()) return;
@@ -54,8 +58,6 @@ export function useProfileEdit(params: UseProfileEditParams) {
           restingHeartRate: data.restingHeartRate,
           activityLevel: data.activityLevel,
         });
-        setEditingProfile(null);
-        setFormData({ name: "" });
       } catch {
         toast.error(TOAST_ERROR);
       }

--- a/packages/workout-spa-editor/src/hooks/energy/use-day-energy-balance-clock.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/energy/use-day-energy-balance-clock.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * useDayEnergyBalance goal-horizon clock test.
+ *
+ * Regression guard: the hook MUST pass the real local day as `today` so the
+ * goal horizon (months-to-target) is measured from the current date, not the
+ * viewed `date`. Viewing a past/future day previously defaulted `today` to that
+ * day, shrinking/growing the horizon and distorting the daily target.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { buildDayEnergyBalance } from "../../application/energy/build-day-energy-balance";
+import { PersistenceProvider } from "../../contexts/persistence-context";
+import { createInMemoryPersistence } from "../../test-utils/in-memory-persistence";
+import { todayIsoDate } from "../../utils/today-iso-date";
+import { useDayEnergyBalance } from "./use-day-energy-balance";
+
+vi.mock("../../application/energy/build-day-energy-balance", () => ({
+  buildDayEnergyBalance: vi.fn(() =>
+    Promise.resolve({ gated: true, reason: "profile-incomplete" })
+  ),
+}));
+
+const VIEWED_DATE = "2026-01-15";
+
+const wrap = ({ children }: { children: ReactNode }) => (
+  <PersistenceProvider persistence={createInMemoryPersistence()}>
+    {children}
+  </PersistenceProvider>
+);
+
+describe("useDayEnergyBalance goal-horizon clock", () => {
+  it("should pass the real local today as the goal horizon, not the viewed date", async () => {
+    // Arrange
+    const mocked = vi.mocked(buildDayEnergyBalance);
+    mocked.mockClear();
+
+    // Act
+    renderHook(() => useDayEnergyBalance("p1", VIEWED_DATE), { wrapper: wrap });
+
+    // Assert
+    await waitFor(() => expect(mocked).toHaveBeenCalled());
+    expect(mocked).toHaveBeenCalledWith(
+      expect.objectContaining({ date: VIEWED_DATE, today: todayIsoDate() })
+    );
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/energy/use-day-energy-balance.ts
+++ b/packages/workout-spa-editor/src/hooks/energy/use-day-energy-balance.ts
@@ -7,20 +7,27 @@
  * callback so every table it touches is observed by a single subscription
  * (design: one query per concern). Returns `undefined` while loading and when
  * `profileId` is null.
+ *
+ * `today` is passed explicitly as the real local day so the goal horizon is
+ * measured from the actual current date, not the displayed `date` — viewing a
+ * past or future day must not shrink/grow the months-to-goal and distort the
+ * daily target.
  */
 import { useLiveQuery } from "dexie-react-hooks";
 
 import { buildDayEnergyBalance } from "../../application/energy/build-day-energy-balance";
 import type { DayEnergyBalanceResult } from "../../application/energy/day-energy-balance-result";
 import { usePersistence } from "../../contexts/persistence-context";
+import { todayIsoDate } from "../../utils/today-iso-date";
 
 export const useDayEnergyBalance = (
   profileId: string | null,
   date: string
 ): DayEnergyBalanceResult | undefined => {
   const persistence = usePersistence();
+  const today = todayIsoDate();
   return useLiveQuery<DayEnergyBalanceResult | undefined>(() => {
     if (!profileId) return Promise.resolve(undefined);
-    return buildDayEnergyBalance({ persistence, profileId, date });
-  }, [persistence, profileId, date]);
+    return buildDayEnergyBalance({ persistence, profileId, date, today });
+  }, [persistence, profileId, date, today]);
 };


### PR DESCRIPTION
Two energy-balance follow-ups surfaced during the manual smoke of #804.

## 1. Profile Personal Data edits never persisted
The profile edit dialog auto-saved **only** the inline name field. The Personal Data tab's `onChange` was wired to a state-only setter (`setFormData`), so `height` / `birthDate` / `sex` / `restingHeartRate` / `activityLevel` edits were never written to Dexie. Compounding it, `handleSave` also reset edit mode (`setEditingProfile(null)` + cleared the form), so its only caller — the name field — dropped back to the profile list after a single keystroke.

**Fix:** `handleSave` now persists **in place** (no edit-mode reset). A single `handleEditFieldChange` path drives both the name field and the Personal Data tab, so every field auto-saves while editing. The edit view is left only via **Back to List** (`handleCancel`); by then all edits are already saved.

## 2. Non-today goal horizon used the viewed date as the clock
`useDayEnergyBalance` never passed `today`, so `buildDayEnergyBalance` defaulted `today = date`. Viewing a past/future day measured the months-to-goal from **that** day instead of the real today, distorting the periodized daily target.

**Fix:** thread `todayIsoDate()` (local-day, #747-safe) as `today`.

## Tests
- New `ProfileEditView.test.tsx` — a Personal Data edit reaches the persisting `onChange`.
- New `use-day-energy-balance-clock.test.tsx` — the hook passes the real local today, not the viewed date.
- Updated `useProfileEdit.test.tsx` to the persist-in-place contract.

## Verification
- `pnpm test:scripts` mechanical guards ✅ (511/511)
- Full SPA suite ✅ (703 files / 5068 tests)
- `pnpm lint` (eslint + tsc + format + archive + specs) ✅

SPA-only change to the private `@kaiord/workout-spa-editor` package — no changeset (not published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed energy balance goal horizon to calculate from today's date instead of the viewed date.

* **New Features**
  * Profile edits now auto-persist in real-time while in edit mode; users no longer need an explicit save action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->