### PR TITLE
test(zwo): fix flaky XSD validation under load (serialize vitest files)

### DIFF
--- a/.changeset/zwo-xsd-serialize.md
+++ b/.changeset/zwo-xsd-serialize.md
@@ -1,0 +1,6 @@
+---
+---
+
+Serialize zwo vitest files so the XSD validation Java subprocess runs one at a
+time, eliminating flaky "does not conform to XSD schema" failures under load
+(CI and the nightly full build). Test-infrastructure only; no runtime change.

--- a/packages/zwo/vitest.config.ts
+++ b/packages/zwo/vitest.config.ts
@@ -4,6 +4,12 @@ export default defineConfig({
   test: {
     globals: false,
     environment: "node",
+    // XSD validation shells out to a Java subprocess (xsd-schema-validator).
+    // Running test files in parallel spawns many JVMs at once; under load (CI,
+    // the nightly's full build) those spawns fail transiently and surface as
+    // spurious "does not conform to XSD schema" errors. Serialize files so at
+    // most one validation subprocess runs at a time.
+    fileParallelism: false,
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Problem
The nightly test-review job failed today: `zwift-round-trip.test.ts` reported 22 `ZwiftValidationError: does not conform to XSD schema` failures. Reproduced GREEN in isolation (285–286/286) — a **flake**, not a code defect.

## Root cause
XSD validation shells out to a **Java subprocess** (`xsd-schema-validator`). vitest runs test files in parallel, so multiple round-trip files spawn many JVMs simultaneously. Under load (CI, the nightly's 16-package build + tests) those Java spawns fail transiently and the thrown error is caught as `valid:false` → spurious schema-nonconformance.

## Fix
`fileParallelism: false` in `packages/zwo/vitest.config.ts` — serializes test files so at most one Java validation subprocess runs at a time. Config-only; no production or coverage change.

## Verification
286 zwo tests pass across repeated runs; coverage unchanged (S95.4/B88.8/F98.98/L95.59, thresholds pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by running certain validation-related tests one at a time, reducing intermittent CI/nightly failures.
  * Helped prevent flaky schema validation errors that could appear under heavy load.

* **Chores**
  * Updated project notes to record the test infrastructure change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->