### PR TITLE
fix(ci): tolerate CWS PUBLISHED-projection 400 in wait-published

### DIFF
--- a/scripts/cws-api.test.mjs
+++ b/scripts/cws-api.test.mjs
@@ -578,6 +578,69 @@ describe("waitPublished", () => {
       }
     );
   });
+
+  it("degrades to IN_REVIEW when the PUBLISHED projection 400s and DRAFT is clean", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        if (url.includes("projection=PUBLISHED")) {
+          return makeResponse({
+            status: 400,
+            body: { error: { message: "Please append ?projection=DRAFT" } },
+          });
+        }
+        return makeResponse({
+          body: { id: "abc", uploadState: "SUCCESS", crxVersion: "1.0.0" },
+        });
+      },
+      async () => {
+        const result = await waitPublished(account, "abc", {
+          version: "1.0.0",
+          timeoutMs: 5000,
+          sleep: async () => {},
+        });
+        strictEqual(result.status, "IN_REVIEW");
+        strictEqual(result.version, "1.0.0");
+      }
+    );
+  });
+
+  it("still returns REJECTED when the PUBLISHED projection 400s but DRAFT shows rejection", async () => {
+    const { pem } = makeKey();
+    const account = makeAccount(pem);
+    await withMockFetch(
+      async (url) => {
+        if (url.includes("oauth2.googleapis.com")) {
+          return makeResponse({ body: { access_token: "AT" } });
+        }
+        if (url.includes("projection=PUBLISHED")) {
+          return makeResponse({
+            status: 400,
+            body: { error: { message: "Please append ?projection=DRAFT" } },
+          });
+        }
+        return makeResponse({
+          body: {
+            id: "abc",
+            uploadState: "FAILURE",
+            itemError: [{ error_code: "ITEM_REJECTED" }],
+          },
+        });
+      },
+      async () => {
+        const result = await waitPublished(account, "abc", {
+          version: "1.0.0",
+          timeoutMs: 120000,
+          sleep: async () => {},
+        });
+        strictEqual(result.status, "REJECTED");
+      }
+    );
+  });
 });
 
 // ---------- CLI dispatch ----------

--- a/scripts/cws-api/poll.mjs
+++ b/scripts/cws-api/poll.mjs
@@ -3,7 +3,7 @@
 // (NOT inside pollUntil) so wait-published can share pollUntil without
 // inheriting the retry behavior.
 
-import { CwsTimeoutError } from "./errors.mjs";
+import { CwsStateError, CwsTimeoutError } from "./errors.mjs";
 import { getItem } from "./state.mjs";
 
 export async function pollUntil(
@@ -64,7 +64,24 @@ export async function waitPublished(
   const start = now();
   const deadline = start + timeoutMs;
   for (;;) {
-    const item = await getItem(serviceAccount, id, "PUBLISHED");
+    let item;
+    try {
+      item = await getItem(serviceAccount, id, "PUBLISHED");
+    } catch (err) {
+      if (!(err instanceof CwsStateError)) throw err;
+      // The CWS API intermittently rejects the PUBLISHED projection with a
+      // 400 ("Please append ?projection=DRAFT"); live-version.mjs already
+      // tolerates the same error. Fall back to the DRAFT projection (the
+      // path wait-uploaded relies on) so a genuine rejection is still
+      // caught; otherwise report IN_REVIEW — the submission succeeded but
+      // the API cannot confirm the published state, and the workflow
+      // treats IN_REVIEW as a non-fatal "track it" outcome.
+      const draft = await getItem(serviceAccount, id, "DRAFT");
+      if (isRejected(draft)) {
+        return { status: "REJECTED", version, raw: draft.rawResponse };
+      }
+      return { status: "IN_REVIEW", version, raw: draft.rawResponse };
+    }
     const rejected = isRejected(item);
     if (rejected) {
       return { status: "REJECTED", version, raw: item.rawResponse };


### PR DESCRIPTION
## Problem

The `CWS Publish` workflow failed publishing **train2go-bridge** (run 28599860724) at *Wait for terminal state*:

```
[CwsStateError] getItem(PUBLISHED) returned 400: "Please append ?projection=DRAFT to your request."
```

The Chrome Web Store API intermittently rejects `getItem` with `projection=PUBLISHED` (garmin-bridge published fine in the same run; train2go hit the 400). `waitPublished` let that `CwsStateError` propagate, crashing the step. This is pre-existing release-tooling behaviour — the PR that shipped the extensions did **not** touch any CWS tooling.

## Fix

`waitPublished` now catches the `CwsStateError` from the PUBLISHED projection and falls back to the **DRAFT** projection (the path `waitUploaded` already relies on):
- DRAFT shows a rejection → `REJECTED` (unchanged fail-fast semantics).
- otherwise → `IN_REVIEW`, which the workflow already treats as a **non-fatal** track-it outcome (only `REJECTED` does `exit 1`).

This mirrors the existing `published_projection_400` tolerance in `live-version.mjs`. Also imports `CwsStateError`, which `waitUploaded` referenced without importing (latent ReferenceError on the upload-itemError path).

## Tests

`node --test scripts/cws-api.test.mjs` → 29/29 pass, including two new cases:
- degrades to IN_REVIEW when the PUBLISHED projection 400s and DRAFT is clean
- still returns REJECTED when the PUBLISHED projection 400s but DRAFT shows rejection

## Not covered (separate follow-ups)
- **whoop-bridge** is not yet wired into `cws-publish.yml` (needs a CWS listing created first).
- A durable tooling fix could stop querying the PUBLISHED projection entirely once Google's deprecation is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publication status handling when the published view is temporarily unavailable.
  * The app now falls back to a draft view to determine whether an item is still under review or has been rejected.
  * Added test coverage for both the clean draft and rejected draft scenarios when the published view returns an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->