### PR TITLE
chore(ci): raise Release job timeout 12->20m for full-fleet publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,13 @@ jobs:
   release:
     name: Version & Publish
     runs-on: ubuntu-latest
-    # P95 = 480s; ceil(P95 × 1.5 / 60) = 12; capped at test-family ceiling 30.
-    # (npm publish is the dominant cost — classify as test-family for the
-    # ceiling since it's external-network-bound, not a long-running build.)
-    timeout-minutes: 12
+    # npm publish is the dominant cost (external-network-bound). The P95-derived
+    # value (ceil(480s × 1.5 / 60) = 12) reflects typical small releases, but a
+    # full-fleet release (all 9 packages in one changeset batch, with provenance)
+    # overruns it — the 9.2.0 release was killed at 12m right after publish, so
+    # changesets never pushed tags / created GitHub releases. Use a fixed 20m of
+    # headroom for the worst case, still within the test-family ceiling of 30.
+    timeout-minutes: 20
     steps:
       # Mint a short-lived (1h) token from the kaiord-release-bot GitHub App.
       # Required so the "Version Packages" PR pushed by changesets/action


### PR DESCRIPTION
## Why
Merging the 9.2.0 release (#753 — a 15-changeset batch bumping **all 9 publishable packages**) published everything to npm, but the **Release** workflow was killed at its `timeout-minutes: 12` **right after npm publish finished** — so `changesets/action` never pushed the git tags and the "Create GitHub Releases" step was skipped. (I recovered both manually: 9 tags + 9 GitHub releases for 9.2.0 are now in place.)

The timeout is P95-derived (`ceil(480s × 1.5 / 60) = 12`), but P95 reflects typical 1–2 package releases. A full-fleet publish (9 packages + provenance) is an outlier that exceeds it.

## Change
`timeout-minutes: 12 → 20` on the `Version & Publish` job (still within the documented test-family ceiling of 30), with an updated comment explaining the full-fleet case.

Workflow-only change; no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-facing changes in this release. This update only adjusts internal release pipeline configuration to improve reliability during the build and deployment process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->