### PR TITLE
refactor(core): reduce to minimal code

### DIFF
--- a/.changeset/core-error-base-dedup.md
+++ b/.changeset/core-error-base-dedup.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/core": patch
+---
+
+Internal code reduction, no behavior change.

--- a/packages/core/src/domain/types/fit-errors.ts
+++ b/packages/core/src/domain/types/fit-errors.ts
@@ -1,3 +1,5 @@
+import { FormatParsingError } from "./shared-errors";
+
 /**
  * Error thrown when FIT file parsing fails.
  *
@@ -20,18 +22,8 @@
  * }
  * ```
  */
-export class FitParsingError extends Error {
+export class FitParsingError extends FormatParsingError {
   public override readonly name = "FitParsingError";
-
-  constructor(
-    message: string,
-    public readonly cause?: unknown
-  ) {
-    super(message);
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, FitParsingError);
-    }
-  }
 }
 
 /**

--- a/packages/core/src/domain/types/garmin-errors.ts
+++ b/packages/core/src/domain/types/garmin-errors.ts
@@ -1,18 +1,10 @@
+import { FormatParsingError } from "./shared-errors";
+
 /**
  * Error thrown when Garmin Connect JSON parsing fails.
  */
-export class GarminParsingError extends Error {
+export class GarminParsingError extends FormatParsingError {
   public override readonly name = "GarminParsingError";
-
-  constructor(
-    message: string,
-    public readonly cause?: unknown
-  ) {
-    super(message);
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, GarminParsingError);
-    }
-  }
 }
 
 export const createGarminParsingError = (

--- a/packages/core/src/domain/types/krd-errors.ts
+++ b/packages/core/src/domain/types/krd-errors.ts
@@ -1,4 +1,5 @@
 import type { ValidationError } from "./error-types";
+import { SchemaValidationError } from "./shared-errors";
 
 /**
  * Error thrown when KRD schema validation fails.
@@ -22,18 +23,8 @@ import type { ValidationError } from "./error-types";
  * }
  * ```
  */
-export class KrdValidationError extends Error {
+export class KrdValidationError extends SchemaValidationError {
   public override readonly name = "KrdValidationError";
-
-  constructor(
-    message: string,
-    public readonly errors: Array<ValidationError>
-  ) {
-    super(message);
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, KrdValidationError);
-    }
-  }
 }
 
 /**

--- a/packages/core/src/domain/types/shared-errors.ts
+++ b/packages/core/src/domain/types/shared-errors.ts
@@ -1,7 +1,7 @@
 import type { ValidationError } from "./error-types";
 
 /**
- * Base class for format-specific parsing errors (FIT, TCX, ZWO, GCN).
+ * Base class for format-specific parsing errors (FIT, Garmin, TCX, Zwift).
  *
  * Subclasses only set their own `name`; the optional `cause` carries the
  * underlying failure and the offending constructor frame is trimmed from

--- a/packages/core/src/domain/types/shared-errors.ts
+++ b/packages/core/src/domain/types/shared-errors.ts
@@ -1,0 +1,36 @@
+import type { ValidationError } from "./error-types";
+
+/**
+ * Base class for format-specific parsing errors (FIT, TCX, ZWO, GCN).
+ *
+ * Subclasses only set their own `name`; the optional `cause` carries the
+ * underlying failure and the offending constructor frame is trimmed from
+ * the stack trace.
+ */
+export abstract class FormatParsingError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}
+
+/**
+ * Base class for schema validation errors carrying an array of field-level
+ * {@link ValidationError} details (KRD, TCX, ZWO).
+ */
+export abstract class SchemaValidationError extends Error {
+  constructor(
+    message: string,
+    public readonly errors: Array<ValidationError>
+  ) {
+    super(message);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+  }
+}

--- a/packages/core/src/domain/types/tcx-errors.ts
+++ b/packages/core/src/domain/types/tcx-errors.ts
@@ -1,4 +1,5 @@
 import type { ValidationError } from "./error-types";
+import { FormatParsingError, SchemaValidationError } from "./shared-errors";
 
 /**
  * Error thrown when TCX file parsing fails.
@@ -21,18 +22,8 @@ import type { ValidationError } from "./error-types";
  * }
  * ```
  */
-export class TcxParsingError extends Error {
+export class TcxParsingError extends FormatParsingError {
   public override readonly name = "TcxParsingError";
-
-  constructor(
-    message: string,
-    public readonly cause?: unknown
-  ) {
-    super(message);
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, TcxParsingError);
-    }
-  }
 }
 
 /**
@@ -67,18 +58,8 @@ export const createTcxParsingError = (
  * }
  * ```
  */
-export class TcxValidationError extends Error {
+export class TcxValidationError extends SchemaValidationError {
   public override readonly name = "TcxValidationError";
-
-  constructor(
-    message: string,
-    public readonly errors: Array<ValidationError>
-  ) {
-    super(message);
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, TcxValidationError);
-    }
-  }
 }
 
 /**

--- a/packages/core/src/domain/types/zwift-errors.ts
+++ b/packages/core/src/domain/types/zwift-errors.ts
@@ -1,4 +1,5 @@
 import type { ValidationError } from "./error-types";
+import { FormatParsingError, SchemaValidationError } from "./shared-errors";
 
 /**
  * Error thrown when Zwift workout file parsing fails.
@@ -21,18 +22,8 @@ import type { ValidationError } from "./error-types";
  * }
  * ```
  */
-export class ZwiftParsingError extends Error {
+export class ZwiftParsingError extends FormatParsingError {
   public override readonly name = "ZwiftParsingError";
-
-  constructor(
-    message: string,
-    public readonly cause?: unknown
-  ) {
-    super(message);
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, ZwiftParsingError);
-    }
-  }
 }
 
 /**
@@ -67,18 +58,8 @@ export const createZwiftParsingError = (
  * }
  * ```
  */
-export class ZwiftValidationError extends Error {
+export class ZwiftValidationError extends SchemaValidationError {
   public override readonly name = "ZwiftValidationError";
-
-  constructor(
-    message: string,
-    public readonly errors: Array<ValidationError>
-  ) {
-    super(message);
-    if (Error.captureStackTrace) {
-      Error.captureStackTrace(this, ZwiftValidationError);
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
Automated nightly code-reduction of @kaiord/core (rotation test run). Consolidates duplicated error-class boilerplate into shared-errors.ts (fit/garmin/krd/tcx/zwift). Local gate passed: build green, core coverage >= baseline, lint clean, changeset added. The watcher will drive CI and merge on green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized error handling across core parsing and validation flows.
  * Improved consistency of error names, causes, and validation details while keeping existing behavior unchanged.
  * Reduced duplicated implementation across multiple format and schema error types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->