### PR TITLE
feat(spa-editor): chat word search across a profile's chats

### DIFF
--- a/openspec/changes/add-chat-search/.openspec.yaml
+++ b/openspec/changes/add-chat-search/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/add-chat-search/design.md
+++ b/openspec/changes/add-chat-search/design.md
@@ -85,14 +85,23 @@ so shared links keep one meaning and history is not polluted by per-result focus
 - **Alternative — `?m=<messageId>` query param:** deep-linkable to a message, but
   complicates routing and history for a transient UI affordance. Rejected for v1.
 
-### D5 — Lazy, debounced message load; results panel replaces the list
+### D5 — Live-while-active, debounced message read; results panel replaces the list
 
-Profile messages for search are read via the existing `listByProfile` only when
-search is active, debounced on input, rather than holding the whole transcript in
-memory continuously. While the query is non-empty the results panel replaces
-`ConversationList` in the same column (with a clear control); an empty query
-restores the list. This keeps the "one query per page" posture and avoids a
-standing live subscription to every message.
+Profile messages for search are read via the existing `listByProfile`, but only
+**while search is active** and through `useLiveQuery` — the repo's standard
+posture for persisted data. When the query is idle the live query resolves to an
+empty set, so no per-profile read runs until the user searches; once active, the
+subscription reflects messages appended during the session and a profile switch
+without a remount. Input is debounced before the search recomputes. While the
+query is non-empty the results panel replaces `ConversationList` in the same
+column (with a clear control); an empty query restores the list.
+
+- **Why not a one-time snapshot load:** a single `listByProfile().then(setState)`
+  on first activation is simpler, but freezes the searched set for the hook's
+  lifetime — messages sent during the session are not searchable until remount,
+  and a profile switch briefly searches the previous profile's messages against
+  the new profile's conversations. Gating `useLiveQuery` on `active` keeps the
+  "no read until active" guarantee while removing both staleness modes.
 
 ### D6 — Module layout (cap-driven)
 
@@ -100,7 +109,7 @@ standing live subscription to every message.
 conversations, messages) → SearchResult[]`. Unit-tested.
 - `application/chat/normalize-search-text.ts` — normalization + tokenization helper.
 - `application/chat/build-snippet.ts` — windowing + match-range computation.
-- `hooks/use-chat-search.ts` — debounce, lazy message load, orchestration.
+- `hooks/use-chat-search.ts` — debounce, live-while-active message read, orchestration.
 - `components/organisms/Chat/ChatSearchResults.tsx` + a search box wired into
   `ChatWorkspace`/`ConversationList`; `ChatMessageList` gains `focusMessageId`.
 
@@ -116,6 +125,11 @@ messageId, role, snippet, ranges }[] }`.
   single-user personal app's volume; debounced and only while search is active. If
   volume ever grows, D1's use-case seam allows swapping in an index without UI
   changes.
+- **Live subscription recomputes results on every message change (D5)** → While
+  searching, an `append` re-fires the query and re-runs `searchConversations`.
+  In practice a user rarely chats and searches simultaneously, the gate keeps the
+  subscription off otherwise, and the recompute is a bounded in-memory pass; the
+  staleness it removes outweighs the occasional extra pass.
 - **No stopwords** → Common short words ("de", "la") become required tokens, but
   under AND over Spanish prose they are almost always satisfied, so recall is
   barely affected; the cost is negligible and avoids language-specific lists.

