### PR TITLE
chore(deps): bump @ai-sdk + add GatewayError gateway-stub export (unblocks #806)

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -33,7 +33,7 @@
     "ai": "^6.0.177"
   },
   "devDependencies": {
-    "@ai-sdk/anthropic": "^3.0.76",
+    "@ai-sdk/anthropic": "^3.0.85",
     "@types/node": "^25.7.0",
     "@vitest/coverage-v8": "^4.1.6",
     "ai": "^6.0.177",

--- a/packages/workout-spa-editor/package.json
+++ b/packages/workout-spa-editor/package.json
@@ -31,9 +31,9 @@
     "clean": "rm -rf dist node_modules/.vite"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.76",
-    "@ai-sdk/google": "^3.0.72",
-    "@ai-sdk/openai": "^3.0.63",
+    "@ai-sdk/anthropic": "^3.0.85",
+    "@ai-sdk/google": "^3.0.83",
+    "@ai-sdk/openai": "^3.0.74",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",

--- a/packages/workout-spa-editor/src/lib/ai-sdk-gateway-stub.ts
+++ b/packages/workout-spa-editor/src/lib/ai-sdk-gateway-stub.ts
@@ -49,3 +49,18 @@ export class GatewayAuthenticationError extends Error {
     return false;
   }
 }
+
+// Base gateway error the `ai` SDK statically imports (newer @ai-sdk/gateway
+// versions). `wrapGatewayError` calls `GatewayError.isInstance(error)`; same
+// reasoning as above — the SPA never reaches the gateway, so it is always
+// `false`, preserving the original provider error.
+export class GatewayError extends Error {
+  constructor(message?: string) {
+    super(message ?? "GatewayError");
+    this.name = "GatewayError";
+  }
+
+  static isInstance(): boolean {
+    return false;
+  }
+}

