### PR TITLE
fix(spa-editor): stop infinite render loop opening the Athlete Edit Profile dialog

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ProfileEditDialog.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ProfileEditDialog.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * ProfileEditDialog regression test.
+ *
+ * Guards against the infinite render loop: the open dialog seeds edit mode via
+ * `handleEdit`, which is recreated each render and writes a fresh `formData`
+ * object. Re-running it on every render looped setState->render->setState and
+ * crashed with React "Maximum update depth exceeded". Opening the dialog must
+ * mount the editor exactly once.
+ */
+
+import { screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "../../../adapters/dexie/dexie-database";
+import { createDexiePersistence } from "../../../adapters/dexie/dexie-persistence-adapter";
+import { renderWithProviders } from "../../../test-utils";
+import type { Profile } from "../../../types/profile";
+import { ProfileEditDialog } from "./ProfileEditDialog";
+
+const PROFILE_ID = "11111111-1111-1111-1111-111111111111";
+
+const PROFILE: Profile = {
+  id: PROFILE_ID,
+  name: "Ana Gomez",
+  sportZones: {},
+  linkedAccounts: [],
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const clearTables = async () => {
+  await db.table("profiles").clear();
+  await db.table("meta").clear();
+};
+
+describe("ProfileEditDialog", () => {
+  beforeEach(clearTables);
+  afterEach(clearTables);
+
+  it("should mount the editor once when opened without an update-depth loop", async () => {
+    // Arrange
+    await db.table<Profile>("profiles").put(PROFILE);
+    await db.table("meta").put({ key: "activeProfileId", value: PROFILE_ID });
+
+    // Act
+    renderWithProviders(
+      <ProfileEditDialog open profile={PROFILE} onClose={vi.fn()} />,
+      { persistence: createDexiePersistence(db) }
+    );
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("Ana Gomez")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ProfileEditDialog.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ProfileEditDialog.tsx
@@ -1,5 +1,5 @@
 import * as Dialog from "@radix-ui/react-dialog";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 import type { Profile } from "../../../types/profile";
 import { ProfileManagerDialog } from "../../organisms/ProfileManager/components/ProfileManagerDialog";
@@ -23,8 +23,20 @@ export function ProfileEditDialog({
   const manager = useProfileManager();
   const { handleEdit } = manager;
 
+  // Enter edit mode once per open. `handleEdit` is recreated every render and
+  // writes a fresh `formData` object, so re-running it on each render would
+  // loop setState -> render -> setState forever (React "max update depth").
+  // Seed only on the closed->open transition; the dialog edits the active
+  // profile, which does not change while the dialog is open.
+  const seeded = useRef(false);
   useEffect(() => {
-    if (open) handleEdit(profile);
+    if (!open) {
+      seeded.current = false;
+      return;
+    }
+    if (seeded.current) return;
+    seeded.current = true;
+    handleEdit(profile);
   }, [open, profile, handleEdit]);
 
   return (


### PR DESCRIPTION
## Bug
Opening the Athlete page's **Edit profile** dialog crashes the app with React error #185 (*Maximum update depth exceeded*).

`ProfileEditDialog` seeds edit mode in a `useEffect` whose deps include `handleEdit`. `useProfileManager` recreates `handleEdit` on every render, and `handleEdit` writes a **fresh `formData` object** (`setFormData({...})`). So every render re-ran the effect → `setState` → render → `setState` … looping forever.

Pre-existing since the mobile redesign (#702) — surfaced while smoke-testing the energy activity-factor (#804). Not a regression from the recent energy PRs (#809/#810/#812); those did not touch `ProfileEditDialog` or `handleEdit`.

## Fix
Seed edit mode **once per open** via a ref guard, so `handleEdit` runs only on the closed→open transition. The dialog edits the active profile, which does not change while the dialog is open, so a single seed is correct.

## Test
New `ProfileEditDialog.test.tsx` renders the open dialog and asserts the editor mounts (the profile name field appears). **Verified the test fails against the pre-fix code** (it crashes with the update-depth loop through Radix's render) and passes with the fix.

## Verification
- `pnpm -r build` ✅ · `pnpm lint` ✅ · `pnpm test:scripts` ✅ · AthletePage tests 11/11 ✅
- Live-confirmed in a preview build: before the fix, clicking *Edit profile* throws #185; the smoke that found this also confirmed the energy activity-factor renders 2450 kcal (BMR 1750 × moderate NEAT 1.4).

SPA-only change to the private `@kaiord/workout-spa-editor` package — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)