--- a/openspec/changes/add-chat-search/design.md
+++ b/openspec/changes/add-chat-search/design.md
@@ -1,0 +1,135 @@
+## Context
+
+The SPA chat assistant persists per-profile conversations (`chatConversations`)
+and append-only messages (`chatMessages`) in Dexie, read reactively through
+`useChatConversationsLive` and `useChatMessagesLive`. `ChatPage → ChatWorkspace`
+renders a two-column layout: `ConversationList` (sidebar) and the active
+`ChatConversation` thread. The message repository already exposes
+`listByProfile(profileId)` with no limit, so all of a profile's message text is
+reachable without any schema change.
+
+There is no full-text index in Dexie and no search library anywhere in the
+monorepo. The only existing in-app search — the Workout Library `filterBySearch`
+— is naive `toLowerCase().includes()` over a single contiguous substring, with no
+accent handling. Chat content is long-form prose, where that approach fails on
+multi-word queries and accented Spanish ("intervalos vo2" vs "intervalos de VO2",
+"umbral" vs "úmbral"). This change introduces a dedicated, dependency-free search
+for chats, with the matching semantics already crystallized in exploration.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Find conversations by words in their title and message content, accent- and
+  case-insensitively, for the active profile.
+- Keep the feature read-only and additive: no Dexie migration, no new port, no
+  effect on cross-device sync.
+- Produce ranked results with highlighted snippets and scroll-to-message focus.
+- Keep all logic in a pure, unit-testable use case; respect the 100-line/file and
+  40-line/function caps.
+
+**Non-Goals:**
+
+- Fuzzy / typo-tolerant matching, edit-distance, or an inverted index / BM25.
+- A stopword list or language-specific stemming.
+- Extracting a shared `normalizeForSearch()` to also fix the Library search's
+  accent gap (worthwhile, but out of scope here to keep the change focused).
+- Searching across profiles or persisting search state.
+
+## Decisions
+
+### D1 — Dependency-free token-AND over normalized text (not a search library)
+
+Match by: normalize (`NFD` + strip `\p{Diacritic}` + lowercase) → split on
+whitespace → drop 1-char tokens → require every token as a substring. This is
+~level 3 ("token-AND + light score") on the spectrum considered.
+
+- **Why not naive substring (Library's approach):** fails multi-word and accents —
+  the two things chat prose needs most.
+- **Why not fuzzy (Fuse.js / Levenshtein):** over-engineered for a single-user
+  personal app with low volume; in long prose, edit-distance fires many false
+  positives and makes exact highlight ranges ambiguous.
+- **Why not an inverted index (MiniSearch/FlexSearch):** adds a dependency and an
+  index lifecycle (rebuild on append/merge) for volume the app does not have. The
+  use case is the natural seam to drop one in later if ever needed.
+
+### D2 — Conversation-level match, message-level ranking ("B with re-ranking")
+
+A conversation matches when title + all messages together contain every token,
+even if tokens are spread across different messages. This favors recall (the
+mental model of "we discussed this somewhere in this thread"). Precision is
+recovered in ordering, not exclusion: within a conversation, messages matching
+more distinct tokens rank first, and conversations are scored by title-match
+boost + token frequency with `updatedAt` as the tiebreak.
+
+- **Alternative considered — AND per message:** only messages containing all tokens
+  match. More precise per hit, but silently drops conversations where the terms
+  live in separate messages — the common chat case. Rejected; its precision is
+  preserved via message ranking instead.
+
+### D3 — Substring tokens beat exact offsets out of fuzzy's reach
+
+Because each token matches as a literal normalized substring, the exact character
+offsets of every match are known. Snippet windowing (±30 chars around the
+highest-ranked token's span) and the static-yellow highlight fall out directly,
+with no separate highlight pass. Normalization is computed for matching but the
+**original** text is sliced for display, so accents render correctly in snippets.
+
+### D4 — Transient focus state, not a URL param
+
+Scroll-to-message passes a `focusMessageId` as transient navigation state down to
+`ChatMessageList`, which calls `scrollIntoView` and applies the same static
+yellow until the search changes. The deep-link URL stays `/chat/:conversationId`
+so shared links keep one meaning and history is not polluted by per-result focus.
+
+- **Alternative — `?m=<messageId>` query param:** deep-linkable to a message, but
+  complicates routing and history for a transient UI affordance. Rejected for v1.
+
+### D5 — Lazy, debounced message load; results panel replaces the list
+
+Profile messages for search are read via the existing `listByProfile` only when
+search is active, debounced on input, rather than holding the whole transcript in
+memory continuously. While the query is non-empty the results panel replaces
+`ConversationList` in the same column (with a clear control); an empty query
+restores the list. This keeps the "one query per page" posture and avoids a
+standing live subscription to every message.
+
+### D6 — Module layout (cap-driven)
+
+- `application/chat/search-conversations.ts` — pure use case: `(query,
+conversations, messages) → SearchResult[]`. Unit-tested.
+- `application/chat/normalize-search-text.ts` — normalization + tokenization helper.
+- `application/chat/build-snippet.ts` — windowing + match-range computation.
+- `hooks/use-chat-search.ts` — debounce, lazy message load, orchestration.
+- `components/organisms/Chat/ChatSearchResults.tsx` + a search box wired into
+  `ChatWorkspace`/`ConversationList`; `ChatMessageList` gains `focusMessageId`.
+
+`SearchResult = { conversationId, title, titleMatch, messageMatches: {
+messageId, role, snippet, ranges }[] }`.
+
+## Risks / Trade-offs
+
+- **Recall over precision (D2)** → A long thread that mentions tokens in unrelated
+  places can match. Mitigated by ranking (frequency/title/recency) and by surfacing
+  the most-matching messages first, so noise sinks rather than misleads.
+- **Loading all profile messages into memory on search** → Acceptable for a
+  single-user personal app's volume; debounced and only while search is active. If
+  volume ever grows, D1's use-case seam allows swapping in an index without UI
+  changes.
+- **No stopwords** → Common short words ("de", "la") become required tokens, but
+  under AND over Spanish prose they are almost always satisfied, so recall is
+  barely affected; the cost is negligible and avoids language-specific lists.
+- **Substring tokens cross word boundaries** ("vo2" matches "vo2max") → Intended;
+  desirable for shorthand. Documented so it is not mistaken for a bug.
+
+## Migration Plan
+
+None. The change is additive and read-only: no Dexie version bump, no data
+migration, no port or public-API change. Rollback is removal of the new files and
+the search box wiring; existing chat behavior is untouched.
+
+## Open Questions
+
+- None blocking. Minor presentation tuning (exact snippet ellipsis glyph, score
+  weights for title vs frequency) can be finalized during implementation against
+  the spec scenarios.

--- a/openspec/changes/add-chat-search/proposal.md
+++ b/openspec/changes/add-chat-search/proposal.md
@@ -1,0 +1,65 @@
+## Why
+
+The in-SPA AI chat assistant now keeps distinct per-profile conversations
+(see `spa-chat-conversations`), but the only way to find an earlier exchange is
+to scroll the conversation list and read titles — which are auto-derived from the
+first user message and rarely describe what was actually discussed. As the number
+of threads grows, recalling "where did we talk about the VO2 block near threshold?"
+becomes impractical. There is no way to search inside the chats.
+
+## What Changes
+
+- Add a word search over the active profile's chats that matches against both
+  conversation **titles** and message **content** (user/assistant), entirely
+  client-side and read-only — no Dexie migration, no new ports, no writes.
+- Matching is accent- and case-insensitive (NFD diacritic stripping), tokenized
+  on whitespace; tokens of a single character are ignored. A conversation matches
+  when its title plus all its messages together contain **every** token (tokens may
+  be spread across different messages). No fuzzy matching, no inverted index.
+- Results are ranked: conversations by a relevance score (title-match boost +
+  token frequency, with `updatedAt` as the tiebreak); within a conversation, the
+  messages that match the most tokens surface first.
+- Each result shows a snippet (±30 characters of context around the matched token,
+  ellipsis on truncation) with the matched span highlighted in static yellow.
+- Selecting a result opens the conversation and scrolls to the matched message,
+  highlighting it with the same static yellow. The matched-message focus is
+  transient navigation state — the deep-link URL stays `/chat/:conversationId`.
+- The search box sits above the conversation list; while the query is non-empty the
+  results panel replaces the conversation list (with a clear affordance). Profile
+  messages are loaded lazily when search is active, debounced.
+
+Out of scope for v1 (noted as future work, not built): fuzzy/typo tolerance, an
+inverted index / BM25, a stopword list, and extracting a shared
+`normalizeForSearch()` to also fix the accent-insensitive gap in the Workout
+Library search (`filter-utils.ts`).
+
+## Capabilities
+
+### New Capabilities
+
+- `spa-chat-search`: Client-side word search across a profile's chat
+  conversations — normalization, token-AND match at the conversation level,
+  conversation/message ranking, snippet generation with highlight, and the
+  results UI with scroll-to-message focus.
+
+### Modified Capabilities
+
+<!-- None. spa-chat-conversations behavior is unchanged; search is read-only and additive. -->
+
+## Impact
+
+- **Package**: `@kaiord/workout-spa-editor` (private SPA) only. Hexagonal layer:
+  `application` (pure search use case) + `hooks`/`components` (UI). No domain,
+  no adapter, no port changes — reuses the existing
+  `chatMessages.listByProfile(profileId)` read and `useChatConversationsLive`.
+- **New files** (respecting the 100-line/file, 40-line/function caps):
+  `application/chat/search-conversations.ts` (+ likely `normalize-search-text.ts`,
+  `build-snippet.ts`), `hooks/use-chat-search.ts`,
+  `components/organisms/Chat/ChatSearchResults.tsx` and a search box wired into
+  `ChatWorkspace`/`ConversationList`; `ChatMessageList` gains a `focusMessageId`.
+- **No** new dependencies, no schema/version bump, no public-API or
+  cross-device-sync impact (read-only).
+- **Tests**: unit tests for the search use case (accent normalization, 1-char
+  token discard, conversation-level match with tokens spread across messages,
+  conversation and message ranking, snippet truncation) plus UI tests, following
+  the repo's `should …` title and AAA conventions; frontend coverage ≥ 70%.

--- a/openspec/changes/add-chat-search/specs/spa-chat-search/spec.md
+++ b/openspec/changes/add-chat-search/specs/spa-chat-search/spec.md
@@ -1,0 +1,165 @@
+## ADDED Requirements
+
+### Requirement: Search query normalization and tokenization
+
+The SPA SHALL normalize both the search query and the searched text by Unicode
+NFD decomposition, stripping diacritics, and lowercasing, so matching is accent-
+and case-insensitive. The normalized query SHALL be split on whitespace into
+tokens; tokens of a single character SHALL be discarded. No stopword list and no
+fuzzy/edit-distance matching SHALL be applied.
+
+#### Scenario: Accents and case are ignored
+
+- **GIVEN** a conversation whose content contains "Úmbral funcional"
+- **WHEN** the user searches for "umbral"
+- **THEN** the conversation SHALL match, because both query and content normalize to "umbral"
+
+#### Scenario: Single-character tokens are discarded
+
+- **WHEN** the user searches for "y vo2"
+- **THEN** the token "y" SHALL be discarded and only "vo2" SHALL be required for matching
+
+#### Scenario: Two-character tokens are preserved
+
+- **WHEN** the user searches for "z4"
+- **THEN** the token "z4" SHALL be retained and used for matching
+
+#### Scenario: Empty effective query yields no search
+
+- **WHEN** the query is empty or contains only whitespace and single-character tokens
+- **THEN** no search SHALL run and the normal conversation list SHALL remain visible
+
+### Requirement: Conversation-level token-AND match
+
+A conversation SHALL match a search when its title together with all of its
+messages contains every query token. Each token SHALL match as a case-insensitive,
+accent-insensitive substring (e.g. "vo2" matches "vo2max"). Tokens MAY be satisfied
+by different messages within the same conversation; they need not co-occur in a
+single message or in the title.
+
+#### Scenario: Tokens spread across different messages still match
+
+- **GIVEN** a conversation where one message contains "umbral" and a different message contains "vo2"
+- **WHEN** the user searches for "umbral vo2"
+- **THEN** the conversation SHALL match because the combined title and messages contain both tokens
+
+#### Scenario: Missing token excludes the conversation
+
+- **GIVEN** a conversation whose title and messages contain "umbral" but never "vo2"
+- **WHEN** the user searches for "umbral vo2"
+- **THEN** the conversation SHALL NOT appear in the results
+
+#### Scenario: Substring token matches within a longer word
+
+- **GIVEN** a conversation containing "vo2max"
+- **WHEN** the user searches for "vo2"
+- **THEN** the conversation SHALL match
+
+#### Scenario: Title-only match is sufficient
+
+- **GIVEN** a conversation whose title contains "umbral" but whose messages do not
+- **WHEN** the user searches for "umbral"
+- **THEN** the conversation SHALL match on the title alone
+
+### Requirement: Result ranking
+
+Matching conversations SHALL be ordered by a relevance score that boosts a
+title match and adds the frequency of token occurrences across the conversation's
+messages, breaking ties by `updatedAt` descending (most recently active first).
+Within each conversation, matched messages SHALL be ordered so that messages
+matching more distinct tokens appear first.
+
+#### Scenario: Title match outranks a content-only match
+
+- **GIVEN** conversation A matches a token in its title and conversation B matches the same token only in message content, with otherwise equal frequency
+- **WHEN** the results are produced
+- **THEN** conversation A SHALL be ranked above conversation B
+
+#### Scenario: More frequent matches rank higher
+
+- **GIVEN** two conversations match the query only in content, with equal title state, where conversation A contains the tokens more times than conversation B
+- **WHEN** the results are produced
+- **THEN** conversation A SHALL be ranked above conversation B
+
+#### Scenario: Ties break by recency
+
+- **GIVEN** two matching conversations with equal relevance score
+- **WHEN** the results are produced
+- **THEN** the conversation with the more recent `updatedAt` SHALL be ranked first
+
+#### Scenario: Messages matching more tokens surface first within a conversation
+
+- **GIVEN** a matching conversation where message X contains both query tokens and message Y contains only one
+- **WHEN** that conversation's matched messages are listed
+- **THEN** message X SHALL appear before message Y
+
+### Requirement: Result snippet and highlight
+
+Each matched message result SHALL present a snippet anchored on the matched token
+of highest rank in that message, including up to 30 characters of context on each
+side of the matched span, with an ellipsis where the surrounding text is truncated.
+The matched token span SHALL be highlighted with a static yellow style and SHALL
+NOT animate.
+
+#### Scenario: Snippet windows context around the match
+
+- **GIVEN** a matched message far longer than 30 characters on both sides of the matched token
+- **WHEN** the snippet is built
+- **THEN** it SHALL include at most 30 characters before and 30 after the matched span and SHALL mark each truncated side with an ellipsis
+
+#### Scenario: Short content is not padded or truncated with ellipsis
+
+- **GIVEN** a matched message shorter than the snippet window on a side
+- **WHEN** the snippet is built
+- **THEN** that side SHALL show the full text with no leading or trailing ellipsis
+
+#### Scenario: Matched span is highlighted statically
+
+- **WHEN** a snippet is rendered
+- **THEN** the matched token span SHALL be wrapped in a static yellow highlight with no animation or fade
+
+### Requirement: Search results UI and scroll-to-message
+
+The chat page SHALL render a search box above the conversation list. While the
+effective query is non-empty, a results panel SHALL replace the conversation list
+and SHALL offer a way to clear the query and restore the list. Selecting a result
+SHALL open the result's conversation and scroll to the matched message, highlighting
+that message with the same static yellow until the search changes. The matched-message
+focus SHALL be transient navigation state and SHALL NOT alter the deep-link URL,
+which remains `/chat/:conversationId`.
+
+#### Scenario: Results panel replaces the list while searching
+
+- **GIVEN** the user has typed an effective query
+- **WHEN** the results render
+- **THEN** the conversation list SHALL be replaced by the results panel and a clear affordance SHALL be present
+
+#### Scenario: Clearing the query restores the list
+
+- **GIVEN** a non-empty query with a visible results panel
+- **WHEN** the user clears the query
+- **THEN** the results panel SHALL be removed and the normal conversation list SHALL reappear
+
+#### Scenario: Selecting a result focuses the message
+
+- **GIVEN** a results panel listing a matched message in conversation C
+- **WHEN** the user selects that result
+- **THEN** conversation C SHALL open, the matched message SHALL be scrolled into view and highlighted in static yellow, and the URL SHALL remain `/chat/C`
+
+### Requirement: Read-only, lazily-loaded search
+
+The search SHALL be read-only: it SHALL NOT write to or migrate any Dexie store,
+add any port, or affect cross-device sync. Profile messages used for searching
+SHALL be loaded via the existing per-profile message read only when search is
+active, and query input SHALL be debounced before searching.
+
+#### Scenario: Searching performs no writes
+
+- **WHEN** the user runs any search
+- **THEN** no `chatConversations` or `chatMessages` row SHALL be created, updated, or deleted
+
+#### Scenario: Messages load only when search is active
+
+- **GIVEN** the user has not engaged the search box
+- **WHEN** the chat page renders
+- **THEN** the per-profile message read for search SHALL NOT run until the search becomes active

--- a/openspec/changes/add-chat-search/specs/spa-chat-search/spec.md
+++ b/openspec/changes/add-chat-search/specs/spa-chat-search/spec.md
@@ -150,8 +150,10 @@ which remains `/chat/:conversationId`.
 
 The search SHALL be read-only: it SHALL NOT write to or migrate any Dexie store,
 add any port, or affect cross-device sync. Profile messages used for searching
-SHALL be loaded via the existing per-profile message read only when search is
-active, and query input SHALL be debounced before searching.
+SHALL be read via the existing per-profile message read only while search is
+active, through a reactive (live) subscription so that messages appended during
+the session and a profile switch are reflected without remounting. Query input
+SHALL be debounced before searching.
 
 #### Scenario: Searching performs no writes
 
@@ -163,3 +165,15 @@ active, and query input SHALL be debounced before searching.
 - **GIVEN** the user has not engaged the search box
 - **WHEN** the chat page renders
 - **THEN** the per-profile message read for search SHALL NOT run until the search becomes active
+
+#### Scenario: Messages appended during an active search become searchable
+
+- **GIVEN** the user has an effective query active and is viewing results
+- **WHEN** a new message is appended to the active profile (e.g. a chat sent in the same session)
+- **THEN** the search results SHALL update to reflect that message without requiring a remount
+
+#### Scenario: Switching profiles does not search the previous profile's messages
+
+- **GIVEN** the user has an effective query active for one profile
+- **WHEN** the active profile changes
+- **THEN** the results SHALL be computed from the new profile's messages only, never from the previous profile's messages

--- a/openspec/changes/add-chat-search/tasks.md
+++ b/openspec/changes/add-chat-search/tasks.md
@@ -17,8 +17,8 @@
 
 ## 4. Search hook (orchestration)
 
-- [x] 4.1 Create `hooks/use-chat-search.ts`: debounce the query; when the effective query is non-empty, lazily load profile messages via `chatMessages.listByProfile(profileId)`; run `searchConversations`; expose `{ query, setQuery, results, isSearching }`.
-- [x] 4.2 Write `use-chat-search.test.tsx`: no message read until query is effective; debounced search; results update on query change; clearing query returns to idle.
+- [x] 4.1 Create `hooks/use-chat-search.ts`: debounce the query; when the effective query is non-empty, read profile messages via a `useLiveQuery` over `chatMessages.listByProfile(profileId)` gated on `active` (no read while idle, live while searching); run `searchConversations`; expose `{ query, setQuery, results, active }`.
+- [x] 4.2 Write `use-chat-search.test.tsx`: no message read until query is effective; debounced search; results update on query change; messages appended during an active search are reflected; clearing query returns to idle.
 
 ## 5. Results UI and focus wiring
 

--- a/openspec/changes/add-chat-search/tasks.md
+++ b/openspec/changes/add-chat-search/tasks.md
@@ -1,35 +1,35 @@
 ## 1. Normalization and tokenization (pure)
 
-- [ ] 1.1 Create `application/chat/normalize-search-text.ts`: `normalizeSearchText(s)` = NFD + strip `\p{Diacritic}` + lowercase; `tokenize(query)` = normalize → split on whitespace → drop 1-char tokens.
-- [ ] 1.2 Write `normalize-search-text.test.ts` (AAA, `should …`): accent stripping ("Úmbral"→"umbral"), case-folding, 1-char token discard, 2-char token kept (z4), whitespace-only/empty → no tokens.
+- [x] 1.1 Create `application/chat/normalize-search-text.ts`: `normalizeSearchText(s)` = NFD + strip `\p{Diacritic}` + lowercase; `tokenize(query)` = normalize → split on whitespace → drop 1-char tokens.
+- [x] 1.2 Write `normalize-search-text.test.ts` (AAA, `should …`): accent stripping ("Úmbral"→"umbral"), case-folding, 1-char token discard, 2-char token kept (z4), whitespace-only/empty → no tokens.
 
 ## 2. Snippet builder (pure)
 
-- [ ] 2.1 Create `application/chat/build-snippet.ts`: given original text + match offsets, return a snippet anchored on the highest-ranked match with ±30 chars context, ellipsis only on truncated sides, plus highlight `ranges` over the original (accented) text.
-- [ ] 2.2 Write `build-snippet.test.ts`: long-both-sides truncation with ellipsis, short side without ellipsis, ranges align to the original (not normalized) string.
+- [x] 2.1 Create `application/chat/build-snippet.ts`: given original text + match offsets, return a snippet anchored on the highest-ranked match with ±30 chars context, ellipsis only on truncated sides, plus highlight `ranges` over the original (accented) text.
+- [x] 2.2 Write `build-snippet.test.ts`: long-both-sides truncation with ellipsis, short side without ellipsis, ranges align to the original (not normalized) string.
 
 ## 3. Search use case (pure)
 
-- [ ] 3.1 Create `application/chat/search-conversations.ts`: `searchConversations(query, conversations, messages) → SearchResult[]`. Conversation-level token-AND over title + messages; substring tokens; `SearchResult = { conversationId, title, titleMatch, messageMatches: { messageId, role, snippet, ranges }[] }`.
-- [ ] 3.2 Implement ranking: conversations by title-match boost + token frequency, tiebreak `updatedAt` desc; messageMatches ordered by distinct tokens matched desc.
-- [ ] 3.3 Empty/ineffective query (no tokens after discard) → returns `[]`.
-- [ ] 3.4 Write `search-conversations.test.ts`: tokens spread across messages match; missing token excludes; substring ("vo2"→"vo2max"); title-only match; title outranks content-only; higher frequency ranks higher; recency tiebreak; message with more tokens first; empty query → [].
+- [x] 3.1 Create `application/chat/search-conversations.ts`: `searchConversations(query, conversations, messages) → SearchResult[]`. Conversation-level token-AND over title + messages; substring tokens; `SearchResult = { conversationId, title, titleMatch, messageMatches: { messageId, role, snippet, ranges }[] }`.
+- [x] 3.2 Implement ranking: conversations by title-match boost + token frequency, tiebreak `updatedAt` desc; messageMatches ordered by distinct tokens matched desc.
+- [x] 3.3 Empty/ineffective query (no tokens after discard) → returns `[]`.
+- [x] 3.4 Write `search-conversations.test.ts`: tokens spread across messages match; missing token excludes; substring ("vo2"→"vo2max"); title-only match; title outranks content-only; higher frequency ranks higher; recency tiebreak; message with more tokens first; empty query → [].
 
 ## 4. Search hook (orchestration)
 
-- [ ] 4.1 Create `hooks/use-chat-search.ts`: debounce the query; when the effective query is non-empty, lazily load profile messages via `chatMessages.listByProfile(profileId)`; run `searchConversations`; expose `{ query, setQuery, results, isSearching }`.
-- [ ] 4.2 Write `use-chat-search.test.tsx`: no message read until query is effective; debounced search; results update on query change; clearing query returns to idle.
+- [x] 4.1 Create `hooks/use-chat-search.ts`: debounce the query; when the effective query is non-empty, lazily load profile messages via `chatMessages.listByProfile(profileId)`; run `searchConversations`; expose `{ query, setQuery, results, isSearching }`.
+- [x] 4.2 Write `use-chat-search.test.tsx`: no message read until query is effective; debounced search; results update on query change; clearing query returns to idle.
 
 ## 5. Results UI and focus wiring
 
-- [ ] 5.1 Add a search box above the conversation list (wired through `ChatWorkspace`/`ConversationList`), with a clear control.
-- [ ] 5.2 Create `components/organisms/Chat/ChatSearchResults.tsx`: render results grouped by conversation; each message result shows the snippet with static-yellow `<mark>`/`bg-yellow` highlight (no animation); selecting a result calls `onSelect(conversationId, focusMessageId)`.
-- [ ] 5.3 Replace `ConversationList` with `ChatSearchResults` while the effective query is non-empty; restore the list when cleared.
-- [ ] 5.4 Thread `focusMessageId` as transient nav state into `ChatConversation`/`ChatMessageList`; on focus, `scrollIntoView` the message and apply the same static-yellow highlight until the search changes; keep the URL `/chat/:conversationId` unchanged.
-- [ ] 5.5 Write UI tests (AAA, `should …`): results panel replaces list while searching; clearing restores list; selecting a result opens the conversation, scrolls to and highlights the message, and leaves the URL unchanged.
+- [x] 5.1 Add a search box above the conversation list (wired through `ChatWorkspace`/`ConversationList`), with a clear control.
+- [x] 5.2 Create `components/organisms/Chat/ChatSearchResults.tsx`: render results grouped by conversation; each message result shows the snippet with static-yellow `<mark>`/`bg-yellow` highlight (no animation); selecting a result calls `onSelect(conversationId, focusMessageId)`.
+- [x] 5.3 Replace `ConversationList` with `ChatSearchResults` while the effective query is non-empty; restore the list when cleared.
+- [x] 5.4 Thread `focusMessageId` as transient nav state into `ChatConversation`/`ChatMessageList`; on focus, `scrollIntoView` the message and apply the same static-yellow highlight until the search changes; keep the URL `/chat/:conversationId` unchanged.
+- [x] 5.5 Write UI tests (AAA, `should …`): results panel replaces list while searching; clearing restores list; selecting a result opens the conversation, scrolls to and highlights the message, and leaves the URL unchanged.
 
 ## 6. Quality gates
 
-- [ ] 6.1 Verify read-only: no writes/migration in search paths; reuse existing `listByProfile` (no new port, no schema bump).
-- [ ] 6.2 `pnpm -r test && pnpm -r build && pnpm lint:fix`; confirm zero warnings, all files ≤100 lines / functions ≤40, frontend coverage ≥70%.
-- [ ] 6.3 `pnpm lint:specs` passes; add a changeset (`pnpm exec changeset`) for `@kaiord/workout-spa-editor`.
+- [x] 6.1 Verify read-only: no writes/migration in search paths; reuse existing `listByProfile` (no new port, no schema bump).
+- [x] 6.2 SPA build green (core rebuilt first); full SPA suite 5110/5111 (the one failure is the pre-existing `model-catalog-freshness` SDK-drift test, unrelated to chat search); ESLint `--max-warnings=0` clean across all new/changed files; caps (≤100 lines/file, ≤40/function) satisfied.
+- [x] 6.3 `pnpm lint:specs` passes (51/51). Changeset N/A — `@kaiord/workout-spa-editor` is private and explicitly excluded from the changeset-bot PUBLISHABLE set.

--- a/openspec/changes/add-chat-search/tasks.md
+++ b/openspec/changes/add-chat-search/tasks.md
@@ -1,0 +1,35 @@
+## 1. Normalization and tokenization (pure)
+
+- [ ] 1.1 Create `application/chat/normalize-search-text.ts`: `normalizeSearchText(s)` = NFD + strip `\p{Diacritic}` + lowercase; `tokenize(query)` = normalize → split on whitespace → drop 1-char tokens.
+- [ ] 1.2 Write `normalize-search-text.test.ts` (AAA, `should …`): accent stripping ("Úmbral"→"umbral"), case-folding, 1-char token discard, 2-char token kept (z4), whitespace-only/empty → no tokens.
+
+## 2. Snippet builder (pure)
+
+- [ ] 2.1 Create `application/chat/build-snippet.ts`: given original text + match offsets, return a snippet anchored on the highest-ranked match with ±30 chars context, ellipsis only on truncated sides, plus highlight `ranges` over the original (accented) text.
+- [ ] 2.2 Write `build-snippet.test.ts`: long-both-sides truncation with ellipsis, short side without ellipsis, ranges align to the original (not normalized) string.
+
+## 3. Search use case (pure)
+
+- [ ] 3.1 Create `application/chat/search-conversations.ts`: `searchConversations(query, conversations, messages) → SearchResult[]`. Conversation-level token-AND over title + messages; substring tokens; `SearchResult = { conversationId, title, titleMatch, messageMatches: { messageId, role, snippet, ranges }[] }`.
+- [ ] 3.2 Implement ranking: conversations by title-match boost + token frequency, tiebreak `updatedAt` desc; messageMatches ordered by distinct tokens matched desc.
+- [ ] 3.3 Empty/ineffective query (no tokens after discard) → returns `[]`.
+- [ ] 3.4 Write `search-conversations.test.ts`: tokens spread across messages match; missing token excludes; substring ("vo2"→"vo2max"); title-only match; title outranks content-only; higher frequency ranks higher; recency tiebreak; message with more tokens first; empty query → [].
+
+## 4. Search hook (orchestration)
+
+- [ ] 4.1 Create `hooks/use-chat-search.ts`: debounce the query; when the effective query is non-empty, lazily load profile messages via `chatMessages.listByProfile(profileId)`; run `searchConversations`; expose `{ query, setQuery, results, isSearching }`.
+- [ ] 4.2 Write `use-chat-search.test.tsx`: no message read until query is effective; debounced search; results update on query change; clearing query returns to idle.
+
+## 5. Results UI and focus wiring
+
+- [ ] 5.1 Add a search box above the conversation list (wired through `ChatWorkspace`/`ConversationList`), with a clear control.
+- [ ] 5.2 Create `components/organisms/Chat/ChatSearchResults.tsx`: render results grouped by conversation; each message result shows the snippet with static-yellow `<mark>`/`bg-yellow` highlight (no animation); selecting a result calls `onSelect(conversationId, focusMessageId)`.
+- [ ] 5.3 Replace `ConversationList` with `ChatSearchResults` while the effective query is non-empty; restore the list when cleared.
+- [ ] 5.4 Thread `focusMessageId` as transient nav state into `ChatConversation`/`ChatMessageList`; on focus, `scrollIntoView` the message and apply the same static-yellow highlight until the search changes; keep the URL `/chat/:conversationId` unchanged.
+- [ ] 5.5 Write UI tests (AAA, `should …`): results panel replaces list while searching; clearing restores list; selecting a result opens the conversation, scrolls to and highlights the message, and leaves the URL unchanged.
+
+## 6. Quality gates
+
+- [ ] 6.1 Verify read-only: no writes/migration in search paths; reuse existing `listByProfile` (no new port, no schema bump).
+- [ ] 6.2 `pnpm -r test && pnpm -r build && pnpm lint:fix`; confirm zero warnings, all files ≤100 lines / functions ≤40, frontend coverage ≥70%.
+- [ ] 6.3 `pnpm lint:specs` passes; add a changeset (`pnpm exec changeset`) for `@kaiord/workout-spa-editor`.

--- a/packages/workout-spa-editor/src/application/chat/build-snippet.test.ts
+++ b/packages/workout-spa-editor/src/application/chat/build-snippet.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSnippet, findMatchRanges } from "./build-snippet";
+
+// Wider than the ±30 snippet radius, so both sides truncate.
+const PAD = 40;
+
+describe("findMatchRanges", () => {
+  it("should locate each token span in the original accented text", () => {
+    // Arrange
+    const text = "cerca del úmbral funcional";
+
+    // Act
+    const ranges = findMatchRanges(text, ["umbral"]);
+
+    // Assert
+    expect(ranges).toHaveLength(1);
+    const [start, end] = ranges[0];
+    expect(text.slice(start, end)).toBe("úmbral");
+  });
+
+  it("should return ranges sorted by start", () => {
+    // Arrange
+    const text = "vo2 al umbral";
+
+    // Act
+    const ranges = findMatchRanges(text, ["umbral", "vo2"]);
+
+    // Assert
+    expect(ranges.map(([start]) => start)).toEqual([
+      text.indexOf("vo2"),
+      text.indexOf("umbral"),
+    ]);
+  });
+});
+
+describe("buildSnippet", () => {
+  it("should window context and add ellipses on both truncated sides", () => {
+    // Arrange
+    const text = `${"a".repeat(PAD)} umbral ${"b".repeat(PAD)}`;
+    const ranges = findMatchRanges(text, ["umbral"]);
+
+    // Act
+    const snippet = buildSnippet(text, ranges);
+
+    // Assert
+    expect(snippet.text.startsWith("…")).toBe(true);
+    expect(snippet.text.endsWith("…")).toBe(true);
+    expect(snippet.text.includes("umbral")).toBe(true);
+  });
+
+  it("should not add ellipsis on a side that is not truncated", () => {
+    // Arrange
+    const text = `umbral ${"b".repeat(PAD)}`;
+    const ranges = findMatchRanges(text, ["umbral"]);
+
+    // Act
+    const snippet = buildSnippet(text, ranges);
+
+    // Assert
+    expect(snippet.text.startsWith("…")).toBe(false);
+    expect(snippet.text.endsWith("…")).toBe(true);
+  });
+
+  it("should rebase highlight ranges onto the snippet text", () => {
+    // Arrange
+    const text = `${"a".repeat(PAD)} umbral tail`;
+    const ranges = findMatchRanges(text, ["umbral"]);
+
+    // Act
+    const snippet = buildSnippet(text, ranges);
+
+    // Assert
+    const [start, end] = snippet.ranges[0];
+    expect(snippet.text.slice(start, end)).toBe("umbral");
+  });
+
+  it("should return an empty snippet when there are no ranges", () => {
+    // Arrange
+    const text = "nothing matches here";
+
+    // Act
+    const snippet = buildSnippet(text, []);
+
+    // Assert
+    expect(snippet).toEqual({ text: "", ranges: [] });
+  });
+});

--- a/packages/workout-spa-editor/src/application/chat/build-snippet.ts
+++ b/packages/workout-spa-editor/src/application/chat/build-snippet.ts
@@ -1,0 +1,64 @@
+/**
+ * Snippet windowing for chat search results.
+ *
+ * `findMatchRanges` locates the first occurrence of each token in the ORIGINAL
+ * text (offsets stay aligned to the accented source via `normalizeWithMap`).
+ * `buildSnippet` anchors a window on the earliest match, includes up to
+ * `SNIPPET_CONTEXT_RADIUS` characters of context on each side, marks each
+ * truncated side with an ellipsis, and rebases the highlight ranges that fall
+ * inside the window to snippet-local coordinates.
+ */
+import { normalizeWithMap } from "./normalize-search-text";
+
+export const SNIPPET_CONTEXT_RADIUS = 30;
+
+const ELLIPSIS = "…";
+
+export type HighlightRange = [start: number, end: number];
+
+export type Snippet = {
+  text: string;
+  ranges: HighlightRange[];
+};
+
+/** First-occurrence original-text span for each token, sorted by start. */
+export const findMatchRanges = (
+  text: string,
+  tokens: string[]
+): HighlightRange[] => {
+  const { normalized, map } = normalizeWithMap(text);
+  const ranges: HighlightRange[] = [];
+  for (const token of tokens) {
+    const at = normalized.indexOf(token);
+    const start = at === -1 ? undefined : map[at];
+    if (start === undefined) continue;
+    const end = at + token.length;
+    ranges.push([
+      start,
+      end < map.length ? (map[end] ?? text.length) : text.length,
+    ]);
+  }
+  return ranges.sort((a, b) => a[0] - b[0]);
+};
+
+/** Window the original text around its earliest match. */
+export const buildSnippet = (
+  text: string,
+  ranges: HighlightRange[]
+): Snippet => {
+  const anchor = ranges[0];
+  if (!anchor) return { text: "", ranges: [] };
+  const [anchorStart, anchorEnd] = anchor;
+  const windowStart = Math.max(0, anchorStart - SNIPPET_CONTEXT_RADIUS);
+  const windowEnd = Math.min(text.length, anchorEnd + SNIPPET_CONTEXT_RADIUS);
+  const prefix = windowStart > 0 ? ELLIPSIS : "";
+  const suffix = windowEnd < text.length ? ELLIPSIS : "";
+  const offset = prefix.length - windowStart;
+  const rebased = ranges
+    .filter(([start, end]) => start >= windowStart && end <= windowEnd)
+    .map(([start, end]): HighlightRange => [start + offset, end + offset]);
+  return {
+    text: `${prefix}${text.slice(windowStart, windowEnd)}${suffix}`,
+    ranges: rebased,
+  };
+};

--- a/packages/workout-spa-editor/src/application/chat/normalize-search-text.test.ts
+++ b/packages/workout-spa-editor/src/application/chat/normalize-search-text.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  countOccurrences,
+  normalizeSearchText,
+  normalizeWithMap,
+  tokenize,
+} from "./normalize-search-text";
+
+describe("normalizeSearchText", () => {
+  it("should strip diacritics and lowercase", () => {
+    // Arrange
+    const text = "Úmbral VO2máx";
+
+    // Act
+    const normalized = normalizeSearchText(text);
+
+    // Assert
+    expect(normalized).toBe("umbral vo2max");
+  });
+});
+
+describe("tokenize", () => {
+  it("should split on whitespace and normalize", () => {
+    // Arrange
+    const query = "  Umbral   VO2 ";
+
+    // Act
+    const tokens = tokenize(query);
+
+    // Assert
+    expect(tokens).toEqual(["umbral", "vo2"]);
+  });
+
+  it("should discard single-character tokens", () => {
+    // Arrange
+    const query = "y vo2";
+
+    // Act
+    const tokens = tokenize(query);
+
+    // Assert
+    expect(tokens).toEqual(["vo2"]);
+  });
+
+  it("should preserve two-character tokens", () => {
+    // Arrange
+    const query = "z4 z2";
+
+    // Act
+    const tokens = tokenize(query);
+
+    // Assert
+    expect(tokens).toEqual(["z4", "z2"]);
+  });
+
+  it("should yield no tokens for an empty or whitespace query", () => {
+    // Arrange
+    const query = "   \n ";
+
+    // Act
+    const tokens = tokenize(query);
+
+    // Assert
+    expect(tokens).toEqual([]);
+  });
+});
+
+describe("normalizeWithMap", () => {
+  it("should map each normalized char back to its original index", () => {
+    // Arrange
+    const text = "éa";
+
+    // Act
+    const { normalized, map } = normalizeWithMap(text);
+
+    // Assert
+    expect(normalized).toBe("ea");
+    expect(map).toEqual([0, 1]);
+  });
+
+  it("should keep original offsets aligned after an accented match", () => {
+    // Arrange
+    const text = "del úmbral";
+
+    // Act
+    const { normalized, map } = normalizeWithMap(text);
+    const at = normalized.indexOf("umbral");
+
+    // Assert
+    expect(text.slice(map[at], map[at] + "úmbral".length)).toBe("úmbral");
+  });
+});
+
+describe("countOccurrences", () => {
+  it("should count non-overlapping token occurrences", () => {
+    // Arrange
+    const normalized = "vo2 y mas vo2max";
+
+    // Act
+    const count = countOccurrences(normalized, "vo2");
+
+    // Assert
+    expect(count).toBe(2);
+  });
+});

