### PR TITLE
fix(spa-editor): add accessible Dialog.Title to profile and coaching dialogs

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-shell.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-shell.test.tsx
@@ -25,6 +25,22 @@ describe("CoachingDialogShell", () => {
     expect(screen.getByText("Body content")).toBeInTheDocument();
   });
 
+  it("should expose an accessible dialog title", () => {
+    // Arrange
+
+    // Act
+    render(
+      <CoachingDialogShell onClose={vi.fn()}>
+        <p>Body</p>
+      </CoachingDialogShell>
+    );
+
+    // Assert
+    expect(
+      screen.getByRole("dialog", { name: "Coaching activity" })
+    ).toBeInTheDocument();
+  });
+
   it("should fire onClose when the user dismisses the dialog with Escape", async () => {
     // Arrange
     const onClose = vi.fn();

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-shell.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-shell.tsx
@@ -23,6 +23,7 @@ export function CoachingDialogShell({
           data-testid="coaching-activity-dialog"
           className="fixed left-1/2 top-1/2 z-50 w-full max-w-md -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800"
         >
+          <Dialog.Title className="sr-only">Coaching activity</Dialog.Title>
           <Dialog.Description className="sr-only">
             Coaching activity details with AI/manual creation, match, and split
             actions.

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/CreateProfileDialog.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/CreateProfileDialog.tsx
@@ -24,10 +24,10 @@ export function CreateProfileDialog({
     <Dialog.Root open={open} onOpenChange={(next) => !next && onClose()}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
-        <Dialog.Content
-          aria-label="Create athlete profile"
-          className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800"
-        >
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800">
+          <Dialog.Title className="sr-only">
+            Create athlete profile
+          </Dialog.Title>
           <ProfileManagerDialog {...manager} />
         </Dialog.Content>
       </Dialog.Portal>

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ProfileEditDialog.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ProfileEditDialog.tsx
@@ -43,10 +43,8 @@ export function ProfileEditDialog({
     <Dialog.Root open={open} onOpenChange={(next) => !next && onClose()}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
-        <Dialog.Content
-          aria-label="Edit profile"
-          className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800"
-        >
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800">
+          <Dialog.Title className="sr-only">Edit profile</Dialog.Title>
           <ProfileManagerDialog {...manager} />
         </Dialog.Content>
       </Dialog.Portal>

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ThresholdEditDialog.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ThresholdEditDialog.tsx
@@ -19,10 +19,8 @@ export function ThresholdEditDialog({
     <Dialog.Root open={open} onOpenChange={(next) => !next && onClose()}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
-        <Dialog.Content
-          aria-label="Edit thresholds"
-          className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800"
-        >
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800">
+          <Dialog.Title className="sr-only">Edit thresholds</Dialog.Title>
           <SportZoneEditor profileId={profileId} />
         </Dialog.Content>
       </Dialog.Portal>

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/dialog-title-a11y.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/dialog-title-a11y.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * A11y regression for the Athlete-page wrapper dialogs.
+ *
+ * These reuse shared content (ProfileManagerDialog / SportZoneEditor) and
+ * previously set only `aria-label` on `Dialog.Content`, which does NOT satisfy
+ * Radix's Dialog.Title requirement — opening them logged "DialogContent
+ * requires a DialogTitle". Each now renders a visually-hidden `Dialog.Title`,
+ * so the dialog exposes an accessible name.
+ */
+import { screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "../../../adapters/dexie/dexie-database";
+import { createDexiePersistence } from "../../../adapters/dexie/dexie-persistence-adapter";
+import { renderWithProviders } from "../../../test-utils";
+import type { Profile } from "../../../types/profile";
+import { CreateProfileDialog } from "./CreateProfileDialog";
+import { ProfileEditDialog } from "./ProfileEditDialog";
+import { ThresholdEditDialog } from "./ThresholdEditDialog";
+
+const PROFILE_ID = "11111111-1111-1111-1111-111111111111";
+
+const PROFILE: Profile = {
+  id: PROFILE_ID,
+  name: "Ana Gomez",
+  sportZones: {},
+  linkedAccounts: [],
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const seed = async () => {
+  await db.table<Profile>("profiles").put(PROFILE);
+  await db.table("meta").put({ key: "activeProfileId", value: PROFILE_ID });
+};
+
+const clear = async () => {
+  await db.table("profiles").clear();
+  await db.table("meta").clear();
+};
+
+const renderDialog = (ui: ReactElement) =>
+  renderWithProviders(ui, { persistence: createDexiePersistence(db) });
+
+describe("Athlete dialog accessible titles", () => {
+  beforeEach(seed);
+  afterEach(clear);
+
+  it("should give the edit-profile dialog an accessible title", async () => {
+    // Arrange
+
+    // Act
+    renderDialog(
+      <ProfileEditDialog open profile={PROFILE} onClose={vi.fn()} />
+    );
+
+    // Assert
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Edit profile" })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should give the create-profile dialog an accessible title", async () => {
+    // Arrange
+
+    // Act
+    renderDialog(<CreateProfileDialog open onClose={vi.fn()} />);
+
+    // Assert
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Create athlete profile" })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("should give the threshold-edit dialog an accessible title", async () => {
+    // Arrange
+
+    // Act
+    renderDialog(
+      <ThresholdEditDialog open profileId={PROFILE_ID} onClose={vi.fn()} />
+    );
+
+    // Assert
+    await waitFor(() => {
+      expect(
+        screen.getByRole("dialog", { name: "Edit thresholds" })
+      ).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## A11y warning
Radix logs **"DialogContent requires a DialogTitle for the component to be accessible"** when a dialog renders no `Dialog.Title` — an `aria-label` on `Dialog.Content` does **not** satisfy it (Radix checks for the Title primitive). Surfaced while smoke-testing the energy feature.

Four dialogs warned:
- `ProfileEditDialog`, `CreateProfileDialog`, `ThresholdEditDialog` — Athlete-page wrappers that reuse shared content (`ProfileManagerDialog` / `SportZoneEditor`) with only an `aria-label`.
- `coaching-dialog-shell` — had a `Dialog.Description` but no `Dialog.Title`.

(The other ~17 `Dialog.Content` usages already render a Title, often via a child component — e.g. `RawWorkoutHeader`, `*Panel` components — so they were not touched.)

## Fix
Each dialog now renders a **visually-hidden `Dialog.Title`** (the established `sr-only` pattern — the coaching shell already used `sr-only` for its Description). The Title also becomes the dialog's accessible name, so the redundant `aria-label`s are removed (accessible names unchanged). Satisfies the repo's zero-accessibility-warnings policy.

## Tests
- New `dialog-title-a11y.test.tsx` asserts the three Athlete dialogs expose an accessible name (`getByRole("dialog", { name })`).
- Extended `coaching-dialog-shell.test.tsx` with the same assertion.

## Verification
- `pnpm -r build` ✅ · `pnpm lint` ✅ (tsc + eslint + prettier) · `pnpm test:scripts` ✅ · full SPA suite ✅ (705 files / 5074 tests)

SPA-only change to the private `@kaiord/workout-spa-editor` package — no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog accessibility across multiple dialogs by implementing proper semantic title elements instead of aria-label attributes for better screen reader support.

* **Tests**
  * Added comprehensive accessibility test suite to verify dialogs render with proper accessible titles and labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->