### PR TITLE
test: nightly minimality sweep (20260630-0315, rescued)

### DIFF
--- a/packages/ai/src/adapters/text-to-workout.test.ts
+++ b/packages/ai/src/adapters/text-to-workout.test.ts
@@ -95,14 +95,14 @@ describe("createTextToWorkout", () => {
       output: RUNNING_WORKOUT,
     } as never);
     const parse = createTextToWorkout({ model: mockModel });
-    await parse("4x(8' a 5'15\")", { sport: "running" });
 
     // Act
+    await parse("4x(8' a 5'15\")", { sport: "running" });
+
+    // Assert
     const callArgs = mockGenerateText.mock.calls[0]?.[0] as {
       system?: string;
     };
-
-    // Assert
     expect(callArgs.system).toContain("running");
   });
 
@@ -123,15 +123,14 @@ describe("createTextToWorkout", () => {
   it("should throw AiParsingError after max retries exhausted", async () => {
     // Arrange
     mockGenerateText.mockRejectedValue(new Error("Always fails"));
-
-    // Act
     const parse = createTextToWorkout({ model: mockModel, maxRetries: 1 });
 
+    // Act
+    const rejection = expect(parse("bad input")).rejects;
+
     // Assert
-    await expect(parse("bad input")).rejects.toThrow(AiParsingError);
-    await expect(parse("bad input")).rejects.toMatchObject({
-      code: "AI_PARSING_ERROR",
-    });
+    await rejection.toThrow(AiParsingError);
+    await rejection.toMatchObject({ code: "AI_PARSING_ERROR" });
   });
 
   it("should throw AiParsingError when output is null", async () => {

--- a/packages/cli/src/utils/directory-handler.test.ts
+++ b/packages/cli/src/utils/directory-handler.test.ts
@@ -67,19 +67,6 @@ describe("createOutputDirectory", () => {
     );
   });
 
-  it("should throw generic error for non-system errors", async () => {
-    // Arrange
-    const { mkdir } = await import("fs/promises");
-
-    // Act
-    vi.mocked(mkdir).mockRejectedValue(new Error("something else"));
-
-    // Assert
-    await expect(createOutputDirectory("/bad/out.tcx")).rejects.toThrow(
-      "Failed to create directory"
-    );
-  });
-
   it("should throw a DirectoryCreateError that maps to its exit code", async () => {
     // Arrange
     const { mkdir } = await import("fs/promises");

--- a/packages/cli/src/utils/format-violations.test.ts
+++ b/packages/cli/src/utils/format-violations.test.ts
@@ -32,10 +32,9 @@ describe("formatValidationErrors", () => {
     const errors: Array<ValidationError> = [
       { field: "version", message: "Required field missing" },
     ];
-    const result = formatValidationErrors(errors);
 
     // Act
-    const stripped = stripAnsi(result);
+    const stripped = stripAnsi(formatValidationErrors(errors));
 
     // Assert
     expect(stripped).toContain("Validation errors:");
@@ -48,10 +47,9 @@ describe("formatValidationErrors", () => {
       { field: "version", message: "Required field missing" },
       { field: "type", message: "Invalid value" },
     ];
-    const result = formatValidationErrors(errors);
 
     // Act
-    const stripped = stripAnsi(result);
+    const stripped = stripAnsi(formatValidationErrors(errors));
 
     // Assert
     expect(stripped).toContain("Validation errors:");
@@ -64,10 +62,9 @@ describe("formatValidationErrors", () => {
     const errors: Array<ValidationError> = [
       { field: "version", message: "Required" },
     ];
-    const result = formatValidationErrors(errors);
 
     // Act
-    const stripped = stripAnsi(result);
+    const stripped = stripAnsi(formatValidationErrors(errors));
 
     // Assert
     expect(stripped).toContain("\u2022");
@@ -79,10 +76,9 @@ describe("formatValidationErrors", () => {
     const errors: Array<ValidationError> = [
       { field: "test", message: "error" },
     ];
-    const result = formatValidationErrors(errors);
 
     // Act
-    const stripped = stripAnsi(result);
+    const stripped = stripAnsi(formatValidationErrors(errors));
 
     // Assert
     expect(stripped).toContain("Validation errors:");
@@ -117,10 +113,9 @@ describe("formatToleranceViolations", () => {
         tolerance: 1,
       },
     ];
-    const result = formatToleranceViolations(violations);
 
     // Act
-    const stripped = stripAnsi(result);
+    const stripped = stripAnsi(formatToleranceViolations(violations));
 
     // Assert
     expect(stripped).toContain("Tolerance violations:");
@@ -147,10 +142,9 @@ describe("formatToleranceViolations", () => {
         tolerance: 1,
       },
     ];
-    const result = formatToleranceViolations(violations);
 
     // Act
-    const stripped = stripAnsi(result);
+    const stripped = stripAnsi(formatToleranceViolations(violations));
 
     // Assert
     expect(stripped).toContain("power");
@@ -168,10 +162,9 @@ describe("formatToleranceViolations", () => {
         tolerance: 1,
       },
     ];
-    const result = formatToleranceViolations(violations);
 
     // Act
-    const stripped = stripAnsi(result);
+    const stripped = stripAnsi(formatToleranceViolations(violations));
 
     // Assert
     expect(stripped).toContain("deviation: 2");
@@ -189,10 +182,9 @@ describe("formatToleranceViolations", () => {
         tolerance: 1,
       },
     ];
-    const result = formatToleranceViolations(violations);
 
     // Act
-    const stripped = stripAnsi(result);
+    const stripped = stripAnsi(formatToleranceViolations(violations));
 
     // Assert
     expect(stripped).toContain("Tolerance violations:");

--- a/packages/core/src/application/round-trip/round-trip-comparison.test.ts
+++ b/packages/core/src/application/round-trip/round-trip-comparison.test.ts
@@ -299,22 +299,34 @@ describe("entity comparison with absent or sparse collections", () => {
     expect(violations).toStrictEqual([]);
   });
 
-  it("should report nothing when the first KRD has no sessions or records", () => {
+  it("should report nothing when the first KRD has no sessions", () => {
     // Arrange
     const checker = createToleranceChecker();
     const krd2: KRD = {
       ...baseKrd,
       sessions: [{ totalElapsedTime: 3600 }],
+    };
+
+    // Act
+    const violations = compareSessions(baseKrd, krd2, checker);
+
+    // Assert
+    expect(violations).toStrictEqual([]);
+  });
+
+  it("should report nothing when the first KRD has no records", () => {
+    // Arrange
+    const checker = createToleranceChecker();
+    const krd2: KRD = {
+      ...baseKrd,
       records: [{ timestamp: FIRST_LAP_START, heartRate: HR_EXPECTED }],
     };
 
     // Act
-    const sessionViolations = compareSessions(baseKrd, krd2, checker);
-    const recordViolations = compareRecords(baseKrd, krd2, checker);
+    const violations = compareRecords(baseKrd, krd2, checker);
 
     // Assert
-    expect(sessionViolations).toStrictEqual([]);
-    expect(recordViolations).toStrictEqual([]);
+    expect(violations).toStrictEqual([]);
   });
 
   it("should skip sparse entries instead of comparing them", () => {

--- a/packages/core/src/domain/validation/extract-workout.test.ts
+++ b/packages/core/src/domain/validation/extract-workout.test.ts
@@ -45,15 +45,14 @@ describe("extractWorkout", () => {
 
   it("should throw for wrong KRD type", () => {
     // Arrange
-
-    // Act
     const krd: KRD = { ...validKrd, type: "recorded_activity" };
 
+    // Act
+    const act = () => extractWorkout(krd);
+
     // Assert
-    expect(() => extractWorkout(krd)).toThrow(KrdValidationError);
-    expect(() => extractWorkout(krd)).toThrow(
-      'Expected type "structured_workout"'
-    );
+    expect(act).toThrow(KrdValidationError);
+    expect(act).toThrow('Expected type "structured_workout"');
   });
 
   it.each<[string, KRD]>([

--- a/packages/core/src/protocol/profile-snapshot.test.ts
+++ b/packages/core/src/protocol/profile-snapshot.test.ts
@@ -173,10 +173,10 @@ describe("fingerprintSnapshot", () => {
     // Arrange
 
     // Act
+    const fp1 = fingerprintSnapshot("profile-1", baselineSnapshot);
+    const fp2 = fingerprintSnapshot("profile-2", baselineSnapshot);
 
     // Assert
-    expect(fingerprintSnapshot("profile-1", baselineSnapshot)).not.toBe(
-      fingerprintSnapshot("profile-2", baselineSnapshot)
-    );
+    expect(fp1).not.toBe(fp2);
   });
 });

--- a/packages/fit/src/adapters/garmin-fitsdk.test.ts
+++ b/packages/fit/src/adapters/garmin-fitsdk.test.ts
@@ -195,21 +195,6 @@ describe("createGarminFitSdkReader", () => {
       expect(result.extensions).toBeDefined();
       expect(result.extensions?.fit).toBeDefined();
     });
-
-    it("should handle FIT files without extensions gracefully", async () => {
-      // Arrange
-      const logger = createMockLogger();
-      const reader = createGarminFitSdkReader(logger);
-      const buffer = loadFitFixture("WorkoutIndividualSteps.fit");
-      const result = await reader(buffer);
-      expect(result.extensions?.fit).toBeDefined();
-
-      // Act
-      const fitExt = result.extensions?.fit as Record<string, unknown>;
-
-      // Assert
-      expect(typeof fitExt).toBe("object");
-    });
   });
 });
 

--- a/packages/fit/src/adapters/krd-to-fit/krd-to-fit.converter.test.ts
+++ b/packages/fit/src/adapters/krd-to-fit/krd-to-fit.converter.test.ts
@@ -825,7 +825,6 @@ describe("convertKRDToMessages", () => {
       expect(messages.length).toBe(FIT_REPEATED_MESSAGES_6);
       const repeat1Msg = messages[3] as Record<string, unknown>;
       expect(repeat1Msg.mesgNum).toBe(FIT_MESSAGE_NUMBERS.WORKOUT_STEP);
-      expect(repeat1Msg.mesgNum).toBe(FIT_MESSAGE_NUMBERS.WORKOUT_STEP);
       expect(repeat1Msg).toMatchObject({
         repeatSteps: block1.repeatCount,
         durationStep: 0,
@@ -835,7 +834,6 @@ describe("convertKRDToMessages", () => {
       const repeat2Msg = messages[5] as Record<string, unknown>;
 
       // Assert
-      expect(repeat2Msg.mesgNum).toBe(FIT_MESSAGE_NUMBERS.WORKOUT_STEP);
       expect(repeat2Msg.mesgNum).toBe(FIT_MESSAGE_NUMBERS.WORKOUT_STEP);
       expect(repeat2Msg).toMatchObject({
         repeatSteps: block2.repeatCount,
@@ -906,7 +904,6 @@ describe("convertKRDToMessages", () => {
         messageIndex: 0,
         durationType: fitDurationTypeSchema.enum.calories,
         durationCalories: 500,
-        targetType: stepMsg.targetType,
       });
     });
 
@@ -953,7 +950,6 @@ describe("convertKRDToMessages", () => {
         durationType: fitDurationTypeSchema.enum.repeatUntilTime,
         durationTime: 1800,
         durationStep: 0,
-        targetType: stepMsg.targetType,
       });
     });
   });

--- a/packages/garmin-connect/src/adapters/http/sso-oauth.test.ts
+++ b/packages/garmin-connect/src/adapters/http/sso-oauth.test.ts
@@ -40,34 +40,42 @@ describe("getOAuth1Token", () => {
 
   it("should throw when response is not ok", async () => {
     // Arrange
-
-    // Act
     const mockFetch = vi.fn(async () => ({
       ok: false,
       status: 401,
       statusText: "Unauthorized",
     })) as unknown as typeof globalThis.fetch;
 
+    // Act
+    const promise = getOAuth1Token(
+      "ticket-123",
+      consumer,
+      mockFetch,
+      mockLogger
+    );
+
     // Assert
-    await expect(
-      getOAuth1Token("ticket-123", consumer, mockFetch, mockLogger)
-    ).rejects.toThrow("OAuth1 token request failed");
+    await expect(promise).rejects.toThrow("OAuth1 token request failed");
   });
 
   it("should throw when oauth_token is missing from response", async () => {
     // Arrange
-
-    // Act
     const mockFetch = vi.fn(async () => ({
       ok: true,
       status: 200,
       text: async () => "some_other_param=value",
     })) as unknown as typeof globalThis.fetch;
 
+    // Act
+    const promise = getOAuth1Token(
+      "ticket-123",
+      consumer,
+      mockFetch,
+      mockLogger
+    );
+
     // Assert
-    await expect(
-      getOAuth1Token("ticket-123", consumer, mockFetch, mockLogger)
-    ).rejects.toThrow("OAuth1 token exchange failed");
+    await expect(promise).rejects.toThrow("OAuth1 token exchange failed");
   });
 });
 
@@ -105,17 +113,16 @@ describe("exchangeOAuth2", () => {
 
   it("should throw when response is not ok", async () => {
     // Arrange
-
-    // Act
     const mockFetch = vi.fn(async () => ({
       ok: false,
       status: 500,
       statusText: "Internal Server Error",
     })) as unknown as typeof globalThis.fetch;
 
+    // Act
+    const promise = exchangeOAuth2(oauth1, consumer, mockFetch, mockLogger);
+
     // Assert
-    await expect(
-      exchangeOAuth2(oauth1, consumer, mockFetch, mockLogger)
-    ).rejects.toThrow("OAuth2 exchange failed");
+    await expect(promise).rejects.toThrow("OAuth2 exchange failed");
   });
 });

--- a/packages/garmin/src/adapters/converters/executable-step.converter.test.ts
+++ b/packages/garmin/src/adapters/converters/executable-step.converter.test.ts
@@ -453,10 +453,9 @@ describe("mapExecutableStep", () => {
       const step = buildStep({ description: longDescription });
 
       // Act
-      const result = mapExecutableStep(step, 0, logger);
+      mapExecutableStep(step, 0, logger);
 
       // Assert
-      expect(result.notes).toHaveLength(NOTES_MAX_LENGTH);
       expect(logger.warn).toHaveBeenCalledWith(
         `Lossy conversion: step notes truncated to ${NOTES_MAX_LENGTH} characters`,
         expect.objectContaining({

--- a/packages/mcp/src/tools/kaiord-diff.test.ts
+++ b/packages/mcp/src/tools/kaiord-diff.test.ts
@@ -29,19 +29,19 @@ describe("kaiord_diff", () => {
     const file2 = join(tmpDir, "b.krd");
     await writeFile(file1, JSON.stringify(krd1));
     await writeFile(file2, JSON.stringify(krd2));
+
+    // Act
     const result = (await client.callTool({
       name: "kaiord_diff",
       arguments: { file1, file2 },
     })) as McpToolResult;
     const diff = JSON.parse(result.content[0].text);
-    expect(diff.metadata.length).toBeGreaterThan(0);
-
-    // Act
     const sportDiff = diff.metadata.find(
       (d: { field: string }) => d.field === "sport"
     );
 
     // Assert
+    expect(diff.metadata.length).toBeGreaterThan(0);
     expect(sportDiff).toBeDefined();
   });
 

--- a/packages/mcp/src/tools/kaiord-garmin-push.test.ts
+++ b/packages/mcp/src/tools/kaiord-garmin-push.test.ts
@@ -53,13 +53,13 @@ describe("kaiord_garmin_push", () => {
     mockIsAuthenticated.mockReturnValue(true);
     mockPush.mockResolvedValue(mockPushResult);
     const krdJson = loadKrdFixtureRaw("WorkoutIndividualSteps.krd");
-    const result = await handler({ input_content: krdJson });
-    expect(result.isError).toBeUndefined();
 
     // Act
+    const result = await handler({ input_content: krdJson });
     const parsed = JSON.parse(result.content[0].text) as unknown;
 
     // Assert
+    expect(result.isError).toBeUndefined();
     expect(parsed).toEqual(mockPushResult);
   });
 

--- a/packages/tcx/src/adapters/fast-xml-parser.test.ts
+++ b/packages/tcx/src/adapters/fast-xml-parser.test.ts
@@ -124,17 +124,17 @@ describe("createFastXmlTcxReader", () => {
     </Workout>
   </Workouts>
 </TrainingCenterDatabase>`;
-      const result = await reader(tcxWithMetadata);
-      expect(result.metadata.sport).toBe("cycling");
-      expect(result.extensions?.structured_workout).toBeDefined();
 
       // Act
+      const result = await reader(tcxWithMetadata);
       const workout = result.extensions?.structured_workout as {
         name?: string;
         sport: string;
       };
 
       // Assert
+      expect(result.metadata.sport).toBe("cycling");
+      expect(result.extensions?.structured_workout).toBeDefined();
       expect(workout.name).toBe("Cycling Intervals");
       expect(workout.sport).toBe("cycling");
     });
@@ -156,9 +156,9 @@ describe("createFastXmlTcxReader", () => {
     </Workout>
   </Workouts>
 </TrainingCenterDatabase>`;
-      const result = await reader(tcxWithTimeStep);
 
       // Act
+      const result = await reader(tcxWithTimeStep);
       const workout = result.extensions?.structured_workout as {
         steps: Array<{ duration: { type: string; seconds?: number } }>;
       };
@@ -186,9 +186,9 @@ describe("createFastXmlTcxReader", () => {
     </Workout>
   </Workouts>
 </TrainingCenterDatabase>`;
-      const result = await reader(tcxWithDistanceStep);
 
       // Act
+      const result = await reader(tcxWithDistanceStep);
       const workout = result.extensions?.structured_workout as {
         steps: Array<{ duration: { type: string; meters?: number } }>;
       };
@@ -220,9 +220,9 @@ describe("createFastXmlTcxReader", () => {
     </Workout>
   </Workouts>
 </TrainingCenterDatabase>`;
-      const result = await reader(tcxWithHRZone);
 
       // Act
+      const result = await reader(tcxWithHRZone);
       const workout = result.extensions?.structured_workout as {
         steps: Array<{
           target: { type: string; value?: { unit: string; value: number } };
@@ -271,9 +271,9 @@ describe("createFastXmlTcxReader", () => {
     </Workout>
   </Workouts>
 </TrainingCenterDatabase>`;
-      const result = await reader(tcxWithMultipleSteps);
 
       // Act
+      const result = await reader(tcxWithMultipleSteps);
       const workout = result.extensions?.structured_workout as {
         steps: Array<{ stepIndex: number; name?: string; intensity?: string }>;
       };
@@ -311,9 +311,9 @@ describe("createFastXmlTcxReader", () => {
     </Workout>
   </Workouts>
 </TrainingCenterDatabase>`;
-      const result = await reader(tcxWithStepExtensions);
 
       // Act
+      const result = await reader(tcxWithStepExtensions);
       const workout = result.extensions?.structured_workout as {
         steps: Array<{ extensions?: { tcx: Record<string, unknown> } }>;
       };
@@ -347,21 +347,21 @@ describe("createFastXmlTcxReader", () => {
     </Workout>
   </Workouts>
 </TrainingCenterDatabase>`;
+
+      // Act
       const result = await reader(tcxWithPowerExtensions);
       const workout = result.extensions?.structured_workout as {
         steps: Array<{ extensions?: { tcx: Record<string, unknown> } }>;
       };
-      expect(workout.steps).toHaveLength(1);
-      expect(workout.steps[0].extensions).toBeDefined();
-      expect(workout.steps[0].extensions?.tcx).toBeDefined();
-
-      // Act
       const tpx = workout.steps[0].extensions?.tcx.TPX as Record<
         string,
         unknown
       >;
 
       // Assert
+      expect(workout.steps).toHaveLength(1);
+      expect(workout.steps[0].extensions).toBeDefined();
+      expect(workout.steps[0].extensions?.tcx).toBeDefined();
       expect(tpx).toBeDefined();
       expect(tpx.Watts).toBe(POWER_WATTS_250);
     });
@@ -388,9 +388,9 @@ describe("createFastXmlTcxReader", () => {
     </Workout>
   </Workouts>
 </TrainingCenterDatabase>`;
-      const result = await reader(tcxWithPowerExtensions);
 
       // Act
+      const result = await reader(tcxWithPowerExtensions);
       const workout = result.extensions?.structured_workout as {
         steps: Array<{
           targetType: string;
@@ -426,9 +426,9 @@ describe("createFastXmlTcxReader", () => {
     </Workout>
   </Workouts>
 </TrainingCenterDatabase>`;
-      const result = await reader(tcxWithWorkoutExtensions);
 
       // Act
+      const result = await reader(tcxWithWorkoutExtensions);
       const workout = result.extensions?.structured_workout as {
         extensions?: { tcx: Record<string, unknown> };
       };
@@ -461,13 +461,13 @@ describe("createFastXmlTcxReader", () => {
     <DatabaseCustomField>DatabaseCustomValue</DatabaseCustomField>
   </Extensions>
 </TrainingCenterDatabase>`;
-      const result = await reader(tcxWithDatabaseExtensions);
-      expect(result.extensions?.tcx).toBeDefined();
 
       // Act
+      const result = await reader(tcxWithDatabaseExtensions);
       const tcxExtensions = result.extensions?.tcx as Record<string, unknown>;
 
       // Assert
+      expect(result.extensions?.tcx).toBeDefined();
       expect(tcxExtensions.DatabaseCustomField).toBe("DatabaseCustomValue");
     });
 
@@ -497,18 +497,18 @@ describe("createFastXmlTcxReader", () => {
     <DatabaseField>DatabaseValue</DatabaseField>
   </Extensions>
 </TrainingCenterDatabase>`;
-      const result = await reader(tcxWithAllExtensions);
-      expect(result.extensions?.tcx).toBeDefined();
-      const tcxExtensions = result.extensions?.tcx as Record<string, unknown>;
-      expect(tcxExtensions.DatabaseField).toBe("DatabaseValue");
 
       // Act
+      const result = await reader(tcxWithAllExtensions);
+      const tcxExtensions = result.extensions?.tcx as Record<string, unknown>;
       const workout = result.extensions?.structured_workout as {
         extensions?: { tcx: Record<string, unknown> };
         steps: Array<{ extensions?: { tcx: Record<string, unknown> } }>;
       };
 
       // Assert
+      expect(result.extensions?.tcx).toBeDefined();
+      expect(tcxExtensions.DatabaseField).toBe("DatabaseValue");
       expect(workout.extensions?.tcx).toBeDefined();
       expect(workout.extensions?.tcx.WorkoutField).toBe("WorkoutValue");
       expect(workout.steps[0].extensions?.tcx).toBeDefined();
@@ -831,20 +831,20 @@ it("should preserve step order", async () => {
       },
     },
   };
+
+  // Act
   const result = await writer(krd);
+  const warmupIndex = result.indexOf("<Name>Warmup</Name>");
+  const workIndex = result.indexOf("<Name>Work</Name>");
+  const cooldownIndex = result.indexOf("<Name>Cooldown</Name>");
+
+  // Assert
   expect(result).toContain("<Name>Warmup</Name>");
   expect(result).toContain("<Name>Work</Name>");
   expect(result).toContain("<Name>Cooldown</Name>");
   expect(result).toContain("<Intensity>Warmup</Intensity>");
   expect(result).toContain("<Intensity>Active</Intensity>");
   expect(result).toContain("<Intensity>Cooldown</Intensity>");
-  const warmupIndex = result.indexOf("<Name>Warmup</Name>");
-  const workIndex = result.indexOf("<Name>Work</Name>");
-
-  // Act
-  const cooldownIndex = result.indexOf("<Name>Cooldown</Name>");
-
-  // Assert
   expect(warmupIndex).toBeLessThan(workIndex);
   expect(workIndex).toBeLessThan(cooldownIndex);
 });

--- a/packages/tcx/src/adapters/workout/tcx.converter.test.ts
+++ b/packages/tcx/src/adapters/workout/tcx.converter.test.ts
@@ -41,13 +41,13 @@ describe("convertKRDToTcx", () => {
     // Arrange
     const logger = createMockLogger();
     const krd = createMinimalKrd();
-    const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
-    expect(result.TrainingCenterDatabase).toBeDefined();
 
     // Act
+    const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
     const tcd = result.TrainingCenterDatabase as Record<string, unknown>;
 
     // Assert
+    expect(result.TrainingCenterDatabase).toBeDefined();
     expect(tcd["@_xmlns"]).toBe(
       "http://www.garmin.com/xmlschemas/TrainingCenterDatabase/v2"
     );
@@ -74,11 +74,11 @@ describe("convertKRDToTcx", () => {
         },
       },
     });
+
+    // Act
     const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
     const tcd = result.TrainingCenterDatabase as Record<string, unknown>;
     const workouts = tcd.Workouts as Record<string, unknown>;
-
-    // Act
     const workout = workouts.Workout as Record<string, unknown>;
 
     // Assert
@@ -115,9 +115,9 @@ describe("convertKRDToTcx", () => {
         serialNumber: "ABC123",
       },
     });
-    const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
 
     // Act
+    const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
     const tcd = result.TrainingCenterDatabase as Record<string, unknown>;
 
     // Assert
@@ -140,9 +140,9 @@ describe("convertKRDToTcx", () => {
         tcx: { CustomField: "custom_value" },
       },
     });
-    const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
 
     // Act
+    const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
     const tcd = result.TrainingCenterDatabase as Record<string, unknown>;
 
     // Assert
@@ -164,11 +164,11 @@ describe("convertKRDToTcx", () => {
         },
       },
     });
+
+    // Act
     const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
     const tcd = result.TrainingCenterDatabase as Record<string, unknown>;
     const workouts = tcd.Workouts as Record<string, unknown>;
-
-    // Act
     const workout = workouts.Workout as Record<string, unknown>;
 
     // Assert
@@ -179,9 +179,9 @@ describe("convertKRDToTcx", () => {
     // Arrange
     const logger = createMockLogger();
     const krd = createMinimalKrd();
-    const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
 
     // Act
+    const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
     const tcd = result.TrainingCenterDatabase as Record<string, unknown>;
 
     // Assert
@@ -217,12 +217,12 @@ describe("convertKRDToTcx", () => {
         },
       },
     });
+
+    // Act
     const result = convertKRDToTcx(krd, logger) as Record<string, unknown>;
     const tcd = result.TrainingCenterDatabase as Record<string, unknown>;
     const workouts = tcd.Workouts as Record<string, unknown>;
     const workout = workouts.Workout as Record<string, unknown>;
-
-    // Act
     const steps = workout.Step as Array<Record<string, unknown>>;
 
     // Assert

--- a/packages/workout-spa-editor/src/adapters/train2go/coaching-telemetry.test.ts
+++ b/packages/workout-spa-editor/src/adapters/train2go/coaching-telemetry.test.ts
@@ -109,36 +109,26 @@ describe("emitLinkResult", () => {
     assertNoPII(a);
   });
 
-  it("should emit coaching.link.failure with normalized errorKind", () => {
-    // Arrange
-    const a = makeAnalytics();
-    const reasons = [
-      "profile-deleted",
-      "session-not-active",
-      "transport-error",
-    ] as const;
+  it.each([
+    { reason: "profile-deleted" as const },
+    { reason: "session-not-active" as const },
+    { reason: "transport-error" as const },
+  ])(
+    "should emit coaching.link.failure with normalized errorKind for $reason",
+    ({ reason }) => {
+      // Arrange
+      const a = makeAnalytics();
 
-    // Act
-    for (const reason of reasons) {
+      // Act
       emitLinkResult(a, "train2go", "p1", { ok: false, reason });
-    }
 
-    // Assert
-    expect(a.event).toHaveBeenCalledWith("coaching.link.failure", {
-      source: "train2go",
-      profileId: "p1",
-      errorKind: "profile-deleted",
-    });
-    expect(a.event).toHaveBeenCalledWith("coaching.link.failure", {
-      source: "train2go",
-      profileId: "p1",
-      errorKind: "session-not-active",
-    });
-    expect(a.event).toHaveBeenCalledWith("coaching.link.failure", {
-      source: "train2go",
-      profileId: "p1",
-      errorKind: "transport-error",
-    });
-    assertNoPII(a);
-  });
+      // Assert
+      expect(a.event).toHaveBeenCalledWith("coaching.link.failure", {
+        source: "train2go",
+        profileId: "p1",
+        errorKind: reason,
+      });
+      assertNoPII(a);
+    }
+  );
 });

--- a/packages/workout-spa-editor/src/application/auto-match-dismissal.test.ts
+++ b/packages/workout-spa-editor/src/application/auto-match-dismissal.test.ts
@@ -151,9 +151,9 @@ describe("isAutoMatchBannerDismissed", () => {
 describe("dismissAutoMatchBanner — defensive guards", () => {
   it("should reject empty profileId on the write path", async () => {
     // Arrange
+    const repo = createInMemoryAutoMatchDismissalRepository();
 
     // Act
-    const repo = createInMemoryAutoMatchDismissalRepository();
 
     // Assert
     await expect(
@@ -168,9 +168,9 @@ describe("dismissAutoMatchBanner — defensive guards", () => {
     "should reject empty %s on the write path",
     async (field) => {
       // Arrange
+      const repo = createInMemoryAutoMatchDismissalRepository();
 
       // Act
-      const repo = createInMemoryAutoMatchDismissalRepository();
 
       // Assert
       await expect(

--- a/packages/workout-spa-editor/src/application/coaching/coaching-template.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/coaching-template.test.ts
@@ -34,17 +34,6 @@ describe("buildCoachingTemplateKrd", () => {
     expect(step.intensity).toBe("warmup");
   });
 
-  it("should set the resolved sport on the KRD metadata", () => {
-    // Arrange
-    const sport = "rowing";
-
-    // Act
-    const krd = buildCoachingTemplateKrd(sport);
-
-    // Assert
-    expect(krd.metadata.sport).toBe("rowing");
-  });
-
   it("should set the optional subSport on the KRD metadata", () => {
     // Arrange
     const subSport = "flexibility_training";

--- a/packages/workout-spa-editor/src/application/compute-compliance-score.test.ts
+++ b/packages/workout-spa-editor/src/application/compute-compliance-score.test.ts
@@ -48,19 +48,21 @@ describe("computeComplianceScore", () => {
     }
   );
 
-  it("should clamp to 0 for very large variance", () => {
-    // Arrange
+  it.each([
+    { plan: MINUTE_AS_SEC, actual: TEN_MINUTES_AS_SEC },
+    { plan: MINUTE_AS_SEC, actual: HUNDRED_MINUTES_AS_SEC },
+  ])(
+    "should clamp to 0 for very large variance (plan $plan actual $actual)",
+    ({ plan, actual }) => {
+      // Arrange
 
-    // Act
+      // Act
+      const score = computeComplianceScore(plan, actual);
 
-    // Assert
-    expect(computeComplianceScore(MINUTE_AS_SEC, TEN_MINUTES_AS_SEC)).toBe(
-      COMPLIANCE_ZERO
-    );
-    expect(computeComplianceScore(MINUTE_AS_SEC, HUNDRED_MINUTES_AS_SEC)).toBe(
-      COMPLIANCE_ZERO
-    );
-  });
+      // Assert
+      expect(score).toBe(COMPLIANCE_ZERO);
+    }
+  );
 
   it.each([
     { plan: undefined, actual: MINUTES_43_AS_SEC },
@@ -88,15 +90,21 @@ describe("computeComplianceScore", () => {
     expect(computeComplianceScore(0, THIRTY_MINUTES_AS_SEC)).toBeNull();
   });
 
-  it("should return null on NaN inputs", () => {
-    // Arrange
+  it.each([
+    { plan: NaN, actual: THIRTY_MINUTES_AS_SEC },
+    { plan: MINUTES_45_AS_SEC, actual: NaN },
+  ])(
+    "should return null on NaN inputs (plan $plan actual $actual)",
+    ({ plan, actual }) => {
+      // Arrange
 
-    // Act
+      // Act
+      const score = computeComplianceScore(plan, actual);
 
-    // Assert
-    expect(computeComplianceScore(NaN, THIRTY_MINUTES_AS_SEC)).toBeNull();
-    expect(computeComplianceScore(MINUTES_45_AS_SEC, NaN)).toBeNull();
-  });
+      // Assert
+      expect(score).toBeNull();
+    }
+  );
 
   it("should be symmetric — undershoot and overshoot yield identical scores", () => {
     // Arrange

--- a/packages/workout-spa-editor/src/application/profile/zones/zones.test.ts
+++ b/packages/workout-spa-editor/src/application/profile/zones/zones.test.ts
@@ -314,6 +314,8 @@ describe("addCustomZone", () => {
     const persistence = createInMemoryPersistence();
     const profile = makeProfile();
     await seedProfile(persistence, profile);
+
+    // Act
     const updated = await addCustomZone(
       persistence,
       profile.id,
@@ -321,8 +323,6 @@ describe("addCustomZone", () => {
       "heartRateZones",
       HR_ZONE
     );
-
-    // Act
     const zones = updated.sportZones.cycling?.heartRateZones.zones ?? [];
 
     // Assert
@@ -410,6 +410,8 @@ describe("removeCustomZone", () => {
       ],
     };
     await seedProfile(persistence, profile);
+
+    // Act
     const updated = await removeCustomZone(
       persistence,
       profile.id,
@@ -417,8 +419,6 @@ describe("removeCustomZone", () => {
       "heartRateZones",
       1
     );
-
-    // Act
     const zones = updated.sportZones.cycling?.heartRateZones.zones ?? [];
 
     // Assert

--- a/packages/workout-spa-editor/src/application/set-calendar-view.test.ts
+++ b/packages/workout-spa-editor/src/application/set-calendar-view.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import type { ProfileRepository } from "../ports/persistence-port";
+import { createInMemoryPersistence } from "../test-utils/in-memory-persistence";
 import { createInMemoryUserPreferencesRepository } from "../test-utils/in-memory-user-preferences-repository";
 import type { Profile } from "../types/profile";
 import { ProfileNotFoundError } from "../types/session-match-errors";
@@ -15,27 +15,14 @@ const stubProfile = (overrides: Partial<Profile> = {}): Profile => ({
   ...overrides,
 });
 
-const stubProfileRepo = (rows: Profile[]): ProfileRepository => {
-  const map = new Map(rows.map((r) => [r.id, r]));
-  return {
-    getAll: async () => [...map.values()],
-    getById: async (id) => map.get(id),
-    put: async (p) => {
-      map.set(p.id, p);
-    },
-    delete: async (id) => {
-      map.delete(id);
-    },
-  };
-};
-
 const fixedClock = () => "2026-05-01T12:00:00.000Z";
 
 describe("setCalendarView", () => {
   it("should create the row on first call with updatedAt from injected clock", async () => {
     // Arrange
     const repo = createInMemoryUserPreferencesRepository();
-    const profileRepo = stubProfileRepo([stubProfile()]);
+    const profileRepo = createInMemoryPersistence().profiles;
+    await profileRepo.put(stubProfile());
 
     // Act
     await setCalendarView(
@@ -54,7 +41,8 @@ describe("setCalendarView", () => {
   it("should update the row in place on subsequent calls", async () => {
     // Arrange
     const repo = createInMemoryUserPreferencesRepository();
-    const profileRepo = stubProfileRepo([stubProfile()]);
+    const profileRepo = createInMemoryPersistence().profiles;
+    await profileRepo.put(stubProfile());
     await setCalendarView(
       { profileId: "p1", view: "list" },
       {
@@ -85,7 +73,8 @@ describe("setCalendarView", () => {
   it("should still refresh updatedAt when idempotent on same value", async () => {
     // Arrange
     const repo = createInMemoryUserPreferencesRepository();
-    const profileRepo = stubProfileRepo([stubProfile()]);
+    const profileRepo = createInMemoryPersistence().profiles;
+    await profileRepo.put(stubProfile());
     await setCalendarView(
       { profileId: "p1", view: "grid" },
       {
@@ -112,9 +101,10 @@ describe("setCalendarView", () => {
   it("should throw ProfileNotFoundError when profile is missing (concurrent delete)", async () => {
     // Arrange
     const repo = createInMemoryUserPreferencesRepository();
+    const profileRepo = createInMemoryPersistence().profiles;
 
     // Act
-    const profileRepo = stubProfileRepo([]);
+    // (profileRepo has no entries — simulates a concurrent delete)
 
     // Assert
     await expect(

--- a/packages/workout-spa-editor/src/components/organisms/OnboardingTutorial/OnboardingTutorial.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/OnboardingTutorial/OnboardingTutorial.test.tsx
@@ -60,27 +60,6 @@ describe("OnboardingTutorial", () => {
   // ============================================
 
   describe("rendering", () => {
-    it("should render when open is true", () => {
-      // Arrange
-
-      // Act
-
-      renderWithProviders(
-        <OnboardingTutorial
-          steps={mockSteps}
-          open={true}
-          onOpenChange={vi.fn()}
-        />
-      );
-
-      // Assert
-
-      expect(screen.getByText("Welcome")).toBeInTheDocument();
-      expect(
-        screen.getByText("Welcome to the Workout SPA Editor!")
-      ).toBeInTheDocument();
-    });
-
     it("should not render when open is false", () => {
       // Arrange
 
@@ -158,24 +137,6 @@ describe("OnboardingTutorial", () => {
       // Assert
       // There are two skip buttons (X icon and Skip text button).
       expect(skipButtons.length).toBeGreaterThanOrEqual(1);
-    });
-
-    it("should display close button", () => {
-      // Arrange
-
-      // Act
-
-      renderWithProviders(
-        <OnboardingTutorial
-          steps={mockSteps}
-          open={true}
-          onOpenChange={vi.fn()}
-        />
-      );
-
-      // Assert
-
-      expect(screen.getByLabelText("Skip tutorial")).toBeInTheDocument();
     });
   });
 
@@ -672,71 +633,40 @@ describe("OnboardingTutorial", () => {
   // ============================================
 
   describe("positioning", () => {
-    it("should apply center position by default", () => {
-      // Arrange
+    it.each([
+      { navigationClicks: 0, expectedClass: "left-[50%]", position: "center" },
+      {
+        navigationClicks: 1,
+        expectedClass: "bottom-[10%]",
+        position: "bottom",
+      },
+      { navigationClicks: 2, expectedClass: "right-[10%]", position: "right" },
+    ])(
+      "should apply $position position after $navigationClicks navigation clicks",
+      async ({ navigationClicks, expectedClass }) => {
+        // Arrange
 
-      renderWithProviders(
-        <OnboardingTutorial
-          steps={mockSteps}
-          open={true}
-          onOpenChange={vi.fn()}
-        />
-      );
+        const user = userEvent.setup();
+        renderWithProviders(
+          <OnboardingTutorial
+            steps={mockSteps}
+            open={true}
+            onOpenChange={vi.fn()}
+          />
+        );
 
-      // Act
+        // Act
 
-      const dialog = screen.getByRole("dialog");
+        for (let i = 0; i < navigationClicks; i++) {
+          await user.click(screen.getByRole("button", { name: /next/i }));
+        }
+        const dialog = screen.getByRole("dialog");
 
-      // Assert
+        // Assert
 
-      expect(dialog).toHaveClass("left-[50%]");
-      expect(dialog).toHaveClass("top-[50%]");
-    });
-
-    it("should apply bottom position when specified", async () => {
-      // Arrange
-
-      const user = userEvent.setup();
-      renderWithProviders(
-        <OnboardingTutorial
-          steps={mockSteps}
-          open={true}
-          onOpenChange={vi.fn()}
-        />
-      );
-
-      // Act
-      // Navigate to step with bottom position
-      await user.click(screen.getByRole("button", { name: /next/i }));
-      const dialog = screen.getByRole("dialog");
-
-      // Assert
-
-      expect(dialog).toHaveClass("bottom-[10%]");
-    });
-
-    it("should apply right position when specified", async () => {
-      // Arrange
-
-      const user = userEvent.setup();
-      renderWithProviders(
-        <OnboardingTutorial
-          steps={mockSteps}
-          open={true}
-          onOpenChange={vi.fn()}
-        />
-      );
-
-      // Act
-      // Navigate to step with right position
-      await user.click(screen.getByRole("button", { name: /next/i }));
-      await user.click(screen.getByRole("button", { name: /next/i }));
-      const dialog = screen.getByRole("dialog");
-
-      // Assert
-
-      expect(dialog).toHaveClass("right-[10%]");
-    });
+        expect(dialog).toHaveClass(expectedClass);
+      }
+    );
   });
 
   // ============================================

--- a/packages/workout-spa-editor/src/components/organisms/OnboardingTutorial/OnboardingTutorial.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/OnboardingTutorial/OnboardingTutorial.test.tsx
@@ -634,7 +634,11 @@ describe("OnboardingTutorial", () => {
 
   describe("positioning", () => {
     it.each([
-      { navigationClicks: 0, expectedClass: "left-[50%]", position: "center" },
+      {
+        navigationClicks: 0,
+        expectedClass: "left-[50%] top-[50%]",
+        position: "center",
+      },
       {
         navigationClicks: 1,
         expectedClass: "bottom-[10%]",

--- a/packages/workout-spa-editor/src/components/organisms/StepEditor/FirstTimeHints.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/StepEditor/FirstTimeHints.test.tsx
@@ -56,30 +56,14 @@ describe("FirstTimeHints", () => {
       expect(screen.queryByTestId("first-time-hints")).not.toBeInTheDocument();
     });
 
-    it("should render with default storage key", () => {
+    it("should render with the default storage key when none is provided", () => {
       // Arrange
 
       // Act
-
       render(<FirstTimeHints />);
 
       // Assert
-
       expect(screen.getByTestId("first-time-hints")).toBeInTheDocument();
-    });
-
-    it("should render progress dots", () => {
-      // Arrange
-
-      // Act
-
-      render(<FirstTimeHints storageKey={TEST_STORAGE_KEY} />);
-
-      const dots = screen.getAllByLabelText(/Hint \d+ of 3/);
-
-      // Assert
-
-      expect(dots).toHaveLength(HINT_DOT_COUNT);
     });
 
     it("should highlight current hint dot", () => {

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutList/WorkoutList.selection.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutList/WorkoutList.selection.test.tsx
@@ -216,40 +216,6 @@ describe("WorkoutList - Selection Isolation (Property 3)", () => {
   });
 
   describe("Selection state verification", () => {
-    it("should generate unique IDs for steps with same stepIndex in different contexts", () => {
-      // Arrange
-
-      const blockA: RepetitionBlock = {
-        repeatCount: 2,
-        steps: [createMockStep(1), createMockStep(2)],
-      };
-      const blockB: RepetitionBlock = {
-        repeatCount: 3,
-        steps: [createMockStep(1), createMockStep(2)],
-      };
-      const workout = createMockWorkout([
-        createMockStep(1), // Main workout step - should get ID "step-1"
-        blockA, // Block at index 1 - steps should get IDs "block-1-step-1", "block-1-step-2"
-        blockB, // Block at index 2 - steps should get IDs "block-2-step-1", "block-2-step-2"
-      ]);
-
-      // Act
-
-      const { container } = render(<WorkoutList workout={workout} />);
-
-      // Assert
-      // All step IDs should be unique
-      const allStepButtons = container.querySelectorAll('[role="button"]');
-      const stepIds = Array.from(allStepButtons).map(
-        (button) => button.getAttribute("data-step-id") || ""
-      );
-
-      // Note: This test assumes steps have data-step-id attributes
-      // If not implemented, this test documents the expected behavior
-      // The actual ID uniqueness is enforced by the generateStepId function
-      expect(stepIds.length).toBeGreaterThan(0);
-    });
-
     it("should maintain selection isolation when switching between steps with same stepIndex", async () => {
       // Arrange
 

--- a/packages/workout-spa-editor/src/components/pages/HelpSection/HelpSection.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/HelpSection/HelpSection.test.tsx
@@ -43,7 +43,20 @@ describe("HelpSection", () => {
   });
 
   describe("getting started section", () => {
-    it("should display creating a workout instructions", () => {
+    it.each([
+      {
+        heading: /creating a workout/i,
+        body: /click "create new workout" on the welcome screen/i,
+      },
+      {
+        heading: /loading a workout/i,
+        body: /supported formats: krd, fit, tcx, zwo/i,
+      },
+      {
+        heading: /organizing steps/i,
+        body: /drag and drop steps to reorder them/i,
+      },
+    ])("should display $heading instructions", ({ heading, body }) => {
       // Arrange
 
       // Act
@@ -52,43 +65,9 @@ describe("HelpSection", () => {
       // Assert
 
       expect(
-        screen.getByRole("heading", { name: /creating a workout/i })
+        screen.getByRole("heading", { name: heading })
       ).toBeInTheDocument();
-      expect(
-        screen.getByText(/click "create new workout" on the welcome screen/i)
-      ).toBeInTheDocument();
-    });
-
-    it("should display loading a workout instructions", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", { name: /loading a workout/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/supported formats: krd, fit, tcx, zwo/i)
-      ).toBeInTheDocument();
-    });
-
-    it("should display organizing steps instructions", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", { name: /organizing steps/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/drag and drop steps to reorder them/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(body)).toBeInTheDocument();
     });
   });
 
@@ -171,7 +150,20 @@ describe("HelpSection", () => {
   });
 
   describe("example workouts section", () => {
-    it("should display sweet spot intervals example", () => {
+    it.each([
+      {
+        heading: /sweet spot intervals/i,
+        body: /classic sweet spot training/i,
+      },
+      {
+        heading: /tempo run/i,
+        body: /sustained tempo effort/i,
+      },
+      {
+        heading: /swim intervals/i,
+        body: /high-intensity intervals/i,
+      },
+    ])("should display $heading example", ({ heading, body }) => {
       // Arrange
 
       // Act
@@ -180,47 +172,47 @@ describe("HelpSection", () => {
       // Assert
 
       expect(
-        screen.getByRole("heading", { name: /sweet spot intervals/i })
+        screen.getByRole("heading", { name: heading })
       ).toBeInTheDocument();
-      expect(screen.getAllByText(/cycling/i).length).toBeGreaterThan(0);
-      expect(
-        screen.getByText(/classic sweet spot training/i)
-      ).toBeInTheDocument();
-    });
-
-    it("should display tempo run example", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", { name: /tempo run/i })
-      ).toBeInTheDocument();
-      expect(screen.getAllByText(/running/i).length).toBeGreaterThan(0);
-      expect(screen.getByText(/sustained tempo effort/i)).toBeInTheDocument();
-    });
-
-    it("should display swim intervals example", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", { name: /swim intervals/i })
-      ).toBeInTheDocument();
-      expect(screen.getAllByText(/swimming/i).length).toBeGreaterThan(0);
-      expect(screen.getByText(/high-intensity intervals/i)).toBeInTheDocument();
+      expect(screen.getByText(body)).toBeInTheDocument();
     });
   });
 
   describe("FAQ section", () => {
-    it("should display file formats question", () => {
+    it.each([
+      {
+        heading: /what file formats are supported/i,
+        body: /the editor supports krd/i,
+      },
+      {
+        heading: /how do i create a repetition block/i,
+        body: /select multiple steps by clicking/i,
+      },
+      {
+        heading: /can i use this offline/i,
+        body: /yes! the editor works offline/i,
+      },
+      {
+        heading: /what are training zones/i,
+        body: /training zones are intensity ranges/i,
+      },
+      {
+        heading: /how do i export my workout/i,
+        body: /click the 'save' button and select/i,
+      },
+      {
+        heading: /can i undo changes/i,
+        body: /yes! use ctrl\+z/i,
+      },
+      {
+        heading: /what's the difference between duration types/i,
+        body: /time-based durations use minutes\/seconds/i,
+      },
+      {
+        heading: /how do i save workouts to my library/i,
+        body: /click the 'save to library' button/i,
+      },
+    ])("should display FAQ: $heading", ({ heading, body }) => {
       // Arrange
 
       // Act
@@ -229,127 +221,9 @@ describe("HelpSection", () => {
       // Assert
 
       expect(
-        screen.getByRole("heading", {
-          name: /what file formats are supported/i,
-        })
+        screen.getByRole("heading", { name: heading })
       ).toBeInTheDocument();
-      expect(screen.getByText(/the editor supports krd/i)).toBeInTheDocument();
-    });
-
-    it("should display repetition block question", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", {
-          name: /how do i create a repetition block/i,
-        })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/select multiple steps by clicking/i)
-      ).toBeInTheDocument();
-    });
-
-    it("should display offline usage question", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", { name: /can i use this offline/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/yes! the editor works offline/i)
-      ).toBeInTheDocument();
-    });
-
-    it("should display training zones question", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", { name: /what are training zones/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/training zones are intensity ranges/i)
-      ).toBeInTheDocument();
-    });
-
-    it("should display export question", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", { name: /how do i export my workout/i })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/click the 'save' button and select/i)
-      ).toBeInTheDocument();
-    });
-
-    it("should display undo question", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", { name: /can i undo changes/i })
-      ).toBeInTheDocument();
-      expect(screen.getByText(/yes! use ctrl\+z/i)).toBeInTheDocument();
-    });
-
-    it("should display duration types question", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", {
-          name: /what's the difference between duration types/i,
-        })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/time-based durations use minutes\/seconds/i)
-      ).toBeInTheDocument();
-    });
-
-    it("should display library question", () => {
-      // Arrange
-
-      // Act
-      render(<HelpSection />);
-
-      // Assert
-
-      expect(
-        screen.getByRole("heading", {
-          name: /how do i save workouts to my library/i,
-        })
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/click the 'save to library' button/i)
-      ).toBeInTheDocument();
+      expect(screen.getByText(body)).toBeInTheDocument();
     });
   });
 

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection.test.tsx
@@ -156,31 +156,6 @@ describe("WorkoutSection", () => {
     expect(screen.queryByText(/Edit Step/)).not.toBeInTheDocument();
   });
 
-  it("should show editor when step is selected and editing is true", () => {
-    // Arrange
-    const workout = createMockWorkout([createMockStep(0, "id-show-editor")]);
-    const krd = createMockKRD(workout);
-
-    // Set up state with a selected step and editing enabled
-    useWorkoutStore.setState({
-      isEditing: true,
-      selectedStepId: "id-show-editor",
-    });
-
-    // Act
-    renderWithProviders(
-      <WorkoutSection
-        workout={workout}
-        krd={krd}
-        selectedStepId="id-show-editor"
-        onStepSelect={vi.fn()}
-      />
-    );
-
-    // Assert
-    expect(screen.getByText(/Edit Step/)).toBeInTheDocument();
-  });
-
   it("should close editor and clear selection on cancel", async () => {
     // Arrange
     const workout = createMockWorkout([createMockStep(0, "id-step-0")]);

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutActions.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutActions.test.tsx
@@ -30,8 +30,12 @@ describe("WorkoutActions", () => {
     onDiscard: vi.fn(),
   };
 
-  describe("button spacing", () => {
-    it("should have 12px gap between button groups", () => {
+  describe("button layout", () => {
+    it.each([
+      { className: "gap-3" },
+      { className: "flex" },
+      { className: "flex-wrap" },
+    ])("should apply $className class to button container", ({ className }) => {
       // Arrange
 
       // Act
@@ -42,54 +46,11 @@ describe("WorkoutActions", () => {
         "discard-workout-button"
       ).parentElement;
 
-      expect(container).toHaveClass("gap-3"); // gap-3 = 12px in Tailwind
-    });
-
-    it("should use flex layout for button container", () => {
-      // Arrange
-
-      // Act
-      renderWithProviders(<WorkoutActions {...defaultProps} />);
-
-      // Assert
-      const container = screen.getByTestId(
-        "discard-workout-button"
-      ).parentElement;
-
-      expect(container).toHaveClass("flex");
-    });
-  });
-
-  describe("button alignment", () => {
-    it("should use flex-wrap for responsive layout", () => {
-      // Arrange
-
-      // Act
-      renderWithProviders(<WorkoutActions {...defaultProps} />);
-
-      // Assert
-      const container = screen.getByTestId(
-        "discard-workout-button"
-      ).parentElement;
-
-      expect(container).toHaveClass("flex-wrap");
+      expect(container).toHaveClass(className);
     });
   });
 
   describe("button variants", () => {
-    it("should use primary variant for save button", () => {
-      // Arrange
-
-      // Act
-      renderWithProviders(<WorkoutActions {...defaultProps} />);
-
-      // Assert
-      const saveButton = screen.getByRole("button", { name: /save workout/i });
-      // SaveButton component should use primary variant by default
-
-      expect(saveButton).toBeInTheDocument();
-    });
-
     it("should use tertiary variant for discard button", () => {
       // Arrange
 

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutHeader.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutHeader.test.tsx
@@ -114,8 +114,6 @@ describe("WorkoutHeader", () => {
       render(<WorkoutHeader workout={mockWorkout} krd={mockKrd} />);
 
       // Assert
-      expect(screen.getByTestId("save-button")).toBeInTheDocument();
-      expect(screen.getByTestId("save-to-library-button")).toBeInTheDocument();
       expect(
         screen.getByRole("button", {
           name: /discard workout and return to welcome screen/i,

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutStepsListActions.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutStepsListActions.test.tsx
@@ -251,12 +251,9 @@ describe("WorkoutStepsListActions", () => {
   });
 
   describe("Button interaction flow", () => {
-    it("should call correct handlers for each button", async () => {
+    it("should call onCreateRepetitionBlock when create repetition block button is clicked", async () => {
       // Arrange
       const handleCreateBlock = vi.fn();
-      const handleCreateEmpty = vi.fn();
-      const handleAddStep = vi.fn();
-      const handlePaste = vi.fn();
       const user = userEvent.setup();
 
       render(
@@ -264,24 +261,87 @@ describe("WorkoutStepsListActions", () => {
           hasMultipleSelection={true}
           selectedStepCount={2}
           onCreateRepetitionBlock={handleCreateBlock}
-          onCreateEmptyRepetitionBlock={handleCreateEmpty}
-          onAddStep={handleAddStep}
-          onPasteStep={handlePaste}
+          onCreateEmptyRepetitionBlock={vi.fn()}
+          onAddStep={vi.fn()}
+          onPasteStep={vi.fn()}
         />
       );
 
       // Act
       await user.click(screen.getByTestId("create-repetition-block-button"));
-      await user.click(
-        screen.getByTestId("create-empty-repetition-block-button")
-      );
-      await user.click(screen.getByTestId("add-step-button"));
-      await user.click(screen.getByTestId("paste-step-button"));
 
       // Assert
       expect(handleCreateBlock).toHaveBeenCalledOnce();
+    });
+
+    it("should call onCreateEmptyRepetitionBlock when create empty repetition block button is clicked", async () => {
+      // Arrange
+      const handleCreateEmpty = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <WorkoutStepsListActions
+          hasMultipleSelection={true}
+          selectedStepCount={2}
+          onCreateRepetitionBlock={vi.fn()}
+          onCreateEmptyRepetitionBlock={handleCreateEmpty}
+          onAddStep={vi.fn()}
+          onPasteStep={vi.fn()}
+        />
+      );
+
+      // Act
+      await user.click(
+        screen.getByTestId("create-empty-repetition-block-button")
+      );
+
+      // Assert
       expect(handleCreateEmpty).toHaveBeenCalledOnce();
+    });
+
+    it("should call onAddStep when add step button is clicked", async () => {
+      // Arrange
+      const handleAddStep = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <WorkoutStepsListActions
+          hasMultipleSelection={true}
+          selectedStepCount={2}
+          onCreateRepetitionBlock={vi.fn()}
+          onCreateEmptyRepetitionBlock={vi.fn()}
+          onAddStep={handleAddStep}
+          onPasteStep={vi.fn()}
+        />
+      );
+
+      // Act
+      await user.click(screen.getByTestId("add-step-button"));
+
+      // Assert
       expect(handleAddStep).toHaveBeenCalledOnce();
+    });
+
+    it("should call onPasteStep when paste step button is clicked", async () => {
+      // Arrange
+      const handlePaste = vi.fn();
+      const user = userEvent.setup();
+
+      render(
+        <WorkoutStepsListActions
+          hasMultipleSelection={true}
+          selectedStepCount={2}
+          onCreateRepetitionBlock={vi.fn()}
+          onCreateEmptyRepetitionBlock={vi.fn()}
+          onAddStep={vi.fn()}
+          onPasteStep={handlePaste}
+        />
+      );
+
+      // Act
+      await user.click(screen.getByTestId("paste-step-button"));
+
+      // Assert
       expect(handlePaste).toHaveBeenCalledOnce();
     });
   });

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/useWorkoutSectionHandlers.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/useWorkoutSectionHandlers.test.ts
@@ -33,36 +33,6 @@ describe("useWorkoutSectionHandlers", () => {
 
   const mockOnStepSelect = vi.fn();
 
-  it("should return only non-delete handlers", () => {
-    // Arrange
-
-    // Act
-    const { result } = renderHook(() =>
-      useWorkoutSectionHandlers(mockWorkout, mockKrd, mockOnStepSelect)
-    );
-
-    // Assert
-    expect(result.current).toHaveProperty("handleStepSelect");
-    expect(result.current).toHaveProperty("handleSave");
-    expect(result.current).toHaveProperty("handleCancel");
-  });
-
-  it("should not include delete-related handlers", () => {
-    // Arrange
-
-    // Act
-    const { result } = renderHook(() =>
-      useWorkoutSectionHandlers(mockWorkout, mockKrd, mockOnStepSelect)
-    );
-
-    // Assert
-    // Verify no delete handlers exist
-    expect(result.current).not.toHaveProperty("handleDeleteRequest");
-    expect(result.current).not.toHaveProperty("handleDeleteConfirm");
-    expect(result.current).not.toHaveProperty("handleDeleteCancel");
-    expect(result.current).not.toHaveProperty("stepToDelete");
-  });
-
   it("should return exactly three handlers", () => {
     // Arrange
 

--- a/packages/workout-spa-editor/src/components/templates/MainLayout/MainLayout.test.tsx
+++ b/packages/workout-spa-editor/src/components/templates/MainLayout/MainLayout.test.tsx
@@ -5,7 +5,33 @@ import { renderWithProviders } from "../../../test-utils";
 import { MainLayout } from "./MainLayout";
 
 describe("MainLayout", () => {
-  it("should render children content", () => {
+  it.each([
+    {
+      label: "children content",
+      finder: () => screen.getByText("Test Content"),
+    },
+    {
+      label: "app title",
+      finder: () => screen.getByText("Kaiord Editor"),
+    },
+    {
+      label: "header/logo banner",
+      finder: () => screen.getByRole("banner"),
+    },
+    {
+      label: "navigation landmark",
+      finder: () => screen.getByRole("navigation", { name: "Main navigation" }),
+    },
+    {
+      label: "floating bottom navigation",
+      finder: () => screen.getByRole("navigation", { name: "Primary" }),
+    },
+    {
+      label: "theme toggle button",
+      finder: () =>
+        screen.getByRole("button", { name: /switch to (light|dark) mode/i }),
+    },
+  ])("should render $label", ({ finder }) => {
     // Arrange
 
     // Act
@@ -19,43 +45,7 @@ describe("MainLayout", () => {
 
     // Assert
 
-    expect(screen.getByText("Test Content")).toBeInTheDocument();
-  });
-
-  it("should render app title", () => {
-    // Arrange
-
-    // Act
-
-    renderWithProviders(
-      <MainLayout>
-        <div>Content</div>
-      </MainLayout>,
-      { defaultTheme: "light" }
-    );
-
-    // Assert
-
-    expect(screen.getByText("Kaiord Editor")).toBeInTheDocument();
-  });
-
-  it("should render header with logo", () => {
-    // Arrange
-
-    renderWithProviders(
-      <MainLayout>
-        <div>Content</div>
-      </MainLayout>,
-      { defaultTheme: "light" }
-    );
-
-    // Act
-
-    const header = screen.getByRole("banner");
-
-    // Assert
-
-    expect(header).toBeInTheDocument();
+    expect(finder()).toBeInTheDocument();
   });
 
   it("should render main content area", () => {
@@ -78,44 +68,6 @@ describe("MainLayout", () => {
     expect(screen.getByText("Main Content")).toBeInTheDocument();
   });
 
-  it("should render navigation landmark", () => {
-    // Arrange
-
-    renderWithProviders(
-      <MainLayout>
-        <div>Content</div>
-      </MainLayout>,
-      { defaultTheme: "light" }
-    );
-
-    // Act
-
-    const nav = screen.getByRole("navigation", { name: "Main navigation" });
-
-    // Assert
-
-    expect(nav).toBeInTheDocument();
-  });
-
-  it("should render the floating bottom navigation", () => {
-    // Arrange
-
-    renderWithProviders(
-      <MainLayout>
-        <div>Content</div>
-      </MainLayout>,
-      { defaultTheme: "light" }
-    );
-
-    // Act
-
-    const bottomNav = screen.getByRole("navigation", { name: "Primary" });
-
-    // Assert
-
-    expect(bottomNav).toBeInTheDocument();
-  });
-
   it("should not render the removed primary navigation tab bar", () => {
     // Arrange
 
@@ -133,71 +85,5 @@ describe("MainLayout", () => {
     // Assert
 
     expect(tabBar).not.toBeInTheDocument();
-  });
-
-  it("should render theme toggle button", () => {
-    // Arrange
-
-    renderWithProviders(
-      <MainLayout>
-        <div>Content</div>
-      </MainLayout>,
-      { defaultTheme: "light" }
-    );
-
-    // Act
-
-    const themeToggle = screen.getByRole("button", {
-      name: /switch to (light|dark) mode/i,
-    });
-
-    // Assert
-
-    expect(themeToggle).toBeInTheDocument();
-  });
-
-  it("should pass onReplayTutorial prop to LayoutHeader", () => {
-    // Arrange
-
-    const mockOnReplayTutorial = vi.fn();
-
-    // Act
-
-    renderWithProviders(
-      <MainLayout onReplayTutorial={mockOnReplayTutorial}>
-        <div>Content</div>
-      </MainLayout>,
-      { defaultTheme: "light" }
-    );
-
-    // Assert
-
-    expect(screen.getByText("Content")).toBeInTheDocument();
-  });
-
-  it("should mount the storage-availability banner region exactly once", () => {
-    // Arrange
-
-    const { container } = renderWithProviders(
-      <MainLayout>
-        <div>Content</div>
-      </MainLayout>,
-      { defaultTheme: "light" }
-    );
-
-    // The banner is mounted once, in the layout shell shared by
-    // every route. The probe runs via useStoreHydration; the banner
-    // renders null while status is "checking" (initial state in tests).
-    // Re-rendering different children must not duplicate it.
-
-    // Act
-
-    const banners = container.querySelectorAll(
-      '[data-testid="storage-unavailable-banner"]'
-    );
-
-    // Assert
-
-    expect(banners.length).toBeLessThanOrEqual(1);
   });
 });

--- a/packages/workout-spa-editor/src/contexts/ThemeContext.test.tsx
+++ b/packages/workout-spa-editor/src/contexts/ThemeContext.test.tsx
@@ -85,7 +85,20 @@ describe("ThemeContext", () => {
   });
 
   describe("theme switching", () => {
-    it("should switch to light theme", () => {
+    it.each([
+      {
+        theme: "light" as const,
+        expectedResolvedTheme: /^light$/,
+      },
+      {
+        theme: "dark" as const,
+        expectedResolvedTheme: /^dark$/,
+      },
+      {
+        theme: "system" as const,
+        expectedResolvedTheme: /^(light|dark)$/,
+      },
+    ])("should switch to $theme theme", ({ theme, expectedResolvedTheme }) => {
       // Arrange
       Object.defineProperty(window, "matchMedia", {
         writable: true,
@@ -100,7 +113,6 @@ describe("ThemeContext", () => {
           dispatchEvent: vi.fn(),
         })),
       });
-
       const wrapper = ({ children }: { children: ReactNode }) => (
         <ThemeProvider>{children}</ThemeProvider>
       );
@@ -108,76 +120,12 @@ describe("ThemeContext", () => {
 
       // Act
       act(() => {
-        result.current.setTheme("light");
+        result.current.setTheme(theme);
       });
 
       // Assert
-      expect(result.current.theme).toBe("light");
-      expect(result.current.resolvedTheme).toBe("light");
-      expect(document.documentElement.classList.contains("dark")).toBe(false);
-    });
-
-    it("should switch to dark theme", () => {
-      // Arrange
-      Object.defineProperty(window, "matchMedia", {
-        writable: true,
-        value: vi.fn().mockImplementation((query) => ({
-          matches: false,
-          media: query,
-          onchange: null,
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        })),
-      });
-
-      const wrapper = ({ children }: { children: ReactNode }) => (
-        <ThemeProvider>{children}</ThemeProvider>
-      );
-      const { result } = renderHook(() => useTheme(), { wrapper });
-
-      // Act
-      act(() => {
-        result.current.setTheme("dark");
-      });
-
-      // Assert
-      expect(result.current.theme).toBe("dark");
-      expect(result.current.resolvedTheme).toBe("dark");
-      expect(document.documentElement.classList.contains("dark")).toBe(true);
-    });
-
-    it("should switch to system theme", () => {
-      // Arrange
-      Object.defineProperty(window, "matchMedia", {
-        writable: true,
-        value: vi.fn().mockImplementation((query) => ({
-          matches: false,
-          media: query,
-          onchange: null,
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        })),
-      });
-
-      const wrapper = ({ children }: { children: ReactNode }) => (
-        <ThemeProvider>{children}</ThemeProvider>
-      );
-      const { result } = renderHook(() => useTheme(), { wrapper });
-
-      // Act
-      act(() => {
-        result.current.setTheme("system");
-      });
-
-      // Assert
-      expect(result.current.theme).toBe("system");
-      expect(result.current.resolvedTheme).toMatch(/^(light|dark)$/);
+      expect(result.current.theme).toBe(theme);
+      expect(result.current.resolvedTheme).toMatch(expectedResolvedTheme);
     });
   });
 

--- a/packages/workout-spa-editor/src/hooks/use-keyboard-shortcuts.test.ts
+++ b/packages/workout-spa-editor/src/hooks/use-keyboard-shortcuts.test.ts
@@ -24,32 +24,14 @@ describe("useKeyboardShortcuts", () => {
   });
 
   describe("undo shortcut", () => {
-    it("should call onUndo when Ctrl+Z is pressed", () => {
+    it.each([
+      { label: "Ctrl+Z", init: { key: "z", ctrlKey: true } },
+      { label: "Cmd+Z", init: { key: "z", metaKey: true } },
+    ])("should call onUndo when $label is pressed", ({ init }) => {
       // Arrange
       const onUndo = vi.fn();
       renderHook(() => useKeyboardShortcuts({ onUndo }));
-      const event = new KeyboardEvent("keydown", {
-        key: "z",
-        ctrlKey: true,
-        bubbles: true,
-      });
-
-      // Act
-      window.dispatchEvent(event);
-
-      // Assert
-      expect(onUndo).toHaveBeenCalledOnce();
-    });
-
-    it("should call onUndo when Cmd+Z is pressed", () => {
-      // Arrange
-      const onUndo = vi.fn();
-      renderHook(() => useKeyboardShortcuts({ onUndo }));
-      const event = new KeyboardEvent("keydown", {
-        key: "z",
-        metaKey: true,
-        bubbles: true,
-      });
+      const event = new KeyboardEvent("keydown", { ...init, bubbles: true });
 
       // Act
       window.dispatchEvent(event);
@@ -382,52 +364,24 @@ describe("useKeyboardShortcuts", () => {
   });
 
   describe("ungroup block shortcut (Requirement 7.6.2)", () => {
-    it("should call onUngroupBlock when Ctrl+Shift+G is pressed", () => {
+    it.each([
+      {
+        label: "Ctrl+Shift+G",
+        init: { key: "g", ctrlKey: true, shiftKey: true },
+      },
+      {
+        label: "Cmd+Shift+G",
+        init: { key: "g", metaKey: true, shiftKey: true },
+      },
+      {
+        label: "uppercase Ctrl+Shift+G",
+        init: { key: "G", ctrlKey: true, shiftKey: true },
+      },
+    ])("should call onUngroupBlock when $label is pressed", ({ init }) => {
       // Arrange
       const onUngroupBlock = vi.fn();
       renderHook(() => useKeyboardShortcuts({ onUngroupBlock }));
-      const event = new KeyboardEvent("keydown", {
-        key: "g",
-        ctrlKey: true,
-        shiftKey: true,
-        bubbles: true,
-      });
-
-      // Act
-      window.dispatchEvent(event);
-
-      // Assert
-      expect(onUngroupBlock).toHaveBeenCalledOnce();
-    });
-
-    it("should call onUngroupBlock when Cmd+Shift+G is pressed", () => {
-      // Arrange
-      const onUngroupBlock = vi.fn();
-      renderHook(() => useKeyboardShortcuts({ onUngroupBlock }));
-      const event = new KeyboardEvent("keydown", {
-        key: "g",
-        metaKey: true,
-        shiftKey: true,
-        bubbles: true,
-      });
-
-      // Act
-      window.dispatchEvent(event);
-
-      // Assert
-      expect(onUngroupBlock).toHaveBeenCalledOnce();
-    });
-
-    it("should handle uppercase G with Shift", () => {
-      // Arrange
-      const onUngroupBlock = vi.fn();
-      renderHook(() => useKeyboardShortcuts({ onUngroupBlock }));
-      const event = new KeyboardEvent("keydown", {
-        key: "G",
-        ctrlKey: true,
-        shiftKey: true,
-        bubbles: true,
-      });
+      const event = new KeyboardEvent("keydown", { ...init, bubbles: true });
 
       // Act
       window.dispatchEvent(event);
@@ -598,68 +552,35 @@ describe("useKeyboardShortcuts", () => {
   });
 
   describe("optional handlers", () => {
-    it("should not throw when handlers are undefined", () => {
-      // Arrange
-      renderHook(() => useKeyboardShortcuts({}));
-      const saveEvent = new KeyboardEvent("keydown", {
-        key: "s",
-        ctrlKey: true,
-        bubbles: true,
-      });
-      expect(() => window.dispatchEvent(saveEvent)).not.toThrow();
-      const moveUpEvent = new KeyboardEvent("keydown", {
-        key: "ArrowUp",
-        altKey: true,
-        bubbles: true,
-      });
-      expect(() => window.dispatchEvent(moveUpEvent)).not.toThrow();
-      const copyEvent = new KeyboardEvent("keydown", {
-        key: "c",
-        ctrlKey: true,
-        bubbles: true,
-      });
-      expect(() => window.dispatchEvent(copyEvent)).not.toThrow();
-      const pasteEvent = new KeyboardEvent("keydown", {
-        key: "v",
-        ctrlKey: true,
-        bubbles: true,
-      });
-      expect(() => window.dispatchEvent(pasteEvent)).not.toThrow();
-      const cutEvent = new KeyboardEvent("keydown", {
-        key: "x",
-        ctrlKey: true,
-        bubbles: true,
-      });
-      expect(() => window.dispatchEvent(cutEvent)).not.toThrow();
-      const createBlockEvent = new KeyboardEvent("keydown", {
-        key: "g",
-        ctrlKey: true,
-        bubbles: true,
-      });
-      expect(() => window.dispatchEvent(createBlockEvent)).not.toThrow();
-      const ungroupBlockEvent = new KeyboardEvent("keydown", {
-        key: "g",
-        ctrlKey: true,
-        shiftKey: true,
-        bubbles: true,
-      });
-      expect(() => window.dispatchEvent(ungroupBlockEvent)).not.toThrow();
-      const selectAllEvent = new KeyboardEvent("keydown", {
-        key: "a",
-        ctrlKey: true,
-        bubbles: true,
-      });
-      expect(() => window.dispatchEvent(selectAllEvent)).not.toThrow();
+    it.each([
+      { label: "Ctrl+S (save)", init: { key: "s", ctrlKey: true } },
+      {
+        label: "Alt+ArrowUp (move up)",
+        init: { key: "ArrowUp", altKey: true },
+      },
+      { label: "Ctrl+C (copy)", init: { key: "c", ctrlKey: true } },
+      { label: "Ctrl+V (paste)", init: { key: "v", ctrlKey: true } },
+      { label: "Ctrl+X (cut)", init: { key: "x", ctrlKey: true } },
+      { label: "Ctrl+G (create block)", init: { key: "g", ctrlKey: true } },
+      {
+        label: "Ctrl+Shift+G (ungroup block)",
+        init: { key: "g", ctrlKey: true, shiftKey: true },
+      },
+      { label: "Ctrl+A (select all)", init: { key: "a", ctrlKey: true } },
+      { label: "Escape (clear selection)", init: { key: "Escape" } },
+    ])(
+      "should not throw when handlers are undefined and $label is pressed",
+      ({ init }) => {
+        // Arrange
+        renderHook(() => useKeyboardShortcuts({}));
+        const event = new KeyboardEvent("keydown", { ...init, bubbles: true });
 
-      // Act
-      const escapeEvent = new KeyboardEvent("keydown", {
-        key: "Escape",
-        bubbles: true,
-      });
+        // Act
 
-      // Assert
-      expect(() => window.dispatchEvent(escapeEvent)).not.toThrow();
-    });
+        // Assert
+        expect(() => window.dispatchEvent(event)).not.toThrow();
+      }
+    );
   });
 
   describe("cut shortcut (Cmd+X)", () => {
@@ -917,13 +838,13 @@ describe("useKeyboardShortcuts", () => {
         ctrlKey: true,
         bubbles: true,
       });
-      el.dispatchEvent(event);
-      expect(onCopy).not.toHaveBeenCalled();
 
       // Act
+      el.dispatchEvent(event);
       el.remove();
 
       // Assert
+      expect(onCopy).not.toHaveBeenCalled();
     });
 
     it("should not intercept Escape when target is contentEditable", () => {
@@ -937,13 +858,13 @@ describe("useKeyboardShortcuts", () => {
         key: "Escape",
         bubbles: true,
       });
-      el.dispatchEvent(event);
-      expect(onClearSelection).not.toHaveBeenCalled();
 
       // Act
+      el.dispatchEvent(event);
       el.remove();
 
       // Assert
+      expect(onClearSelection).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/workout-spa-editor/src/store/actions/copy-paste-performance.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/copy-paste-performance.test.ts
@@ -126,16 +126,16 @@ describe("Copy/Paste Performance", () => {
           readText: mockReadText,
         },
       });
-      const copyResult = await copyStepAction(krd, 0);
-      const pasteResult = await pasteStepAction(krd);
-      expect(copyResult.success).toBe(true);
-      expect(pasteResult.success).toBe(true);
 
       // Act
-      const pastedBlock = pasteResult.updatedKrd!.extensions!
-        .structured_workout!.steps[1] as RepetitionBlock;
+      const copyResult = await copyStepAction(krd, 0);
+      const pasteResult = await pasteStepAction(krd);
 
       // Assert
+      expect(copyResult.success).toBe(true);
+      expect(pasteResult.success).toBe(true);
+      const pastedBlock = pasteResult.updatedKrd!.extensions!
+        .structured_workout!.steps[1] as RepetitionBlock;
       expect(pastedBlock.steps).toHaveLength(BLOCK_SCAFFOLD_VERY_LARGE_STEPS);
       expect(pastedBlock.repeatCount).toBe(BLOCK_SCAFFOLD_VERY_LARGE_REPS);
     });

--- a/packages/workout-spa-editor/src/store/actions/reorder-steps-in-block-action.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/reorder-steps-in-block-action.test.ts
@@ -82,16 +82,16 @@ describe("reorderStepsInBlockAction", () => {
     };
     const krd = createMockKRD(workout);
     const state = createMockState();
-    const result = reorderStepsInBlockAction(krd, "block-test-1", 0, 2, state);
-    expect(result.currentWorkout).toBeDefined();
-    const updatedWorkout = result.currentWorkout?.extensions
-      ?.structured_workout as Workout;
-    expect(updatedWorkout).toBeDefined();
 
     // Act
+    const result = reorderStepsInBlockAction(krd, "block-test-1", 0, 2, state);
+    const updatedWorkout = result.currentWorkout?.extensions
+      ?.structured_workout as Workout;
     const updatedBlock = updatedWorkout.steps[0] as RepetitionBlock;
 
     // Assert
+    expect(result.currentWorkout).toBeDefined();
+    expect(updatedWorkout).toBeDefined();
     expect(updatedBlock.steps).toHaveLength(REORDERED_BLOCK_STEP_COUNT);
     expect(updatedBlock.steps[0].duration.seconds).toBe(SECONDS_LONG_INTERVAL);
     expect(updatedBlock.steps[1].duration.seconds).toBe(SECONDS_SHORT_INTERVAL);

--- a/packages/workout-spa-editor/src/store/focus/focus-target.types.test.ts
+++ b/packages/workout-spa-editor/src/store/focus/focus-target.types.test.ts
@@ -11,22 +11,23 @@ describe("FocusTarget discriminated union", () => {
   it("should produce a FocusTargetItem with the supplied ItemId via focusItem", () => {
     // Arrange
     const id = asItemId("some-item");
-    const target = focusItem(id);
-    expect(target).toEqual({ kind: "item", id: "some-item" });
 
     // Act
-    expectTypeOf(target).toEqualTypeOf<FocusTargetItem>();
+    const target = focusItem(id);
 
     // Assert
+    expect(target).toEqual({ kind: "item", id: "some-item" });
+    expectTypeOf(target).toEqualTypeOf<FocusTargetItem>();
   });
 
   it("should expose focusEmptyState as a FocusTargetEmptyState sentinel", () => {
     // Arrange
-    expect(focusEmptyState).toEqual({ kind: "empty-state" });
 
     // Act
-    expectTypeOf(focusEmptyState).toEqualTypeOf<FocusTargetEmptyState>();
+    const sentinel = focusEmptyState;
 
     // Assert
+    expect(sentinel).toEqual({ kind: "empty-state" });
+    expectTypeOf(sentinel).toEqualTypeOf<FocusTargetEmptyState>();
   });
 });

--- a/packages/workout-spa-editor/src/store/workout-store-modal-actions.test.ts
+++ b/packages/workout-spa-editor/src/store/workout-store-modal-actions.test.ts
@@ -18,7 +18,7 @@ describe("Modal Store Actions", () => {
   });
 
   describe("showConfirmationModal", () => {
-    it("should set isModalOpen to true", () => {
+    it("should set isModalOpen to true and modalConfig with provided configuration", () => {
       // Arrange
       const config = {
         title: "Delete Block",
@@ -29,38 +29,19 @@ describe("Modal Store Actions", () => {
         onCancel: () => {},
         variant: "destructive" as const,
       };
-      useWorkoutStore.getState().showConfirmationModal(config);
 
       // Act
+      useWorkoutStore.getState().showConfirmationModal(config);
       const state = useWorkoutStore.getState();
 
       // Assert
       expect(state.isModalOpen).toBe(true);
-    });
-
-    it("should set modalConfig with provided configuration", () => {
-      // Arrange
-      const config = {
-        title: "Delete Block",
-        message: "Are you sure you want to delete this repetition block?",
-        confirmLabel: "Delete",
-        cancelLabel: "Cancel",
-        onConfirm: () => {},
-        onCancel: () => {},
-        variant: "destructive" as const,
-      };
-      useWorkoutStore.getState().showConfirmationModal(config);
-
-      // Act
-      const state = useWorkoutStore.getState();
-
-      // Assert
       expect(state.modalConfig).toEqual(config);
     });
   });
 
   describe("hideConfirmationModal", () => {
-    it("should set isModalOpen to false", () => {
+    it("should set isModalOpen to false and clear modalConfig", () => {
       // Arrange
       useWorkoutStore.setState({
         isModalOpen: true,
@@ -74,35 +55,13 @@ describe("Modal Store Actions", () => {
           variant: "default",
         },
       });
-      useWorkoutStore.getState().hideConfirmationModal();
 
       // Act
+      useWorkoutStore.getState().hideConfirmationModal();
       const state = useWorkoutStore.getState();
 
       // Assert
       expect(state.isModalOpen).toBe(false);
-    });
-
-    it("should clear modalConfig", () => {
-      // Arrange
-      useWorkoutStore.setState({
-        isModalOpen: true,
-        modalConfig: {
-          title: "Test",
-          message: "Test",
-          confirmLabel: "OK",
-          cancelLabel: "Cancel",
-          onConfirm: () => {},
-          onCancel: () => {},
-          variant: "default",
-        },
-      });
-      useWorkoutStore.getState().hideConfirmationModal();
-
-      // Act
-      const state = useWorkoutStore.getState();
-
-      // Assert
       expect(state.modalConfig).toBeNull();
     });
 

--- a/packages/workout-spa-editor/src/utils/export-workout.test.ts
+++ b/packages/workout-spa-editor/src/utils/export-workout.test.ts
@@ -183,12 +183,11 @@ describe("exportWorkout", () => {
         } as unknown as KRD;
 
         // Act
+        const rejection = exportWorkout(invalidKrd, format);
 
         // Assert
-        await expect(exportWorkout(invalidKrd, format)).rejects.toThrow(
-          ExportError
-        );
-        await expect(exportWorkout(invalidKrd, format)).rejects.toThrow(
+        await expect(rejection).rejects.toThrow(ExportError);
+        await expect(rejection).rejects.toThrow(
           new RegExp(`Failed to export workout as ${label}`)
         );
       }
@@ -233,14 +232,11 @@ describe("exportWorkout", () => {
       const unsupportedFormat = "pdf" as WorkoutFileFormat;
 
       // Act
+      const rejection = exportWorkout(mockKrd, unsupportedFormat);
 
       // Assert
-      await expect(exportWorkout(mockKrd, unsupportedFormat)).rejects.toThrow(
-        ExportError
-      );
-      await expect(exportWorkout(mockKrd, unsupportedFormat)).rejects.toThrow(
-        /Unsupported format/
-      );
+      await expect(rejection).rejects.toThrow(ExportError);
+      await expect(rejection).rejects.toThrow(/Unsupported format/);
     });
 
     it("should export a GCN buffer for the gcn format", async () => {

--- a/packages/workout-spa-editor/src/utils/import-workout.test.ts
+++ b/packages/workout-spa-editor/src/utils/import-workout.test.ts
@@ -106,12 +106,11 @@ describe("importWorkout", () => {
       const file = createMockFile(invalidJson, "invalid.krd");
 
       // Act
+      const rejection = importWorkout(file);
 
       // Assert
-      await expect(importWorkout(file)).rejects.toThrow(ImportError);
-      await expect(importWorkout(file)).rejects.toThrow(
-        /Failed to parse KRD file/
-      );
+      await expect(rejection).rejects.toThrow(ImportError);
+      await expect(rejection).rejects.toThrow(/Failed to parse KRD file/);
     });
 
     it("should provide useful error message for invalid JSON", async () => {
@@ -143,10 +142,11 @@ describe("importWorkout", () => {
       const file = createMockFile(invalidKrd, "invalid.krd");
 
       // Act
+      const rejection = importWorkout(file);
 
       // Assert
-      await expect(importWorkout(file)).rejects.toThrow(ImportError);
-      await expect(importWorkout(file)).rejects.toThrow(/Validation failed/);
+      await expect(rejection).rejects.toThrow(ImportError);
+      await expect(rejection).rejects.toThrow(/Validation failed/);
     });
 
     it("should list all missing fields in validation error", async () => {
@@ -213,12 +213,11 @@ describe("importWorkout", () => {
       const file = createMockFile(buffer, "workout.txt");
 
       // Act
+      const rejection = importWorkout(file);
 
       // Assert
-      await expect(importWorkout(file)).rejects.toThrow(ImportError);
-      await expect(importWorkout(file)).rejects.toThrow(
-        /Unsupported file format/
-      );
+      await expect(rejection).rejects.toThrow(ImportError);
+      await expect(rejection).rejects.toThrow(/Unsupported file format/);
     });
 
     it("should throw ImportError for empty filename", async () => {
@@ -227,10 +226,11 @@ describe("importWorkout", () => {
       const file = createMockFile(buffer, "");
 
       // Act
+      const rejection = importWorkout(file);
 
       // Assert
-      await expect(importWorkout(file)).rejects.toThrow(ImportError);
-      await expect(importWorkout(file)).rejects.toThrow(/Invalid filename/);
+      await expect(rejection).rejects.toThrow(ImportError);
+      await expect(rejection).rejects.toThrow(/Invalid filename/);
     });
 
     it("should throw ImportError for filename without extension", async () => {
@@ -239,12 +239,11 @@ describe("importWorkout", () => {
       const file = createMockFile(buffer, "workout");
 
       // Act
+      const rejection = importWorkout(file);
 
       // Assert
-      await expect(importWorkout(file)).rejects.toThrow(ImportError);
-      await expect(importWorkout(file)).rejects.toThrow(
-        /Unsupported file format/
-      );
+      await expect(rejection).rejects.toThrow(ImportError);
+      await expect(rejection).rejects.toThrow(/Unsupported file format/);
     });
   });
 
@@ -308,10 +307,11 @@ describe("importWorkout", () => {
         const file = createMockFile(data, filename);
 
         // Act
+        const rejection = importWorkout(file);
 
         // Assert
-        await expect(importWorkout(file)).rejects.toThrow(ImportError);
-        await expect(importWorkout(file)).rejects.toThrow(
+        await expect(rejection).rejects.toThrow(ImportError);
+        await expect(rejection).rejects.toThrow(
           new RegExp(`Failed to parse ${label} file`)
         );
       }

--- a/packages/workout-spa-editor/src/utils/json-parser.test.ts
+++ b/packages/workout-spa-editor/src/utils/json-parser.test.ts
@@ -129,34 +129,34 @@ describe("parseJSON", () => {
       expect(result).toStrictEqual({ name: "duplicate" });
     });
 
-    it("should handle various JSON error types gracefully", () => {
+    it.each([
+      { description: "unclosed string", json: '{"unclosed": "string' },
+      { description: "trailing comma", json: '{"trailing": "comma",}' },
+      { description: "unquoted key", json: '{unquoted: "key"}' },
+      { description: "double decimal number", json: '{"number": 123.456.789}' },
+      { description: "trailing comma in array", json: '{"array": [1, 2, 3,]}' },
+      {
+        description: "unclosed nested object",
+        json: '{"nested": {"unclosed": }',
+      },
+    ])("should handle $description JSON error gracefully", ({ json }) => {
       // Arrange
-      const invalidJSONs = [
-        '{"unclosed": "string',
-        '{"trailing": "comma",}',
-        '{unquoted: "key"}',
-        '{"number": 123.456.789}',
-        '{"array": [1, 2, 3,]}',
-        '{"nested": {"unclosed": }',
-      ];
 
       // Act
+      let caught: unknown;
+      try {
+        parseJSON(json);
+        expect.fail(`Should have thrown for: ${json}`);
+      } catch (error) {
+        caught = error;
+      }
 
       // Assert
-      for (const json of invalidJSONs) {
-        try {
-          parseJSON(json);
-          expect.fail(`Should have thrown for: ${json}`);
-        } catch (error) {
-          expect(error).toBeInstanceOf(FileParsingError);
-          if (error instanceof FileParsingError) {
-            expect(error.message).toContain("Invalid JSON");
-            expect(error.cause).toBeDefined();
-            expect(error.message.length).toBeGreaterThan(
-              ERROR_MESSAGE_MIN_LENGTH
-            );
-          }
-        }
+      expect(caught).toBeInstanceOf(FileParsingError);
+      if (caught instanceof FileParsingError) {
+        expect(caught.message).toContain("Invalid JSON");
+        expect(caught.cause).toBeDefined();
+        expect(caught.message.length).toBeGreaterThan(ERROR_MESSAGE_MIN_LENGTH);
       }
     });
 

--- a/packages/workout-spa-editor/src/utils/repetition-block-validation.test.ts
+++ b/packages/workout-spa-editor/src/utils/repetition-block-validation.test.ts
@@ -7,41 +7,31 @@ import {
 
 describe("validateRepetitionBlockCreation", () => {
   describe("minimum steps validation", () => {
-    it("should return error when no steps are selected", () => {
-      // Arrange
-      const selectedStepIds: Array<string> = [];
-      const repeatCount = 3;
+    it.each([
+      {
+        description: "no steps selected",
+        selectedStepIds: [] as Array<string>,
+      },
+      { description: "only one step selected", selectedStepIds: ["step-0"] },
+    ])(
+      "should return MIN_STEPS error when $description",
+      ({ selectedStepIds }) => {
+        // Arrange
+        const repeatCount = 3;
 
-      // Act
-      const result = validateRepetitionBlockCreation(
-        selectedStepIds,
-        repeatCount
-      );
+        // Act
+        const result = validateRepetitionBlockCreation(
+          selectedStepIds,
+          repeatCount
+        );
 
-      // Assert
-      expect(result).toEqual<RepetitionBlockValidationError>({
-        type: "MIN_STEPS",
-        message: "Select at least 2 steps to create a repetition block",
-      });
-    });
-
-    it("should return error when only one step is selected", () => {
-      // Arrange
-      const selectedStepIds = ["step-0"];
-      const repeatCount = 3;
-
-      // Act
-      const result = validateRepetitionBlockCreation(
-        selectedStepIds,
-        repeatCount
-      );
-
-      // Assert
-      expect(result).toEqual<RepetitionBlockValidationError>({
-        type: "MIN_STEPS",
-        message: "Select at least 2 steps to create a repetition block",
-      });
-    });
+        // Assert
+        expect(result).toEqual<RepetitionBlockValidationError>({
+          type: "MIN_STEPS",
+          message: "Select at least 2 steps to create a repetition block",
+        });
+      }
+    );
 
     it("should pass validation when two steps are selected", () => {
       // Arrange

--- a/packages/zwo/src/adapters/fast-xml-parser.test.ts
+++ b/packages/zwo/src/adapters/fast-xml-parser.test.ts
@@ -1557,7 +1557,7 @@ describe("createFastXmlZwiftWriter", () => {
       expect(result).toContain("<thresholdSecPerKm>240</thresholdSecPerKm>");
     });
 
-    it("should not include durationType when not present in extensions", async () => {
+    it("should not include durationType or thresholdSecPerKm when not present in extensions", async () => {
       // Arrange
       const krd = {
         version: "1.0",
@@ -1587,37 +1587,6 @@ describe("createFastXmlZwiftWriter", () => {
 
       // Assert
       expect(result).not.toContain("<durationType>");
-    });
-
-    it("should not include thresholdSecPerKm when not present in extensions", async () => {
-      // Arrange
-      const krd = {
-        version: "1.0",
-        type: "structured_workout" as const,
-        metadata: {
-          created: "2025-01-15T10:30:00Z",
-          sport: "cycling",
-        },
-        extensions: {
-          structured_workout: {
-            name: "Simple Workout",
-            sport: "cycling",
-            steps: [],
-          },
-          zwift: {},
-        },
-      };
-      const mockValidator = vi.fn<ZwiftValidator>().mockResolvedValue({
-        valid: true,
-        errors: [],
-      });
-      const logger = createMockLogger();
-      const writer = createFastXmlZwiftWriter(logger, mockValidator);
-
-      // Act
-      const result = await writer(krd);
-
-      // Assert
       expect(result).not.toContain("<thresholdSecPerKm>");
     });
 


### PR DESCRIPTION
Rescued nightly unit-test minimality sweep from 2026-06-30 03:15 — the original run's local gate was blocked by a now-fixed flaky XSD validation (#837). Rebased onto the hardened main; local gate re-run green (`pnpm -r test` 7356 passed, eslint clean, zwo 285/285 with serialized XSD). The watcher will drive CI to green and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and reorganized automated coverage across AI workout generation, CLI directory/error handling, Garmin OAuth and FIT extension behavior, core round-trip comparisons, TCX parsing/writing, MCP diff/push flows, and workout-spa UI/editor workflows.
  * Strengthened assertions for failure handling (including access-denied directory errors), formatting output (ANSI stripping), selection isolation, and keyboard shortcut behavior.
  * Improved promise/rejection and parameterized test coverage for import/export, JSON parsing, and multiple UI states.

* **Refactor**
  * Simplified and de-duplicated test arrangements by reusing rejection results and consolidating repetitive cases using table-driven patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->