### PR TITLE
chore: add routines to agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,6 +151,53 @@ Before any non-trivial change:
 5. Update docs if public API changes.
 6. After merge: `/opsx:archive`; then `pnpm archive:index` to refresh the index.
 
+## Automated nightly maintenance (maintainer machine)
+
+Autonomous **launchd jobs** run on the maintainer's Mac (not CI, not part of the
+repo). They open **labeled PRs**; a paired watcher drives each PR's CI to green.
+Recognize these bot-authored branches/labels — they appear without a human
+opening them.
+
+| launchd label                    | Schedule    | Script                          | Produces                                                    |
+| -------------------------------- | ----------- | ------------------------------- | ----------------------------------------------------------- |
+| `com.kaiord.nightly-test-review` | 03:15 daily | `~/.kaiord/nightly-test-review.sh` | `chore/nightly-test-review-*` → PR label `auto-test-review` |
+| `com.kaiord.watch-test-review`   | every 20m   | `~/.kaiord/watch-test-review-pr.sh` | drives `auto-test-review` PRs to green + merges          |
+| `com.kaiord.nightly-minify`      | 04:15 daily | `~/.kaiord/nightly-minify.sh`   | `chore/minify-<pkg>-*` → PR label `auto-minify`             |
+| `com.kaiord.watch-minify-pr`     | every 20m   | `~/.kaiord/watch-minify-pr.sh`  | drives `auto-minify` PRs to green (merges only if opted in) |
+
+Shared conventions: every script does `unset ANTHROPIC_API_KEY` to use the Claude
+**subscription** login (`~/.claude`, never the paid API), runs
+`claude -p --dangerously-skip-permissions --model claude-opus-4-8`, works in a
+**dedicated worktree** under `~/development/kaiord.worktrees/` with `main` as the
+fetch anchor, never merges from the nightly (only opens a labeled PR), and logs to
+`~/.kaiord/*-YYYYMMDD.log`.
+
+### Nightly minify (`nightly-minify.sh`)
+
+Minimizes ONE package per night (queue `~/.kaiord/minify-queue.txt`, hexagonal
+order `core → … → landing`), reducing `packages/<pkg>/src` to the least code that
+still solves the problem: **dead code, duplication, needless indirection, and
+redundant types only** — never rewriting for style, weakening tests, lowering
+thresholds, widening `coverage.exclude`, or breaking the size/boundary
+conventions. Local gate before the PR: `@kaiord/<pkg>` tests green + lint clean +
+coverage (lines/statements/functions/branches) **≥ the pre-edit baseline**.
+Outcomes update the queue line to `done` / `nochange` / `blocked`.
+
+### Minify watcher (`watch-minify-pr.sh`)
+
+Every 20 min: rebases conflicts, drives `auto-minify` PRs to green (fixing without
+weakening tests/coverage, or reverting the offending reduction), and — only when
+`MINIFY_AUTOMERGE=1` is set in `~/.kaiord/env` (OFF by default) — squash-merges on
+green. Respects `hold` / `needs-human` / required-review gates. If a merge leaves
+`main` red it opens a `needs-human` issue and never auto-edits production.
+
+### Control
+
+- Pause: `launchctl unload ~/Library/LaunchAgents/<label>.plist`; enable:
+  `launchctl load -w ~/Library/LaunchAgents/<label>.plist`.
+- Retry a package: set its line back to `pending` in `~/.kaiord/minify-queue.txt`.
+- Opt into minify auto-merge: add `export MINIFY_AUTOMERGE=1` to `~/.kaiord/env`.
+
 ## Dependencies
 
 ### External


### PR DESCRIPTION
Adds agent routines documentation to AGENTS.md.

This commit was made directly on local main and couldn't be pushed (protected branch), so it's being landed through this PR instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for automated nightly maintenance on the maintainer’s Mac, including scheduled review and minification workflows.
  * Documented how bot-authored PRs are labeled and when they run.
  * Clarified operating conventions for the maintenance machine, including worktree usage, logging, and review/merge safeguards.
  * Added instructions for pausing, resuming, retrying, and optionally enabling auto-merge for the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->