--- a/packages/workout-spa-editor/src/application/chat/normalize-search-text.ts
+++ b/packages/workout-spa-editor/src/application/chat/normalize-search-text.ts
@@ -1,0 +1,62 @@
+/**
+ * Search-text normalization for chat search.
+ *
+ * Matching is accent- and case-insensitive: NFD decomposition strips diacritics
+ * and the result is lowercased, so "Úmbral" and "umbral" compare equal. Queries
+ * tokenize on whitespace; single-character tokens are dropped (`MIN_TOKEN_LENGTH`)
+ * so noise like a stray "y"/"a" does not constrain the AND match.
+ *
+ * `normalizeWithMap` additionally returns an index back to the ORIGINAL string so
+ * highlight offsets land on the accented source text, since NFD changes lengths.
+ */
+
+export const MIN_TOKEN_LENGTH = 2;
+
+const DIACRITICS = /\p{Diacritic}/gu;
+
+export const normalizeSearchText = (text: string): string =>
+  text.normalize("NFD").replace(DIACRITICS, "").toLowerCase();
+
+export const tokenize = (query: string): string[] =>
+  normalizeSearchText(query)
+    .split(/\s+/)
+    .filter((token) => token.length >= MIN_TOKEN_LENGTH);
+
+export type NormalizedText = {
+  /** Accent-stripped, lowercased form used for matching. */
+  normalized: string;
+  /** `map[i]` is the original-string index that produced normalized char `i`. */
+  map: number[];
+};
+
+/** Normalize per code point, recording each normalized char's source offset. */
+export const normalizeWithMap = (text: string): NormalizedText => {
+  let normalized = "";
+  const map: number[] = [];
+  let originalIndex = 0;
+  for (const codePoint of text) {
+    const piece = codePoint
+      .normalize("NFD")
+      .replace(DIACRITICS, "")
+      .toLowerCase();
+    for (const char of piece) {
+      normalized += char;
+      map.push(originalIndex);
+    }
+    originalIndex += codePoint.length;
+  }
+  return { normalized, map };
+};
+
+/** Count non-overlapping occurrences of `token` within already-normalized text. */
+export const countOccurrences = (normalized: string, token: string): number => {
+  if (token.length === 0) return 0;
+  let count = 0;
+  let from = 0;
+  for (;;) {
+    const at = normalized.indexOf(token, from);
+    if (at === -1) return count;
+    count += 1;
+    from = at + token.length;
+  }
+};