--- a/packages/workout-spa-editor/src/lib/generated/model-catalog.ts
+++ b/packages/workout-spa-editor/src/lib/generated/model-catalog.ts
@@ -24,6 +24,8 @@ export const MODEL_CATALOG: Record<LlmProviderType, ModelOption[]> = {
     { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
     { id: "claude-opus-4-6", label: "claude-opus-4-6" },
     { id: "claude-opus-4-7", label: "claude-opus-4-7" },
+    { id: "claude-opus-4-8", label: "claude-opus-4-8" },
+    { id: "claude-fable-5", label: "claude-fable-5" },
   ],
   openai: [
     { id: "o1", label: "o1" },
@@ -90,6 +92,7 @@ export const MODEL_CATALOG: Record<LlmProviderType, ModelOption[]> = {
     { id: "gemini-3.1-pro-preview", label: "gemini-3.1-pro-preview" },
     { id: "gemini-3.1-pro-preview-customtools", label: "gemini-3.1-pro-preview-customtools" },
     { id: "gemini-3.1-flash-lite-preview", label: "gemini-3.1-flash-lite-preview" },
+    { id: "gemini-3.5-flash", label: "gemini-3.5-flash" },
     { id: "gemini-pro-latest", label: "gemini-pro-latest" },
     { id: "gemini-flash-latest", label: "gemini-flash-latest" },
     { id: "gemini-flash-lite-latest", label: "gemini-flash-lite-latest" },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.76
-        version: 3.0.76(zod@4.4.3)
+        specifier: ^3.0.85
+        version: 3.0.85(zod@4.4.3)
       '@types/node':
         specifier: ^25.7.0
         version: 25.7.0
@@ -544,14 +544,14 @@ importers:
   packages/workout-spa-editor:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: ^3.0.76
-        version: 3.0.76(zod@4.4.3)
+        specifier: ^3.0.85
+        version: 3.0.85(zod@4.4.3)
       '@ai-sdk/google':
-        specifier: ^3.0.72
-        version: 3.0.72(zod@4.4.3)
+        specifier: ^3.0.83
+        version: 3.0.83(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: ^3.0.63
-        version: 3.0.63(zod@4.4.3)
+        specifier: ^3.0.74
+        version: 3.0.74(zod@4.4.3)
       '@dnd-kit/core':
         specifier: ^6.3.1
         version: 6.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -773,8 +773,8 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/anthropic@3.0.76':
-    resolution: {integrity: sha512-kOuvT9e6PygFvgYpkr4v9gjvmcMPfJp79jaXjeRl9Gpoj2OXdtc3ero7o1ic+tiSBw5IMubxXFO68BCA/axGJA==}
+  '@ai-sdk/anthropic@3.0.85':
+    resolution: {integrity: sha512-fNeDB644l5wbRNQU0FnI+F7UTtOenMnPtACfMPUJaS2zJfuBlseEa1TMg+otHkETZgaJB+6Na51NQEv0+m7czw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -785,20 +785,26 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@3.0.72':
-    resolution: {integrity: sha512-9EVG0AdUhs0hJ2+sqRb4IURZnsBahuU1CQELu+hfItm0wUTzxnVhIbQ4/jJkG/QFPtBUvMefCwDT7HX8T2HVbQ==}
+  '@ai-sdk/google@3.0.83':
+    resolution: {integrity: sha512-Pz7aCX0dy+5x+r4K/37HbLZNaPtPL4q2NduzJW64VffLv5sI9Nb478wAd7PlH2r2asiypJsz/Jerf9draTciUA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.63':
-    resolution: {integrity: sha512-4yY/m8a57MNNVoJCsXuNblKf6BO4yuAuLKRX4tzSNffBEBSp1FlcWdPE0Z4FkqUeS0AJhYSSqp0GIiA/cIcDNA==}
+  '@ai-sdk/openai@3.0.74':
+    resolution: {integrity: sha512-LPDBWd2WCv0GQs29K2pHcNrGx24hm4D8QEP386HwUAUPr1URho6bNVXHNmIv0FxaW+xDkLpNMTen+mFCUBp2LA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/provider-utils@4.0.27':
     resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.30':
+    resolution: {integrity: sha512-VO7I+vPffqI5sMnPoUq5DCSqKIgQIk/naJWRdQVpz2ma2zoprC/lqiJiUEl2s6DfvTD76TbhD3q39ROjlA6rGw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -7732,10 +7738,10 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/anthropic@3.0.76(zod@4.4.3)':
+  '@ai-sdk/anthropic@3.0.85(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/gateway@3.0.112(zod@4.4.3)':
@@ -7745,19 +7751,26 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
-  '@ai-sdk/google@3.0.72(zod@4.4.3)':
+  '@ai-sdk/google@3.0.83(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai@3.0.63(zod@4.4.3)':
+  '@ai-sdk/openai@3.0.74(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
-      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.30(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0


### PR DESCRIPTION
Refs #806. Resolves the root cause of #806's red build.

## Investigation
The grouped dependabot PR #806 (52 bumps) fails its `build` with:
```
[MISSING_EXPORT] "GatewayError" is not exported by "src/lib/ai-sdk-gateway-stub.ts"
  import { GatewayError } from "@ai-sdk/gateway";
```
The `@ai-sdk` portion of #806 bumps `@ai-sdk/gateway` 3.0.112→3.0.133 (+ anthropic/google/openai). The newer `ai` SDK **statically imports `GatewayError`** from `@ai-sdk/gateway`, which the SPA aliases to a local stub (`ai-sdk-gateway-stub.ts`, dropping ~60 KB / the full model-id catalog). The stub exported `createGateway` / `gateway` / `GatewayAuthenticationError` — but **not** `GatewayError`, so rolldown failed the SPA build.

## Change
- Add the missing `GatewayError` export to the stub (mirrors `GatewayAuthenticationError`: `isInstance() => false`, since the SPA never reaches the gateway).
- Bump the `@ai-sdk` subset to #806's versions: anthropic `3.0.85`, google `3.0.83`, openai `3.0.74`.

This lands the `@ai-sdk` upgrade dependabot couldn't (it lacked the stub fix), so the remaining #806 bumps can be recreated/merged without the blocker.

## Verification
- `pnpm -r build` green — SPA vite/rolldown build `✓` (the exact stage that failed in #806).
- `@kaiord/ai` 75 tests pass; `provider-factory` tests pass; eslint clean.
- `@ai-sdk/anthropic` is a devDep of `@kaiord/ai` and `workout-spa-editor` is private → no published runtime change, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)