### PR TITLE
refactor(garmin-connect): reduce to minimal code

### DIFF
--- a/.changeset/garmin-connect-code-reduction.md
+++ b/.changeset/garmin-connect-code-reduction.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/garmin-connect": patch
+---
+
+Internal code reduction, no behavior change.

--- a/packages/garmin-connect/src/adapters/client/garmin-connect-client.ts
+++ b/packages/garmin-connect/src/adapters/client/garmin-connect-client.ts
@@ -12,11 +12,6 @@ import type {
 } from "./garmin-connect-client.types";
 import { createGarminWorkoutService } from "./garmin-workout-service";
 
-export type {
-  GarminConnectClient,
-  GarminConnectClientOptions,
-} from "./garmin-connect-client.types";
-
 /**
  * Create a Garmin Connect client with auth, workout service, and optional token auto-restore.
  *

--- a/packages/garmin-connect/src/adapters/http/garmin-http-client.ts
+++ b/packages/garmin-connect/src/adapters/http/garmin-http-client.ts
@@ -4,8 +4,6 @@ import type { TokenReader } from "../token/token-manager.types";
 import { authFetch } from "./garmin-auth-fetch";
 import type { FetchFn, GarminHttpClient } from "./types";
 
-export type { GarminHttpClient } from "./types";
-
 export const createGarminHttpClient = (
   tokenReader: TokenReader,
   fetchFn: FetchFn,

--- a/packages/garmin-connect/src/adapters/http/oauth-signer.ts
+++ b/packages/garmin-connect/src/adapters/http/oauth-signer.ts
@@ -4,7 +4,6 @@ import OAuth from "oauth-1.0a";
 
 import type { OAuthConsumer } from "./types";
 
-export type { OAuthConsumer } from "./types";
 type OAuthToken = { key: string; secret: string };
 
 export type OAuthSigner = {

--- a/packages/garmin-connect/src/adapters/http/sso-oauth.ts
+++ b/packages/garmin-connect/src/adapters/http/sso-oauth.ts
@@ -3,8 +3,7 @@ import { createServiceAuthError } from "@kaiord/core";
 
 import { createOAuthSigner } from "./oauth-signer";
 import { nowEpochSeconds } from "./time";
-import type { FetchFn, OAuthConsumer } from "./types";
-import type { OAuth1Token, OAuth2Token } from "./types";
+import type { FetchFn, OAuth1Token, OAuth2Token, OAuthConsumer } from "./types";
 import { GARMIN_SSO_EMBED, OAUTH_URL, USER_AGENT_MOBILE } from "./urls";
 
 export const getOAuth1Token = async (


### PR DESCRIPTION
Automated nightly code-reduction of @kaiord/garmin-connect (rotation). Local gate passed: build green, garmin-connect coverage >= baseline (base[99.18 89.7 97.46 98.72] now[99.18 89.7 97.46 98.72]), lint clean. The watcher will fix any CI findings and merge on green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a patch release note for `@kaiord/garmin-connect`.
  * Cleaned up type-only imports and reduced unnecessary public type re-exports.
  * No user-facing behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->