### PR TITLE
test(spa-editor): add /health/* route refresh e2e tests (#680)

### DIFF
--- a/packages/workout-spa-editor/e2e/health-routes.spec.ts
+++ b/packages/workout-spa-editor/e2e/health-routes.spec.ts
@@ -1,0 +1,97 @@
+import { execSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { expect, test } from "@playwright/test";
+
+import {
+  startStaticPagesServer,
+  type StaticPagesServer,
+} from "./fixtures/static-pages-server";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "..", "..", "..");
+
+const ENABLED = process.env.E2E_PROD_BASE === "1";
+
+// Each /health/* sub-route renders a dedicated page marked with a stable
+// `data-testid` (see components/pages/health/*). The refresh test asserts the
+// page survives a hard reload under the `/editor/` base (the SPA-fallback path),
+// catching router-base regressions specific to these routes.
+const HEALTH_ROUTES = [
+  { path: "sleep", testId: "health-sleep" },
+  { path: "weight", testId: "health-weight" },
+  { path: "recovery", testId: "health-recovery" },
+  { path: "activity", testId: "health-activity" },
+] as const;
+
+const RENDER_TIMEOUT_MS = 15_000;
+
+// Tagged @spa-route-refresh so the production-base CI job
+// (`test:e2e --grep '@spa-route-refresh'`) picks these up.
+test.describe("@spa-route-refresh health route refresh", () => {
+  test.skip(!ENABLED, "Production-base e2e gated behind E2E_PROD_BASE=1");
+
+  let server: StaticPagesServer;
+  let mergedDist: string;
+
+  test.beforeAll(async () => {
+    execSync("pnpm --filter @kaiord/workout-spa-editor build", {
+      cwd: repoRoot,
+      env: { ...process.env, VITE_BASE_PATH: "/editor/" },
+      stdio: "inherit",
+    });
+
+    mergedDist = mkdtempSync(join(tmpdir(), "merged-dist-health-"));
+    mkdirSync(join(mergedDist, "editor"), { recursive: true });
+    cpSync(
+      join(repoRoot, "packages/workout-spa-editor/dist"),
+      join(mergedDist, "editor"),
+      { recursive: true }
+    );
+    writeFileSync(
+      join(mergedDist, "404.html"),
+      "<!DOCTYPE html><html><body>404</body></html>"
+    );
+
+    execSync(`node scripts/inject-spa-fallback.mjs ${mergedDist}`, {
+      cwd: repoRoot,
+      stdio: "inherit",
+    });
+
+    server = await startStaticPagesServer(mergedDist);
+  });
+
+  test.afterAll(async () => {
+    if (server) await server.close();
+    if (mergedDist) rmSync(mergedDist, { recursive: true, force: true });
+  });
+
+  for (const route of HEALTH_ROUTES) {
+    test(`hard refresh on /health/${route.path} restores the route and renders`, async ({
+      page,
+    }) => {
+      const path = `/editor/health/${route.path}`;
+      const marker = page.getByTestId(route.testId);
+
+      // Deep-load the route and confirm the dedicated page rendered.
+      await page.goto(`${server.url}${path}`, { waitUntil: "load" });
+      await expect(marker).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+
+      // Hard refresh — exercises the static 404 -> SPA-fallback restore path.
+      await page.reload({ waitUntil: "load" });
+
+      // The route must re-render in place: same URL (no redirect to /health or
+      // the calendar catch-all), the page marker present, and the SPA bundle
+      // re-served under the /editor base.
+      await expect(marker).toBeVisible({ timeout: RENDER_TIMEOUT_MS });
+      expect(new URL(page.url()).pathname).toBe(path);
+      const scriptCount = await page
+        .locator('script[src^="/editor/assets/index-"]')
+        .count();
+      expect(scriptCount).toBeGreaterThan(0);
+    });
+  }
+});


### PR DESCRIPTION
Closes #680 (deferred from `add-health-metrics-to-krd` §8.9; unblocked now that the SPA is hosted at kaiord.com).

## What
Adds `packages/workout-spa-editor/e2e/health-routes.spec.ts` — hard-refresh tests for the four health sub-routes:

| Route | Asserts |
|---|---|
| `/health/sleep` | `data-testid="health-sleep"` re-renders after reload |
| `/health/weight` | `data-testid="health-weight"` |
| `/health/recovery` | `data-testid="health-recovery"` |
| `/health/activity` | `data-testid="health-activity"` |

Each test deep-loads the route under the `/editor` base, hard-refreshes, then asserts: the dedicated page re-renders, the URL is **preserved** (no redirect to `/health` or the calendar catch-all), and the SPA bundle is re-served — catching SPA-router-base regressions specific to these routes.

## How it fits
Mirrors the existing `spa-route-refresh.spec.ts`: same prod-base harness (build with `VITE_BASE_PATH=/editor/` → merged dist → `inject-spa-fallback.mjs` → static server), gated behind `E2E_PROD_BASE=1`, and tagged `@spa-route-refresh` so the **e2e-prod-base** CI job (`test:e2e --project=chromium --grep '@spa-route-refresh'`) runs it.

## Verification
Ran locally with `E2E_PROD_BASE=1 … --grep '@spa-route-refresh'`: **9 passed** (5 existing + 4 new). eslint + workspace `tsc` + `test:scripts` green. No changeset (e2e test only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for health pages to ensure they load correctly, survive a hard refresh, and keep the expected URL without redirecting.
  * Improved confidence that key app routes continue to render properly when served as static files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->