### PR TITLE
refactor(fit): reduce to minimal code

### DIFF
--- a/.changeset/fit-code-reduction.md
+++ b/.changeset/fit-code-reduction.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/fit": patch
+---
+
+Internal code reduction, no behavior change.

--- a/packages/fit/src/adapters/messages/activity.mapper.ts
+++ b/packages/fit/src/adapters/messages/activity.mapper.ts
@@ -4,6 +4,7 @@ import { fileTypeSchema } from "@kaiord/core";
 
 import { convertFitToKrdEvents } from "../event";
 import { extractFitExtensions } from "../extensions/extensions.extractor";
+import { convertFitTimeCreatedToIso } from "../health/shared/health-metadata.builder";
 import { convertFitToKrdLaps } from "../lap";
 import { convertFitToKrdRecords } from "../record";
 import { fitMessageKeySchema } from "../schemas/fit-message-keys";
@@ -12,21 +13,11 @@ import type { FitMessages } from "../shared/types";
 
 const KRD_VERSION = "1.0" as const;
 
-/**
- * Converts FIT timeCreated to ISO string, handling Date objects and numbers
- */
-const convertTimeCreated = (timeCreated: unknown): string => {
-  if (timeCreated instanceof Date) return timeCreated.toISOString();
-  if (typeof timeCreated === "number")
-    return new Date(timeCreated * 1000).toISOString();
-  return new Date().toISOString();
-};
-
 const buildKrdMetadata = (
   fileId: Record<string, unknown> | undefined,
   session: ReturnType<typeof convertFitToKrdSession> | undefined
 ) => ({
-  created: convertTimeCreated(fileId ? fileId.timeCreated : undefined),
+  created: convertFitTimeCreatedToIso(fileId ? fileId.timeCreated : undefined),
   sport: (session ? session.sport : undefined) ?? "generic",
   subSport: session ? session.subSport : undefined,
 });

--- a/packages/fit/src/adapters/record/AGENTS.md
+++ b/packages/fit/src/adapters/record/AGENTS.md
@@ -16,7 +16,6 @@ Time-series record (sample) conversion between FIT and KRD. Handles per-second a
 | `krd-to-fit-record.converter.ts` | Converts KRD TimeSeries samples to FIT record messages. |
 | `record-from-fit.mapper.ts`      | Maps individual FIT record fields to KRD sample fields. |
 | `record-to-fit.mapper.ts`        | Maps individual KRD sample fields to FIT record fields. |
-| `record.mapper.ts`               | Re-exports mappers.                                     |
 
 ## Subdirectories
 

--- a/packages/fit/src/adapters/record/fit-to-krd-record.converter.ts
+++ b/packages/fit/src/adapters/record/fit-to-krd-record.converter.ts
@@ -2,7 +2,7 @@ import type { KRDRecord } from "@kaiord/core";
 
 import { type FitRecord, fitRecordSchema } from "../schemas/fit-record";
 import { validateCoordinates } from "../shared/coordinate.converter";
-import { mapFitRecordToKrd } from "./record.mapper";
+import { mapFitRecordToKrd } from "./record-from-fit.mapper";
 
 /**
  * Converts a FIT RECORD message to KRD record format.

--- a/packages/fit/src/adapters/record/krd-to-fit-record.converter.ts
+++ b/packages/fit/src/adapters/record/krd-to-fit-record.converter.ts
@@ -1,7 +1,7 @@
 import { type KRDRecord, krdRecordSchema } from "@kaiord/core";
 
 import type { FitRecord } from "../schemas/fit-record";
-import { mapKrdRecordToFit } from "./record.mapper";
+import { mapKrdRecordToFit } from "./record-to-fit.mapper";
 
 /**
  * Converts a KRD record to FIT RECORD message format.

--- a/packages/fit/src/adapters/record/record.mapper.ts
+++ b/packages/fit/src/adapters/record/record.mapper.ts
@@ -1,2 +1,0 @@
-export { mapFitRecordToKrd } from "./record-from-fit.mapper";
-export { mapKrdRecordToFit } from "./record-to-fit.mapper";

--- a/packages/fit/src/adapters/session/index.ts
+++ b/packages/fit/src/adapters/session/index.ts
@@ -1,3 +1,2 @@
 export { convertFitToKrdSession } from "./fit-to-krd-session.converter";
-export { convertKrdToFitSession } from "./krd-to-fit-session.converter";
-export { mapFitSessionToKrd, mapKrdSessionToFit } from "./session.mapper";
+export { mapFitSessionToKrd } from "./session.mapper";


### PR DESCRIPTION
Automated nightly code-reduction of @kaiord/fit (rotation, 05:00 run — rescued from a gate false-negative now fixed). Dedupes the FIT time helper, drops pass-through re-exports and a dead mapper. Changeset included. The watcher will drive CI and merge on green.