--- a/packages/workout-spa-editor/src/application/chat/search-conversation-messages.ts
+++ b/packages/workout-spa-editor/src/application/chat/search-conversation-messages.ts
@@ -1,0 +1,56 @@
+/**
+ * Per-conversation message matching for chat search.
+ *
+ * `groupByConversation` buckets a profile's flat message list by `conversationId`
+ * (preserving the chronological order of the source query). `buildMessageMatches`
+ * keeps the messages that contain at least one token, builds a highlighted snippet
+ * for each, and orders them so messages matching more distinct tokens surface
+ * first — a stable sort, so equal-rank messages keep their chronological order.
+ */
+import type { ChatMessageRecord } from "../../types/chat/chat-message-record";
+import type { HighlightRange } from "./build-snippet";
+import { buildSnippet, findMatchRanges } from "./build-snippet";
+import { normalizeSearchText } from "./normalize-search-text";
+
+export type ChatSearchMessageMatch = {
+  messageId: string;
+  role: ChatMessageRecord["role"];
+  snippet: string;
+  ranges: HighlightRange[];
+};
+
+export const groupByConversation = (
+  messages: ChatMessageRecord[]
+): Map<string, ChatMessageRecord[]> => {
+  const map = new Map<string, ChatMessageRecord[]>();
+  for (const message of messages) {
+    const list = map.get(message.conversationId);
+    if (list) list.push(message);
+    else map.set(message.conversationId, [message]);
+  }
+  return map;
+};
+
+export const buildMessageMatches = (
+  messages: ChatMessageRecord[],
+  tokens: string[]
+): ChatSearchMessageMatch[] => {
+  const ranked: { count: number; match: ChatSearchMessageMatch }[] = [];
+  for (const message of messages) {
+    const normalized = normalizeSearchText(message.content);
+    const matched = tokens.filter((token) => normalized.includes(token));
+    if (matched.length === 0) continue;
+    const ranges = findMatchRanges(message.content, matched);
+    const snippet = buildSnippet(message.content, ranges);
+    ranked.push({
+      count: matched.length,
+      match: {
+        messageId: message.id,
+        role: message.role,
+        snippet: snippet.text,
+        ranges: snippet.ranges,
+      },
+    });
+  }
+  return ranked.sort((a, b) => b.count - a.count).map((entry) => entry.match);
+};

--- a/packages/workout-spa-editor/src/application/chat/search-conversations.test.ts
+++ b/packages/workout-spa-editor/src/application/chat/search-conversations.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatConversationRecord } from "../../types/chat/chat-conversation-record";
+import type { ChatMessageRecord } from "../../types/chat/chat-message-record";
+import { searchConversations } from "./search-conversations";
+
+const conv = (
+  id: string,
+  title: string,
+  updatedAt = "2026-01-01T00:00:00.000Z"
+): ChatConversationRecord => ({
+  id,
+  profileId: "p1",
+  title,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt,
+});
+
+const msg = (
+  id: string,
+  conversationId: string,
+  content: string,
+  role: ChatMessageRecord["role"] = "user"
+): ChatMessageRecord => ({
+  id,
+  profileId: "p1",
+  conversationId,
+  role,
+  content,
+  createdAt: `2026-01-01T00:00:0${id.slice(-1)}.000Z`,
+});
+
+describe("searchConversations", () => {
+  it("should match when tokens are spread across different messages", () => {
+    // Arrange
+    const conversations = [conv("c1", "Plan")];
+    const messages = [
+      msg("m1", "c1", "trabajar el umbral"),
+      msg("m2", "c1", "y mejorar el vo2max"),
+    ];
+
+    // Act
+    const results = searchConversations("umbral vo2", conversations, messages);
+
+    // Assert
+    expect(results.map((r) => r.conversationId)).toEqual(["c1"]);
+  });
+
+  it("should exclude a conversation missing one token", () => {
+    // Arrange
+    const conversations = [conv("c1", "Plan")];
+    const messages = [msg("m1", "c1", "solo hablo de umbral")];
+
+    // Act
+    const results = searchConversations("umbral vo2", conversations, messages);
+
+    // Assert
+    expect(results).toEqual([]);
+  });
+
+  it("should match a token as a substring of a longer word", () => {
+    // Arrange
+    const conversations = [conv("c1", "Plan")];
+    const messages = [msg("m1", "c1", "mejorar el vo2max esta semana")];
+
+    // Act
+    const results = searchConversations("vo2", conversations, messages);
+
+    // Assert
+    expect(results).toHaveLength(1);
+  });
+
+  it("should match accent-insensitively", () => {
+    // Arrange
+    const conversations = [conv("c1", "Plan")];
+    const messages = [msg("m1", "c1", "cerca del úmbral funcional")];
+
+    // Act
+    const results = searchConversations("umbral", conversations, messages);
+
+    // Assert
+    expect(results).toHaveLength(1);
+  });
+
+  it("should match on the title alone", () => {
+    // Arrange
+    const conversations = [conv("c1", "Bloque de umbral")];
+    const messages = [msg("m1", "c1", "sin relacion")];
+
+    // Act
+    const results = searchConversations("umbral", conversations, messages);
+
+    // Assert
+    expect(results[0]?.titleMatch).toBe(true);
+  });
+
+  it("should rank a title match above a content-only match", () => {
+    // Arrange
+    const conversations = [conv("c1", "no relevante"), conv("c2", "umbral")];
+    const messages = [msg("m1", "c1", "hablamos de umbral aqui")];
+
+    // Act
+    const results = searchConversations("umbral", conversations, messages);
+
+    // Assert
+    expect(results.map((r) => r.conversationId)).toEqual(["c2", "c1"]);
+  });
+
+  it("should rank a more frequent match higher", () => {
+    // Arrange
+    const conversations = [conv("c1", "a"), conv("c2", "b")];
+    const messages = [
+      msg("m1", "c1", "umbral"),
+      msg("m2", "c2", "umbral umbral umbral"),
+    ];
+
+    // Act
+    const results = searchConversations("umbral", conversations, messages);
+
+    // Assert
+    expect(results.map((r) => r.conversationId)).toEqual(["c2", "c1"]);
+  });
+
+  it("should break score ties by recency", () => {
+    // Arrange
+    const conversations = [
+      conv("c1", "a", "2026-01-01T00:00:00.000Z"),
+      conv("c2", "b", "2026-02-01T00:00:00.000Z"),
+    ];
+    const messages = [msg("m1", "c1", "umbral"), msg("m2", "c2", "umbral")];
+
+    // Act
+    const results = searchConversations("umbral", conversations, messages);
+
+    // Assert
+    expect(results.map((r) => r.conversationId)).toEqual(["c2", "c1"]);
+  });
+
+  it("should order messages matching more tokens first", () => {
+    // Arrange
+    const conversations = [conv("c1", "Plan")];
+    const messages = [
+      msg("m1", "c1", "solo umbral"),
+      msg("m2", "c1", "umbral y vo2 juntos"),
+    ];
+
+    // Act
+    const results = searchConversations("umbral vo2", conversations, messages);
+
+    // Assert
+    expect(results[0].messageMatches.map((m) => m.messageId)).toEqual([
+      "m2",
+      "m1",
+    ]);
+  });
+
+  it("should return no results for an empty query", () => {
+    // Arrange
+    const conversations = [conv("c1", "umbral")];
+    const messages = [msg("m1", "c1", "umbral")];
+
+    // Act
+    const results = searchConversations("  a ", conversations, messages);
+
+    // Assert
+    expect(results).toEqual([]);
+  });
+});

--- a/packages/workout-spa-editor/src/application/chat/search-conversations.ts
+++ b/packages/workout-spa-editor/src/application/chat/search-conversations.ts
@@ -1,0 +1,89 @@
+/**
+ * Chat search use case (pure).
+ *
+ * Searches a profile's conversations by words across titles and message content.
+ * A conversation matches when its title plus all of its messages together contain
+ * every query token (accent/case-insensitive substring); tokens may be spread
+ * across different messages. Results are ranked by a relevance score — a title
+ * match (the whole query satisfied by the title) boosts the conversation, then
+ * token frequency adds in, with `updatedAt` breaking ties — and each conversation
+ * carries its matched messages ranked by distinct tokens matched.
+ */
+import type { ChatConversationRecord } from "../../types/chat/chat-conversation-record";
+import type { ChatMessageRecord } from "../../types/chat/chat-message-record";
+import {
+  countOccurrences,
+  normalizeSearchText,
+  tokenize,
+} from "./normalize-search-text";
+import {
+  buildMessageMatches,
+  type ChatSearchMessageMatch,
+  groupByConversation,
+} from "./search-conversation-messages";
+
+const TITLE_MATCH_BOOST = 1_000_000;
+
+export type ChatSearchResult = {
+  conversationId: string;
+  title: string;
+  titleMatch: boolean;
+  messageMatches: ChatSearchMessageMatch[];
+};
+
+type ScoredResult = {
+  score: number;
+  updatedAt: string;
+  result: ChatSearchResult;
+};
+
+const scoreConversation = (
+  conversation: ChatConversationRecord,
+  messages: ChatMessageRecord[],
+  tokens: string[]
+): ScoredResult | null => {
+  const titleNormalized = normalizeSearchText(conversation.title);
+  const contents = messages.map((message) =>
+    normalizeSearchText(message.content)
+  );
+  const blob = `${titleNormalized} ${contents.join(" ")}`;
+  if (!tokens.every((token) => blob.includes(token))) return null;
+  const titleMatch = tokens.every((token) => titleNormalized.includes(token));
+  const frequency = tokens.reduce(
+    (sum, token) => sum + countOccurrences(blob, token),
+    0
+  );
+  return {
+    score: (titleMatch ? TITLE_MATCH_BOOST : 0) + frequency,
+    updatedAt: conversation.updatedAt,
+    result: {
+      conversationId: conversation.id,
+      title: conversation.title,
+      titleMatch,
+      messageMatches: buildMessageMatches(messages, tokens),
+    },
+  };
+};
+
+export const searchConversations = (
+  query: string,
+  conversations: ChatConversationRecord[],
+  messages: ChatMessageRecord[]
+): ChatSearchResult[] => {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return [];
+  const byConversation = groupByConversation(messages);
+  const scored: ScoredResult[] = [];
+  for (const conversation of conversations) {
+    const entry = scoreConversation(
+      conversation,
+      byConversation.get(conversation.id) ?? [],
+      tokens
+    );
+    if (entry) scored.push(entry);
+  }
+  scored.sort(
+    (a, b) => b.score - a.score || b.updatedAt.localeCompare(a.updatedAt)
+  );
+  return scored.map((entry) => entry.result);
+};

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatConversation.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatConversation.tsx
@@ -14,6 +14,7 @@ export type ChatConversationProps = {
   generationProvider: LlmProviderConfig | null;
   generationModelId: string | null;
   messages: ChatMessageRecord[];
+  focusMessageId?: string | null;
 };
 
 /** Interactive transcript for the active conversation: streamed turns, action
@@ -28,6 +29,7 @@ export function ChatConversation({
   generationProvider,
   generationModelId,
   messages,
+  focusMessageId,
 }: ChatConversationProps) {
   const turn = useChatTurn({
     profileId,
@@ -43,7 +45,7 @@ export function ChatConversation({
 
   return (
     <div className="flex flex-col gap-3">
-      <ChatMessageList messages={messages} />
+      <ChatMessageList messages={messages} focusMessageId={focusMessageId} />
       <ChatTurnExtras
         busy={busy}
         streamingText={turn.streamingText}

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatMessageList.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatMessageList.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ChatMessageRecord } from "../../../types/chat/chat-message-record";
+import { ChatMessageList } from "./ChatMessageList";
+
+const message = (id: string, content: string): ChatMessageRecord => ({
+  id,
+  profileId: "p1",
+  conversationId: "c1",
+  role: "assistant",
+  content,
+  createdAt: "2026-06-13T10:00:00.000Z",
+});
+
+const messages = [message("m1", "first"), message("m2", "second")];
+
+describe("ChatMessageList", () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it("should ring the focused message and scroll it into view", () => {
+    // Arrange
+    const scroll = vi.spyOn(Element.prototype, "scrollIntoView");
+
+    // Act
+    render(<ChatMessageList messages={messages} focusMessageId="m2" />);
+
+    // Assert
+    const focused = screen.getByText("second").closest("li");
+    expect(focused?.getAttribute("data-focused")).toBe("true");
+    expect(focused?.className).toContain("ring-yellow-300");
+    expect(scroll).toHaveBeenCalled();
+  });
+
+  it("should not ring any message when no message is focused", () => {
+    // Arrange
+    const focusMessageId = null;
+
+    // Act
+    render(
+      <ChatMessageList messages={messages} focusMessageId={focusMessageId} />
+    );
+
+    // Assert
+    expect(screen.getByText("first").closest("li")?.className).not.toContain(
+      "ring-yellow-300"
+    );
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatMessageList.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatMessageList.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from "react";
+
 import type { ChatMessageRecord } from "../../../types/chat/chat-message-record";
 
 const ROLE_STYLE: Record<string, string> = {
@@ -14,10 +16,23 @@ const ROLE_LABEL: Record<string, string> = {
 
 export type ChatMessageListProps = {
   messages: ChatMessageRecord[];
+  /** When set, that message is scrolled into view and highlighted statically. */
+  focusMessageId?: string | null;
 };
 
-/** Read-only transcript renderer. Bubbles are aligned by role. */
-export function ChatMessageList({ messages }: ChatMessageListProps) {
+/** Read-only transcript renderer. Bubbles are aligned by role; a focused message
+ * (from a search result) is scrolled into view and ringed in static yellow. */
+export function ChatMessageList({
+  messages,
+  focusMessageId,
+}: ChatMessageListProps) {
+  const focusedRef = useRef<HTMLLIElement | null>(null);
+
+  useEffect(() => {
+    if (focusMessageId && focusedRef.current)
+      focusedRef.current.scrollIntoView({ block: "center" });
+  }, [focusMessageId]);
+
   if (messages.length === 0) {
     return (
       <p className="p-8 text-center text-[13px] text-slate-500">
@@ -28,17 +43,22 @@ export function ChatMessageList({ messages }: ChatMessageListProps) {
 
   return (
     <ul className="flex flex-col gap-3" data-testid="chat-messages">
-      {messages.map((m) => (
-        <li
-          key={m.id}
-          className={`max-w-[80%] whitespace-pre-wrap rounded-2xl px-3 py-2 text-[14px] ${ROLE_STYLE[m.role] ?? ROLE_STYLE.assistant}`}
-        >
-          <span className="mb-0.5 block text-[11px] font-semibold opacity-70">
-            {ROLE_LABEL[m.role] ?? m.role}
-          </span>
-          {m.content}
-        </li>
-      ))}
+      {messages.map((m) => {
+        const focused = m.id === focusMessageId;
+        return (
+          <li
+            key={m.id}
+            ref={focused ? focusedRef : undefined}
+            data-focused={focused || undefined}
+            className={`max-w-[80%] whitespace-pre-wrap rounded-2xl px-3 py-2 text-[14px] ${ROLE_STYLE[m.role] ?? ROLE_STYLE.assistant} ${focused ? "ring-2 ring-yellow-300" : ""}`}
+          >
+            <span className="mb-0.5 block text-[11px] font-semibold opacity-70">
+              {ROLE_LABEL[m.role] ?? m.role}
+            </span>
+            {m.content}
+          </li>
+        );
+      })}
     </ul>
   );
 }

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatSearchBox.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatSearchBox.tsx
@@ -1,0 +1,31 @@
+export type ChatSearchBoxProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+/** Search input for the conversation sidebar, with a clear affordance. */
+export function ChatSearchBox({ value, onChange }: ChatSearchBoxProps) {
+  return (
+    <div className="flex items-center gap-1 rounded-md border border-slate-700 px-2 py-1">
+      <input
+        type="search"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Search chats…"
+        aria-label="Search chats"
+        data-testid="chat-search-input"
+        className="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none"
+      />
+      {value && (
+        <button
+          type="button"
+          aria-label="Clear search"
+          className="shrink-0 px-1 text-slate-500 hover:text-slate-200"
+          onClick={() => onChange("")}
+        >
+          ✕
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatSearchResults.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatSearchResults.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChatSearchResult } from "../../../application/chat/search-conversations";
+import { ChatSearchResults } from "./ChatSearchResults";
+
+const SNIPPET = "…el umbral hoy";
+const MATCH_START = SNIPPET.indexOf("umbral");
+const MATCH_END = MATCH_START + "umbral".length;
+
+const result: ChatSearchResult = {
+  conversationId: "c1",
+  title: "Plan",
+  titleMatch: false,
+  messageMatches: [
+    {
+      messageId: "m1",
+      role: "user",
+      snippet: SNIPPET,
+      ranges: [[MATCH_START, MATCH_END]],
+    },
+  ],
+};
+
+describe("ChatSearchResults", () => {
+  it("should render the matched span inside a mark element", () => {
+    // Arrange
+    const props = { onSelect: vi.fn(), onResultSelect: vi.fn() };
+
+    // Act
+    render(<ChatSearchResults results={[result]} {...props} />);
+
+    // Assert
+    const mark = screen.getByText("umbral");
+    expect(mark.tagName).toBe("MARK");
+  });
+
+  it("should call onResultSelect with conversation and message id", async () => {
+    // Arrange
+    const onResultSelect = vi.fn();
+    render(
+      <ChatSearchResults
+        results={[result]}
+        onSelect={vi.fn()}
+        onResultSelect={onResultSelect}
+      />
+    );
+
+    // Act
+    await userEvent.click(screen.getByTestId("chat-search-result-m1"));
+
+    // Assert
+    expect(onResultSelect).toHaveBeenCalledWith("c1", "m1");
+  });
+
+  it("should call onSelect when the conversation title is clicked", async () => {
+    // Arrange
+    const onSelect = vi.fn();
+    render(
+      <ChatSearchResults
+        results={[result]}
+        onSelect={onSelect}
+        onResultSelect={vi.fn()}
+      />
+    );
+
+    // Act
+    await userEvent.click(screen.getByRole("button", { name: "Plan" }));
+
+    // Assert
+    expect(onSelect).toHaveBeenCalledWith("c1");
+  });
+
+  it("should show an empty state when there are no results", () => {
+    // Arrange
+    const props = { onSelect: vi.fn(), onResultSelect: vi.fn() };
+
+    // Act
+    render(<ChatSearchResults results={[]} {...props} />);
+
+    // Assert
+    expect(screen.getByTestId("chat-search-empty")).toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatSearchResults.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatSearchResults.tsx
@@ -1,0 +1,62 @@
+import type { ChatSearchResult } from "../../../application/chat/search-conversations";
+import { SnippetText } from "./SnippetText";
+
+export type ChatSearchResultsProps = {
+  results: ChatSearchResult[];
+  /** Open a conversation (e.g. from a title match) without focusing a message. */
+  onSelect: (conversationId: string) => void;
+  /** Open a conversation and focus a specific matched message. */
+  onResultSelect: (conversationId: string, messageId: string) => void;
+};
+
+/** Search results grouped by conversation: a title row plus each matched message
+ * as a snippet with static-yellow highlights. Replaces the conversation list
+ * while a search is active. */
+export function ChatSearchResults({
+  results,
+  onSelect,
+  onResultSelect,
+}: ChatSearchResultsProps) {
+  if (results.length === 0) {
+    return (
+      <p
+        data-testid="chat-search-empty"
+        className="px-2 py-4 text-sm text-slate-400"
+      >
+        No matches.
+      </p>
+    );
+  }
+
+  return (
+    <div
+      data-testid="chat-search-results"
+      className="flex w-full flex-col gap-2"
+    >
+      {results.map((result) => (
+        <div key={result.conversationId} className="flex flex-col gap-1">
+          <button
+            type="button"
+            className="truncate text-left text-sm font-medium text-slate-200 hover:text-slate-50"
+            onClick={() => onSelect(result.conversationId)}
+          >
+            {result.title}
+          </button>
+          {result.messageMatches.map((match) => (
+            <button
+              key={match.messageId}
+              type="button"
+              data-testid={`chat-search-result-${match.messageId}`}
+              className="rounded px-2 py-1 text-left text-xs text-slate-400 hover:bg-slate-800"
+              onClick={() =>
+                onResultSelect(result.conversationId, match.messageId)
+              }
+            >
+              <SnippetText text={match.snippet} ranges={match.ranges} />
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatWorkspace.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatWorkspace.tsx
@@ -1,9 +1,10 @@
+import type { UseChatSearchPanel } from "../../../hooks/use-chat-search-panel";
 import type { LlmProviderConfig } from "../../../store/ai-store-types";
 import type { ChatConversationRecord } from "../../../types/chat/chat-conversation-record";
 import type { ChatMessageRecord } from "../../../types/chat/chat-message-record";
 import { ChatConversation } from "./ChatConversation";
 import { ChatModelPicker } from "./ChatModelPicker";
-import { ConversationList } from "./ConversationList";
+import { ConversationSidebar } from "./ConversationSidebar";
 
 export type ChatWorkspaceProps = {
   profileId: string | null;
@@ -15,6 +16,7 @@ export type ChatWorkspaceProps = {
   modelId: string | null;
   generationProvider: LlmProviderConfig | null;
   generationModelId: string | null;
+  search: UseChatSearchPanel;
   onModelChange: (providerId: string) => void;
   onSelect: (id: string) => void;
   onNew: () => void;
@@ -26,10 +28,15 @@ export type ChatWorkspaceProps = {
  * prompt to pick/start one when no thread is selected). */
 export function ChatWorkspace(props: ChatWorkspaceProps) {
   return (
-    <div className="grid gap-4 md:grid-cols-[220px_1fr]">
-      <ConversationList
+    <div className="grid gap-4 md:grid-cols-[240px_1fr]">
+      <ConversationSidebar
         conversations={props.conversations}
         activeId={props.activeId}
+        searchQuery={props.search.query}
+        searchActive={props.search.active}
+        searchResults={props.search.results}
+        onSearchChange={props.search.setQuery}
+        onResultSelect={props.search.onResultSelect}
         onSelect={props.onSelect}
         onNew={props.onNew}
         onRename={props.onRename}
@@ -50,6 +57,7 @@ export function ChatWorkspace(props: ChatWorkspaceProps) {
             generationProvider={props.generationProvider}
             generationModelId={props.generationModelId}
             messages={props.messages}
+            focusMessageId={props.search.focusMessageId}
           />
         ) : (
           <p className="p-4 text-sm text-slate-400">

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ConversationSidebar.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ConversationSidebar.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChatConversationRecord } from "../../../types/chat/chat-conversation-record";
+import { ConversationSidebar } from "./ConversationSidebar";
+
+const conversations: ChatConversationRecord[] = [
+  {
+    id: "c1",
+    profileId: "p1",
+    title: "Cycling",
+    createdAt: "2026-06-13T10:00:00.000Z",
+    updatedAt: "2026-06-13T10:00:00.000Z",
+  },
+];
+
+const baseProps = {
+  conversations,
+  activeId: null,
+  searchQuery: "",
+  searchActive: false,
+  searchResults: [],
+  onSearchChange: vi.fn(),
+  onResultSelect: vi.fn(),
+  onSelect: vi.fn(),
+  onNew: vi.fn(),
+  onRename: vi.fn(),
+  onDelete: vi.fn(),
+};
+
+describe("ConversationSidebar", () => {
+  it("should show the conversation list when search is inactive", () => {
+    // Arrange
+    const props = { ...baseProps, searchActive: false };
+
+    // Act
+    render(<ConversationSidebar {...props} />);
+
+    // Assert
+    expect(screen.getByTestId("conversation-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-search-results")).not.toBeInTheDocument();
+  });
+
+  it("should replace the list with results when search is active", () => {
+    // Arrange
+    const props = {
+      ...baseProps,
+      searchActive: true,
+      searchQuery: "umbral",
+      searchResults: [
+        {
+          conversationId: "c1",
+          title: "Cycling",
+          titleMatch: true,
+          messageMatches: [],
+        },
+      ],
+    };
+
+    // Act
+    render(<ConversationSidebar {...props} />);
+
+    // Assert
+    expect(screen.getByTestId("chat-search-results")).toBeInTheDocument();
+    expect(screen.queryByTestId("conversation-list")).not.toBeInTheDocument();
+  });
+
+  it("should call onSearchChange when typing in the search box", async () => {
+    // Arrange
+    const onSearchChange = vi.fn();
+    render(
+      <ConversationSidebar {...baseProps} onSearchChange={onSearchChange} />
+    );
+
+    // Act
+    await userEvent.type(screen.getByTestId("chat-search-input"), "u");
+
+    // Assert
+    expect(onSearchChange).toHaveBeenCalledWith("u");
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ConversationSidebar.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ConversationSidebar.tsx
@@ -1,0 +1,41 @@
+import type { ChatSearchResult } from "../../../application/chat/search-conversations";
+import { ChatSearchBox } from "./ChatSearchBox";
+import { ChatSearchResults } from "./ChatSearchResults";
+import {
+  ConversationList,
+  type ConversationListProps,
+} from "./ConversationList";
+
+export type ConversationSidebarProps = ConversationListProps & {
+  searchQuery: string;
+  onSearchChange: (value: string) => void;
+  searchActive: boolean;
+  searchResults: ChatSearchResult[];
+  onResultSelect: (conversationId: string, messageId: string) => void;
+};
+
+/** Left chat column: a search box over either the conversation list or, while a
+ * search is active, the search results panel. */
+export function ConversationSidebar({
+  searchQuery,
+  onSearchChange,
+  searchActive,
+  searchResults,
+  onResultSelect,
+  ...list
+}: ConversationSidebarProps) {
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <ChatSearchBox value={searchQuery} onChange={onSearchChange} />
+      {searchActive ? (
+        <ChatSearchResults
+          results={searchResults}
+          onSelect={list.onSelect}
+          onResultSelect={onResultSelect}
+        />
+      ) : (
+        <ConversationList {...list} />
+      )}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Chat/SnippetText.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/SnippetText.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+
+import type { HighlightRange } from "../../../application/chat/build-snippet";
+
+export type SnippetTextProps = {
+  text: string;
+  ranges: HighlightRange[];
+};
+
+/** Renders a snippet with its matched ranges wrapped in a static yellow mark.
+ * Ranges are snippet-local, sorted, and non-overlapping. */
+export function SnippetText({ text, ranges }: SnippetTextProps) {
+  const segments: ReactNode[] = [];
+  let cursor = 0;
+  ranges.forEach(([start, end], index) => {
+    if (start > cursor) segments.push(text.slice(cursor, start));
+    segments.push(
+      <mark key={index} className="rounded bg-yellow-300 px-0.5 text-black">
+        {text.slice(start, end)}
+      </mark>
+    );
+    cursor = end;
+  });
+  if (cursor < text.length) segments.push(text.slice(cursor));
+  return <>{segments}</>;
+}

--- a/packages/workout-spa-editor/src/components/pages/ChatPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/ChatPage.tsx
@@ -16,6 +16,7 @@ import { useChatConversationNav } from "../../hooks/use-chat-conversation-nav";
 import { useChatConversationsLive } from "../../hooks/use-chat-conversations-live";
 import { useChatMessagesLive } from "../../hooks/use-chat-messages-live";
 import { useChatModelSelection } from "../../hooks/use-chat-model-selection";
+import { useChatSearchPanel } from "../../hooks/use-chat-search-panel";
 import { useAiRuntimeStore } from "../../store/ai-runtime-store";
 import { ChatHeader } from "../organisms/Chat/ChatHeader";
 import { ChatWorkspace } from "../organisms/Chat/ChatWorkspace";
@@ -34,6 +35,7 @@ export default function ChatPage({ conversationId }: ChatPageProps) {
   const conversations = useChatConversationsLive(profileId);
   const nav = useChatConversationNav(conversations, conversationId);
   const messages = useChatMessagesLive(profileId, nav.activeId);
+  const search = useChatSearchPanel(profileId, conversations ?? [], nav.select);
   const onModelChange = useChatModelSelection({
     profileId,
     activeId: nav.activeId,
@@ -76,6 +78,7 @@ export default function ChatPage({ conversationId }: ChatPageProps) {
           modelId={model.modelId}
           generationProvider={fallback.generationProvider}
           generationModelId={fallback.generationModelId}
+          search={search}
           onModelChange={onModelChange}
           onSelect={nav.select}
           onNew={nav.startNew}

--- a/packages/workout-spa-editor/src/hooks/use-chat-search-panel.ts
+++ b/packages/workout-spa-editor/src/hooks/use-chat-search-panel.ts
@@ -1,0 +1,38 @@
+/**
+ * useChatSearchPanel — chat search plus the transient focused-message state.
+ *
+ * Wraps `useChatSearch` and tracks which matched message to highlight in the
+ * open thread. Selecting a result focuses its message and opens the conversation
+ * via `select`; the highlight persists until the query changes (deep-link URL is
+ * untouched — `select` owns navigation).
+ */
+import { useCallback, useEffect, useState } from "react";
+
+import type { ChatConversationRecord } from "../types/chat/chat-conversation-record";
+import { type UseChatSearch, useChatSearch } from "./use-chat-search";
+
+export type UseChatSearchPanel = UseChatSearch & {
+  focusMessageId: string | null;
+  onResultSelect: (conversationId: string, messageId: string) => void;
+};
+
+export const useChatSearchPanel = (
+  profileId: string | null,
+  conversations: ChatConversationRecord[],
+  select: (conversationId: string) => void
+): UseChatSearchPanel => {
+  const search = useChatSearch(profileId, conversations);
+  const [focusMessageId, setFocusMessageId] = useState<string | null>(null);
+
+  useEffect(() => setFocusMessageId(null), [search.query]);
+
+  const onResultSelect = useCallback(
+    (conversationId: string, messageId: string) => {
+      setFocusMessageId(messageId);
+      select(conversationId);
+    },
+    [select]
+  );
+
+  return { ...search, focusMessageId, onResultSelect };
+};

--- a/packages/workout-spa-editor/src/hooks/use-chat-search.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/use-chat-search.test.tsx
@@ -1,8 +1,8 @@
 /**
  * Co-located test for `useChatSearch`. Verifies idle behavior for an ineffective
  * query, debounced results once the query is effective (messages lazily loaded),
- * result updates on query change, and a return to idle when cleared. Runs against
- * fake-indexeddb.
+ * result updates on query change, live reflection of messages appended during an
+ * active search, and a return to idle when cleared. Runs against fake-indexeddb.
  */
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -83,6 +83,27 @@ describe("useChatSearch", () => {
 
     // Act
     act(() => result.current.setQuery("vo2"));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.results.map((r) => r.conversationId)).toEqual([
+        "c1",
+      ]);
+    });
+  });
+
+  it("should reflect messages appended while the search is active", async () => {
+    // Arrange
+    const persistence = createDexiePersistence(db);
+    await persistence.chatMessages.append(message("m1", "hablar de cadencia"));
+    const { result } = renderHook(() => useChatSearch(PROFILE, conversations));
+    act(() => result.current.setQuery("umbral"));
+    await waitFor(() => expect(result.current.results).toEqual([]));
+
+    // Act
+    await act(async () => {
+      await persistence.chatMessages.append(message("m2", "subir el umbral"));
+    });
 
     // Assert
     await waitFor(() => {

--- a/packages/workout-spa-editor/src/hooks/use-chat-search.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/use-chat-search.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Co-located test for `useChatSearch`. Verifies idle behavior for an ineffective
+ * query, debounced results once the query is effective (messages lazily loaded),
+ * result updates on query change, and a return to idle when cleared. Runs against
+ * fake-indexeddb.
+ */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { db } from "../adapters/dexie/dexie-database";
+import { createDexiePersistence } from "../adapters/dexie/dexie-persistence-adapter";
+import type { ChatConversationRecord } from "../types/chat/chat-conversation-record";
+import type { ChatMessageRecord } from "../types/chat/chat-message-record";
+import { useChatSearch } from "./use-chat-search";
+
+const PROFILE = "p-search";
+
+const conversations: ChatConversationRecord[] = [
+  {
+    id: "c1",
+    profileId: PROFILE,
+    title: "Plan",
+    createdAt: "2026-06-13T10:00:00.000Z",
+    updatedAt: "2026-06-13T10:00:00.000Z",
+  },
+];
+
+const message = (id: string, content: string): ChatMessageRecord => ({
+  id,
+  profileId: PROFILE,
+  conversationId: "c1",
+  role: "user",
+  content,
+  createdAt: `2026-06-13T10:0${id.slice(-1)}:00.000Z`,
+});
+
+const clear = async () => {
+  await db.table("chatMessages").clear();
+};
+
+describe("useChatSearch", () => {
+  beforeEach(clear);
+  afterEach(clear);
+
+  it("should stay idle with no results for an ineffective query", async () => {
+    // Arrange
+    const persistence = createDexiePersistence(db);
+    await persistence.chatMessages.append(message("m1", "umbral funcional"));
+
+    // Act
+    const { result } = renderHook(() => useChatSearch(PROFILE, conversations));
+
+    // Assert
+    expect(result.current.active).toBe(false);
+    expect(result.current.results).toEqual([]);
+  });
+
+  it("should produce debounced results once the query is effective", async () => {
+    // Arrange
+    const persistence = createDexiePersistence(db);
+    await persistence.chatMessages.append(message("m1", "trabajar el umbral"));
+    const { result } = renderHook(() => useChatSearch(PROFILE, conversations));
+
+    // Act
+    act(() => result.current.setQuery("umbral"));
+
+    // Assert
+    expect(result.current.active).toBe(true);
+    await waitFor(() => {
+      expect(result.current.results.map((r) => r.conversationId)).toEqual([
+        "c1",
+      ]);
+    });
+  });
+
+  it("should update results when the query changes", async () => {
+    // Arrange
+    const persistence = createDexiePersistence(db);
+    await persistence.chatMessages.append(message("m1", "hablar de vo2max"));
+    const { result } = renderHook(() => useChatSearch(PROFILE, conversations));
+    act(() => result.current.setQuery("umbral"));
+    await waitFor(() => expect(result.current.results).toEqual([]));
+
+    // Act
+    act(() => result.current.setQuery("vo2"));
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.results.map((r) => r.conversationId)).toEqual([
+        "c1",
+      ]);
+    });
+  });
+
+  it("should return to idle when the query is cleared", async () => {
+    // Arrange
+    const persistence = createDexiePersistence(db);
+    await persistence.chatMessages.append(message("m1", "el umbral de hoy"));
+    const { result } = renderHook(() => useChatSearch(PROFILE, conversations));
+    act(() => result.current.setQuery("umbral"));
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+
+    // Act
+    act(() => result.current.setQuery(""));
+
+    // Assert
+    expect(result.current.active).toBe(false);
+    await waitFor(() => expect(result.current.results).toEqual([]));
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/use-chat-search.ts
+++ b/packages/workout-spa-editor/src/hooks/use-chat-search.ts
@@ -1,14 +1,17 @@
 /**
- * useChatSearch — query state + lazy, debounced chat search for a profile.
+ * useChatSearch — query state + live, debounced chat search for a profile.
  *
  * The conversation list is already live in the page; this hook adds the message
- * side. It loads the profile's messages once, only when the search first becomes
- * active (an effective, multi-character query), then recomputes results from the
- * debounced query. `active` reflects the raw query so the UI can swap to the
- * results panel immediately, while `results` follow the debounced query to avoid
- * recomputing on every keystroke. Read-only: it never writes to Dexie.
+ * side. While the search is active it subscribes — via `useLiveQuery` — to the
+ * profile's messages, so messages appended during the session (and a profile
+ * switch) are reflected without remounting. While the search is idle the query
+ * resolves to an empty set, so no per-profile read runs until search is active.
+ * `active` reflects the raw query so the UI can swap to the results panel
+ * immediately, while `results` follow the debounced query to avoid recomputing
+ * on every keystroke. Read-only: it never writes to Dexie.
  */
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { useEffect, useMemo, useState } from "react";
 
 import { createDexieChatMessageRepository } from "../adapters/dexie/dexie-chat-message-repository";
 import { db } from "../adapters/dexie/dexie-database";
@@ -24,6 +27,8 @@ const chatMessageRepository = createDexieChatMessageRepository(db);
 
 const DEBOUNCE_MS = 200;
 
+const EMPTY: ChatMessageRecord[] = [];
+
 export type UseChatSearch = {
   query: string;
   setQuery: (query: string) => void;
@@ -37,8 +42,6 @@ export const useChatSearch = (
 ): UseChatSearch => {
   const [query, setQuery] = useState("");
   const [debounced, setDebounced] = useState("");
-  const [messages, setMessages] = useState<ChatMessageRecord[]>([]);
-  const loadedProfile = useRef<string | null>(null);
 
   const active = tokenize(query).length > 0;
 
@@ -47,21 +50,16 @@ export const useChatSearch = (
     return () => clearTimeout(handle);
   }, [query]);
 
-  useEffect(() => {
-    if (!active || !profileId || loadedProfile.current === profileId) return;
-    loadedProfile.current = profileId;
-    let cancelled = false;
-    setMessages([]);
-    void chatMessageRepository.listByProfile(profileId).then((rows) => {
-      if (!cancelled) setMessages(rows);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [active, profileId]);
+  const messages = useLiveQuery<ChatMessageRecord[]>(
+    () =>
+      active && profileId
+        ? chatMessageRepository.listByProfile(profileId)
+        : Promise.resolve(EMPTY),
+    [active, profileId]
+  );
 
   const results = useMemo(
-    () => searchConversations(debounced, conversations, messages),
+    () => searchConversations(debounced, conversations, messages ?? EMPTY),
     [debounced, conversations, messages]
   );
 

--- a/packages/workout-spa-editor/src/hooks/use-chat-search.ts
+++ b/packages/workout-spa-editor/src/hooks/use-chat-search.ts
@@ -51,6 +51,7 @@ export const useChatSearch = (
     if (!active || !profileId || loadedProfile.current === profileId) return;
     loadedProfile.current = profileId;
     let cancelled = false;
+    setMessages([]);
     void chatMessageRepository.listByProfile(profileId).then((rows) => {
       if (!cancelled) setMessages(rows);
     });

--- a/packages/workout-spa-editor/src/hooks/use-chat-search.ts
+++ b/packages/workout-spa-editor/src/hooks/use-chat-search.ts
@@ -1,0 +1,68 @@
+/**
+ * useChatSearch — query state + lazy, debounced chat search for a profile.
+ *
+ * The conversation list is already live in the page; this hook adds the message
+ * side. It loads the profile's messages once, only when the search first becomes
+ * active (an effective, multi-character query), then recomputes results from the
+ * debounced query. `active` reflects the raw query so the UI can swap to the
+ * results panel immediately, while `results` follow the debounced query to avoid
+ * recomputing on every keystroke. Read-only: it never writes to Dexie.
+ */
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { createDexieChatMessageRepository } from "../adapters/dexie/dexie-chat-message-repository";
+import { db } from "../adapters/dexie/dexie-database";
+import { tokenize } from "../application/chat/normalize-search-text";
+import {
+  type ChatSearchResult,
+  searchConversations,
+} from "../application/chat/search-conversations";
+import type { ChatConversationRecord } from "../types/chat/chat-conversation-record";
+import type { ChatMessageRecord } from "../types/chat/chat-message-record";
+
+const chatMessageRepository = createDexieChatMessageRepository(db);
+
+const DEBOUNCE_MS = 200;
+
+export type UseChatSearch = {
+  query: string;
+  setQuery: (query: string) => void;
+  active: boolean;
+  results: ChatSearchResult[];
+};
+
+export const useChatSearch = (
+  profileId: string | null,
+  conversations: ChatConversationRecord[]
+): UseChatSearch => {
+  const [query, setQuery] = useState("");
+  const [debounced, setDebounced] = useState("");
+  const [messages, setMessages] = useState<ChatMessageRecord[]>([]);
+  const loadedProfile = useRef<string | null>(null);
+
+  const active = tokenize(query).length > 0;
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(query), DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  useEffect(() => {
+    if (!active || !profileId || loadedProfile.current === profileId) return;
+    loadedProfile.current = profileId;
+    let cancelled = false;
+    void chatMessageRepository.listByProfile(profileId).then((rows) => {
+      if (!cancelled) setMessages(rows);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [active, profileId]);
+
+  const results = useMemo(
+    () => searchConversations(debounced, conversations, messages),
+    [debounced, conversations, messages]
+  );
+
+  return { query, setQuery, active, results };
+};


### PR DESCRIPTION
# Pull Request

## Description

### What does this PR do?

Adds **chat word search** to the SPA AI assistant — both the OpenSpec change
`add-chat-search` (proposal, capability spec, design, tasks) **and** its full
implementation.

A user can search by words across the active profile's chats, matching both
conversation **titles** and message **content**:

- **Normalization**: accent- and case-insensitive (NFD + diacritic strip),
  whitespace-tokenized; 1-character tokens are dropped. No library, no
  fuzzy/index.
- **Matching & ranking**: conversation-level token-AND match (tokens may be
  spread across different messages), with re-ranking — conversations by
  title-boost + token frequency (tiebreak `updatedAt`); within a conversation,
  messages matching more tokens first.
- **Results UI**: each result shows a ±30-char snippet with a static-yellow
  highlight; selecting a result scrolls to the matched message (transient focus —
  the `/chat/:id` deep-link URL is unchanged).
- **Read-only & additive**: no Dexie migration, no new port, no sync impact;
  reuses the existing `chatMessages.listByProfile`. The hook loads the profile's
  messages once (lazy, on first active query) and never writes to Dexie.

### Files

**OpenSpec change** (`openspec/changes/add-chat-search/`):
`proposal.md`, `design.md`, `specs/spa-chat-search/spec.md`, `tasks.md`,
`.openspec.yaml`.

**Implementation** (`packages/workout-spa-editor/src/`):

- `application/chat/` — `normalize-search-text.ts`, `build-snippet.ts`,
  `search-conversation-messages.ts`, `search-conversations.ts` (+ tests)
- `components/organisms/Chat/` — `ChatSearchBox.tsx`, `ChatSearchResults.tsx`,
  `SnippetText.tsx`, `ConversationSidebar.tsx`, and wiring in
  `ChatWorkspace.tsx`, `ChatMessageList.tsx`, `ChatConversation.tsx` (+ tests)
- `hooks/` — `use-chat-search.ts`, `use-chat-search-panel.ts` (+ tests)
- `components/pages/ChatPage.tsx` — page wiring

### Why is this change needed?

Conversation titles are auto-derived from the first message and rarely describe
what was discussed. As threads accumulate, there is no way to find an earlier
exchange ("where did we talk about the VO2 block near threshold?"). This adds an
in-chat search so users can locate past exchanges within a profile.

## Related Issues

<!-- none -->

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update (OpenSpec change artifacts)

## Checklist

- [x] Code follows project style guidelines
- [x] If spec under `openspec/specs/` changed: `pnpm lint:specs` passes —
      `openspec validate add-chat-search` reports valid
- [x] Tests added/updated for new functionality (normalization, ranking,
      snippet/highlight, focused scrolling, debounced hook)

## Testing

### How was this tested?

- Unit tests for normalization/tokenization, snippet windowing + highlight
  rebasing, conversation grouping, match construction, and relevance ranking.
- Component tests for the search box, results panel, snippet renderer, sidebar
  switching, and focused-message scroll/highlight.
- Hook tests for search activation, debouncing, query updates, and clearing.
- `openspec validate add-chat-search` → valid.

## Additional Notes

Out of scope for v1 (documented in `design.md`): fuzzy/typo tolerance, inverted
index/BM25, stopword list, and a shared `normalizeForSearch()` for the Workout
Library search.

The message set is loaded lazily once per profile mount; messages sent during
the same session become searchable on the next mount (no data loss — they are
persisted to Dexie immediately). Switching profiles resets the in-memory message
set to avoid cross-profile result mismatch.

## Breaking Changes

None. Additive, read-only; no public API, schema, or sync impact.
