### PR TITLE
feat: Data Hub V2 — Garmin activities pull + conversational hub tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,12 @@ Before any non-trivial change:
   **camelCase** (`indoorCycling`).
 - Files: `kebab-case.ts`. Mappers `*.mapper.ts` (pure, no tests). Converters
   `*.converter.ts` (logic, requires tests).
+- **Worktree hygiene**: one worktree per feature/program under
+  `~/development/kaiord.worktrees/`. Remove a worktree as soon as its work is
+  finished (branch pushed/merged and no agent still working in it):
+  `git worktree remove <path> && git worktree prune`. Branches survive worktree
+  removal; regenerated `packages/*/icons/*.png` noise is safe to discard with
+  `--force`. Never leave finished worktrees around — keep the workspace clean.
 
 ### Testing requirements
 
@@ -158,13 +164,13 @@ repo). They open **labeled PRs**; a paired watcher drives each PR's CI to green.
 Recognize these bot-authored branches/labels — they appear without a human
 opening them.
 
-| launchd label                    | Schedule    | Script                          | Produces                                                    |
-| -------------------------------- | ----------- | ------------------------------- | ----------------------------------------------------------- |
-| `com.kaiord.nightly-test-review` | 03:15 daily | `~/.kaiord/nightly-test-review.sh` | `chore/nightly-test-review-*` → PR label `auto-test-review` |
-| `com.kaiord.watch-test-review`   | every 20m   | `~/.kaiord/watch-test-review-pr.sh` | drives `auto-test-review` PRs to green + merges          |
-| `com.kaiord.nightly-minify`      | 04:15 daily | `~/.kaiord/nightly-minify.sh`   | `chore/minify-<pkg>-*` → PR label `auto-minify`             |
-| `com.kaiord.watch-minify-pr`     | every 20m   | `~/.kaiord/watch-minify-pr.sh`  | drives `auto-minify` PRs to green (merges only if opted in) |
-| `com.kaiord.watch-main-green`    | every 20m   | `~/.kaiord/watch-main-green.sh`  | read-only guard: opens `needs-human` issue if the tip of `main` has a red **full-CI** run (any merge source) |
+| launchd label                    | Schedule    | Script                              | Produces                                                                                                     |
+| -------------------------------- | ----------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `com.kaiord.nightly-test-review` | 03:15 daily | `~/.kaiord/nightly-test-review.sh`  | `chore/nightly-test-review-*` → PR label `auto-test-review`                                                  |
+| `com.kaiord.watch-test-review`   | every 20m   | `~/.kaiord/watch-test-review-pr.sh` | drives `auto-test-review` PRs to green + merges                                                              |
+| `com.kaiord.nightly-minify`      | 04:15 daily | `~/.kaiord/nightly-minify.sh`       | `chore/minify-<pkg>-*` → PR label `auto-minify`                                                              |
+| `com.kaiord.watch-minify-pr`     | every 20m   | `~/.kaiord/watch-minify-pr.sh`      | drives `auto-minify` PRs to green (merges only if opted in)                                                  |
+| `com.kaiord.watch-main-green`    | every 20m   | `~/.kaiord/watch-main-green.sh`     | read-only guard: opens `needs-human` issue if the tip of `main` has a red **full-CI** run (any merge source) |
 
 Shared conventions: every script does `unset ANTHROPIC_API_KEY` to use the Claude
 **subscription** login (`~/.claude`, never the paid API), runs
@@ -175,7 +181,7 @@ fetch anchor, never merges from the nightly (only opens a labeled PR), and logs 
 
 **Invariant — "green" means the FULL CI run, not the required-checks subset.** The
 branch-protection-required checks (`detect-changes, lint, typecheck, test, build,
-round-trip, Check for Changeset, Link checker`) are a *subset* of what the `CI`
+round-trip, Check for Changeset, Link checker`) are a _subset_ of what the `CI`
 workflow runs. Non-required jobs (`test-frontend`, `e2e-frontend`, `e2e-prod-base`,
 `size-limit`, `jscpd`) still run on both the PR and the `main` push, and a
 dependency/SDK **major** bump can turn one red while every required check passes (e.g.

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -23,6 +23,7 @@
     "lint": "tsc --noEmit && eslint . && prettier --check src",
     "lint:fix": "eslint . --fix && prettier --write src",
     "eval": "tsx src/evals/run-evals.ts",
+    "eval:chat-tools": "tsx src/evals/run-chat-tool-evals.ts",
     "clean": "rm -rf dist"
   },
   "dependencies": {

--- a/packages/ai/src/evals/AGENTS.md
+++ b/packages/ai/src/evals/AGENTS.md
@@ -5,15 +5,21 @@
 
 ## Purpose
 
-Evaluation and benchmarking suite for validating LLM output quality. Defines benchmark cases (22 curated workout descriptions), runs assertions (schema validation, sport correctness, step count, zone accuracy), and produces JSON reports. Evals are manual-trigger only in CI (not part of standard test suite) because they require API keys and incur costs.
+Evaluation and benchmarking suite for validating LLM output quality. Defines benchmark cases (22 curated workout descriptions), runs assertions (schema validation, sport correctness, step count, zone accuracy), and produces JSON reports. A second suite (`chat-tool-*`) evaluates the Data Hub chat tools (F6): does the model call `get_data_routes`/`set_data_route` correctly for the spec's two hub-conversation scenarios. Evals are manual-trigger only in CI (not part of standard test suite) because they require API keys and incur costs.
 
 ## Key Files
 
 - `benchmarks.json` — 22 curated workout descriptions across sports (cycling, running, swimming, generic), complexity (simple, intervals, repetition blocks, mixed), languages (English, Spanish, mixed), and edge cases
 - `types.ts` — Type definitions: `Benchmark`, `EvalResult`, `EvalReport`, `ZoneCheck`
 - `assertions.ts` — `evaluateBenchmark(benchmark, workout, durationMs)` validates schema, sport, step count, zone ranges
-- `reporter.ts` — Report generation (`createReport`, `formatReport`) with category/language breakdowns
+- `reporter.ts` — Report generation (`createReport`, `formatReport`) with category/language breakdowns; reused as-is by the chat-tool evals (both result shapes carry `id`/`pass`/`errors`/`durationMs`)
 - `run-evals.ts` — CLI entry point: loads Anthropic model, runs all benchmarks, outputs report JSON and markdown
+- `load-anthropic-model.ts` — shared `ANTHROPIC_API_KEY`/`EVAL_MODEL` loader used by both eval CLIs
+- `chat-tool-benchmarks.json` — Data Hub hub-conversation scenarios (F6): "where do my planned sessions come from" (read) and "read sleep only from Whoop" (action)
+- `chat-tool-types.ts` — Type definitions: `ChatToolBenchmark`, `ChatToolEvalResult`
+- `chat-tool-fixtures.ts` — local `get_data_routes`/`set_data_route` `ChatTool` fixtures mirroring the real schemas registered in `@kaiord/workout-spa-editor` (hand-kept in sync; that package cannot be a dependency here)
+- `chat-tool-assertions.ts` — `evaluateChatToolBenchmark(benchmark, chatTurnResult, durationMs)`: read scenarios check the expected tool was called and the final answer names the real source; action scenarios check the paused `pendingAction` matches the expected tool + input fields
+- `run-chat-tool-evals.ts` — CLI entry point: loads Anthropic model, runs `createChatAgent` against the hub tool fixtures for each benchmark, outputs report JSON and markdown
 
 ## Assertions per Benchmark
 
@@ -45,6 +51,25 @@ Overall pass rate: ≥90% to exit with code 0; <90% exits with code 1.
 }
 ```
 
+## Chat-Tool Benchmark Schema
+
+```json
+{
+  "id": "unique-id",
+  "userText": "Natural language user message",
+  "category": "read|action",
+  "expectedTool": "get_data_routes|set_data_route",
+  "expectedAnswerIncludes": ["train2go"],
+  "expectedActionInput": {
+    "action": "set_source_policy",
+    "dataType": "sleep",
+    "mode": "priority"
+  }
+}
+```
+
+`expectedAnswerIncludes` applies to `category: "read"` (checked against the completed turn's final text); `expectedActionInput` applies to `category: "action"` (checked as a partial match against the paused `pendingAction.input`).
+
 ## For AI Agents
 
 ### Working In This Directory
@@ -53,13 +78,16 @@ Overall pass rate: ≥90% to exit with code 0; <90% exits with code 1.
 - **Modify assertions**: Update `assertions.ts` (e.g., change tolerance from 5% to 10%), re-run evals
 - **Customize report**: Edit `reporter.ts` formatting (markdown, JSON structure)
 - **Run locally**: `ANTHROPIC_API_KEY=sk-ant-... pnpm --filter @kaiord/ai eval` (outputs JSON and formatted text)
+- **Add a chat-tool benchmark**: Edit `chat-tool-benchmarks.json`, follow the schema above; if the scenario needs a new fixture answer, extend `chat-tool-fixtures.ts`
+- **Run chat-tool evals locally**: `ANTHROPIC_API_KEY=sk-ant-... pnpm --filter @kaiord/ai eval:chat-tools`
 
 ### Testing Requirements
 
 - `assertions.test.ts`: Unit tests for `evaluateBenchmark`, zone checks, step counting
 - `reporter.test.ts`: Unit tests for `createReport` grouping and `formatReport` output
-- No integration tests for `run-evals.ts` (it's a CLI; manually tested)
-- All assertions test mocked workouts (no LLM calls)
+- `chat-tool-assertions.test.ts`: Unit tests for `evaluateChatToolBenchmark` against fabricated `ChatTurnResult` values (no LLM calls)
+- No integration tests for `run-evals.ts` / `run-chat-tool-evals.ts` (CLIs; manually tested)
+- All assertions test mocked workouts / chat turns (no LLM calls)
 
 ### Common Patterns
 
@@ -72,15 +100,17 @@ Overall pass rate: ≥90% to exit with code 0; <90% exits with code 1.
 
 ### Internal
 
-- `@kaiord/core` — `Workout`, `workoutSchema`
-- `../index` — `createTextToWorkout`
-- `./types` — Type definitions
-- `./benchmarks.json` — Benchmark data
+- `@kaiord/core` — `Workout`, `workoutSchema`, `managedDataTypes` (chat-tool fixtures)
+- `../index` — `createTextToWorkout`, `createChatAgent`, `ChatTool`, `ChatTurnResult`
+- `./types` / `./chat-tool-types` — Type definitions
+- `./benchmarks.json` / `./chat-tool-benchmarks.json` — Benchmark data
+- `./load-anthropic-model` — shared model loader
 
 ### External
 
-- `ai` — `LanguageModel` (via `run-evals.ts` dynamic import)
-- `@ai-sdk/anthropic` — `createAnthropic` for `run-evals.ts`
+- `ai` — `LanguageModel`, `ModelMessage` (via dynamic import in the CLIs)
+- `@ai-sdk/anthropic` — `createAnthropic` for the CLIs
+- `zod` — chat-tool fixture schemas
 
 ## File Line Limits
 
@@ -88,6 +118,7 @@ Overall pass rate: ≥90% to exit with code 0; <90% exits with code 1.
 - `assertions.ts`: 90 lines
 - `reporter.ts`: 64 lines
 - `run-evals.ts`: 72 lines
+- `chat-tool-types.ts`, `chat-tool-fixtures.ts`, `chat-tool-assertions.ts`, `run-chat-tool-evals.ts`: same budget as their workout-eval counterparts
 
 Functions: `evaluateBenchmark` ~40 LOC, `checkZones` ~30 LOC, `countSteps` <10 LOC, helpers <20 LOC.
 

--- a/packages/ai/src/evals/chat-tool-assertions.test.ts
+++ b/packages/ai/src/evals/chat-tool-assertions.test.ts
@@ -1,0 +1,252 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatTurnResult } from "../index";
+import { EVAL_DURATION_MS_DEFAULT } from "../test-utils/constants";
+import { evaluateChatToolBenchmark } from "./chat-tool-assertions";
+import type { ChatToolBenchmark } from "./chat-tool-types";
+
+const readBenchmark: ChatToolBenchmark = {
+  id: "read-1",
+  userText: "where do my planned sessions come from?",
+  category: "read",
+  expectedTool: "get_data_routes",
+  expectedAnswerIncludes: ["train2go"],
+};
+
+const actionBenchmark: ChatToolBenchmark = {
+  id: "action-1",
+  userText: "read sleep only from whoop",
+  category: "action",
+  expectedTool: "set_data_route",
+  expectedActionInput: {
+    action: "set_source_policy",
+    dataType: "sleep",
+    mode: "priority",
+  },
+};
+
+const completeWithToolCall = (
+  text: string,
+  toolName: string
+): ChatTurnResult => ({
+  status: "complete",
+  text,
+  messages: [
+    {
+      role: "assistant",
+      content: [{ type: "tool-call", toolCallId: "c1", toolName, input: {} }],
+    },
+  ],
+});
+
+describe("evaluateChatToolBenchmark — read scenario", () => {
+  it("should pass when the expected tool was called and the answer names the source", () => {
+    // Arrange
+    const result = completeWithToolCall(
+      "Your planned sessions come from Train2Go.",
+      "get_data_routes"
+    );
+
+    // Act
+    const evalResult = evaluateChatToolBenchmark(
+      readBenchmark,
+      result,
+      EVAL_DURATION_MS_DEFAULT
+    );
+
+    // Assert
+    expect(evalResult.pass).toBe(true);
+    expect(evalResult.errors).toHaveLength(0);
+    expect(evalResult.toolCalled).toBe("get_data_routes");
+  });
+
+  it("should fail when the expected tool was never called", () => {
+    // Arrange
+    const result: ChatTurnResult = {
+      status: "complete",
+      text: "Your planned sessions come from Train2Go.",
+      messages: [],
+    };
+
+    // Act
+    const evalResult = evaluateChatToolBenchmark(
+      readBenchmark,
+      result,
+      EVAL_DURATION_MS_DEFAULT
+    );
+
+    // Assert
+    expect(evalResult.pass).toBe(false);
+    expect(evalResult.errors.some((e) => e.includes("get_data_routes"))).toBe(
+      true
+    );
+  });
+
+  it("should fail when the answer never names the real source", () => {
+    // Arrange
+    const result = completeWithToolCall(
+      "I don't have that information.",
+      "get_data_routes"
+    );
+
+    // Act
+    const evalResult = evaluateChatToolBenchmark(
+      readBenchmark,
+      result,
+      EVAL_DURATION_MS_DEFAULT
+    );
+
+    // Assert
+    expect(evalResult.pass).toBe(false);
+    expect(evalResult.errors.some((e) => e.includes("train2go"))).toBe(true);
+  });
+
+  it("should fail when the turn is still pending an action instead of complete", () => {
+    // Arrange
+    const result: ChatTurnResult = {
+      status: "pending_action",
+      pendingAction: {
+        toolName: "set_data_route",
+        toolCallId: "c1",
+        input: {},
+      },
+      messages: [],
+    };
+
+    // Act
+    const evalResult = evaluateChatToolBenchmark(
+      readBenchmark,
+      result,
+      EVAL_DURATION_MS_DEFAULT
+    );
+
+    // Assert
+    expect(evalResult.pass).toBe(false);
+  });
+});
+
+describe("evaluateChatToolBenchmark — action scenario", () => {
+  it("should pass when the pending action matches the expected tool and input", () => {
+    // Arrange
+    const result: ChatTurnResult = {
+      status: "pending_action",
+      pendingAction: {
+        toolName: "set_data_route",
+        toolCallId: "c1",
+        input: {
+          action: "set_source_policy",
+          dataType: "sleep",
+          mode: "priority",
+          sourceOrder: ["whoop"],
+        },
+      },
+      messages: [],
+    };
+
+    // Act
+    const evalResult = evaluateChatToolBenchmark(
+      actionBenchmark,
+      result,
+      EVAL_DURATION_MS_DEFAULT
+    );
+
+    // Assert
+    expect(evalResult.pass).toBe(true);
+    expect(evalResult.toolCalled).toBe("set_data_route");
+  });
+
+  it("should fail when a different tool is proposed", () => {
+    // Arrange
+    const result: ChatTurnResult = {
+      status: "pending_action",
+      pendingAction: {
+        toolName: "push_to_garmin",
+        toolCallId: "c1",
+        input: {},
+      },
+      messages: [],
+    };
+
+    // Act
+    const evalResult = evaluateChatToolBenchmark(
+      actionBenchmark,
+      result,
+      EVAL_DURATION_MS_DEFAULT
+    );
+
+    // Assert
+    expect(evalResult.pass).toBe(false);
+    expect(evalResult.errors.some((e) => e.includes("push_to_garmin"))).toBe(
+      true
+    );
+  });
+
+  it("should fail when the proposed input has the wrong mode", () => {
+    // Arrange
+    const result: ChatTurnResult = {
+      status: "pending_action",
+      pendingAction: {
+        toolName: "set_data_route",
+        toolCallId: "c1",
+        input: {
+          action: "set_source_policy",
+          dataType: "sleep",
+          mode: "union",
+        },
+      },
+      messages: [],
+    };
+
+    // Act
+    const evalResult = evaluateChatToolBenchmark(
+      actionBenchmark,
+      result,
+      EVAL_DURATION_MS_DEFAULT
+    );
+
+    // Assert
+    expect(evalResult.pass).toBe(false);
+    expect(evalResult.errors.some((e) => e.includes("mode"))).toBe(true);
+  });
+
+  it("should fail when the turn completed instead of pausing for confirmation", () => {
+    // Arrange
+    const result: ChatTurnResult = {
+      status: "complete",
+      text: "Done.",
+      messages: [],
+    };
+
+    // Act
+    const evalResult = evaluateChatToolBenchmark(
+      actionBenchmark,
+      result,
+      EVAL_DURATION_MS_DEFAULT
+    );
+
+    // Assert
+    expect(evalResult.pass).toBe(false);
+  });
+});
+
+describe("evaluateChatToolBenchmark — step limit", () => {
+  it("should fail regardless of category when the turn hits the step limit", () => {
+    // Arrange
+    const result: ChatTurnResult = {
+      status: "step_limit",
+      text: "",
+      messages: [],
+    };
+
+    // Act
+    const evalResult = evaluateChatToolBenchmark(
+      readBenchmark,
+      result,
+      EVAL_DURATION_MS_DEFAULT
+    );
+
+    // Assert
+    expect(evalResult.pass).toBe(false);
+    expect(evalResult.errors[0]).toContain("step limit");
+  });
+});

--- a/packages/ai/src/evals/chat-tool-assertions.ts
+++ b/packages/ai/src/evals/chat-tool-assertions.ts
@@ -1,0 +1,86 @@
+import type { ModelMessage } from "ai";
+
+import type { ChatTurnResult } from "../index";
+import type { ChatToolBenchmark, ChatToolEvalResult } from "./chat-tool-types";
+
+const calledTool = (messages: ModelMessage[], toolName: string): boolean =>
+  messages.some(
+    (m) =>
+      m.role === "assistant" &&
+      Array.isArray(m.content) &&
+      m.content.some(
+        (part) => part.type === "tool-call" && part.toolName === toolName
+      )
+  );
+
+const evaluateAction = (
+  benchmark: ChatToolBenchmark,
+  result: ChatTurnResult
+): { errors: string[]; toolCalled?: string } => {
+  if (result.status !== "pending_action") {
+    return { errors: [`Expected a pending action, got "${result.status}"`] };
+  }
+  const errors: string[] = [];
+  const { toolName, input } = result.pendingAction;
+  if (toolName !== benchmark.expectedTool) {
+    errors.push(`Expected tool "${benchmark.expectedTool}", got "${toolName}"`);
+  }
+  const expected = benchmark.expectedActionInput ?? {};
+  const actual = (input ?? {}) as Record<string, unknown>;
+  for (const [key, value] of Object.entries(expected)) {
+    if (actual[key] !== value) {
+      errors.push(
+        `Expected input.${key}=${JSON.stringify(value)}, got ${JSON.stringify(actual[key])}`
+      );
+    }
+  }
+  return { errors, toolCalled: toolName };
+};
+
+const evaluateRead = (
+  benchmark: ChatToolBenchmark,
+  result: ChatTurnResult
+): { errors: string[]; toolCalled?: string } => {
+  if (result.status !== "complete") {
+    return { errors: [`Expected a completed turn, got "${result.status}"`] };
+  }
+  const errors: string[] = [];
+  if (!calledTool(result.messages, benchmark.expectedTool)) {
+    errors.push(`Expected tool "${benchmark.expectedTool}" to be called`);
+  }
+  const answer = result.text.toLowerCase();
+  for (const phrase of benchmark.expectedAnswerIncludes ?? []) {
+    if (!answer.includes(phrase.toLowerCase())) {
+      errors.push(`Expected the answer to mention "${phrase}"`);
+    }
+  }
+  return { errors, toolCalled: benchmark.expectedTool };
+};
+
+export const evaluateChatToolBenchmark = (
+  benchmark: ChatToolBenchmark,
+  result: ChatTurnResult,
+  durationMs: number
+): ChatToolEvalResult => {
+  if (result.status === "step_limit") {
+    return {
+      id: benchmark.id,
+      pass: false,
+      errors: ["Hit the step limit without completing the turn"],
+      durationMs,
+    };
+  }
+
+  const { errors, toolCalled } =
+    benchmark.category === "action"
+      ? evaluateAction(benchmark, result)
+      : evaluateRead(benchmark, result);
+
+  return {
+    id: benchmark.id,
+    pass: errors.length === 0,
+    errors,
+    toolCalled,
+    durationMs,
+  };
+};

--- a/packages/ai/src/evals/chat-tool-benchmarks.json
+++ b/packages/ai/src/evals/chat-tool-benchmarks.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "hub-read-planned-session-source",
+    "userText": "¿De dónde vienen mis planificaciones?",
+    "category": "read",
+    "expectedTool": "get_data_routes",
+    "expectedAnswerIncludes": ["train2go"]
+  },
+  {
+    "id": "hub-action-sleep-whoop-only",
+    "userText": "Lee el sueño solo de Whoop a partir de ahora.",
+    "category": "action",
+    "expectedTool": "set_data_route",
+    "expectedActionInput": {
+      "action": "set_source_policy",
+      "dataType": "sleep",
+      "mode": "priority"
+    }
+  }
+]

--- a/packages/ai/src/evals/chat-tool-fixtures.ts
+++ b/packages/ai/src/evals/chat-tool-fixtures.ts
@@ -1,0 +1,88 @@
+/**
+ * Local fixtures for the F6 Data Hub chat-tool evals. The schemas and
+ * descriptions mirror the real tools registered in
+ * @kaiord/workout-spa-editor (application/chat/tools/get-data-routes-tool.ts,
+ * set-data-route-tool.ts) — @kaiord/ai cannot depend on the SPA package, so
+ * these are hand-kept in sync; drift is caught by review.
+ */
+import { managedDataTypes } from "@kaiord/core";
+import { z } from "zod";
+
+import type { ChatTool } from "../index";
+
+const directionSchema = z.enum(["import", "export"]);
+const sourceModeSchema = z.enum(["union", "priority"]);
+
+const getDataRoutesSchema = z.object({
+  dataType: z.enum(managedDataTypes).optional(),
+});
+
+const routeFields = {
+  dataType: z.enum(managedDataTypes),
+  integrationId: z.string().min(1),
+  direction: directionSchema,
+};
+
+const setDataRouteSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("enable_route"), ...routeFields }),
+  z.object({ action: z.literal("disable_route"), ...routeFields }),
+  z.object({
+    action: z.literal("set_source_policy"),
+    dataType: z.enum(managedDataTypes),
+    mode: sourceModeSchema,
+    sourceOrder: z.array(z.string()).optional(),
+  }),
+]);
+
+/** Canned get_data_routes answer: planned-session imports actively from
+    Train2Go — the fixture the "where do my planned sessions come from"
+    scenario is graded against. */
+const FIXTURE_ROUTES = {
+  day: "2026-07-07",
+  dataTypes: [
+    {
+      dataType: "planned-session",
+      label: "Planned Session",
+      routes: [
+        {
+          integrationId: "train2go",
+          direction: "import",
+          state: "active",
+          enabled: true,
+          mode: "auto",
+          lastSyncedAt: "2026-07-06T08:00:00.000Z",
+        },
+      ],
+      sourcePolicy: { mode: "union", sourceOrder: [] },
+    },
+  ],
+};
+
+export const createHubChatToolFixtures = (): ChatTool[] => [
+  {
+    name: "get_data_routes",
+    description:
+      "Read the Data Hub routing for the active profile: which integration " +
+      "each data type is imported from or exported to, whether the route " +
+      "is enabled, its multi-source semantics (union or priority order), " +
+      "and freshness. Use it for questions like 'where do my planned " +
+      "sessions come from'.",
+    inputSchema: getDataRoutesSchema,
+    requiresConfirmation: false,
+    execute: async () => FIXTURE_ROUTES,
+  },
+  {
+    name: "set_data_route",
+    description:
+      "Change Data Hub routing for the active profile. enable_route / " +
+      "disable_route turn a (data type, integration, direction) route on " +
+      "or off. set_source_policy sets whether a data type merges every " +
+      "enabled source (union) or reads a priority order with automatic " +
+      "fallback (priority) — e.g. 'read sleep only from Whoop' is " +
+      "set_source_policy with mode priority and sourceOrder ['whoop']. " +
+      "Requires the user to confirm before running.",
+    inputSchema: setDataRouteSchema,
+    requiresConfirmation: true,
+    execute: async (raw) => setDataRouteSchema.parse(raw),
+  },
+];

--- a/packages/ai/src/evals/chat-tool-types.ts
+++ b/packages/ai/src/evals/chat-tool-types.ts
@@ -1,0 +1,25 @@
+/**
+ * Type definitions for the F6 Data Hub chat-tool evals: does the model
+ * call `get_data_routes`/`set_data_route` correctly for the two hub
+ * conversational scenarios from the spec?
+ */
+export type ChatToolBenchmark = {
+  id: string;
+  userText: string;
+  category: "read" | "action";
+  expectedTool: string;
+  /** Read scenarios: the final answer must mention every phrase
+      (case-insensitive substring match). */
+  expectedAnswerIncludes?: string[];
+  /** Action scenarios: the proposed tool call's input must match every
+      key/value pair (partial match — extra fields are allowed). */
+  expectedActionInput?: Record<string, unknown>;
+};
+
+export type ChatToolEvalResult = {
+  id: string;
+  pass: boolean;
+  errors: string[];
+  toolCalled?: string;
+  durationMs: number;
+};

--- a/packages/ai/src/evals/load-anthropic-model.ts
+++ b/packages/ai/src/evals/load-anthropic-model.ts
@@ -1,0 +1,22 @@
+import type { LanguageModel } from "ai";
+
+export type LoadedModel = {
+  model: LanguageModel;
+  provider: string;
+  modelName: string;
+};
+
+/**
+ * Shared model loader for the eval CLIs. Requires `ANTHROPIC_API_KEY`;
+ * override the model with `EVAL_MODEL`. Evals are manual-trigger only
+ * (see AGENTS.md) — this never runs in the standard test suite.
+ */
+export const loadAnthropicModel = async (): Promise<LoadedModel> => {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error("Set ANTHROPIC_API_KEY env variable");
+
+  const { createAnthropic } = await import("@ai-sdk/anthropic");
+  const modelName = process.env.EVAL_MODEL ?? "claude-sonnet-4-5-20241022";
+  const provider = createAnthropic({ apiKey });
+  return { model: provider(modelName), provider: "anthropic", modelName };
+};

--- a/packages/ai/src/evals/run-chat-tool-evals.ts
+++ b/packages/ai/src/evals/run-chat-tool-evals.ts
@@ -1,0 +1,73 @@
+#!/usr/bin/env tsx
+import { createChatAgent } from "../index";
+import { evaluateChatToolBenchmark } from "./chat-tool-assertions";
+import { createHubChatToolFixtures } from "./chat-tool-fixtures";
+import { loadAnthropicModel } from "./load-anthropic-model";
+import { createReport, formatReport } from "./reporter";
+import benchmarks from "./chat-tool-benchmarks.json";
+import type { ChatToolBenchmark, ChatToolEvalResult } from "./chat-tool-types";
+
+const SYSTEM_PROMPT = [
+  "You are Kaiord's in-app fitness assistant, running the Data Hub chat",
+  "tools. Answer ONLY from tool results — call get_data_routes for",
+  "questions about where data comes from or goes to. Call set_data_route",
+  "to change routing when the user asks; it always requires the user's",
+  "confirmation before it runs, so just propose the call.",
+].join("\n");
+
+const runEvals = async () => {
+  const { model, provider, modelName } = await loadAnthropicModel();
+  const agent = createChatAgent({
+    model,
+    tools: createHubChatToolFixtures(),
+    system: SYSTEM_PROMPT,
+  });
+
+  console.log(
+    `Running ${benchmarks.length} hub chat-tool benchmarks with ${provider}/${modelName}...\n`
+  );
+
+  const results: Array<ChatToolEvalResult> = [];
+  for (const bench of benchmarks as Array<ChatToolBenchmark>) {
+    const start = Date.now();
+    try {
+      const turn = await agent.sendTurn([
+        { role: "user", content: bench.userText },
+      ]);
+      const result = evaluateChatToolBenchmark(bench, turn, Date.now() - start);
+      results.push(result);
+      console.log(
+        `[${result.pass ? "PASS" : "FAIL"}] ${bench.id} (${result.durationMs}ms)`
+      );
+    } catch (error: unknown) {
+      const msg = error instanceof Error ? error.message : String(error);
+      results.push({
+        id: bench.id,
+        pass: false,
+        errors: [`Exception: ${msg}`],
+        durationMs: Date.now() - start,
+      });
+      console.log(`[FAIL] ${bench.id} - Exception: ${msg}`);
+    }
+  }
+
+  const report = createReport(results, provider, modelName);
+  console.log("\n" + formatReport(report));
+
+  const fs = await import("fs");
+  const path = await import("path");
+  const packageDir = path.join(import.meta.dirname, "..", "..");
+  const outPath = path.join(
+    packageDir,
+    `chat-tool-eval-report-${Date.now()}.json`
+  );
+  fs.writeFileSync(outPath, JSON.stringify(report, null, 2));
+  console.log(`\nReport saved to ${outPath}`);
+
+  process.exit(report.passRate >= 90 ? 0 : 1);
+};
+
+runEvals().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/packages/ai/src/evals/run-evals.ts
+++ b/packages/ai/src/evals/run-evals.ts
@@ -1,27 +1,13 @@
 #!/usr/bin/env tsx
 import { createTextToWorkout } from "../index";
 import { evaluateBenchmark } from "./assertions";
+import { loadAnthropicModel } from "./load-anthropic-model";
 import { createReport, formatReport } from "./reporter";
 import benchmarks from "./benchmarks.json";
 import type { Benchmark, EvalResult } from "./types";
-import type { LanguageModel } from "ai";
-
-const loadModel = async (): Promise<{
-  model: LanguageModel;
-  provider: string;
-  modelName: string;
-}> => {
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) throw new Error("Set ANTHROPIC_API_KEY env variable");
-
-  const { createAnthropic } = await import("@ai-sdk/anthropic");
-  const modelName = process.env.EVAL_MODEL ?? "claude-sonnet-4-5-20241022";
-  const provider = createAnthropic({ apiKey });
-  return { model: provider(modelName), provider: "anthropic", modelName };
-};
 
 const runEvals = async () => {
-  const { model, provider, modelName } = await loadModel();
+  const { model, provider, modelName } = await loadAnthropicModel();
   const textToWorkout = createTextToWorkout({ model });
 
   console.log(

--- a/packages/garmin-bridge/background.js
+++ b/packages/garmin-bridge/background.js
@@ -193,6 +193,81 @@ const pushWorkout = async (gcn) => {
   return res.data;
 };
 
+// ── Garmin activities pull (F5) ──
+//
+// Read-only pull of the athlete's recent Garmin Connect activities via
+// the user's authenticated session. Governed SPA-side by a DataRoute
+// (activity←garmin — the SPA never asks unless the route is active). This
+// handler adds bridge-side safety: a throttle so rapid re-syncs cannot
+// hammer Garmin (ToS), retry-with-backoff for transient session hiccups,
+// and a kill-switch (chrome.storage.local flag) so the pull can be
+// disabled — degrading the SPA to manual FIT import — if Garmin changes
+// the endpoint shape. The raw activity feed is returned as-is; mapping to
+// the domain `activity` type happens SPA-side where the Zod schema lives.
+const ACTIVITIES_PATH =
+  "/activitylist-service/activities/search/activities?start=0&limit=20";
+const ACTIVITIES_KILL_SWITCH_KEY = "activitiesPullDisabled";
+const ACTIVITIES_LAST_FETCH_KEY = "lastActivitiesFetchAt";
+const ACTIVITIES_MIN_INTERVAL_MS = 30000;
+const ACTIVITIES_MAX_ATTEMPTS = 3;
+const ACTIVITIES_BACKOFF_BASE_MS = 500;
+
+const isActivitiesPullDisabled = () =>
+  chrome.storage.local
+    .get(ACTIVITIES_KILL_SWITCH_KEY)
+    .then((r) => r[ACTIVITIES_KILL_SWITCH_KEY] === true);
+
+const sleep = (ms) =>
+  ms > 0
+    ? new Promise((resolve) => setTimeout(resolve, ms))
+    : Promise.resolve();
+
+const fetchActivitiesOnce = async () => {
+  const res = await garminFetch(ACTIVITIES_PATH, "GET");
+  if (!res?.ok) throw toBridgeError("Activities pull failed", res);
+  return res.data;
+};
+
+const fetchActivitiesWithBackoff = async (maxAttempts, backoffBaseMs) => {
+  let lastErr;
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    try {
+      return await fetchActivitiesOnce();
+    } catch (e) {
+      lastErr = e;
+      if (attempt < maxAttempts - 1) await sleep(backoffBaseMs * 2 ** attempt);
+    }
+  }
+  throw lastErr;
+};
+
+const listActivities = async (opts = {}) => {
+  const {
+    minIntervalMs = ACTIVITIES_MIN_INTERVAL_MS,
+    maxAttempts = ACTIVITIES_MAX_ATTEMPTS,
+    backoffBaseMs = ACTIVITIES_BACKOFF_BASE_MS,
+  } = opts;
+
+  if (await isActivitiesPullDisabled()) {
+    return { activities: [], disabled: true, throttled: false };
+  }
+
+  const now = Date.now();
+  const { [ACTIVITIES_LAST_FETCH_KEY]: last = 0 } =
+    await chrome.storage.session.get(ACTIVITIES_LAST_FETCH_KEY);
+  if (now - last < minIntervalMs) {
+    return { activities: [], disabled: false, throttled: true };
+  }
+  await chrome.storage.session.set({ [ACTIVITIES_LAST_FETCH_KEY]: now });
+
+  const data = await fetchActivitiesWithBackoff(maxAttempts, backoffBaseMs);
+  return {
+    activities: Array.isArray(data) ? data : [],
+    disabled: false,
+    throttled: false,
+  };
+};
+
 const openGarmin = async () => {
   await chrome.tabs.create({ url: GARMIN_DASHBOARD });
 };
@@ -227,6 +302,8 @@ const handleAction = async (message) => {
       return await checkSession();
     case "list":
       return await listWorkouts();
+    case "activities":
+      return await listActivities();
     case "push":
       if (!message.gcn) throw new Error("Missing gcn payload");
       return await pushWorkout(message.gcn);
@@ -340,8 +417,15 @@ if (typeof module !== "undefined") {
     garminFetch,
     checkSession,
     listWorkouts,
+    listActivities,
+    fetchActivitiesWithBackoff,
+    isActivitiesPullDisabled,
     pushWorkout,
     openGarmin,
+    ACTIVITIES_PATH,
+    ACTIVITIES_KILL_SWITCH_KEY,
+    ACTIVITIES_LAST_FETCH_KEY,
+    ACTIVITIES_MIN_INTERVAL_MS,
     persistSnapshot,
     clearSnapshot,
     reinjectContentScripts,

--- a/packages/garmin-bridge/background.js
+++ b/packages/garmin-bridge/background.js
@@ -14,7 +14,7 @@ const BRIDGE_MANIFEST = {
   name: "Garmin Connect",
   version: "7.2.0",
   protocolVersion: PROTOCOL_VERSION,
-  capabilities: ["write:workouts"],
+  capabilities: ["write:workouts", "read:activities"],
 };
 
 // ── Swallowed-error telemetry ──

--- a/packages/garmin-bridge/content.js
+++ b/packages/garmin-bridge/content.js
@@ -15,6 +15,12 @@ const FETCH_TIMEOUT_MS = 30000;
 const ALLOWED = [
   { method: "GET", pattern: /^\/workout-service\/workouts(\?.*)?$/ },
   { method: "POST", pattern: /^\/workout-service\/workout$/ },
+  // Read-only pull of the athlete's recent activities (F5). GET only —
+  // the executed-activity feed is never mutated through the bridge.
+  {
+    method: "GET",
+    pattern: /^\/activitylist-service\/activities\/search\/activities(\?.*)?$/,
+  },
 ];
 
 const isAllowed = (method, path) =>

--- a/packages/garmin-bridge/kaiord-announce.js
+++ b/packages/garmin-bridge/kaiord-announce.js
@@ -19,7 +19,7 @@
 const BRIDGE_ID = "garmin-bridge";
 const BRIDGE_NAME = "Garmin Connect";
 const PROTOCOL_VERSION = 1;
-const CAPABILITIES = ["write:workouts"];
+const CAPABILITIES = ["write:workouts", "read:activities"];
 
 const isContextValid = () => {
   try {

--- a/packages/garmin-bridge/test/background.test.js
+++ b/packages/garmin-bridge/test/background.test.js
@@ -7,6 +7,8 @@ const {
   handleAction,
   getCsrfToken,
   checkSession,
+  listActivities,
+  fetchActivitiesWithBackoff,
   reinjectContentScripts,
   logSwallowed,
   TELEMETRY_KEY,
@@ -443,6 +445,123 @@ describe("background.js", () => {
       const result = await handleAction({ action: "push", gcn });
 
       expect(result).toEqual({ workoutId: 123 });
+    });
+
+    it("routes the activities action to listActivities", async () => {
+      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
+      chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) =>
+        cb({ ok: true, status: 200, data: [{ activityId: 5 }] })
+      );
+
+      const result = await handleAction({ action: "activities" });
+
+      expect(result).toEqual({
+        activities: [{ activityId: 5 }],
+        disabled: false,
+        throttled: false,
+      });
+    });
+  });
+
+  describe("listActivities", () => {
+    it("returns the raw feed and stamps the throttle timestamp on the happy path", async () => {
+      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
+      chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) =>
+        cb({ ok: true, status: 200, data: [{ activityId: 111 }] })
+      );
+
+      const result = await listActivities();
+
+      expect(result).toEqual({
+        activities: [{ activityId: 111 }],
+        disabled: false,
+        throttled: false,
+      });
+      expect(chrome.storage.session.set).toHaveBeenCalledWith(
+        expect.objectContaining({ lastActivitiesFetchAt: expect.any(Number) })
+      );
+    });
+
+    it("requests the read-only activities search endpoint", async () => {
+      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
+      chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) => {
+        expect(msg.method).toBe("GET");
+        expect(msg.path).toBe(
+          "/activitylist-service/activities/search/activities?start=0&limit=20"
+        );
+        cb({ ok: true, status: 200, data: [] });
+      });
+
+      await listActivities();
+
+      expect(chrome.tabs.sendMessage).toHaveBeenCalled();
+    });
+
+    it("short-circuits without fetching when the kill-switch flag is set", async () => {
+      await chrome.storage.local.set({ activitiesPullDisabled: true });
+      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
+
+      const result = await listActivities();
+
+      expect(result).toEqual({
+        activities: [],
+        disabled: true,
+        throttled: false,
+      });
+      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("throttles a second pull within the minimum interval", async () => {
+      await chrome.storage.session.set({ lastActivitiesFetchAt: Date.now() });
+      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
+
+      const result = await listActivities();
+
+      expect(result).toEqual({
+        activities: [],
+        disabled: false,
+        throttled: true,
+      });
+      expect(chrome.tabs.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty feed when the endpoint yields a non-array payload", async () => {
+      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
+      chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) =>
+        cb({ ok: true, status: 200, data: null })
+      );
+
+      const result = await listActivities();
+
+      expect(result.activities).toEqual([]);
+    });
+  });
+
+  describe("fetchActivitiesWithBackoff", () => {
+    it("retries a transient failure then returns the payload", async () => {
+      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
+      let calls = 0;
+      chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) => {
+        calls += 1;
+        if (calls === 1) cb({ ok: false, status: 503 });
+        else cb({ ok: true, status: 200, data: [{ activityId: 9 }] });
+      });
+
+      const result = await fetchActivitiesWithBackoff(3, 0);
+
+      expect(result).toEqual([{ activityId: 9 }]);
+      expect(calls).toBe(2);
+    });
+
+    it("throws after exhausting all attempts", async () => {
+      chrome.tabs.query.mockImplementation((q, cb) => cb([{ id: 1 }]));
+      chrome.tabs.sendMessage.mockImplementation((tabId, msg, cb) =>
+        cb({ ok: false, status: 503 })
+      );
+
+      await expect(fetchActivitiesWithBackoff(2, 0)).rejects.toThrow(
+        "Activities pull failed: 503"
+      );
     });
   });
 

--- a/packages/garmin-bridge/test/background.test.js
+++ b/packages/garmin-bridge/test/background.test.js
@@ -38,7 +38,7 @@ describe("background.js", () => {
         name: "Garmin Connect",
         version: pkg.version,
         protocolVersion: 1,
-        capabilities: ["write:workouts"],
+        capabilities: ["write:workouts", "read:activities"],
       });
     });
 
@@ -82,6 +82,8 @@ describe("background.js", () => {
       "read:body",
       "read:sleep",
       "read:training-plan",
+      "read:training-zones",
+      "read:activities",
     ]);
     return (m) => {
       const errors = [];
@@ -241,7 +243,7 @@ describe("background.js", () => {
         name: "Garmin Connect",
         version: pkg.version,
         protocolVersion: 1,
-        capabilities: ["write:workouts"],
+        capabilities: ["write:workouts", "read:activities"],
       });
     });
   });
@@ -292,7 +294,7 @@ describe("background.js", () => {
         id: "garmin-bridge",
         name: "Garmin Connect",
         protocolVersion: 1,
-        capabilities: ["write:workouts"],
+        capabilities: ["write:workouts", "read:activities"],
       });
     });
 
@@ -320,7 +322,7 @@ describe("background.js", () => {
           name: "Garmin Connect",
           version: pkg.version,
           protocolVersion: 1,
-          capabilities: ["write:workouts"],
+          capabilities: ["write:workouts", "read:activities"],
           csrfCaptured: true,
           gcApi: { ok: true, data: [{ workoutId: 1 }] },
         },
@@ -358,7 +360,7 @@ describe("background.js", () => {
         name: "Garmin Connect",
         version: pkg.version,
         protocolVersion: 1,
-        capabilities: ["write:workouts"],
+        capabilities: ["write:workouts", "read:activities"],
       });
     });
 

--- a/packages/garmin-bridge/test/content.test.js
+++ b/packages/garmin-bridge/test/content.test.js
@@ -97,6 +97,27 @@ describe("content.js", () => {
     it("rejects GET /workout-service/workout (singular without POST)", () => {
       expect(isAllowed("GET", "/workout-service/workout")).toBe(false);
     });
+
+    it("allows GET /activitylist-service/activities/search/activities", () => {
+      expect(
+        isAllowed("GET", "/activitylist-service/activities/search/activities")
+      ).toBe(true);
+    });
+
+    it("allows GET activities search with query params", () => {
+      expect(
+        isAllowed(
+          "GET",
+          "/activitylist-service/activities/search/activities?start=0&limit=20"
+        )
+      ).toBe(true);
+    });
+
+    it("rejects POST to the activities search endpoint (read-only)", () => {
+      expect(
+        isAllowed("POST", "/activitylist-service/activities/search/activities")
+      ).toBe(false);
+    });
   });
 
   describe("handleGarminFetch", () => {

--- a/packages/garmin-bridge/test/kaiord-announce.test.js
+++ b/packages/garmin-bridge/test/kaiord-announce.test.js
@@ -23,7 +23,7 @@ describe("kaiord-announce.js (garmin-bridge)", () => {
         name: "Garmin Connect",
         version: "0.2.0",
         protocolVersion: 1,
-        capabilities: ["write:workouts"],
+        capabilities: ["write:workouts", "read:activities"],
       });
     });
 

--- a/packages/garmin-bridge/test/profile-snapshot.test.js
+++ b/packages/garmin-bridge/test/profile-snapshot.test.js
@@ -5,11 +5,17 @@ import {
   validateSnapshot,
   isAllowedSenderOrigin,
 } from "../profile-snapshot.js";
-import * as bridge from "../background.js";
 import {
   positiveSnapshotFixtures,
   negativeSnapshotFixtures,
 } from "@kaiord/core/test-utils";
+
+// Load background.js via require (not import) to match background.test.js.
+// A require/import split loads background.js as two module instances, which
+// makes the v8 per-function coverage merge non-deterministic (Functions
+// oscillated 58%↔86% across identical runs). Unifying on require collapses
+// it to a single instrumented instance and stabilises coverage.
+const bridge = require("../background.js");
 
 beforeEach(() => {
   globalThis.__resetChromeMock();

--- a/packages/workout-spa-editor/e2e/garmin-activities-via-policy.spec.ts
+++ b/packages/workout-spa-editor/e2e/garmin-activities-via-policy.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * F5.3 — governed Garmin activities pull (kill test).
+ *
+ * The calendar-mount pull consults resolveImportPolicies(profileId,
+ * 'activity', 'import') BEFORE touching the bridge:
+ *   (a) no enabled activity←garmin route → the bridge `activities` action is
+ *       never called and no activity row is written (kill test);
+ *   (b) an enabled route → the pull fires and the activity is persisted.
+ *
+ * Bridge discovery + the stubbed `activities` feed use the garmin-bridge-stub
+ * helper (chrome.runtime.sendMessage is not interceptable via page.route).
+ */
+import type { Page } from "@playwright/test";
+
+import { expect, test } from "./fixtures/base";
+import {
+  GARMIN_BRIDGE_ID,
+  getGarminBridgeCallActions,
+  installGarminBridgeStub,
+} from "./helpers/garmin-bridge-stub";
+
+const PROFILE_ID = "garmin-activities-policy-e2e";
+
+type DexieDb = {
+  table: (n: string) => {
+    put: (r: unknown) => Promise<void>;
+    toArray: () => Promise<unknown[]>;
+  };
+};
+
+const stubActivity = () => ({
+  activityId: 778899,
+  startTimeLocal: "2026-07-05 07:30:00",
+  activityType: { typeKey: "cycling" },
+  duration: 3600,
+  distance: 30000,
+});
+
+const waitForDb = (page: Page): Promise<unknown> =>
+  page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
+    { timeout: 10_000 }
+  );
+
+const seedProfile = async (page: Page): Promise<void> => {
+  await page.evaluate(async (pid) => {
+    const db = (window as unknown as Record<string, unknown>)
+      .__KAIORD_DB__ as DexieDb;
+    const now = new Date().toISOString();
+    await db.table("profiles").put({
+      id: pid,
+      name: "Activities Pull Profile",
+      linkedAccounts: [],
+      sportZones: {},
+      createdAt: now,
+      updatedAt: now,
+    });
+    await db.table("meta").put({ key: "activeProfileId", value: pid });
+    await db
+      .table("userPreferences")
+      .put({ profileId: pid, calendarView: "grid", updatedAt: now });
+  }, PROFILE_ID);
+};
+
+const addActivityImportPolicy = async (page: Page): Promise<void> => {
+  await page.evaluate(
+    async ({ pid, bid }) => {
+      const db = (window as unknown as Record<string, unknown>)
+        .__KAIORD_DB__ as DexieDb;
+      const now = new Date().toISOString();
+      await db.table("integrationPolicies").put({
+        id: `policy-${bid}-activity-import`,
+        profileId: pid,
+        dataType: "activity",
+        bridgeId: bid,
+        direction: "import",
+        mode: "auto",
+        enabled: true,
+        updatedAt: now,
+      });
+    },
+    { pid: PROFILE_ID, bid: GARMIN_BRIDGE_ID }
+  );
+};
+
+const readActivities = (page: Page): Promise<unknown[]> =>
+  page.evaluate(async () => {
+    const db = (window as unknown as Record<string, unknown>)
+      .__KAIORD_DB__ as DexieDb;
+    return db.table("activities").toArray();
+  });
+
+test.describe("Garmin activities pull governance (F5.3)", () => {
+  test("should pull and persist an activity when the import route is enabled", async ({
+    page,
+  }) => {
+    // Arrange
+    await installGarminBridgeStub(page, { activities: [stubActivity()] });
+    await page.goto("/calendar");
+    await waitForDb(page);
+    await seedProfile(page);
+    await addActivityImportPolicy(page);
+
+    // Act — re-enter the calendar so the mount pull runs with the route live.
+    await page.goto("/calendar");
+    await expect
+      .poll(() => getGarminBridgeCallActions(page), { timeout: 10_000 })
+      .toContain("activities");
+
+    // Assert — the pulled activity was persisted (garmin-bridge provenance).
+    await expect
+      .poll(async () => (await readActivities(page)).length, { timeout: 8_000 })
+      .toBe(1);
+    const rows = (await readActivities(page)) as {
+      sourceBridgeId: string;
+      externalId: string;
+    }[];
+    expect(rows[0]?.sourceBridgeId).toBe("garmin-bridge");
+    expect(rows[0]?.externalId).toBe("778899");
+  });
+
+  test("should not touch the bridge or persist when no activity route is enabled", async ({
+    page,
+  }) => {
+    // Arrange — bridge online + discovered, but NO activity import policy.
+    await installGarminBridgeStub(page, { activities: [stubActivity()] });
+    await page.goto("/calendar");
+    await waitForDb(page);
+    await seedProfile(page);
+
+    // Act — discovery verifies the bridge (a `ping` fires); the gated pull runs.
+    await page.goto("/calendar");
+    await expect
+      .poll(() => getGarminBridgeCallActions(page), { timeout: 10_000 })
+      .toContain("ping");
+
+    // Assert — the pull is fail-closed: no `activities` call, no rows written.
+    expect(await getGarminBridgeCallActions(page)).not.toContain("activities");
+    expect(await readActivities(page)).toHaveLength(0);
+  });
+});

--- a/packages/workout-spa-editor/e2e/helpers/garmin-bridge-stub-page-script.ts
+++ b/packages/workout-spa-editor/e2e/helpers/garmin-bridge-stub-page-script.ts
@@ -13,6 +13,8 @@ export type GarminStubScriptArgs = {
   extensionId: string;
   bridgeId: string;
   caps: readonly string[];
+  /** Raw activity feed returned by the read-only `activities` action (F5). */
+  activities?: readonly unknown[];
 };
 
 export const installGarminStubScript = (args: GarminStubScriptArgs): void => {
@@ -37,6 +39,12 @@ export const installGarminStubScript = (args: GarminStubScriptArgs): void => {
     ping: () => wrap({ ...m, gcApi: { ok: true } }),
     push: () => wrap({ workoutId: "stub-garmin-id" }),
     list: () => wrap([]),
+    activities: () =>
+      wrap({
+        activities: args.activities ?? [],
+        disabled: false,
+        throttled: false,
+      }),
   };
   (window as unknown as Record<string, unknown>).chrome = {
     runtime: {

--- a/packages/workout-spa-editor/e2e/helpers/garmin-bridge-stub.ts
+++ b/packages/workout-spa-editor/e2e/helpers/garmin-bridge-stub.ts
@@ -13,17 +13,30 @@ import { installGarminStubScript } from "./garmin-bridge-stub-page-script";
 export const GARMIN_EXTENSION_ID = "garmin-stub-ext";
 export const GARMIN_BRIDGE_ID = "garmin-bridge";
 
-const DEFAULT_CAPS = ["write:workouts", "read:workouts"] as const;
+const DEFAULT_CAPS = [
+  "write:workouts",
+  "read:workouts",
+  "read:activities",
+] as const;
+
+export type GarminStubOptions = {
+  /** Raw Garmin activity feed the `activities` action returns (F5). */
+  activities?: readonly unknown[];
+};
 
 /**
  * Install the bridge stub. Call BEFORE `page.goto(...)` so the
  * `addInitScript` runs before the SPA boots and bridge-discovery starts.
  */
-export const installGarminBridgeStub = async (page: Page): Promise<void> => {
+export const installGarminBridgeStub = async (
+  page: Page,
+  options: GarminStubOptions = {}
+): Promise<void> => {
   await page.addInitScript(installGarminStubScript, {
     extensionId: GARMIN_EXTENSION_ID,
     bridgeId: GARMIN_BRIDGE_ID,
     caps: DEFAULT_CAPS,
+    activities: options.activities ?? [],
   });
 };
 

--- a/packages/workout-spa-editor/src/adapters/bridge/garmin-activities-transport.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/garmin-activities-transport.ts
@@ -1,0 +1,33 @@
+/**
+ * Bridge transport for the read-only Garmin activities pull (F5).
+ *
+ * Sends the `activities` action to the garmin-bridge extension and validates
+ * the envelope with `safeParse` before it crosses into the application layer
+ * (defense-in-depth against a Garmin API shape drift). The bridge already
+ * enforces throttle/backoff/kill-switch; this layer only transports + parses.
+ */
+import {
+  type GarminActivitiesResponse,
+  garminActivitiesResponseSchema,
+} from "../../application/import/garmin-activity-schema";
+import { sendBridgeMessage } from "./bridge-transport";
+
+const ACTIVITIES_TIMEOUT_MS = 15_000;
+
+export const readGarminActivities = async (
+  extensionId: string
+): Promise<GarminActivitiesResponse> => {
+  const res = await sendBridgeMessage(
+    extensionId,
+    { action: "activities" },
+    ACTIVITIES_TIMEOUT_MS
+  );
+  if (!res.ok) {
+    throw new Error(res.error ?? "Garmin activities pull failed");
+  }
+  const parsed = garminActivitiesResponseSchema.safeParse(res.data);
+  if (!parsed.success) {
+    throw new Error("Malformed Garmin activities response");
+  }
+  return parsed.data;
+};

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-activity-repository.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-activity-repository.ts
@@ -21,4 +21,11 @@ export const createDexieActivityRepository = (
     await table.add(record);
     return { created: true };
   },
+
+  getByProfileAndDateRange: async (profileId, start, end) =>
+    db
+      .table<ActivityRecord>("activities")
+      .where("[profileId+date]")
+      .between([profileId, start], [profileId, end], true, true)
+      .toArray(),
 });

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-matched-sessions-read-model.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-matched-sessions-read-model.ts
@@ -6,7 +6,9 @@
  * `useLiveQuery` reactivity is preserved when the hooks read through the port.
  */
 
+import { activityToWorkoutRecord } from "../../application/coaching/activity-to-workout-record";
 import type { MatchedSessionsReadModel } from "../../ports/matched-sessions-read-model";
+import type { ActivityRecord } from "../../types/activity-record";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { CoachingActivityRecord } from "../../types/coaching-activity-record";
 import type { SessionMatch } from "../../types/session-match";
@@ -17,24 +19,39 @@ export function createDexieMatchedSessionsReadModel(
 ): MatchedSessionsReadModel {
   const activities = () =>
     db.table<CoachingActivityRecord>("coachingActivities");
+  const executedActivities = () => db.table<ActivityRecord>("activities");
   const workouts = () => db.table<WorkoutRecord>("workouts");
   const sessionMatches = () => db.table<SessionMatch>("sessionMatches");
 
   return {
     loadJoinSources: async (activityIds, workoutIds) => {
-      const [activityRows, workoutRows] = await Promise.all([
-        activities()
-          .where("id")
-          .anyOf([...activityIds])
-          .toArray(),
-        workouts()
-          .where("id")
-          .anyOf([...workoutIds])
-          .toArray(),
-      ]);
+      const [activityRows, workoutRows, executedActivityRows] =
+        await Promise.all([
+          activities()
+            .where("id")
+            .anyOf([...activityIds])
+            .toArray(),
+          workouts()
+            .where("id")
+            .anyOf([...workoutIds])
+            .toArray(),
+          executedActivities()
+            .where("id")
+            .anyOf([...workoutIds])
+            .toArray(),
+        ]);
+      const workoutsById = new Map(workoutRows.map((w) => [w.id, w]));
+      // No-twin executed activities (e.g. the Garmin pull) have no
+      // WorkoutRecord; project one so the executed slot renders through the
+      // unchanged resolveExecuted join. Real WorkoutRecords win on id clash.
+      for (const a of executedActivityRows) {
+        if (!workoutsById.has(a.id)) {
+          workoutsById.set(a.id, activityToWorkoutRecord(a));
+        }
+      }
       return {
         activitiesById: new Map(activityRows.map((a) => [a.id, a])),
-        workoutsById: new Map(workoutRows.map((w) => [w.id, w])),
+        workoutsById,
       };
     },
 

--- a/packages/workout-spa-editor/src/adapters/dexie/dexie-snapshot-port.ts
+++ b/packages/workout-spa-editor/src/adapters/dexie/dexie-snapshot-port.ts
@@ -20,6 +20,14 @@ import type { KaiordDatabase } from "./dexie-database";
 
 const TOMBSTONES = "tombstones";
 // Device-local; never exported to / imported from a remote snapshot.
+//
+// The v27 `activities` store (executed sessions) is intentionally NOT listed
+// here: it rides the cloud snapshot like `workouts`, `plannedSessions`, and
+// the health stores — it is user fitness data that must sync cross-device. F5
+// retired the transitional dual-write (executed FIT drops used to also write a
+// twin WorkoutRecord, which syncs), so `activities` staying in the snapshot set
+// preserves cross-device parity. Snapshot-at-rest encryption of this fitness
+// data is tracked as a separate epic (Phase-4 security note, LOW).
 const DEVICE_LOCAL = new Set([
   TOMBSTONES,
   "connections",

--- a/packages/workout-spa-editor/src/application/chat/tools/build-chat-tools.test.ts
+++ b/packages/workout-spa-editor/src/application/chat/tools/build-chat-tools.test.ts
@@ -3,22 +3,25 @@ import { describe, expect, it, vi } from "vitest";
 import { createInMemoryPersistence } from "../../../test-utils/in-memory-persistence";
 import { buildChatTools } from "./build-chat-tools";
 
+const makeDeps = () => ({
+  persistence: createInMemoryPersistence(),
+  profileId: "p1",
+  today: "2026-06-13",
+  actions: {
+    syncCoaching: vi.fn(),
+    createWorkout: vi.fn(),
+    logHealthMetric: vi.fn(),
+    logIntake: vi.fn(),
+    pushToGarmin: vi.fn(),
+    setDataRoute: vi.fn(),
+  },
+  getMatrixSignals: vi.fn(),
+});
+
 describe("buildChatTools", () => {
   it("should assemble the full read + action tool registry", () => {
     // Arrange
-    const persistence = createInMemoryPersistence();
-    const deps = {
-      persistence,
-      profileId: "p1",
-      today: "2026-06-13",
-      actions: {
-        syncCoaching: vi.fn(),
-        createWorkout: vi.fn(),
-        logHealthMetric: vi.fn(),
-        logIntake: vi.fn(),
-        pushToGarmin: vi.fn(),
-      },
-    };
+    const deps = makeDeps();
 
     // Act
     const tools = buildChatTools(deps);
@@ -26,6 +29,7 @@ describe("buildChatTools", () => {
     // Assert
     expect(tools.map((t) => t.name).sort()).toEqual([
       "create_workout",
+      "get_data_routes",
       "get_today",
       "log_health_metric",
       "log_intake",
@@ -34,25 +38,14 @@ describe("buildChatTools", () => {
       "query_energy_balance",
       "query_health",
       "query_workouts",
+      "set_data_route",
       "sync_coaching",
     ]);
   });
 
-  it("should mark exactly the five action tools as requiring confirmation", () => {
+  it("should mark exactly the six action tools as requiring confirmation", () => {
     // Arrange
-    const persistence = createInMemoryPersistence();
-    const deps = {
-      persistence,
-      profileId: "p1",
-      today: "2026-06-13",
-      actions: {
-        syncCoaching: vi.fn(),
-        createWorkout: vi.fn(),
-        logHealthMetric: vi.fn(),
-        logIntake: vi.fn(),
-        pushToGarmin: vi.fn(),
-      },
-    };
+    const deps = makeDeps();
 
     // Act
     const confirmed = buildChatTools(deps)
@@ -66,6 +59,7 @@ describe("buildChatTools", () => {
       "log_health_metric",
       "log_intake",
       "push_to_garmin",
+      "set_data_route",
       "sync_coaching",
     ]);
   });

--- a/packages/workout-spa-editor/src/application/chat/tools/build-chat-tools.ts
+++ b/packages/workout-spa-editor/src/application/chat/tools/build-chat-tools.ts
@@ -6,6 +6,7 @@ import {
   createSyncCoachingTool,
 } from "./action-tools";
 import type { ChatToolDeps } from "./chat-tool-deps";
+import { createGetDataRoutesTool } from "./get-data-routes-tool";
 import { createGetTodayTool } from "./get-today-tool";
 import { createLogIntakeTool } from "./log-intake-tool";
 import { createPushToGarminTool } from "./push-to-garmin-tool";
@@ -13,6 +14,7 @@ import { createQueryCoachingTool } from "./query-coaching-tool";
 import { createQueryEnergyBalanceTool } from "./query-energy-balance-tool";
 import { createQueryHealthTool } from "./query-health-tool";
 import { createQueryWorkoutsTool } from "./query-workouts-tool";
+import { createSetDataRouteTool } from "./set-data-route-tool";
 
 /**
  * Assembles the full chat tool registry for one conversation. Read tools
@@ -32,10 +34,15 @@ export const buildChatTools = (deps: ChatToolDeps): ChatTool[] => {
     createQueryHealthTool(read),
     createQueryEnergyBalanceTool(read),
     createQueryCoachingTool(read),
+    createGetDataRoutesTool({
+      ...read,
+      getMatrixSignals: deps.getMatrixSignals,
+    }),
     createSyncCoachingTool(deps.actions),
     createCreateWorkoutTool(deps.actions),
     createLogHealthMetricTool(deps.actions),
     createLogIntakeTool(deps.actions),
     createPushToGarminTool(deps.actions),
+    createSetDataRouteTool(deps.actions),
   ];
 };

--- a/packages/workout-spa-editor/src/application/chat/tools/chat-tool-deps.ts
+++ b/packages/workout-spa-editor/src/application/chat/tools/chat-tool-deps.ts
@@ -7,9 +7,12 @@
  * sync, workout-generation, and manual-health use cases) so the
  * application layer never reaches into React or Dexie directly.
  */
-import type { MealSlot } from "@kaiord/core";
+import type { ManagedDataType, MealSlot } from "@kaiord/core";
 
 import type { PersistencePort } from "../../../ports/persistence-port";
+import type { DataTypeSourceMode } from "../../../types/data-type-source-policy";
+import type { IntegrationPolicyDirection } from "../../../types/integration-policy";
+import type { DataHubMatrixSignals } from "../../data-hub/build-data-hub-matrix";
 import type { ManualHealthMetric } from "../../health/manual-health-metric";
 
 export type ReadToolDeps = {
@@ -45,12 +48,40 @@ export type PushToGarminInput = {
   workoutId: string;
 };
 
+/**
+ * `set_data_route` input (F6). `integrationId` is the chat-facing
+ * INTEGRATION_REGISTRY id (e.g. "whoop", "train2go"), resolved to the
+ * IntegrationPolicy/DataTypeSourcePolicy storage key (the bridge id) by
+ * the op implementation — see hooks/chat/do-set-data-route.ts. A
+ * `set_source_policy` sourceOrder of a single integration id means "read
+ * only from that source" (the resolver's reconciliation invariant already
+ * ignores sources outside the order).
+ */
+export type SetDataRouteInput =
+  | {
+      action: "enable_route" | "disable_route";
+      dataType: ManagedDataType;
+      integrationId: string;
+      direction: IntegrationPolicyDirection;
+    }
+  | {
+      action: "set_source_policy";
+      dataType: ManagedDataType;
+      mode: DataTypeSourceMode;
+      sourceOrder?: string[];
+    };
+
 export type ChatActionOps = {
   syncCoaching: () => Promise<unknown>;
   createWorkout: (input: CreateWorkoutInput) => Promise<unknown>;
   logHealthMetric: (input: LogHealthMetricInput) => Promise<unknown>;
   logIntake: (input: LogIntakeInput) => Promise<unknown>;
   pushToGarmin: (input: PushToGarminInput) => Promise<unknown>;
+  setDataRoute: (input: SetDataRouteInput) => Promise<unknown>;
 };
 
-export type ChatToolDeps = ReadToolDeps & { actions: ChatActionOps };
+export type ChatToolDeps = ReadToolDeps & {
+  actions: ChatActionOps;
+  /** One-shot snapshot provider for the get_data_routes read tool. */
+  getMatrixSignals: () => Promise<DataHubMatrixSignals>;
+};

--- a/packages/workout-spa-editor/src/application/chat/tools/data-route-answer.test.ts
+++ b/packages/workout-spa-editor/src/application/chat/tools/data-route-answer.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+
+import { createInMemoryPersistence } from "../../../test-utils/in-memory-persistence";
+import type { DataHubRow } from "../../data-hub/build-data-hub-matrix";
+import { buildDataRouteAnswer } from "./data-route-answer";
+
+const PROFILE_ID = "p1";
+const DAY = "2026-07-07";
+
+const row = (over: Partial<DataHubRow> = {}): DataHubRow => ({
+  dataType: "planned-session",
+  label: "Planned Session",
+  cells: [
+    {
+      integrationId: "train2go",
+      direction: "import",
+      state: "active",
+      enabled: true,
+      lastSyncedAt: "2026-07-06T08:00:00.000Z",
+      routeId: "route-1",
+      routeMode: "auto",
+    },
+    {
+      integrationId: "manual",
+      direction: "import",
+      state: "na",
+      enabled: false,
+    },
+  ],
+  ...over,
+});
+
+describe("buildDataRouteAnswer", () => {
+  it("should default the source policy to union with an empty order when unset", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const answer = await buildDataRouteAnswer(row(), {
+      persistence,
+      profileId: PROFILE_ID,
+      today: DAY,
+    });
+
+    // Assert
+    expect(answer.sourcePolicy).toEqual({ mode: "union", sourceOrder: [] });
+  });
+
+  it("should surface a persisted source policy's mode and order", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    await persistence.dataTypeSourcePolicy.put({
+      profileId: PROFILE_ID,
+      dataType: "planned-session",
+      mode: "priority",
+      sourceOrder: ["train2go-bridge"],
+    });
+
+    // Act
+    const answer = await buildDataRouteAnswer(row(), {
+      persistence,
+      profileId: PROFILE_ID,
+      today: DAY,
+    });
+
+    // Assert
+    expect(answer.sourcePolicy).toEqual({
+      mode: "priority",
+      sourceOrder: ["train2go-bridge"],
+    });
+  });
+
+  it("should drop not-applicable cells from the routes list", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const answer = await buildDataRouteAnswer(row(), {
+      persistence,
+      profileId: PROFILE_ID,
+      today: DAY,
+    });
+
+    // Assert
+    expect(answer.routes).toHaveLength(1);
+    expect(answer.routes[0]).toMatchObject({
+      integrationId: "train2go",
+      enabled: true,
+      mode: "auto",
+      lastSyncedAt: "2026-07-06T08:00:00.000Z",
+    });
+  });
+
+  it("should omit effectiveSourceToday for a non-health data type", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const answer = await buildDataRouteAnswer(row(), {
+      persistence,
+      profileId: PROFILE_ID,
+      today: DAY,
+    });
+
+    // Assert
+    expect(answer.effectiveSourceToday).toBeUndefined();
+  });
+
+  it("should summarize union sources for a health data type", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    await persistence.healthSleep.put({
+      id: "s1",
+      profileId: PROFILE_ID,
+      date: DAY,
+      krd: { hours: 8 } as never,
+      sourceBridgeId: "whoop-bridge",
+    });
+    await persistence.healthSleep.put({
+      id: "s2",
+      profileId: PROFILE_ID,
+      date: DAY,
+      krd: { hours: 7 } as never,
+      sourceBridgeId: "garmin-bridge",
+    });
+
+    // Act
+    const answer = await buildDataRouteAnswer(row({ dataType: "sleep" }), {
+      persistence,
+      profileId: PROFILE_ID,
+      today: DAY,
+    });
+
+    // Assert
+    expect(answer.effectiveSourceToday).toEqual({
+      mode: "union",
+      sources: ["whoop-bridge", "garmin-bridge"],
+    });
+  });
+
+  it("should summarize the priority winner and fallback flag for a health data type", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    await persistence.dataTypeSourcePolicy.put({
+      profileId: PROFILE_ID,
+      dataType: "sleep",
+      mode: "priority",
+      sourceOrder: ["whoop-bridge", "garmin-bridge"],
+    });
+    await persistence.integrationPolicy.put({
+      id: "ip1",
+      profileId: PROFILE_ID,
+      dataType: "sleep",
+      bridgeId: "garmin-bridge",
+      direction: "import",
+      mode: "auto",
+      enabled: true,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    });
+    await persistence.healthSleep.put({
+      id: "s3",
+      profileId: PROFILE_ID,
+      date: DAY,
+      krd: { hours: 7 } as never,
+      sourceBridgeId: "garmin-bridge",
+    });
+
+    // Act
+    const answer = await buildDataRouteAnswer(row({ dataType: "sleep" }), {
+      persistence,
+      profileId: PROFILE_ID,
+      today: DAY,
+    });
+
+    // Assert
+    // whoop-bridge is ranked first but has no enabled import policy, so the
+    // reconciled order picks garmin-bridge without treating it as a fallback.
+    expect(answer.effectiveSourceToday).toEqual({
+      mode: "priority",
+      effectiveSource: "garmin-bridge",
+      usedFallback: false,
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/application/chat/tools/data-route-answer.ts
+++ b/packages/workout-spa-editor/src/application/chat/tools/data-route-answer.ts
@@ -1,0 +1,80 @@
+/**
+ * buildDataRouteAnswer — one managed-data-type's routing state, shared by
+ * the `get_data_routes` read tool and the `set_data_route` confirmation
+ * result. Reuses the exact Data Hub matrix cell derivation and the F3.2
+ * multi-source resolver — the chat answer is never a second source of
+ * truth against the Settings matrix.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { PersistencePort } from "../../../ports/persistence-port";
+import type {
+  IntegrationPolicyDirection,
+  IntegrationPolicyMode,
+} from "../../../types/integration-policy";
+import type {
+  DataHubCellState,
+  DataHubRow,
+} from "../../data-hub/build-data-hub-matrix";
+import {
+  type EffectiveSourceAnswer,
+  getEffectiveSourceToday,
+} from "./effective-source-today";
+
+export type DataRouteEntry = {
+  integrationId: string;
+  direction: IntegrationPolicyDirection;
+  state: DataHubCellState;
+  enabled: boolean;
+  mode?: IntegrationPolicyMode;
+  lastSyncedAt?: string;
+};
+
+export type DataRouteAnswer = {
+  dataType: ManagedDataType;
+  label: string;
+  routes: DataRouteEntry[];
+  sourcePolicy: { mode: "union" | "priority"; sourceOrder: string[] };
+  effectiveSourceToday?: EffectiveSourceAnswer;
+};
+
+export type DataRouteAnswerDeps = {
+  persistence: PersistencePort;
+  profileId: string;
+  today: string;
+};
+
+export const buildDataRouteAnswer = async (
+  row: DataHubRow,
+  deps: DataRouteAnswerDeps
+): Promise<DataRouteAnswer> => {
+  const sourcePolicy =
+    await deps.persistence.dataTypeSourcePolicy.findByProfileAndType({
+      profileId: deps.profileId,
+      dataType: row.dataType,
+    });
+  return {
+    dataType: row.dataType,
+    label: row.label,
+    routes: row.cells
+      .filter((cell) => cell.state !== "na")
+      .map((cell) => ({
+        integrationId: cell.integrationId,
+        direction: cell.direction,
+        state: cell.state,
+        enabled: cell.enabled,
+        mode: cell.routeMode,
+        lastSyncedAt: cell.lastSyncedAt,
+      })),
+    sourcePolicy: {
+      mode: sourcePolicy?.mode ?? "union",
+      sourceOrder: sourcePolicy?.sourceOrder ?? [],
+    },
+    effectiveSourceToday: await getEffectiveSourceToday(
+      deps.persistence,
+      deps.profileId,
+      row.dataType,
+      deps.today
+    ),
+  };
+};

--- a/packages/workout-spa-editor/src/application/chat/tools/effective-source-today.ts
+++ b/packages/workout-spa-editor/src/application/chat/tools/effective-source-today.ts
@@ -1,0 +1,50 @@
+/**
+ * getEffectiveSourceToday — today's effective health source for one
+ * managed data type, summarized for the chat hub tools. Reuses the F3.2
+ * multi-source resolver; only health-record-backed types have a
+ * meaningful answer (everything else is undefined).
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { PersistencePort } from "../../../ports/persistence-port";
+import {
+  getHealthRecordsForDay,
+  HEALTH_REPO_KEY_FOR_TYPE,
+} from "../../data-source-policy/get-health-records-for-day";
+import {
+  resolveEffectiveSource,
+  type ResolveEffectiveSourceResult,
+} from "../../data-source-policy/resolve-effective-source.use-case";
+
+export type EffectiveSourceAnswer =
+  | { mode: "union"; sources: string[] }
+  | { mode: "priority"; effectiveSource?: string; usedFallback: boolean };
+
+const summarize = (
+  result: ResolveEffectiveSourceResult<unknown>
+): EffectiveSourceAnswer =>
+  result.mode === "union"
+    ? { mode: "union", sources: result.records.map((r) => r.sourceBridgeId) }
+    : {
+        mode: "priority",
+        effectiveSource: result.effective?.sourceBridgeId,
+        usedFallback: result.usedFallback,
+      };
+
+export const getEffectiveSourceToday = async (
+  persistence: PersistencePort,
+  profileId: string,
+  dataType: ManagedDataType,
+  day: string
+): Promise<EffectiveSourceAnswer | undefined> => {
+  if (!(dataType in HEALTH_REPO_KEY_FOR_TYPE)) return undefined;
+  const result = await resolveEffectiveSource<unknown>(
+    {
+      sourcePolicyRepo: persistence.dataTypeSourcePolicy,
+      policyRepo: persistence.integrationPolicy,
+      getRecordsForDay: (i) => getHealthRecordsForDay(persistence, i),
+    },
+    { profileId, dataType, day }
+  );
+  return summarize(result);
+};

--- a/packages/workout-spa-editor/src/application/chat/tools/get-data-routes-tool.test.ts
+++ b/packages/workout-spa-editor/src/application/chat/tools/get-data-routes-tool.test.ts
@@ -1,0 +1,116 @@
+import { managedDataTypes } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import { createInMemoryPersistence } from "../../../test-utils/in-memory-persistence";
+import type { DataHubMatrixSignals } from "../../data-hub/build-data-hub-matrix";
+import { createGetDataRoutesTool } from "./get-data-routes-tool";
+
+const PROFILE_ID = "p1";
+const TODAY = "2026-07-07";
+
+const signals = (): DataHubMatrixSignals => ({
+  isConnected: () => false,
+  isBridgeOnline: (bridgeId) => bridgeId === "train2go-bridge",
+  bridgeAnnounces: (bridgeId, token) =>
+    bridgeId === "train2go-bridge" && token === "read:training-plan",
+  isRouteEnabled: (dataType, direction, bridgeId) =>
+    dataType === "planned-session" &&
+    direction === "import" &&
+    bridgeId === "train2go-bridge",
+  lastSyncedAt: (id) =>
+    id === "train2go" ? "2026-07-06T08:00:00.000Z" : undefined,
+  findRoute: (dataType, direction, bridgeId) =>
+    dataType === "planned-session" &&
+    direction === "import" &&
+    bridgeId === "train2go-bridge"
+      ? { id: "route-1", mode: "auto" as const }
+      : undefined,
+});
+
+type ToolResult = { day: string; dataTypes: Array<{ dataType: string }> };
+
+describe("createGetDataRoutesTool", () => {
+  it("should be a read tool that never requires confirmation", () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const tool = createGetDataRoutesTool({
+      persistence,
+      profileId: PROFILE_ID,
+      today: TODAY,
+      getMatrixSignals: async () => signals(),
+    });
+
+    // Act
+
+    // Assert
+    expect(tool.requiresConfirmation).toBe(false);
+    expect(tool.name).toBe("get_data_routes");
+  });
+
+  it("should return every managed data type when no filter is given", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const tool = createGetDataRoutesTool({
+      persistence,
+      profileId: PROFILE_ID,
+      today: TODAY,
+      getMatrixSignals: async () => signals(),
+    });
+
+    // Act
+    const result = (await tool.execute({})) as ToolResult;
+
+    // Assert
+    expect(result.dataTypes.map((d) => d.dataType).sort()).toEqual(
+      [...managedDataTypes].sort()
+    );
+  });
+
+  it("should restrict the answer to the requested data type", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const tool = createGetDataRoutesTool({
+      persistence,
+      profileId: PROFILE_ID,
+      today: TODAY,
+      getMatrixSignals: async () => signals(),
+    });
+
+    // Act
+    const result = (await tool.execute({
+      dataType: "planned-session",
+    })) as ToolResult;
+
+    // Assert
+    expect(result.dataTypes).toHaveLength(1);
+    expect(result.dataTypes[0].dataType).toBe("planned-session");
+  });
+
+  it("should name the real active source for a routed data type", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    const tool = createGetDataRoutesTool({
+      persistence,
+      profileId: PROFILE_ID,
+      today: TODAY,
+      getMatrixSignals: async () => signals(),
+    });
+
+    // Act
+    const result = (await tool.execute({ dataType: "planned-session" })) as {
+      dataTypes: Array<{
+        routes: Array<{
+          integrationId: string;
+          state: string;
+          enabled: boolean;
+        }>;
+      }>;
+    };
+
+    // Assert
+    const route = result.dataTypes[0].routes.find(
+      (r) => r.integrationId === "train2go"
+    );
+    expect(route).toMatchObject({ state: "active", enabled: true });
+  });
+});

--- a/packages/workout-spa-editor/src/application/chat/tools/get-data-routes-tool.ts
+++ b/packages/workout-spa-editor/src/application/chat/tools/get-data-routes-tool.ts
@@ -1,0 +1,65 @@
+/**
+ * get_data_routes — read tool (auto-executed) answering "where do my X
+ * come from / go to" for the active profile. Reuses `buildDataHubMatrix`
+ * (same derivation as the Settings matrix) so this is never a second
+ * source of truth; `getMatrixSignals` is injected so this stays adapter
+ * and React-free (see hooks/chat/build-data-route-signals.ts).
+ */
+import type { ChatTool } from "@kaiord/ai";
+import { managedDataTypes } from "@kaiord/core";
+import { z } from "zod";
+
+import { INTEGRATION_REGISTRY } from "../../../integrations/integration-registry";
+import {
+  buildDataHubMatrix,
+  type DataHubMatrixSignals,
+} from "../../data-hub/build-data-hub-matrix";
+import type { ReadToolDeps } from "./chat-tool-deps";
+import { buildDataRouteAnswer } from "./data-route-answer";
+
+const inputSchema = z.object({
+  dataType: z
+    .enum(managedDataTypes)
+    .optional()
+    .describe(
+      "Restrict to one managed data type, e.g. planned-session, activity, " +
+        "or sleep. Omit to return every data type."
+    ),
+});
+
+export type GetDataRoutesDeps = ReadToolDeps & {
+  /** One-shot snapshot of the live matrix signals (bridge discovery,
+      connections, IntegrationPolicy rows, Train2Go freshness). */
+  getMatrixSignals: () => Promise<DataHubMatrixSignals>;
+};
+
+export const createGetDataRoutesTool = (deps: GetDataRoutesDeps): ChatTool => ({
+  name: "get_data_routes",
+  description:
+    "Read the Data Hub routing for the active profile: which integration " +
+    "each data type (planned sessions, activities, workouts, health " +
+    "metrics, ...) is imported from or exported to, whether the route is " +
+    "enabled, its multi-source semantics (union or priority order), " +
+    "freshness (last synced), and — for health metrics — today's " +
+    "effective source. Use it for questions like 'where do my planned " +
+    "sessions come from' or 'what syncs to Garmin'.",
+  inputSchema,
+  requiresConfirmation: false,
+  execute: async (raw) => {
+    const input = inputSchema.parse(raw);
+    const signals = await deps.getMatrixSignals();
+    const rows = buildDataHubMatrix(INTEGRATION_REGISTRY, signals).filter(
+      (row) => !input.dataType || row.dataType === input.dataType
+    );
+    const dataTypes = await Promise.all(
+      rows.map((row) =>
+        buildDataRouteAnswer(row, {
+          persistence: deps.persistence,
+          profileId: deps.profileId,
+          today: deps.today,
+        })
+      )
+    );
+    return { day: deps.today, dataTypes };
+  },
+});

--- a/packages/workout-spa-editor/src/application/chat/tools/set-data-route-tool.test.ts
+++ b/packages/workout-spa-editor/src/application/chat/tools/set-data-route-tool.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChatActionOps } from "./chat-tool-deps";
+import { createSetDataRouteTool } from "./set-data-route-tool";
+
+const makeOps = (over: Partial<ChatActionOps> = {}): ChatActionOps => ({
+  syncCoaching: vi.fn(),
+  createWorkout: vi.fn(),
+  logHealthMetric: vi.fn(),
+  logIntake: vi.fn(),
+  pushToGarmin: vi.fn(),
+  setDataRoute: over.setDataRoute ?? vi.fn().mockResolvedValue({ ok: true }),
+});
+
+describe("createSetDataRouteTool", () => {
+  it("should require confirmation", () => {
+    // Arrange
+    const tool = createSetDataRouteTool(makeOps());
+
+    // Act
+
+    // Assert
+    expect(tool.requiresConfirmation).toBe(true);
+    expect(tool.name).toBe("set_data_route");
+  });
+
+  it("should delegate an enable_route call to the injected op", async () => {
+    // Arrange
+    const setDataRoute = vi.fn().mockResolvedValue({ enabled: true });
+    const tool = createSetDataRouteTool(makeOps({ setDataRoute }));
+    const input = {
+      action: "enable_route",
+      dataType: "planned-session",
+      integrationId: "train2go",
+      direction: "import",
+    };
+
+    // Act
+    const result = await tool.execute(input);
+
+    // Assert
+    expect(setDataRoute).toHaveBeenCalledWith(input);
+    expect(result).toEqual({ enabled: true });
+  });
+
+  it("should delegate a set_source_policy call with a single-source priority order", async () => {
+    // Arrange
+    const setDataRoute = vi.fn().mockResolvedValue({ mode: "priority" });
+    const tool = createSetDataRouteTool(makeOps({ setDataRoute }));
+    const input = {
+      action: "set_source_policy",
+      dataType: "sleep",
+      mode: "priority",
+      sourceOrder: ["whoop"],
+    };
+
+    // Act
+    await tool.execute(input);
+
+    // Assert
+    expect(setDataRoute).toHaveBeenCalledWith(input);
+  });
+
+  it("should reject an input with an unknown action", () => {
+    // Arrange
+    const tool = createSetDataRouteTool(makeOps());
+
+    // Act
+    const parsed = tool.inputSchema.safeParse({
+      action: "delete_route",
+      dataType: "sleep",
+      integrationId: "whoop",
+      direction: "import",
+    });
+
+    // Assert
+    expect(parsed.success).toBe(false);
+  });
+
+  it("should reject enable_route input missing the direction field", () => {
+    // Arrange
+    const tool = createSetDataRouteTool(makeOps());
+
+    // Act
+    const parsed = tool.inputSchema.safeParse({
+      action: "enable_route",
+      dataType: "sleep",
+      integrationId: "whoop",
+    });
+
+    // Assert
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/packages/workout-spa-editor/src/application/chat/tools/set-data-route-tool.ts
+++ b/packages/workout-spa-editor/src/application/chat/tools/set-data-route-tool.ts
@@ -1,0 +1,58 @@
+/**
+ * set_data_route — action tool (confirmation-gated) for changing Data Hub
+ * routing: enable/disable a (dataType, integration, direction) route, or
+ * set a data type's multi-source semantics (union, or a priority order of
+ * integrations with automatic fallback). Delegates to the injected
+ * `ChatActionOps.setDataRoute`, which wraps the same IntegrationPolicy
+ * upsert/delete and DataTypeSourcePolicy write paths the Settings matrix
+ * uses — no new write path.
+ */
+import type { ChatTool } from "@kaiord/ai";
+import { managedDataTypes } from "@kaiord/core";
+import { z } from "zod";
+
+import { dataTypeSourceModeSchema } from "../../../types/data-type-source-policy";
+import { integrationPolicyDirectionSchema } from "../../../types/integration-policy";
+import type { ChatActionOps } from "./chat-tool-deps";
+
+const routeFields = {
+  dataType: z.enum(managedDataTypes),
+  integrationId: z
+    .string()
+    .min(1)
+    .describe("Integration id, e.g. garmin, whoop, train2go, manual"),
+  direction: integrationPolicyDirectionSchema,
+};
+
+const setDataRouteSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("enable_route"), ...routeFields }),
+  z.object({ action: z.literal("disable_route"), ...routeFields }),
+  z.object({
+    action: z.literal("set_source_policy"),
+    dataType: z.enum(managedDataTypes),
+    mode: dataTypeSourceModeSchema,
+    sourceOrder: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Integration ids in priority order, most preferred first. Only " +
+          "used when mode is priority; a single id means read only from " +
+          "that source (e.g. 'read sleep only from Whoop' -> mode " +
+          "priority, sourceOrder ['whoop'])."
+      ),
+  }),
+]);
+
+export const createSetDataRouteTool = (ops: ChatActionOps): ChatTool => ({
+  name: "set_data_route",
+  description:
+    "Change Data Hub routing for the active profile. enable_route / " +
+    "disable_route turn a (data type, integration, direction) route on or " +
+    "off. set_source_policy sets whether a data type merges every enabled " +
+    "source (union, the default) or reads a priority order with automatic " +
+    "fallback (priority). Requires the user to confirm before running; " +
+    "the result reflects the new persisted state.",
+  inputSchema: setDataRouteSchema,
+  requiresConfirmation: true,
+  execute: (raw) => ops.setDataRoute(setDataRouteSchema.parse(raw)),
+});

--- a/packages/workout-spa-editor/src/application/coaching/activity-to-workout-record.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/activity-to-workout-record.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import { buildSourceActivityRecord } from "../../types/activity-record";
-import { activityToWorkoutRecord } from "./activity-to-workout-record";
+import type { WorkoutRecord } from "../../types/calendar-record";
+import {
+  activityToWorkoutRecord,
+  isProjectedWorkoutRecord,
+} from "./activity-to-workout-record";
 
 describe("activityToWorkoutRecord", () => {
   it("should project a source activity into a renderable WorkoutRecord", () => {
@@ -51,5 +55,54 @@ describe("activityToWorkoutRecord", () => {
     // Assert
     expect(workout.raw?.duration).toBeNull();
     expect(workout.raw?.distance).toBeNull();
+  });
+
+  it("should mark the projection so callers can route it away from the editor", () => {
+    // Arrange
+    const activity = buildSourceActivityRecord({
+      profileId: "p1",
+      date: "2026-07-05",
+      sport: "cycling",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "9",
+    });
+
+    // Act
+    const workout = activityToWorkoutRecord(activity);
+
+    // Assert
+    expect(workout.projectedFromActivity).toBe(true);
+    expect(isProjectedWorkoutRecord(workout)).toBe(true);
+  });
+
+  it("should not flag a real persisted WorkoutRecord as projected", () => {
+    // Arrange
+    const persisted: WorkoutRecord = {
+      id: "w-1",
+      profileId: "p1",
+      date: "2026-07-05",
+      sport: "cycling",
+      source: "kaiord",
+      sourceId: null,
+      planId: null,
+      state: "structured",
+      raw: null,
+      krd: null,
+      lastProcessingError: null,
+      feedback: null,
+      aiMeta: null,
+      garminPushId: null,
+      tags: [],
+      previousState: null,
+      createdAt: "2026-07-05T00:00:00.000Z",
+      modifiedAt: null,
+      updatedAt: "2026-07-05T00:00:00.000Z",
+    };
+
+    // Act
+    const result = isProjectedWorkoutRecord(persisted);
+
+    // Assert
+    expect(result).toBe(false);
   });
 });

--- a/packages/workout-spa-editor/src/application/coaching/activity-to-workout-record.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/activity-to-workout-record.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSourceActivityRecord } from "../../types/activity-record";
+import { activityToWorkoutRecord } from "./activity-to-workout-record";
+
+describe("activityToWorkoutRecord", () => {
+  it("should project a source activity into a renderable WorkoutRecord", () => {
+    // Arrange
+    const activity = buildSourceActivityRecord({
+      profileId: "p1",
+      date: "2026-07-05",
+      sport: "running",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "555",
+      durationSeconds: 3600,
+      distanceMeters: 10000,
+    });
+
+    // Act
+    const workout = activityToWorkoutRecord(activity);
+
+    // Assert
+    expect(workout).toMatchObject({
+      id: activity.id,
+      profileId: "p1",
+      date: "2026-07-05",
+      sport: "running",
+      source: "garmin-bridge",
+      sourceId: "555",
+      state: "structured",
+      raw: {
+        duration: { value: 3600, unit: "s" },
+        distance: { value: 10000, unit: "m" },
+      },
+    });
+  });
+
+  it("should leave duration and distance null when the summary omits them", () => {
+    // Arrange
+    const activity = buildSourceActivityRecord({
+      profileId: "p1",
+      date: "2026-07-05",
+      sport: "cycling",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "9",
+    });
+
+    // Act
+    const workout = activityToWorkoutRecord(activity);
+
+    // Assert
+    expect(workout.raw?.duration).toBeNull();
+    expect(workout.raw?.distance).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/application/coaching/activity-to-workout-record.ts
+++ b/packages/workout-spa-editor/src/application/coaching/activity-to-workout-record.ts
@@ -1,0 +1,53 @@
+/**
+ * Projects an executed `ActivityRecord` into the WorkoutRecord shape the
+ * calendar renders (executed slot of a matched card, or a solo actual).
+ *
+ * This reverses the transitional dual-write: instead of persisting a twin
+ * WorkoutRecord, the calendar projects one on the fly from the activity, so
+ * the render components stay unchanged and one event is stored once. Only
+ * source-only activities (no twin, `linkedWorkoutId === null`) are projected;
+ * historical twins still render through their own WorkoutRecord.
+ */
+import type { ActivityRecord } from "../../types/activity-record";
+import type { WorkoutRaw } from "../../types/calendar-fragments";
+import type { WorkoutRecord } from "../../types/calendar-record";
+
+const buildRaw = (activity: ActivityRecord): WorkoutRaw => ({
+  title: activity.sport,
+  description: "",
+  comments: [],
+  distance:
+    activity.distanceMeters !== undefined
+      ? { value: activity.distanceMeters, unit: "m" }
+      : null,
+  duration:
+    activity.durationSeconds !== undefined
+      ? { value: activity.durationSeconds, unit: "s" }
+      : null,
+  prescribedRpe: null,
+  rawHash: activity.externalId,
+});
+
+export const activityToWorkoutRecord = (
+  activity: ActivityRecord
+): WorkoutRecord => ({
+  id: activity.id,
+  profileId: activity.profileId,
+  date: activity.date,
+  sport: activity.sport,
+  source: activity.sourceBridgeId,
+  sourceId: activity.externalId,
+  planId: null,
+  state: "structured",
+  raw: buildRaw(activity),
+  krd: activity.krd,
+  lastProcessingError: null,
+  feedback: null,
+  aiMeta: null,
+  garminPushId: null,
+  tags: [],
+  previousState: null,
+  createdAt: activity.createdAt,
+  modifiedAt: null,
+  updatedAt: activity.createdAt,
+});

--- a/packages/workout-spa-editor/src/application/coaching/activity-to-workout-record.ts
+++ b/packages/workout-spa-editor/src/application/coaching/activity-to-workout-record.ts
@@ -7,10 +7,26 @@
  * the render components stay unchanged and one event is stored once. Only
  * source-only activities (no twin, `linkedWorkoutId === null`) are projected;
  * historical twins still render through their own WorkoutRecord.
+ *
+ * The projected record's `id` lives in the `activities` table, not
+ * `workouts` — it was never persisted as a workout, so it cannot be
+ * opened in the editor (which reads `workouts` by id) nor rescheduled
+ * (`rescheduleWorkout` reads the same table). `projectedFromActivity`
+ * marks that, so callers can route clicks/drag away from those flows
+ * without changing `WorkoutRecord`'s own persisted schema.
  */
 import type { ActivityRecord } from "../../types/activity-record";
 import type { WorkoutRaw } from "../../types/calendar-fragments";
 import type { WorkoutRecord } from "../../types/calendar-record";
+
+export type ProjectedWorkoutRecord = WorkoutRecord & {
+  readonly projectedFromActivity: true;
+};
+
+export const isProjectedWorkoutRecord = (
+  workout: WorkoutRecord
+): workout is ProjectedWorkoutRecord =>
+  (workout as Partial<ProjectedWorkoutRecord>).projectedFromActivity === true;
 
 const buildRaw = (activity: ActivityRecord): WorkoutRaw => ({
   title: activity.sport,
@@ -30,7 +46,7 @@ const buildRaw = (activity: ActivityRecord): WorkoutRaw => ({
 
 export const activityToWorkoutRecord = (
   activity: ActivityRecord
-): WorkoutRecord => ({
+): ProjectedWorkoutRecord => ({
   id: activity.id,
   profileId: activity.profileId,
   date: activity.date,
@@ -50,4 +66,5 @@ export const activityToWorkoutRecord = (
   createdAt: activity.createdAt,
   modifiedAt: null,
   updatedAt: activity.createdAt,
+  projectedFromActivity: true,
 });

--- a/packages/workout-spa-editor/src/application/coaching/match-executed-refs.ts
+++ b/packages/workout-spa-editor/src/application/coaching/match-executed-refs.ts
@@ -1,50 +1,30 @@
 /**
  * Executed-reference indexing for the auto-match use case.
+ *
+ * The executed side is the v27 `activities` table — the single source of
+ * truth for executed sessions. Each activity contributes one ref: its twin
+ * WorkoutRecord id when it has one (historical dual-write), otherwise its own
+ * id (source-only pulls like Garmin, projected for render by the read model).
  */
 import type { ActivityRecord } from "../../types/activity-record";
-import type { WorkoutRecord } from "../../types/calendar-record";
-
-const TRAIN2GO = "train2go";
 
 /** An appendable executed reference: a renderable id + its canonical sport. */
 export type ExecutedRef = { id: string; canonical: string | null };
 
 export type CanonicalSport = (raw: string) => string | null;
 
-const isExecuted = (w: WorkoutRecord): boolean => w.source !== TRAIN2GO;
-
-/**
- * Index the executed side by date: the union of v27 activities and the legacy
- * executed workouts (source !== train2go), EXCLUDING every workout whose id is
- * the twin (`linkedWorkoutId`) of an activity — so a dual-written event is
- * matched once. Each activity appends its twin's renderable id, or its own id
- * when it has no twin (e.g. a future Garmin pull).
- */
 export const indexExecutedRefsByDate = (
-  workouts: readonly WorkoutRecord[],
   activities: readonly ActivityRecord[],
   canonicalSport: CanonicalSport
 ): Map<string, ExecutedRef[]> => {
   const out = new Map<string, ExecutedRef[]>();
-  const push = (date: string, ref: ExecutedRef): void => {
-    const bucket = out.get(date) ?? [];
-    bucket.push(ref);
-    out.set(date, bucket);
-  };
-  const linked = new Set(
-    activities
-      .map((a) => a.linkedWorkoutId)
-      .filter((id): id is string => id !== null)
-  );
-  for (const w of workouts) {
-    if (!isExecuted(w) || linked.has(w.id)) continue;
-    push(w.date, { id: w.id, canonical: canonicalSport(w.sport) });
-  }
   for (const a of activities) {
-    push(a.date, {
+    const bucket = out.get(a.date) ?? [];
+    bucket.push({
       id: a.linkedWorkoutId ?? a.id,
       canonical: canonicalSport(a.sport),
     });
+    out.set(a.date, bucket);
   }
   return out;
 };

--- a/packages/workout-spa-editor/src/application/coaching/match-executed-workouts.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/match-executed-workouts.test.ts
@@ -24,7 +24,7 @@ const workout = (overrides: Partial<WorkoutRecord> = {}): WorkoutRecord =>
     id: "w-x",
     date: DAY,
     sport: "cycling",
-    source: "garmin",
+    source: "train2go",
     state: "ready",
     raw: { title: "Ride", duration: { value: 3600, unit: "s" } },
     ...overrides,
@@ -36,7 +36,7 @@ const activity = (overrides: Partial<ActivityRecord> = {}): ActivityRecord =>
     profileId: "p1",
     date: DAY,
     sport: "cycling",
-    sourceBridgeId: "fit-import",
+    sourceBridgeId: "garmin-bridge",
     externalId: "hash-x",
     linkedWorkoutId: null,
     krd: null,
@@ -58,6 +58,7 @@ describe("matchExecutedWorkouts", () => {
     const input = {
       sessionMatches: [] as SessionMatch[],
       workouts: [workout({ id: "w-1" })],
+      activities: [activity()],
       canonicalSport: canonical,
     };
 
@@ -68,49 +69,33 @@ describe("matchExecutedWorkouts", () => {
     expect(result).toEqual([]);
   });
 
-  it("should append a same-day same-sport executed workout to a match", () => {
+  it("should append a same-day same-sport executed activity to a match", () => {
     // Arrange
-    const structured = workout({ id: "w-structured-1", source: "train2go" });
-    const executed = workout({ id: "w-exec-1", source: "garmin" });
-    const input = {
-      sessionMatches: [baseMatch()],
-      workouts: [structured, executed],
-      canonicalSport: canonical,
-    };
-
-    // Act
-    const result = matchExecutedWorkouts(input);
-
-    // Assert
-    expect(result).toEqual([{ matchId: "m-1", toAppend: ["w-exec-1"] }]);
-  });
-
-  it("should skip a workout already listed in executedWorkoutIds (dedup)", () => {
-    // Arrange
-    const structured = workout({ id: "w-structured-1", source: "train2go" });
-    const executed = workout({ id: "w-exec-1", source: "garmin" });
-    const match = baseMatch({ executedWorkoutIds: ["w-exec-1"] });
-    const input = {
-      sessionMatches: [match],
-      workouts: [structured, executed],
-      canonicalSport: canonical,
-    };
-
-    // Act
-    const result = matchExecutedWorkouts(input);
-
-    // Assert
-    expect(result).toEqual([]);
-  });
-
-  it("should never append the structured workoutId itself", () => {
-    // Arrange
-    // The structured side is the matched workout — exclude it even
-    // when its source is non-train2go (defensive).
-    const structured = workout({ id: "w-structured-1", source: "garmin" });
+    const structured = workout({ id: "w-structured-1" });
+    const executed = activity({ id: "a-exec-1" });
     const input = {
       sessionMatches: [baseMatch()],
       workouts: [structured],
+      activities: [executed],
+      canonicalSport: canonical,
+    };
+
+    // Act
+    const result = matchExecutedWorkouts(input);
+
+    // Assert
+    expect(result).toEqual([{ matchId: "m-1", toAppend: ["a-exec-1"] }]);
+  });
+
+  it("should skip an activity already listed in executedWorkoutIds (dedup)", () => {
+    // Arrange
+    const structured = workout({ id: "w-structured-1" });
+    const executed = activity({ id: "a-exec-1" });
+    const match = baseMatch({ executedWorkoutIds: ["a-exec-1"] });
+    const input = {
+      sessionMatches: [match],
+      workouts: [structured],
+      activities: [executed],
       canonicalSport: canonical,
     };
 
@@ -121,14 +106,35 @@ describe("matchExecutedWorkouts", () => {
     expect(result).toEqual([]);
   });
 
-  it("should append multiple executeds on the same day for the same match (1-N)", () => {
+  it("should never append the match's own structured workoutId", () => {
     // Arrange
-    const structured = workout({ id: "w-structured-1", source: "train2go" });
-    const executed1 = workout({ id: "w-exec-1", source: "garmin" });
-    const executed2 = workout({ id: "w-exec-2", source: "fit" });
+    // An activity whose renderable id collides with the structured slot
+    // must be skipped by the `taken` guard.
+    const structured = workout({ id: "w-structured-1" });
+    const collide = activity({ id: "w-structured-1" });
     const input = {
       sessionMatches: [baseMatch()],
-      workouts: [structured, executed1, executed2],
+      workouts: [structured],
+      activities: [collide],
+      canonicalSport: canonical,
+    };
+
+    // Act
+    const result = matchExecutedWorkouts(input);
+
+    // Assert
+    expect(result).toEqual([]);
+  });
+
+  it("should append multiple executed activities on the same day for one match (1-N)", () => {
+    // Arrange
+    const structured = workout({ id: "w-structured-1" });
+    const e1 = activity({ id: "a-exec-1" });
+    const e2 = activity({ id: "a-exec-2" });
+    const input = {
+      sessionMatches: [baseMatch()],
+      workouts: [structured],
+      activities: [e1, e2],
       canonicalSport: canonical,
     };
 
@@ -137,25 +143,18 @@ describe("matchExecutedWorkouts", () => {
 
     // Assert
     expect(result).toEqual([
-      { matchId: "m-1", toAppend: ["w-exec-1", "w-exec-2"] },
+      { matchId: "m-1", toAppend: ["a-exec-1", "a-exec-2"] },
     ]);
   });
 
-  it("should reject an executed whose canonical sport differs from the match", () => {
+  it("should reject an executed activity whose canonical sport differs", () => {
     // Arrange
-    const structured = workout({
-      id: "w-structured-1",
-      sport: "cycling",
-      source: "train2go",
-    });
-    const wrongSport = workout({
-      id: "w-exec-run",
-      sport: "running",
-      source: "garmin",
-    });
+    const structured = workout({ id: "w-structured-1", sport: "cycling" });
+    const wrongSport = activity({ id: "a-run", sport: "running" });
     const input = {
       sessionMatches: [baseMatch()],
-      workouts: [structured, wrongSport],
+      workouts: [structured],
+      activities: [wrongSport],
       canonicalSport: canonical,
     };
 
@@ -166,13 +165,14 @@ describe("matchExecutedWorkouts", () => {
     expect(result).toEqual([]);
   });
 
-  it("should reject an executed whose canonical sport is null (unknown)", () => {
+  it("should reject an executed activity whose canonical sport is null", () => {
     // Arrange
-    const structured = workout({ id: "w-structured-1", source: "train2go" });
-    const unknown = workout({ id: "w-exec-?", sport: "kayak" });
+    const structured = workout({ id: "w-structured-1" });
+    const unknown = activity({ id: "a-?", sport: "kayak" });
     const input = {
       sessionMatches: [baseMatch()],
-      workouts: [structured, unknown],
+      workouts: [structured],
+      activities: [unknown],
       canonicalSport: canonical,
     };
 
@@ -185,15 +185,12 @@ describe("matchExecutedWorkouts", () => {
 
   it("should skip the match when the structured workout's sport is unknown", () => {
     // Arrange
-    const structured = workout({
-      id: "w-structured-1",
-      sport: "kayak",
-      source: "train2go",
-    });
-    const executed = workout({ id: "w-exec-1", source: "garmin" });
+    const structured = workout({ id: "w-structured-1", sport: "kayak" });
+    const executed = activity({ id: "a-exec-1" });
     const input = {
       sessionMatches: [baseMatch()],
-      workouts: [structured, executed],
+      workouts: [structured],
+      activities: [executed],
       canonicalSport: canonical,
     };
 
@@ -206,10 +203,11 @@ describe("matchExecutedWorkouts", () => {
 
   it("should skip the match when its structured workout is missing", () => {
     // Arrange
-    const executed = workout({ id: "w-exec-1", source: "garmin" });
+    const executed = activity({ id: "a-exec-1" });
     const input = {
       sessionMatches: [baseMatch()],
-      workouts: [executed],
+      workouts: [],
+      activities: [executed],
       canonicalSport: canonical,
     };
 
@@ -220,17 +218,14 @@ describe("matchExecutedWorkouts", () => {
     expect(result).toEqual([]);
   });
 
-  it("should reject an executed on a different date", () => {
+  it("should reject an executed activity on a different date", () => {
     // Arrange
-    const structured = workout({ id: "w-structured-1", source: "train2go" });
-    const otherDay = workout({
-      id: "w-exec-1",
-      date: "2026-04-30",
-      source: "garmin",
-    });
+    const structured = workout({ id: "w-structured-1" });
+    const otherDay = activity({ id: "a-exec-1", date: "2026-04-30" });
     const input = {
       sessionMatches: [baseMatch()],
-      workouts: [structured, otherDay],
+      workouts: [structured],
+      activities: [otherDay],
       canonicalSport: canonical,
     };
 
@@ -241,12 +236,11 @@ describe("matchExecutedWorkouts", () => {
     expect(result).toEqual([]);
   });
 
-  it("should dedup an activity against its co-written executed workout", () => {
+  it("should append a twin activity's linked WorkoutRecord id, not its own id", () => {
     // Arrange
-    // New drop: the FIT file produced BOTH an activity and its twin
-    // WorkoutRecord (linkedWorkoutId). The twin is excluded from the legacy
-    // scan so the event is matched exactly once (test d).
-    const structured = workout({ id: "w-structured-1", source: "train2go" });
+    // Historical dual-write: the activity carries the twin WorkoutRecord id,
+    // so the renderable executed slot is the twin (matched exactly once).
+    const structured = workout({ id: "w-structured-1" });
     const twin = workout({ id: "w-exec-1", source: "kaiord" });
     const input = {
       sessionMatches: [baseMatch()],
@@ -262,10 +256,9 @@ describe("matchExecutedWorkouts", () => {
     expect(result).toEqual([{ matchId: "m-1", toAppend: ["w-exec-1"] }]);
   });
 
-  it("should append an activity's own id when no executed workout represents it", () => {
+  it("should append a source-only activity's own id when it has no twin", () => {
     // Arrange
-    // Forward-ready (F5): a garmin-only activity with no co-written workout.
-    const structured = workout({ id: "w-structured-1", source: "train2go" });
+    const structured = workout({ id: "w-structured-1" });
     const input = {
       sessionMatches: [baseMatch()],
       workouts: [structured],
@@ -280,13 +273,13 @@ describe("matchExecutedWorkouts", () => {
     expect(result).toEqual([{ matchId: "m-1", toAppend: ["a-garmin"] }]);
   });
 
-  it("should match a legacy executed workout when no activity exists", () => {
+  it("should NOT match a bare executed workout with no activity (heuristic retired)", () => {
     // Arrange
-    const structured = workout({ id: "w-structured-1", source: "train2go" });
-    const executed = workout({ id: "w-exec-1", source: "garmin" });
+    const structured = workout({ id: "w-structured-1" });
+    const bareExecuted = workout({ id: "w-exec-1", source: "garmin" });
     const input = {
       sessionMatches: [baseMatch()],
-      workouts: [structured, executed],
+      workouts: [structured, bareExecuted],
       activities: [],
       canonicalSport: canonical,
     };
@@ -295,6 +288,6 @@ describe("matchExecutedWorkouts", () => {
     const result = matchExecutedWorkouts(input);
 
     // Assert
-    expect(result).toEqual([{ matchId: "m-1", toAppend: ["w-exec-1"] }]);
+    expect(result).toEqual([]);
   });
 });

--- a/packages/workout-spa-editor/src/application/coaching/match-executed-workouts.ts
+++ b/packages/workout-spa-editor/src/application/coaching/match-executed-workouts.ts
@@ -2,12 +2,10 @@
  * Auto-match use case for the Train2Go three-slot grouping.
  *
  * For every existing `sessionMatch`, pick up executed activities on the same
- * `(profileId, date, canonical sport)` slot. The executed side is the UNION
- * of the v27 `activities` table and the legacy heuristic ("a workout whose
- * source is not train2go") — the latter still covers historical data and the
- * transitional dual-written WorkoutRecords. See `match-executed-refs` for how
- * an activity resolves to its renderable id and dedups against the legacy scan
- * (no double-match of one event).
+ * `(profileId, date, canonical sport)` slot. The executed side is the v27
+ * `activities` table — see `match-executed-refs` for how an activity resolves
+ * to its renderable id (twin WorkoutRecord id, or its own id when source-only).
+ * `workouts` supplies only the planned side (the match's structured workout).
  *
  * Pure: no IO, no clock — the caller supplies the week slice and the
  * `canonicalSport` function. Returns the per-match ids to append.
@@ -24,8 +22,9 @@ import {
 
 export type MatchExecutedWorkoutsInput = {
   sessionMatches: readonly SessionMatch[];
+  /** Planned side only — the structured workout each match points at. */
   workouts: readonly WorkoutRecord[];
-  /** Executed activities (v27); unioned with the legacy workout heuristic. */
+  /** Executed activities (v27) — the sole source of executed refs. */
   activities?: readonly ActivityRecord[];
   /** Returns the canonical sport key or `null` for "unknown — skip". */
   canonicalSport: CanonicalSport;
@@ -67,7 +66,6 @@ export const matchExecutedWorkouts = (
   input: MatchExecutedWorkoutsInput
 ): MatchExecutedWorkoutsAppend[] => {
   const refsByDate = indexExecutedRefsByDate(
-    input.workouts,
     input.activities ?? [],
     input.canonicalSport
   );

--- a/packages/workout-spa-editor/src/application/coaching/session-match-garmin-activity.integration.test.ts
+++ b/packages/workout-spa-editor/src/application/coaching/session-match-garmin-activity.integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Foundational Data Hub scenario (F5.3): with planned-session←train2go AND
+ * activity←garmin both active, a pulled Garmin activity links to the planned
+ * session's existing SessionMatch. Kill test: disabling activity←garmin stops
+ * the pull entirely. Exercises the real use cases end to end over in-memory
+ * repos (governed pull → persist → executed auto-match).
+ */
+import { describe, expect, it } from "vitest";
+
+import { createInMemoryActivityRepository } from "../../test-utils/in-memory-activity-repository";
+import type { ActivityRecord } from "../../types/activity-record";
+import type { WorkoutRecord } from "../../types/calendar-record";
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import { pullGarminActivities } from "../import/pull-garmin-activities.use-case";
+import type { IntegrationPolicyRepository } from "../integration-policy/integration-policy-repository.port";
+import { matchExecutedWorkouts } from "./match-executed-workouts";
+
+const PROFILE = "11111111-1111-4111-8111-111111111111";
+const DAY = "2026-07-05";
+
+const garminRoute = (enabled: boolean): IntegrationPolicy => ({
+  id: "route-activity-garmin",
+  profileId: PROFILE,
+  dataType: "activity",
+  bridgeId: "garmin-bridge",
+  direction: "import",
+  mode: "auto",
+  enabled,
+  updatedAt: "2026-07-06T00:00:00.000Z",
+});
+
+const policyRepo = (
+  rows: IntegrationPolicy[]
+): IntegrationPolicyRepository => ({
+  findByProfileDirection: async ({ profileId, dataType, direction }) =>
+    rows.filter(
+      (r) =>
+        r.profileId === profileId &&
+        r.dataType === dataType &&
+        r.direction === direction
+    ),
+  findByNaturalKey: async () => undefined,
+  put: async () => undefined,
+  deleteById: async () => undefined,
+});
+
+const syncStateRepo = () => ({
+  getBySourceAndProfile: async () => undefined,
+  put: async () => undefined,
+  deleteByProfile: async () => undefined,
+});
+
+const garminActivity = () => ({
+  activityId: 42_042,
+  startTimeLocal: `${DAY} 07:30:00`,
+  activityType: { typeKey: "cycling" },
+  duration: 3600,
+  distance: 30000,
+});
+
+const plannedWorkout = (): WorkoutRecord =>
+  ({
+    id: "w-planned-1",
+    profileId: PROFILE,
+    date: DAY,
+    sport: "cycling",
+    source: "train2go",
+    state: "structured",
+  }) as WorkoutRecord;
+
+const canonical = (raw: string): string | null =>
+  ["bike", "cycling"].includes(raw.toLowerCase()) ? "cycling" : null;
+
+describe("session-match garmin activity (F5.3 foundational scenario)", () => {
+  it("should link a pulled garmin activity to the planned session's match", async () => {
+    // Arrange
+    const store = new Map<string, ActivityRecord>();
+    const activities = createInMemoryActivityRepository(store);
+    const deps = {
+      policyRepo: policyRepo([garminRoute(true)]),
+      activities,
+      coachingSyncState: syncStateRepo(),
+      readActivities: async () => ({
+        activities: [garminActivity()],
+        disabled: false,
+        throttled: false,
+      }),
+      now: () => "2026-07-07T00:00:00.000Z",
+    };
+
+    // Act
+    // Governed pull persists the activity, then the executed match runs.
+    const pull = await pullGarminActivities(deps, PROFILE);
+    const persisted = await activities.getByProfileAndDateRange(
+      PROFILE,
+      DAY,
+      DAY
+    );
+    const appends = matchExecutedWorkouts({
+      sessionMatches: [
+        {
+          id: "m-1",
+          profileId: PROFILE,
+          coachingActivityId: `${PROFILE}:train2go:1`,
+          workoutId: "w-planned-1",
+          date: DAY,
+          createdAt: "2026-07-04T10:00:00.000Z",
+          source: "auto-coaching",
+          executedWorkoutIds: [],
+        },
+      ],
+      workouts: [plannedWorkout()],
+      activities: persisted,
+      canonicalSport: canonical,
+    });
+
+    // Assert
+    expect(pull).toMatchObject({ ok: true, imported: 1 });
+    expect(persisted).toHaveLength(1);
+    expect(appends).toEqual([{ matchId: "m-1", toAppend: [persisted[0]!.id] }]);
+  });
+
+  it("should stop the pull when the activity garmin route is disabled (kill test)", async () => {
+    // Arrange
+    const store = new Map<string, ActivityRecord>();
+    let fetched = false;
+    const deps = {
+      policyRepo: policyRepo([garminRoute(false)]),
+      activities: createInMemoryActivityRepository(store),
+      coachingSyncState: syncStateRepo(),
+      readActivities: async () => {
+        fetched = true;
+        return {
+          activities: [garminActivity()],
+          disabled: false,
+          throttled: false,
+        };
+      },
+    };
+
+    // Act
+    const pull = await pullGarminActivities(deps, PROFILE);
+
+    // Assert
+    expect(pull).toEqual({ ok: false, reason: "route-inactive" });
+    expect(fetched).toBe(false);
+    expect(store.size).toBe(0);
+  });
+});

--- a/packages/workout-spa-editor/src/application/data-source-policy/get-health-records-for-day.ts
+++ b/packages/workout-spa-editor/src/application/data-source-policy/get-health-records-for-day.ts
@@ -26,7 +26,9 @@ type HealthMetricRepoKey =
   | "healthBodyComposition"
   | "healthStress";
 
-const HEALTH_REPO_KEY_FOR_TYPE: Partial<
+/** Exported so callers can test "does this data type have a health-table
+    reader?" (e.g. the chat hub tools) without duplicating this mapping. */
+export const HEALTH_REPO_KEY_FOR_TYPE: Partial<
   Record<ManagedDataType, HealthMetricRepoKey>
 > = {
   weight: "healthWeight",

--- a/packages/workout-spa-editor/src/application/import/garmin-activity-schema.ts
+++ b/packages/workout-spa-editor/src/application/import/garmin-activity-schema.ts
@@ -1,0 +1,34 @@
+/**
+ * Wire schema for the raw Garmin Connect activity feed returned by the
+ * garmin-bridge `activities` action. Kept in the application layer (neutral,
+ * framework-free) so both the bridge adapter transport and the pull use case
+ * share one definition. `safeParse` at the bridge edge is defense-in-depth
+ * against a Garmin API shape change (the pre-existing pattern for un-parsed
+ * bridge reads). Unknown Garmin fields are stripped, not rejected.
+ */
+import { z } from "zod";
+
+export const garminRawActivitySchema = z.object({
+  activityId: z.union([z.number(), z.string()]),
+  activityName: z.string().optional(),
+  /** Garmin local start, "YYYY-MM-DD HH:mm:ss". */
+  startTimeLocal: z.string().optional(),
+  startTimeGMT: z.string().optional(),
+  activityType: z.object({ typeKey: z.string().optional() }).optional(),
+  /** meters */
+  distance: z.number().nonnegative().optional(),
+  /** seconds */
+  duration: z.number().nonnegative().optional(),
+});
+
+export type GarminRawActivity = z.infer<typeof garminRawActivitySchema>;
+
+export const garminActivitiesResponseSchema = z.object({
+  activities: z.array(garminRawActivitySchema),
+  disabled: z.boolean(),
+  throttled: z.boolean(),
+});
+
+export type GarminActivitiesResponse = z.infer<
+  typeof garminActivitiesResponseSchema
+>;

--- a/packages/workout-spa-editor/src/application/import/map-garmin-activity.test.ts
+++ b/packages/workout-spa-editor/src/application/import/map-garmin-activity.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import type { GarminRawActivity } from "./garmin-activity-schema";
+import { mapGarminActivity } from "./map-garmin-activity";
+
+describe("mapGarminActivity", () => {
+  it("should map a raw Garmin activity to a summary-only ActivityRecord", () => {
+    // Arrange
+    const raw: GarminRawActivity = {
+      activityId: 987654,
+      startTimeLocal: "2026-07-05 07:30:00",
+      activityType: { typeKey: "running" },
+      distance: 10000,
+      duration: 3600,
+    };
+
+    // Act
+    const record = mapGarminActivity(raw, "profile-1");
+
+    // Assert
+    expect(record).toMatchObject({
+      profileId: "profile-1",
+      date: "2026-07-05",
+      sport: "running",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "987654",
+      durationSeconds: 3600,
+      distanceMeters: 10000,
+      linkedWorkoutId: null,
+      krd: null,
+    });
+  });
+
+  it("should default the sport to unknown when the type is absent", () => {
+    // Arrange
+    const raw: GarminRawActivity = {
+      activityId: 1,
+      startTimeGMT: "2026-07-06 05:00:00",
+    };
+
+    // Act
+    const record = mapGarminActivity(raw, "p");
+
+    // Assert
+    expect(record?.sport).toBe("unknown");
+  });
+
+  it("should return null when the activity has no usable date", () => {
+    // Arrange
+    const raw: GarminRawActivity = { activityId: 42 };
+
+    // Act
+    const record = mapGarminActivity(raw, "p");
+
+    // Assert
+    expect(record).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/application/import/map-garmin-activity.ts
+++ b/packages/workout-spa-editor/src/application/import/map-garmin-activity.ts
@@ -1,0 +1,44 @@
+/**
+ * Maps a raw Garmin Connect activity into a persisted ActivityRecord.
+ *
+ * Summary only — the activities-search endpoint carries no recorded detail,
+ * so `krd` stays null (never forced). Provenance is stamped through the
+ * shared `stampProvenance` helper: source `garmin-bridge`, externalId = the
+ * Garmin activityId (stable dedup key). Returns null when the activity has no
+ * usable calendar date, so the caller can skip it rather than persist garbage.
+ */
+import type { ActivityRecord } from "../../types/activity-record";
+import { buildSourceActivityRecord } from "../../types/activity-record";
+import type { GarminRawActivity } from "./garmin-activity-schema";
+import { stampProvenance } from "./stamp-provenance";
+
+export const GARMIN_BRIDGE_SOURCE = "garmin-bridge";
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+const toIsoDate = (raw: GarminRawActivity): string | null => {
+  const stamp = raw.startTimeLocal ?? raw.startTimeGMT;
+  if (!stamp) return null;
+  const date = stamp.slice(0, 10);
+  return ISO_DATE.test(date) ? date : null;
+};
+
+export const mapGarminActivity = (
+  raw: GarminRawActivity,
+  profileId: string
+): ActivityRecord | null => {
+  const date = toIsoDate(raw);
+  if (!date) return null;
+  const provenance = stampProvenance(
+    GARMIN_BRIDGE_SOURCE,
+    String(raw.activityId)
+  );
+  return buildSourceActivityRecord({
+    profileId,
+    date,
+    sport: raw.activityType?.typeKey ?? "unknown",
+    sourceBridgeId: provenance.sourceBridgeId,
+    externalId: provenance.externalId,
+    durationSeconds: raw.duration,
+    distanceMeters: raw.distance,
+  });
+};

--- a/packages/workout-spa-editor/src/application/import/pull-garmin-activities.use-case.test.ts
+++ b/packages/workout-spa-editor/src/application/import/pull-garmin-activities.use-case.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ActivityRecord } from "../../types/activity-record";
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import type { IntegrationPolicyRepository } from "../integration-policy/integration-policy-repository.port";
+import type { GarminActivitiesResponse } from "./garmin-activity-schema";
+import {
+  pullGarminActivities,
+  type PullGarminActivitiesDeps,
+} from "./pull-garmin-activities.use-case";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+const makePolicy = (
+  overrides: Partial<IntegrationPolicy> = {}
+): IntegrationPolicy => ({
+  id: crypto.randomUUID(),
+  profileId: PROFILE_ID,
+  dataType: "activity",
+  bridgeId: "garmin-bridge",
+  direction: "import",
+  mode: "manual",
+  enabled: true,
+  updatedAt: "2026-07-06T00:00:00.000Z",
+  ...overrides,
+});
+
+const makePolicyRepo = (
+  rows: IntegrationPolicy[]
+): IntegrationPolicyRepository => ({
+  findByProfileDirection: async ({ profileId, dataType, direction }) =>
+    rows.filter(
+      (r) =>
+        r.profileId === profileId &&
+        r.dataType === dataType &&
+        r.direction === direction
+    ),
+  findByNaturalKey: async () => undefined,
+  put: async () => undefined,
+  deleteById: async () => undefined,
+});
+
+const response = (
+  activities: GarminActivitiesResponse["activities"],
+  over: Partial<GarminActivitiesResponse> = {}
+): GarminActivitiesResponse => ({
+  activities,
+  disabled: false,
+  throttled: false,
+  ...over,
+});
+
+const makeDeps = (
+  over: Partial<PullGarminActivitiesDeps> = {}
+): {
+  deps: PullGarminActivitiesDeps;
+  stored: ActivityRecord[];
+  syncPut: ReturnType<typeof vi.fn>;
+  readActivities: ReturnType<typeof vi.fn>;
+} => {
+  const stored: ActivityRecord[] = [];
+  const syncPut = vi.fn(async () => undefined);
+  const readActivities = vi.fn(async () => response([]));
+  const deps: PullGarminActivitiesDeps = {
+    policyRepo: makePolicyRepo([makePolicy()]),
+    activities: {
+      upsertByExternalId: async (record) => {
+        const exists = stored.some(
+          (s) =>
+            s.sourceBridgeId === record.sourceBridgeId &&
+            s.externalId === record.externalId
+        );
+        if (exists) return { created: false };
+        stored.push(record);
+        return { created: true };
+      },
+    },
+    coachingSyncState: {
+      getBySourceAndProfile: async () => undefined,
+      put: syncPut,
+      deleteByProfile: async () => undefined,
+    },
+    readActivities,
+    now: () => "2026-07-07T00:00:00.000Z",
+    ...over,
+  };
+  return { deps, stored, syncPut, readActivities };
+};
+
+describe("pullGarminActivities", () => {
+  it("should not fetch when no enabled garmin activity route exists", async () => {
+    // Arrange
+    const { deps, readActivities } = makeDeps({
+      policyRepo: makePolicyRepo([makePolicy({ enabled: false })]),
+    });
+
+    // Act
+    const result = await pullGarminActivities(deps, PROFILE_ID);
+
+    // Assert
+    expect(result).toEqual({ ok: false, reason: "route-inactive" });
+    expect(readActivities).not.toHaveBeenCalled();
+  });
+
+  it("should import and dedup activities and record sync freshness", async () => {
+    // Arrange
+    const raw = {
+      activityId: 555,
+      startTimeLocal: "2026-07-05 07:30:00",
+      activityType: { typeKey: "running" },
+      duration: 3600,
+      distance: 10000,
+    };
+    const { deps, stored, syncPut, readActivities } = makeDeps();
+    readActivities.mockResolvedValue(response([raw, raw]));
+
+    // Act
+    const result = await pullGarminActivities(deps, PROFILE_ID);
+
+    // Assert
+    expect(result).toEqual({
+      ok: true,
+      imported: 1,
+      skipped: 1,
+      disabled: false,
+      throttled: false,
+    });
+    expect(stored).toHaveLength(1);
+    expect(syncPut).toHaveBeenCalledWith({
+      source: "garmin-bridge",
+      profileId: PROFILE_ID,
+      lastSyncedAt: "2026-07-07T00:00:00.000Z",
+    });
+  });
+
+  it("should not persist when the bridge reports the kill-switch is engaged", async () => {
+    // Arrange
+    const { deps, stored, syncPut, readActivities } = makeDeps();
+    readActivities.mockResolvedValue(response([], { disabled: true }));
+
+    // Act
+    const result = await pullGarminActivities(deps, PROFILE_ID);
+
+    // Assert
+    expect(result).toMatchObject({ ok: true, imported: 0, disabled: true });
+    expect(stored).toHaveLength(0);
+    expect(syncPut).not.toHaveBeenCalled();
+  });
+
+  it("should return a transport error when the bridge read throws", async () => {
+    // Arrange
+    const { deps, readActivities } = makeDeps();
+    readActivities.mockRejectedValue(new Error("Extension did not respond"));
+
+    // Act
+    const result = await pullGarminActivities(deps, PROFILE_ID);
+
+    // Assert
+    expect(result).toEqual({
+      ok: false,
+      reason: "transport-error",
+      error: "Extension did not respond",
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/application/import/pull-garmin-activities.use-case.ts
+++ b/packages/workout-spa-editor/src/application/import/pull-garmin-activities.use-case.ts
@@ -1,0 +1,95 @@
+/**
+ * pullGarminActivities — governed import of executed Garmin activities (F5.3).
+ *
+ * The action consults the route policy BEFORE fetching (fail-closed forward):
+ * without an enabled `activity←garmin-bridge` import route the pull never
+ * touches the bridge, and the caller surfaces a visible "route inactive"
+ * state (kill test). When active, each activity is deduped through
+ * `ActivityRepository.upsertByExternalId` (Garmin activityId natural key) and
+ * a `coachingSyncState` row records source + timestamp so the matrix cell
+ * shows freshness. Pure application layer: the bridge read is injected.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { ActivityRepository } from "../../ports/activity-repository";
+import type { CoachingSyncStateRepository } from "../../ports/persistence-port";
+import type { IntegrationPolicyRepository } from "../integration-policy/integration-policy-repository.port";
+import { resolveImportPolicies } from "../integration-policy/resolve-import-policies.use-case";
+import type { GarminActivitiesResponse } from "./garmin-activity-schema";
+import { GARMIN_BRIDGE_SOURCE, mapGarminActivity } from "./map-garmin-activity";
+
+const ACTIVITY: ManagedDataType = "activity";
+
+export type PullGarminActivitiesDeps = {
+  policyRepo: IntegrationPolicyRepository;
+  activities: ActivityRepository;
+  coachingSyncState: CoachingSyncStateRepository;
+  readActivities: () => Promise<GarminActivitiesResponse>;
+  now?: () => string;
+};
+
+export type PullGarminActivitiesResult =
+  | {
+      ok: true;
+      imported: number;
+      skipped: number;
+      disabled: boolean;
+      throttled: boolean;
+    }
+  | { ok: false; reason: "route-inactive" | "transport-error"; error?: string };
+
+export const pullGarminActivities = async (
+  deps: PullGarminActivitiesDeps,
+  profileId: string
+): Promise<PullGarminActivitiesResult> => {
+  const policies = await resolveImportPolicies(
+    { policyRepo: deps.policyRepo },
+    { profileId, dataType: ACTIVITY }
+  );
+  const active = policies.some(
+    (p) => p.enabled && p.bridgeId === GARMIN_BRIDGE_SOURCE
+  );
+  if (!active) return { ok: false, reason: "route-inactive" };
+
+  let response: GarminActivitiesResponse;
+  try {
+    response = await deps.readActivities();
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "transport-error",
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  if (response.disabled || response.throttled) {
+    return {
+      ok: true,
+      imported: 0,
+      skipped: 0,
+      disabled: response.disabled,
+      throttled: response.throttled,
+    };
+  }
+
+  let imported = 0;
+  let skipped = 0;
+  for (const raw of response.activities) {
+    const record = mapGarminActivity(raw, profileId);
+    if (!record) {
+      skipped += 1;
+      continue;
+    }
+    const { created } = await deps.activities.upsertByExternalId(record);
+    if (created) imported += 1;
+    else skipped += 1;
+  }
+
+  const now = deps.now?.() ?? new Date().toISOString();
+  await deps.coachingSyncState.put({
+    source: GARMIN_BRIDGE_SOURCE,
+    profileId,
+    lastSyncedAt: now,
+  });
+  return { ok: true, imported, skipped, disabled: false, throttled: false };
+};

--- a/packages/workout-spa-editor/src/components/molecules/ExecutedActivityDialog/ExecutedActivityDialog.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/ExecutedActivityDialog/ExecutedActivityDialog.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { activityToWorkoutRecord } from "../../../application/coaching/activity-to-workout-record";
+import { buildSourceActivityRecord } from "../../../types/activity-record";
+import { ExecutedActivityDialog } from "./ExecutedActivityDialog";
+
+const activityWorkout = () =>
+  activityToWorkoutRecord(
+    buildSourceActivityRecord({
+      profileId: "p1",
+      date: "2026-04-06",
+      sport: "running",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "ext-1",
+      durationSeconds: 1800,
+      distanceMeters: 5000,
+    })
+  );
+
+describe("ExecutedActivityDialog", () => {
+  it("should not render content when workout is null", () => {
+    // Arrange
+
+    // Act
+    render(<ExecutedActivityDialog workout={null} onClose={vi.fn()} />);
+
+    // Assert
+    expect(
+      screen.queryByTestId("executed-activity-dialog")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should render the recorded activity's real content", () => {
+    // Arrange
+    const workout = activityWorkout();
+
+    // Act
+    render(<ExecutedActivityDialog workout={workout} onClose={vi.fn()} />);
+
+    // Assert
+    expect(screen.getByTestId("executed-activity-dialog")).toBeInTheDocument();
+    expect(screen.getByText("running")).toBeInTheDocument();
+    expect(screen.getByText(/2026-04-06/)).toBeInTheDocument();
+    expect(screen.getByTestId("executed-activity-duration")).toHaveTextContent(
+      "30:00"
+    );
+    expect(screen.getByTestId("executed-activity-distance")).toHaveTextContent(
+      "5.00 km"
+    );
+  });
+
+  it("should call onClose when dismissed", async () => {
+    // Arrange
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <ExecutedActivityDialog workout={activityWorkout()} onClose={onClose} />
+    );
+
+    // Act
+    await user.click(screen.getByLabelText("Close"));
+
+    // Assert
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/ExecutedActivityDialog/ExecutedActivityDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/ExecutedActivityDialog/ExecutedActivityDialog.tsx
@@ -1,0 +1,77 @@
+/**
+ * ExecutedActivityDialog - Read-only preview for a projected activity
+ * (an execution with no persisted WorkoutRecord). The record is already
+ * in memory (projected on the fly from `activities`), so there is no
+ * fetch to fail; the dialog only ever shows real data.
+ */
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import {
+  formatDistance,
+  formatDuration,
+} from "../../organisms/WorkoutStats/format-helpers";
+
+export type ExecutedActivityDialogProps = {
+  workout: WorkoutRecord | null;
+  onClose: () => void;
+};
+
+export function ExecutedActivityDialog({
+  workout,
+  onClose,
+}: ExecutedActivityDialogProps) {
+  return (
+    <Dialog.Root
+      open={workout !== null}
+      onOpenChange={(open) => !open && onClose()}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800">
+          <Dialog.Description className="sr-only">
+            Recorded activity details. Executions are read-only and cannot be
+            edited or rescheduled.
+          </Dialog.Description>
+          {workout && (
+            <div data-testid="executed-activity-dialog" className="space-y-3">
+              <div className="flex items-center justify-between">
+                <Dialog.Title className="text-lg font-semibold">
+                  {workout.raw?.title ?? workout.sport}
+                </Dialog.Title>
+                <Dialog.Close asChild>
+                  <button
+                    type="button"
+                    aria-label="Close"
+                    className="rounded p-1"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </Dialog.Close>
+              </div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Recorded {workout.sport} on {workout.date}
+              </p>
+              <div className="flex gap-4 text-sm">
+                {workout.raw?.duration && (
+                  <span data-testid="executed-activity-duration">
+                    {formatDuration(workout.raw.duration.value)}
+                  </span>
+                )}
+                {workout.raw?.distance && (
+                  <span data-testid="executed-activity-distance">
+                    {formatDistance(workout.raw.distance.value)}
+                  </span>
+                )}
+              </div>
+              <p className="text-xs text-gray-400 dark:text-gray-500">
+                This is a completed execution — recorded data is read-only.
+              </p>
+            </div>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/WorkoutCard/day-column-cards.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WorkoutCard/day-column-cards.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { activityToWorkoutRecord } from "../../../application/coaching/activity-to-workout-record";
+import { buildSourceActivityRecord } from "../../../types/activity-record";
+import type { WorkoutRecord } from "../../../types/calendar-record";
+import { renderDayCards } from "./day-column-cards";
+
+const realWorkout = (): WorkoutRecord =>
+  ({
+    id: "w-real",
+    date: "2026-04-06",
+    sport: "running",
+    source: "kaiord",
+    state: "structured",
+    raw: null,
+  }) as unknown as WorkoutRecord;
+
+const projectedWorkout = () =>
+  activityToWorkoutRecord(
+    buildSourceActivityRecord({
+      profileId: "p1",
+      date: "2026-04-06",
+      sport: "running",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "ext-1",
+    })
+  );
+
+describe("renderDayCards", () => {
+  it("should wire drag binding for a real workout but not for a projected activity", () => {
+    // Arrange
+    const bind = vi.fn(() => vi.fn());
+    const activity = projectedWorkout();
+
+    // Act
+    render(
+      <>
+        {renderDayCards({
+          matchedSessions: [],
+          soloPlans: [],
+          soloActuals: [realWorkout(), activity],
+          view: "grid",
+          onWorkoutClick: vi.fn(),
+          workoutCardPointerDownFor: bind,
+        })}
+      </>
+    );
+
+    // Assert
+    expect(bind).toHaveBeenCalledTimes(1);
+    expect(bind).toHaveBeenCalledWith("w-real");
+    expect(bind).not.toHaveBeenCalledWith(activity.id);
+  });
+
+  it("should still forward clicks on a projected activity card", async () => {
+    // Arrange
+    const onWorkoutClick = vi.fn();
+    const activity = projectedWorkout();
+    const user = userEvent.setup();
+
+    // Act
+    render(
+      <>
+        {renderDayCards({
+          matchedSessions: [],
+          soloPlans: [],
+          soloActuals: [activity],
+          view: "grid",
+          onWorkoutClick,
+          workoutCardPointerDownFor: vi.fn(() => vi.fn()),
+        })}
+      </>
+    );
+    await user.click(screen.getByTestId(`workout-card-${activity.id}`));
+
+    // Assert
+    expect(onWorkoutClick).toHaveBeenCalledWith(activity);
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/WorkoutCard/day-column-cards.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WorkoutCard/day-column-cards.tsx
@@ -14,6 +14,7 @@
 
 import type { PointerEvent } from "react";
 
+import { isProjectedWorkoutRecord } from "../../../application/coaching/activity-to-workout-record";
 import type { MatchedSessionWithMetadata } from "../../../hooks/use-matched-sessions";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { CoachingActivity } from "../../../types/coaching-activity";
@@ -59,7 +60,10 @@ export function renderDayCards(buckets: DayCardBuckets) {
         />
       ))}
       {buckets.soloActuals.map((w) =>
-        bindCardDrag ? (
+        // Projected activities have no WorkoutRecord to reschedule (F5
+        // gate A1) — never wire drag for them, so there is no failed
+        // persistence call to catch/toast in the first place.
+        bindCardDrag && !isProjectedWorkoutRecord(w) ? (
           <div key={w.id} onPointerDown={bindCardDrag(w.id)}>
             <WorkoutCard workout={w} onClick={buckets.onWorkoutClick} />
           </div>

--- a/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/persist-imported-workout.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/persist-imported-workout.test.ts
@@ -1,9 +1,9 @@
 /**
- * Transitional dual-write (F0 step 0.5). An imported file classified as an
- * executed activity lands as BOTH a first-class `activity` row (fit-import
- * provenance + content-hash externalId, deduped) and — transitionally — a
- * WorkoutRecord so the calendar keeps rendering it. A structured workout with
- * no executed data writes only the WorkoutRecord.
+ * An imported file classified as an executed activity lands as a first-class
+ * `activity` row only (fit-import provenance + content-hash externalId,
+ * deduped); the calendar renders it natively (F5 GATE A1), no twin
+ * WorkoutRecord. A structured workout with no executed data writes only the
+ * WorkoutRecord.
  */
 import "fake-indexeddb/auto";
 
@@ -40,7 +40,7 @@ const structuredKrd = (): KRD =>
     metadata: { created: "2026-04-29T06:30:00.000Z", sport: "cycling" },
   }) as KRD;
 
-describe("persistImportedWorkout dual-write", () => {
+describe("persistImportedWorkout", () => {
   let db: KaiordDatabase;
   let name: string;
 
@@ -55,12 +55,12 @@ describe("persistImportedWorkout dual-write", () => {
     await Dexie.delete(name);
   });
 
-  it("should write an activity row with provenance plus a WorkoutRecord for an execution", async () => {
+  it("should write only an activity row with provenance and no twin for an execution", async () => {
     // Arrange
     const persistence = createDexiePersistence(db);
 
     // Act
-    await persistImportedWorkout(persistence, {
+    const result = await persistImportedWorkout(persistence, {
       krd: activityKrd(),
       date: DATE,
       profileId: PROFILE,
@@ -70,16 +70,16 @@ describe("persistImportedWorkout dual-write", () => {
     const workouts = await db.table("workouts").toArray();
 
     // Assert
+    expect(result.kind).toBe("activity");
     expect(activities).toHaveLength(1);
     expect(activities[0]).toMatchObject({
       profileId: PROFILE,
       date: DATE,
       sourceBridgeId: "fit-import",
+      linkedWorkoutId: null,
     });
     expect(activities[0].externalId).toEqual(expect.any(String));
-    expect(workouts).toHaveLength(1);
-    // The activity links to its transitional twin WorkoutRecord.
-    expect(activities[0].linkedWorkoutId).toBe(workouts[0].id);
+    expect(workouts).toHaveLength(0);
   });
 
   it("should not duplicate the activity when the same file is re-imported", async () => {
@@ -110,7 +110,7 @@ describe("persistImportedWorkout dual-write", () => {
     const persistence = createDexiePersistence(db);
 
     // Act
-    await persistImportedWorkout(persistence, {
+    const result = await persistImportedWorkout(persistence, {
       krd: structuredKrd(),
       date: DATE,
       profileId: PROFILE,
@@ -120,6 +120,7 @@ describe("persistImportedWorkout dual-write", () => {
     const workouts = await db.table("workouts").toArray();
 
     // Assert
+    expect(result.kind).toBe("workout");
     expect(activities).toHaveLength(0);
     expect(workouts).toHaveLength(1);
   });

--- a/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/persist-imported-workout.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/persist-imported-workout.ts
@@ -11,7 +11,10 @@ import { deriveExternalId } from "@kaiord/core";
 
 import { stampProvenance } from "../../../application/import/stamp-provenance";
 import type { PersistencePort } from "../../../ports/persistence-port";
-import { buildActivityRecord } from "../../../types/activity-record";
+import {
+  type ActivityRecord,
+  buildActivityRecord,
+} from "../../../types/activity-record";
 import {
   createStructuredWorkoutRecord,
   type WorkoutRecord,
@@ -28,43 +31,47 @@ export type PersistImportedInput = {
   sport: string;
 };
 
+export type PersistImportedResult =
+  | { kind: "workout"; workout: WorkoutRecord }
+  | { kind: "activity"; activity: ActivityRecord };
+
 const persistActivity = async (
   persistence: PersistencePort,
-  input: PersistImportedInput,
-  linkedWorkoutId: string
-): Promise<void> => {
+  input: PersistImportedInput
+): Promise<ActivityRecord> => {
   const externalId = deriveExternalId({
     payload: input.krd as unknown as Record<string, unknown>,
     measuredAt: input.krd.metadata.created,
   });
   const provenance = stampProvenance(FIT_IMPORT_SOURCE, externalId);
-  await persistence.activities.upsertByExternalId(
-    buildActivityRecord({
-      profileId: input.profileId,
-      date: input.date,
-      sport: input.sport,
-      sourceBridgeId: provenance.sourceBridgeId,
-      externalId: provenance.externalId,
-      linkedWorkoutId,
-      krd: input.krd,
-    })
-  );
+  const activity = buildActivityRecord({
+    profileId: input.profileId,
+    date: input.date,
+    sport: input.sport,
+    sourceBridgeId: provenance.sourceBridgeId,
+    externalId: provenance.externalId,
+    linkedWorkoutId: null,
+    krd: input.krd,
+  });
+  await persistence.activities.upsertByExternalId(activity);
+  return activity;
 };
 
 export async function persistImportedWorkout(
   persistence: PersistencePort,
   input: PersistImportedInput
-): Promise<WorkoutRecord> {
-  // Transitional dual-write: a file classified as an executed activity is
-  // persisted as a first-class `activity` row (fit-import provenance +
-  // content-hash externalId, deduped) AND — for now — as a WorkoutRecord so
-  // the calendar/library keep rendering it unchanged. The activity row
-  // stores `linkedWorkoutId` = the twin WorkoutRecord id so the
-  // executed-match union excludes that workout from the legacy scan (one
-  // event is never matched twice). The WorkoutRecord is TRANSITIONAL: it
-  // retires once the calendar consumes `activities` natively.
-  // Structured workouts write only the WorkoutRecord.
-  const record = createStructuredWorkoutRecord({
+): Promise<PersistImportedResult> {
+  // A file classified as an executed activity (records/laps) is persisted as a
+  // first-class `activity` row only — the calendar renders it natively (F5
+  // GATE A1), deduped by fit-import provenance + content-hash externalId.
+  // A structured workout with no execution stays a library WorkoutRecord.
+  if (classifyImportedKrd(input.krd).kind === "activity") {
+    return {
+      kind: "activity",
+      activity: await persistActivity(persistence, input),
+    };
+  }
+  const workout = createStructuredWorkoutRecord({
     profileId: input.profileId,
     date: input.date,
     sport: input.sport,
@@ -73,9 +80,6 @@ export async function persistImportedWorkout(
     tags: [],
     raw: null,
   });
-  await persistence.workouts.put(record);
-  if (classifyImportedKrd(input.krd).kind === "activity") {
-    await persistActivity(persistence, input, record.id);
-  }
-  return record;
+  await persistence.workouts.put(workout);
+  return { kind: "workout", workout };
 }

--- a/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/use-import-on-load.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/use-import-on-load.ts
@@ -20,6 +20,7 @@ import { usePersistence } from "../../../contexts/persistence-context";
 import { useToastContext } from "../../../contexts/ToastContext";
 import { useAppHandlers } from "../../../hooks/use-app-handlers";
 import { parseBackOrigin } from "../../../routing/back-origin";
+import { calendarWeekHref } from "../../../routing/calendar-week-href";
 import { withOrigin } from "../../../routing/with-origin";
 import type { KRD } from "../../../types/krd";
 import { isValidCalendarDate } from "../../../utils/is-valid-calendar-date";
@@ -62,17 +63,22 @@ export function useImportOnLoad(date: string | null, from: string | null) {
       .getActiveId()
       .then(async (profileId) => {
         if (!profileId) return;
-        const record = await persistImportedWorkout(persistence, {
+        const result = await persistImportedWorkout(persistence, {
           krd,
           date,
           profileId,
           sport,
         });
+        // Executed activities have no editable workout document — land on the
+        // calendar week where the activity renders (F5 GATE A1); structured
+        // workouts open in the editor.
         navigate(
-          withOrigin(
-            `/workout/${record.id}`,
-            parseBackOrigin(from) ?? "calendar"
-          )
+          result.kind === "workout"
+            ? withOrigin(
+                `/workout/${result.workout.id}`,
+                parseBackOrigin(from) ?? "calendar"
+              )
+            : calendarWeekHref(date)
         );
       })
       .catch(() => {

--- a/packages/workout-spa-editor/src/components/pages/CalendarDialogs.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarDialogs.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+
+import { activityToWorkoutRecord } from "../../application/coaching/activity-to-workout-record";
+import { CoachingRegistryProvider } from "../../contexts/coaching-registry-context";
+import { GarminBridgeProvider } from "../../contexts/garmin-bridge-context";
+import { PersistenceProvider } from "../../contexts/persistence-context";
+import { createInMemoryPersistence } from "../../test-utils/in-memory-persistence";
+import { buildSourceActivityRecord } from "../../types/activity-record";
+import type { WorkoutRecord } from "../../types/calendar-record";
+import { AppToastProvider } from "../providers/AppToastProvider";
+import { CalendarDialogs } from "./CalendarDialogs";
+
+const rawWorkout: WorkoutRecord = {
+  id: "w-raw",
+  profileId: "p1",
+  date: "2026-04-06",
+  sport: "running",
+  source: "kaiord",
+  sourceId: null,
+  planId: null,
+  state: "raw",
+  raw: {
+    title: "Easy run",
+    description: "",
+    comments: [],
+    distance: null,
+    duration: null,
+    prescribedRpe: null,
+    rawHash: "abc",
+  },
+  krd: null,
+  lastProcessingError: null,
+  feedback: null,
+  aiMeta: null,
+  garminPushId: null,
+  tags: [],
+  previousState: null,
+  createdAt: "2026-04-06T00:00:00.000Z",
+  modifiedAt: null,
+  updatedAt: "2026-04-06T00:00:00.000Z",
+};
+
+const projectedWorkout = () =>
+  activityToWorkoutRecord(
+    buildSourceActivityRecord({
+      profileId: "p1",
+      date: "2026-04-06",
+      sport: "running",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "ext-1",
+    })
+  );
+
+function renderDialogs(selectedWorkout: WorkoutRecord | null) {
+  const { hook } = memoryLocation({ path: "/calendar", record: true });
+  return render(
+    <PersistenceProvider persistence={createInMemoryPersistence()}>
+      <GarminBridgeProvider>
+        <CoachingRegistryProvider factories={[]}>
+          <AppToastProvider>
+            <Router hook={hook}>
+              <CalendarDialogs
+                selectedWorkout={selectedWorkout}
+                onCloseWorkout={vi.fn()}
+                expandActivity={vi.fn()}
+              />
+            </Router>
+          </AppToastProvider>
+        </CoachingRegistryProvider>
+      </GarminBridgeProvider>
+    </PersistenceProvider>
+  );
+}
+
+describe("CalendarDialogs", () => {
+  it("should open RawWorkoutDialog for a raw workout, not the executed preview", () => {
+    // Arrange
+
+    // Act
+    renderDialogs(rawWorkout);
+
+    // Assert
+    expect(screen.getByTestId("raw-workout-dialog")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("executed-activity-dialog")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should open the executed preview for a projected activity, not RawWorkoutDialog", () => {
+    // Arrange
+    const activity = projectedWorkout();
+
+    // Act
+    renderDialogs(activity);
+
+    // Assert
+    expect(screen.getByTestId("executed-activity-dialog")).toBeInTheDocument();
+    expect(screen.queryByTestId("raw-workout-dialog")).not.toBeInTheDocument();
+  });
+
+  it("should keep both dialogs closed when nothing is selected", () => {
+    // Arrange
+
+    // Act
+    renderDialogs(null);
+
+    // Assert
+    expect(screen.queryByTestId("raw-workout-dialog")).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("executed-activity-dialog")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/CalendarDialogs.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarDialogs.tsx
@@ -6,9 +6,11 @@
  * navigates to `/workout/new?date=Y-M-D`.
  */
 
+import { isProjectedWorkoutRecord } from "../../application/coaching/activity-to-workout-record";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { CoachingActivity } from "../../types/coaching-activity";
 import { CoachingActivityDialog } from "../molecules/CoachingCard/CoachingActivityDialog";
+import { ExecutedActivityDialog } from "../molecules/ExecutedActivityDialog/ExecutedActivityDialog";
 import { RawWorkoutDialog } from "../molecules/RawWorkoutDialog/RawWorkoutDialog";
 import { useDialogHandlers } from "./use-dialog-handlers";
 
@@ -32,18 +34,29 @@ export function CalendarDialogs({
   onOpenExecuted,
   buildProcessHref,
 }: CalendarDialogsProps) {
+  // Projected activities (executions with no persisted WorkoutRecord) get
+  // the read-only preview; RawWorkoutDialog's Process/Skip actions assume
+  // the raw-import workflow and don't apply to an already-recorded event.
+  const isExecuted = selectedWorkout
+    ? isProjectedWorkoutRecord(selectedWorkout)
+    : false;
+  const rawWorkout = isExecuted ? null : selectedWorkout;
   const { handleProcess, handleSkip, handleUnskip, isSubmitting } =
-    useDialogHandlers(selectedWorkout, onCloseWorkout, buildProcessHref);
+    useDialogHandlers(rawWorkout, onCloseWorkout, buildProcessHref);
 
   return (
     <>
       <RawWorkoutDialog
-        workout={selectedWorkout}
+        workout={rawWorkout}
         onClose={onCloseWorkout}
         onProcess={handleProcess}
         onSkip={handleSkip}
         onUnskip={handleUnskip}
         isSubmitting={isSubmitting}
+      />
+      <ExecutedActivityDialog
+        workout={isExecuted ? selectedWorkout : null}
+        onClose={onCloseWorkout}
       />
       <CoachingActivityDialog
         activity={selectedCoachingActivity}

--- a/packages/workout-spa-editor/src/components/pages/CalendarPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 import { Route, Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
@@ -7,7 +8,9 @@ import { db } from "../../adapters/dexie/dexie-database";
 import { CoachingRegistryProvider } from "../../contexts/coaching-registry-context";
 import { GarminBridgeProvider } from "../../contexts/garmin-bridge-context";
 import { PersistenceProvider } from "../../contexts/persistence-context";
+import type { PersistencePort } from "../../ports/persistence-port";
 import { createInMemoryPersistence } from "../../test-utils/in-memory-persistence";
+import { buildSourceActivityRecord } from "../../types/activity-record";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import { AppToastProvider } from "../providers/AppToastProvider";
 import CalendarPage from "./CalendarPage";
@@ -47,10 +50,13 @@ function makeWorkout(overrides: Partial<WorkoutRecord> = {}): WorkoutRecord {
   };
 }
 
-function renderCalendar(path = "/calendar/2026-W15") {
-  const { hook } = memoryLocation({ path, record: true });
-  return render(
-    <PersistenceProvider persistence={createInMemoryPersistence()}>
+function renderCalendar(
+  path = "/calendar/2026-W15",
+  persistence: PersistencePort = createInMemoryPersistence()
+) {
+  const { hook, history } = memoryLocation({ path, record: true });
+  const rendered = render(
+    <PersistenceProvider persistence={persistence}>
       <GarminBridgeProvider>
         <CoachingRegistryProvider factories={[]}>
           <AppToastProvider>
@@ -64,6 +70,7 @@ function renderCalendar(path = "/calendar/2026-W15") {
       </GarminBridgeProvider>
     </PersistenceProvider>
   );
+  return { ...rendered, history };
 }
 
 describe("CalendarPage", () => {
@@ -210,5 +217,34 @@ describe("CalendarPage", () => {
     expect(screen.getByLabelText("Previous week")).toBeInTheDocument();
     expect(screen.getByLabelText("Next week")).toBeInTheDocument();
     expect(screen.getByText("Today")).toBeInTheDocument();
+  });
+
+  it("should preview a projected activity card instead of opening the editor", async () => {
+    // Arrange
+
+    const persistence = createInMemoryPersistence();
+    const activity = buildSourceActivityRecord({
+      profileId: PROFILE_ID,
+      date: "2026-04-06",
+      sport: "running",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "ext-1",
+      durationSeconds: 1800,
+    });
+    await persistence.activities.upsertByExternalId(activity);
+    const user = userEvent.setup();
+
+    // Act
+
+    const { history } = renderCalendar("/calendar/2026-W15", persistence);
+    const card = await screen.findByTestId(`workout-card-${activity.id}`);
+    await user.click(card);
+
+    // Assert
+
+    expect(
+      await screen.findByTestId("executed-activity-dialog")
+    ).toBeInTheDocument();
+    expect(history.at(-1)).toBe("/calendar/2026-W15");
   });
 });

--- a/packages/workout-spa-editor/src/components/pages/Daily/use-daily-entry-open.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/use-daily-entry-open.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 import { Router } from "wouter";
 import { memoryLocation } from "wouter/memory-location";
 
+import { activityToWorkoutRecord } from "../../../application/coaching/activity-to-workout-record";
+import { buildSourceActivityRecord } from "../../../types/activity-record";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 import { useDailyEntryOpen } from "./use-daily-entry-open";
@@ -23,6 +25,17 @@ const ACTIVITY: CoachingActivity = {
 
 const workout = (o: Partial<WorkoutRecord>): WorkoutRecord =>
   ({ id: "w-1", date: FOCUS, sport: "cycling", ...o }) as WorkoutRecord;
+
+const projectedActivityWorkout = () =>
+  activityToWorkoutRecord(
+    buildSourceActivityRecord({
+      profileId: "p1",
+      date: FOCUS,
+      sport: "running",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "ext-1",
+    })
+  );
 
 function setup() {
   const { hook, history } = memoryLocation({ path: "/daily", record: true });
@@ -71,6 +84,19 @@ describe("useDailyEntryOpen", () => {
 
     // Assert
     expect(history.at(-1)).toBe("/workout/w-1?from=daily&date=2026-06-10");
+  });
+
+  it("should preview a projected activity instead of navigating to the editor", () => {
+    // Arrange
+    const { result, history } = setup();
+    const activityWorkout = projectedActivityWorkout();
+
+    // Act
+    act(() => result.current.handleWorkoutClick(activityWorkout));
+
+    // Assert
+    expect(result.current.selectedWorkout?.id).toBe(activityWorkout.id);
+    expect(history.at(-1)).toBe("/daily");
   });
 
   it("should clear the opposite selection so dialogs never overlap", () => {

--- a/packages/workout-spa-editor/src/components/pages/Daily/use-daily-entry-open.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/use-daily-entry-open.ts
@@ -7,6 +7,7 @@
 import { useCallback, useState } from "react";
 import { useLocation } from "wouter";
 
+import { isProjectedWorkoutRecord } from "../../../application/coaching/activity-to-workout-record";
 import { withOrigin } from "../../../routing/with-origin";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { CoachingActivity } from "../../../types/coaching-activity";
@@ -36,7 +37,13 @@ export function useDailyEntryOpen(
     (workout: WorkoutRecord) => {
       // Clear the opposite selection so the two dialogs never overlap.
       setSelectedActivity(null);
-      if (workout.state === "raw" || workout.state === "skipped") {
+      // Projected activities have no id in `workouts` — preview in place
+      // instead of navigating to an editor that can never resolve them.
+      if (
+        workout.state === "raw" ||
+        workout.state === "skipped" ||
+        isProjectedWorkoutRecord(workout)
+      ) {
         setSelectedWorkout(workout);
       } else {
         setSelectedWorkout(null);

--- a/packages/workout-spa-editor/src/components/pages/calendar-buckets.test.ts
+++ b/packages/workout-spa-editor/src/components/pages/calendar-buckets.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import type { MatchedSessionWithMetadata } from "../../hooks/use-matched-sessions";
+import {
+  type ActivityRecord,
+  buildSourceActivityRecord,
+} from "../../types/activity-record";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { CoachingActivity } from "../../types/coaching-activity";
 import type { SessionMatch } from "../../types/session-match";
@@ -220,6 +224,89 @@ describe("buildCalendarBuckets", () => {
     // Assert
     expect(buckets.matchedByDay[DAY]).toHaveLength(1);
     expect(buckets.soloActualsByDay[DAY]).toEqual([]);
+  });
+
+  it("should render an unmatched source-only activity as a solo actual", () => {
+    // Arrange
+    const act = buildSourceActivityRecord({
+      profileId: "p1",
+      date: DAY,
+      sport: "running",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "555",
+      durationSeconds: 1800,
+    });
+    const args = {
+      days: DAYS,
+      coachingByDay: {},
+      workoutsByDay: {},
+      activitiesByDay: { [DAY]: [act] },
+      matched: [],
+    };
+
+    // Act
+    const buckets = buildCalendarBuckets(args);
+
+    // Assert
+    expect(buckets.soloActualsByDay[DAY]).toHaveLength(1);
+    expect(buckets.soloActualsByDay[DAY]?.[0]?.id).toBe(act.id);
+    expect(buckets.soloActualsByDay[DAY]?.[0]?.source).toBe("garmin-bridge");
+  });
+
+  it("should not render a matched source-only activity as a solo actual (no double render)", () => {
+    // Arrange
+    const act = buildSourceActivityRecord({
+      profileId: "p1",
+      date: DAY,
+      sport: "cycling",
+      sourceBridgeId: "garmin-bridge",
+      externalId: "9",
+    });
+    const ms = matched({
+      match: match({ executedWorkoutIds: [act.id] }),
+    });
+    const args = {
+      days: DAYS,
+      coachingByDay: { [DAY]: [activity()] },
+      workoutsByDay: { [DAY]: [workout()] },
+      activitiesByDay: { [DAY]: [act] },
+      matched: [ms],
+    };
+
+    // Act
+    const buckets = buildCalendarBuckets(args);
+
+    // Assert
+    expect(buckets.soloActualsByDay[DAY]).toEqual([]);
+  });
+
+  it("should not project a twin activity whose WorkoutRecord already renders", () => {
+    // Arrange
+    const twin: ActivityRecord = {
+      ...buildSourceActivityRecord({
+        profileId: "p1",
+        date: DAY,
+        sport: "cycling",
+        sourceBridgeId: "fit-import",
+        externalId: "hash-1",
+      }),
+      linkedWorkoutId: "w-7",
+    };
+    const args = {
+      days: DAYS,
+      coachingByDay: {},
+      workoutsByDay: { [DAY]: [workout({ id: "w-7" })] },
+      activitiesByDay: { [DAY]: [twin] },
+      matched: [],
+    };
+
+    // Act
+    const buckets = buildCalendarBuckets(args);
+
+    // Assert
+    // Only the twin WorkoutRecord renders; the activity is not projected.
+    expect(buckets.soloActualsByDay[DAY]).toHaveLength(1);
+    expect(buckets.soloActualsByDay[DAY]?.[0]?.id).toBe("w-7");
   });
 
   it("should produce empty buckets for days with no items in either lane", () => {

--- a/packages/workout-spa-editor/src/components/pages/calendar-buckets.ts
+++ b/packages/workout-spa-editor/src/components/pages/calendar-buckets.ts
@@ -1,4 +1,6 @@
+import { activityToWorkoutRecord } from "../../application/coaching/activity-to-workout-record";
 import type { MatchedSessionWithMetadata as PageMatchedSession } from "../../hooks/use-matched-sessions";
+import type { ActivityRecord } from "../../types/activity-record";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { CoachingActivity } from "../../types/coaching-activity";
 
@@ -6,8 +8,23 @@ export type BuildBucketsArgs = {
   days: string[];
   workoutsByDay: Record<string, WorkoutRecord[]>;
   coachingByDay: Record<string, CoachingActivity[]>;
+  /** Executed activities (v27) rendered natively; defaults to none. */
+  activitiesByDay?: Record<string, ActivityRecord[]>;
   matched: PageMatchedSession[];
 };
+
+/**
+ * Unmatched source-only activities (no twin WorkoutRecord), projected for the
+ * calendar's solo-actual lane. Twin activities are skipped — their own
+ * WorkoutRecord already renders. Matched activities are absorbed by the card.
+ */
+const soloActivityActuals = (
+  activities: ActivityRecord[],
+  matchedWorkoutIds: ReadonlySet<string>
+): WorkoutRecord[] =>
+  activities
+    .filter((a) => a.linkedWorkoutId === null && !matchedWorkoutIds.has(a.id))
+    .map(activityToWorkoutRecord);
 
 export type CalendarBuckets = {
   matchedByDay: Record<string, PageMatchedSession[]>;
@@ -32,6 +49,7 @@ export function buildCalendarBuckets({
   days,
   workoutsByDay,
   coachingByDay,
+  activitiesByDay = {},
   matched,
 }: BuildBucketsArgs): CalendarBuckets {
   const matchedActivityIds = new Set(matched.map((m) => m.activity.id));
@@ -48,9 +66,10 @@ export function buildCalendarBuckets({
     soloPlansByDay[day] = (coachingByDay[day] ?? []).filter(
       (a) => !matchedActivityIds.has(a.id)
     );
-    soloActualsByDay[day] = (workoutsByDay[day] ?? []).filter(
-      (w) => !matchedWorkoutIds.has(w.id)
-    );
+    soloActualsByDay[day] = [
+      ...(workoutsByDay[day] ?? []).filter((w) => !matchedWorkoutIds.has(w.id)),
+      ...soloActivityActuals(activitiesByDay[day] ?? [], matchedWorkoutIds),
+    ];
   }
   return { matchedByDay, soloPlansByDay, soloActualsByDay };
 }

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-buckets-memo.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-buckets-memo.ts
@@ -6,6 +6,7 @@
 import { useMemo } from "react";
 
 import type { MatchedSessionWithMetadata } from "../../hooks/use-matched-sessions";
+import type { ActivityRecord } from "../../types/activity-record";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { CoachingActivity } from "../../types/coaching-activity";
 import type { CalendarBuckets } from "./calendar-buckets";
@@ -15,6 +16,7 @@ export type UseCalendarBucketsArgs = {
   days: string[];
   workoutsByDay: Record<string, WorkoutRecord[]>;
   coachingByDay: Record<string, CoachingActivity[]>;
+  activitiesByDay: Record<string, ActivityRecord[]>;
   matched: MatchedSessionWithMetadata[];
 };
 
@@ -22,9 +24,17 @@ export const useCalendarBucketsMemo = ({
   days,
   workoutsByDay,
   coachingByDay,
+  activitiesByDay,
   matched,
 }: UseCalendarBucketsArgs): CalendarBuckets =>
   useMemo(
-    () => buildCalendarBuckets({ days, workoutsByDay, coachingByDay, matched }),
-    [days, workoutsByDay, coachingByDay, matched]
+    () =>
+      buildCalendarBuckets({
+        days,
+        workoutsByDay,
+        coachingByDay,
+        activitiesByDay,
+        matched,
+      }),
+    [days, workoutsByDay, coachingByDay, activitiesByDay, matched]
   );

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-page.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-page.ts
@@ -20,10 +20,9 @@ import {
   useAutoMatchBannerActions,
 } from "../../hooks/use-auto-match-banner-actions";
 import { useAutoMatchSuggestions } from "../../hooks/use-auto-match-suggestions";
+import { useCalendarExecuted } from "../../hooks/use-calendar-executed";
 import { useCoachingActivities } from "../../hooks/use-coaching-activities";
 import { useCoachingAutoSync } from "../../hooks/use-coaching-auto-sync";
-import { useExecutedMatchAutoForCalendar } from "../../hooks/use-executed-match-auto";
-import { useGarminActivitiesPull } from "../../hooks/use-garmin-activities-pull";
 import { useMatchedSessions } from "../../hooks/use-matched-sessions";
 import { useSetCalendarView } from "../../hooks/use-set-calendar-view";
 import { useUserPreferences } from "../../hooks/use-user-preferences";
@@ -67,9 +66,8 @@ export function useCalendarPage(): CalendarPageState {
     weekStart,
     s.data.days.at(-1) ?? ""
   );
-  useGarminActivitiesPull(profileId);
   const rawMatched = useMatchedSessions(profileId, s.data.days);
-  useExecutedMatchAutoForCalendar(rawMatched, s.data.workoutsByDay);
+  const activitiesByDay = useCalendarExecuted(profileId, rawMatched, s.data);
   const suggestions = useAutoMatchSuggestions(profileId, weekStart);
   const bannerActions = useAutoMatchBannerActions(profileId, weekStart);
   const prefs = useUserPreferences({ profileId, defaultView: defaultView() });
@@ -77,6 +75,7 @@ export function useCalendarPage(): CalendarPageState {
     days: s.data.days,
     workoutsByDay: s.data.workoutsByDay,
     coachingByDay: coaching.byDay,
+    activitiesByDay,
     matched: rawMatched ?? [],
   });
   const onViewChange = useSetCalendarView(profileId);

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-page.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-page.ts
@@ -23,6 +23,7 @@ import { useAutoMatchSuggestions } from "../../hooks/use-auto-match-suggestions"
 import { useCoachingActivities } from "../../hooks/use-coaching-activities";
 import { useCoachingAutoSync } from "../../hooks/use-coaching-auto-sync";
 import { useExecutedMatchAutoForCalendar } from "../../hooks/use-executed-match-auto";
+import { useGarminActivitiesPull } from "../../hooks/use-garmin-activities-pull";
 import { useMatchedSessions } from "../../hooks/use-matched-sessions";
 import { useSetCalendarView } from "../../hooks/use-set-calendar-view";
 import { useUserPreferences } from "../../hooks/use-user-preferences";
@@ -66,6 +67,7 @@ export function useCalendarPage(): CalendarPageState {
     weekStart,
     s.data.days.at(-1) ?? ""
   );
+  useGarminActivitiesPull(profileId);
   const rawMatched = useMatchedSessions(profileId, s.data.days);
   useExecutedMatchAutoForCalendar(rawMatched, s.data.workoutsByDay);
   const suggestions = useAutoMatchSuggestions(profileId, weekStart);

--- a/packages/workout-spa-editor/src/components/pages/use-calendar-state.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-calendar-state.ts
@@ -5,6 +5,7 @@
 import { useCallback, useState } from "react";
 import { useLocation } from "wouter";
 
+import { isProjectedWorkoutRecord } from "../../application/coaching/activity-to-workout-record";
 import { useGarminBridge } from "../../contexts";
 import { useActiveProfileLive } from "../../hooks/use-active-profile-live";
 import { withOrigin } from "../../routing/with-origin";
@@ -40,7 +41,15 @@ export function useCalendarState() {
 
   const handleWorkoutClick = useCallback(
     (workout: WorkoutRecord) => {
-      if (workout.state === "raw" || workout.state === "skipped") {
+      // Projected activities (executions with no persisted WorkoutRecord)
+      // have no id in the `workouts` table — the editor can never resolve
+      // them, so they preview in place instead of navigating (kill test:
+      // no infinite editor spinner for a card that visibly exists).
+      if (
+        workout.state === "raw" ||
+        workout.state === "skipped" ||
+        isProjectedWorkoutRecord(workout)
+      ) {
         setSelectedWorkout(workout);
       } else {
         // Carry the originating week so Back returns to THIS grid.

--- a/packages/workout-spa-editor/src/hooks/chat/apply-route-toggle.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/apply-route-toggle.ts
@@ -1,0 +1,53 @@
+/**
+ * Applies enable_route/disable_route: upserts the IntegrationPolicy row
+ * for the resolved bridge, preserving its existing mode, and returns the
+ * resulting state so the assistant can confirm it in natural language.
+ */
+import type { SetDataRouteInput } from "../../application/chat/tools/chat-tool-deps";
+import { upsertIntegrationPolicy } from "../../application/integration-policy/upsert-integration-policy.use-case";
+import type { PersistencePort } from "../../ports/persistence-port";
+import { resolveBridgeId } from "./resolve-integration-key";
+
+export type RouteToggleInput = Extract<
+  SetDataRouteInput,
+  { action: "enable_route" | "disable_route" }
+>;
+
+export const applyRouteToggle = async (
+  persistence: PersistencePort,
+  profileId: string,
+  input: RouteToggleInput
+): Promise<unknown> => {
+  const bridgeId = resolveBridgeId(input.integrationId);
+  if (!bridgeId) {
+    return {
+      error: "integration_not_bridged",
+      integrationId: input.integrationId,
+    };
+  }
+
+  const existing = await persistence.integrationPolicy.findByNaturalKey({
+    profileId,
+    dataType: input.dataType,
+    direction: input.direction,
+    bridgeId,
+  });
+  const updated = await upsertIntegrationPolicy(
+    { policyRepo: persistence.integrationPolicy },
+    {
+      profileId,
+      dataType: input.dataType,
+      bridgeId,
+      direction: input.direction,
+      mode: existing?.mode ?? "auto",
+      enabled: input.action === "enable_route",
+    }
+  );
+  return {
+    dataType: updated.dataType,
+    integrationId: input.integrationId,
+    direction: updated.direction,
+    enabled: updated.enabled,
+    mode: updated.mode,
+  };
+};

--- a/packages/workout-spa-editor/src/hooks/chat/build-chat-agent.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/build-chat-agent.ts
@@ -8,6 +8,7 @@ import { type ChatAgent, type ChatTool, createChatAgent } from "@kaiord/ai";
 import { buildChatSystemPrompt } from "../../application/chat/chat-system-prompt";
 import { buildChatTools } from "../../application/chat/tools/build-chat-tools";
 import type { ChatActionOps } from "../../application/chat/tools/chat-tool-deps";
+import type { DataHubMatrixSignals } from "../../application/data-hub/build-data-hub-matrix";
 import {
   createLanguageModel,
   type ProviderCredential,
@@ -23,6 +24,7 @@ export type BuildChatAgentArgs = {
   provider: ProviderCredential;
   modelId: string;
   actions: ChatActionOps;
+  getMatrixSignals: () => Promise<DataHubMatrixSignals>;
   onTextDelta: (delta: string) => void;
 };
 
@@ -34,6 +36,7 @@ export const buildChatAgent = async (
     profileId: args.profileId,
     today: args.today,
     actions: args.actions,
+    getMatrixSignals: args.getMatrixSignals,
   });
   const model = await createLanguageModel(args.provider, args.modelId);
   const agent = createChatAgent({

--- a/packages/workout-spa-editor/src/hooks/chat/build-data-route-signals.test.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/build-data-route-signals.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createInMemoryPersistence } from "../../test-utils/in-memory-persistence";
+import { buildDataRouteSignals } from "./build-data-route-signals";
+
+const getExtensionId = vi.fn();
+const getCapabilities = vi.fn();
+
+vi.mock("../../adapters/bridge/bridge-discovery", () => ({
+  bridgeDiscovery: {
+    getExtensionId: (id: string) => getExtensionId(id),
+    getCapabilities: (id: string) => getCapabilities(id),
+  },
+}));
+
+const PROFILE_ID = "p1";
+
+describe("buildDataRouteSignals", () => {
+  it("should read bridge online/announces state from bridge discovery", async () => {
+    // Arrange
+    getExtensionId.mockImplementation((id: string) =>
+      id === "train2go-bridge" ? "ext-1" : null
+    );
+    getCapabilities.mockImplementation((id: string) =>
+      id === "train2go-bridge" ? ["read:training-plan"] : null
+    );
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const signals = await buildDataRouteSignals(persistence, PROFILE_ID);
+
+    // Assert
+    expect(signals.isBridgeOnline("train2go-bridge")).toBe(true);
+    expect(signals.isBridgeOnline("garmin-bridge")).toBe(false);
+    expect(
+      signals.bridgeAnnounces("train2go-bridge", "read:training-plan")
+    ).toBe(true);
+    expect(signals.bridgeAnnounces("train2go-bridge", "read:activities")).toBe(
+      false
+    );
+  });
+
+  it("should read enabled routes and freshness from persisted IntegrationPolicy rows", async () => {
+    // Arrange
+    getExtensionId.mockReturnValue(null);
+    getCapabilities.mockReturnValue(null);
+    const persistence = createInMemoryPersistence();
+    await persistence.integrationPolicy.put({
+      id: "route-1",
+      profileId: PROFILE_ID,
+      dataType: "planned-session",
+      bridgeId: "train2go-bridge",
+      direction: "import",
+      mode: "auto",
+      enabled: true,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    });
+    await persistence.coachingSyncState.put({
+      source: "train2go",
+      profileId: PROFILE_ID,
+      lastSyncedAt: "2026-07-06T08:00:00.000Z",
+    });
+
+    // Act
+    const signals = await buildDataRouteSignals(persistence, PROFILE_ID);
+
+    // Assert
+    expect(
+      signals.isRouteEnabled("planned-session", "import", "train2go-bridge")
+    ).toBe(true);
+    expect(
+      signals.findRoute("planned-session", "import", "train2go-bridge")
+    ).toEqual({ id: "route-1", mode: "auto" });
+    expect(signals.lastSyncedAt("train2go")).toBe("2026-07-06T08:00:00.000Z");
+    expect(signals.lastSyncedAt("garmin")).toBeUndefined();
+  });
+
+  it("should read connection status from the connections store", async () => {
+    // Arrange
+    getExtensionId.mockReturnValue(null);
+    getCapabilities.mockReturnValue(null);
+    const persistence = createInMemoryPersistence();
+    await persistence.connections.put({
+      profileId: PROFILE_ID,
+      providerId: "intervals",
+      status: "connected",
+      connectedAt: "2026-07-01T00:00:00.000Z",
+    } as never);
+
+    // Act
+    const signals = await buildDataRouteSignals(persistence, PROFILE_ID);
+
+    // Assert
+    expect(signals.isConnected("intervals")).toBe(true);
+    expect(signals.isConnected("strava")).toBe(false);
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/chat/build-data-route-signals.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/build-data-route-signals.ts
@@ -1,0 +1,84 @@
+/**
+ * buildDataRouteSignals — one-shot (non-reactive) `DataHubMatrixSignals`
+ * snapshot for the `get_data_routes` chat tool. Mirrors
+ * `useDataHubMatrix`'s signal wiring (bridge discovery, the v24
+ * connections store, IntegrationPolicy rows, Train2Go sync freshness) as
+ * a plain async function, so the application-layer tool never imports
+ * adapters directly (patrón do-push-to-garmin.ts).
+ */
+import type { ManagedDataType } from "@kaiord/core";
+import { MANAGED_DATA_REGISTRY, managedDataTypes } from "@kaiord/core";
+
+import { bridgeDiscovery } from "../../adapters/bridge/bridge-discovery";
+import type { DataHubMatrixSignals } from "../../application/data-hub/build-data-hub-matrix";
+import type { PersistencePort } from "../../ports/persistence-port";
+import type { IntegrationPolicy } from "../../types/integration-policy";
+
+const TRAIN2GO = "train2go";
+
+type ByDataType = Map<
+  ManagedDataType,
+  { import: IntegrationPolicy[]; export: IntegrationPolicy[] }
+>;
+
+const fetchPoliciesByDataType = async (
+  persistence: PersistencePort,
+  profileId: string
+): Promise<ByDataType> => {
+  const byDataType: ByDataType = new Map();
+  for (const dataType of managedDataTypes) {
+    const reg = MANAGED_DATA_REGISTRY[dataType];
+    const [imports, exports] = await Promise.all([
+      reg.capabilities.import
+        ? persistence.integrationPolicy.findByProfileDirection({
+            profileId,
+            dataType,
+            direction: "import",
+          })
+        : Promise.resolve([]),
+      reg.capabilities.export
+        ? persistence.integrationPolicy.findByProfileDirection({
+            profileId,
+            dataType,
+            direction: "export",
+          })
+        : Promise.resolve([]),
+    ]);
+    byDataType.set(dataType, { import: imports, export: exports });
+  }
+  return byDataType;
+};
+
+export const buildDataRouteSignals = async (
+  persistence: PersistencePort,
+  profileId: string
+): Promise<DataHubMatrixSignals> => {
+  const [connections, byDataType, train2goState] = await Promise.all([
+    persistence.connections.getByProfile(profileId),
+    fetchPoliciesByDataType(persistence, profileId),
+    persistence.coachingSyncState.getBySourceAndProfile(TRAIN2GO, profileId),
+  ]);
+  const connectionByProvider = new Map(
+    connections.map((c) => [c.providerId, c])
+  );
+
+  return {
+    isConnected: (id) => connectionByProvider.get(id)?.status === "connected",
+    isBridgeOnline: (bridgeId) =>
+      bridgeDiscovery.getExtensionId(bridgeId) !== null,
+    bridgeAnnounces: (bridgeId, token) =>
+      (bridgeDiscovery.getCapabilities(bridgeId) ?? []).includes(token),
+    isRouteEnabled: (dataType, direction, bridgeId) =>
+      (byDataType.get(dataType)?.[direction] ?? []).some(
+        (p) => p.bridgeId === bridgeId && p.enabled
+      ),
+    lastSyncedAt: (id) =>
+      id === TRAIN2GO ? train2goState?.lastSyncedAt : undefined,
+    findRoute: (dataType, direction, bridgeId) => {
+      const match = (byDataType.get(dataType)?.[direction] ?? []).find(
+        (p) => p.bridgeId === bridgeId
+      );
+      return match ? { id: match.id, mode: match.mode } : undefined;
+    },
+  };
+};

--- a/packages/workout-spa-editor/src/hooks/chat/chat-turn-runner.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/chat-turn-runner.ts
@@ -10,6 +10,7 @@ import { recordsToModelMessages } from "../../application/chat/chat-message-mapp
 import { ensureConversationForTurn } from "../../application/chat/ensure-conversation";
 import type { ChatMessageRecord } from "../../types/chat/chat-message-record";
 import { buildChatAgent } from "./build-chat-agent";
+import { buildDataRouteSignals } from "./build-data-route-signals";
 import { runAgent } from "./chat-turn-context";
 import type { ChatTurnCtx } from "./chat-turn-types";
 
@@ -38,6 +39,8 @@ export const sendTurn = async (
       provider: ctx.provider,
       modelId: ctx.modelId,
       actions: ctx.ops,
+      getMatrixSignals: () =>
+        buildDataRouteSignals(ctx.persistence, ctx.profileId),
       onTextDelta: (d) => ctx.set.streamingText((p) => p + d),
     });
     ctx.agentRef.current = built.agent;

--- a/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.test.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for doSetDataRoute — the set_data_route action-op implementation.
+ * Includes the conversational kill test: disabling a route via chat must
+ * cut the SAME real gate the production sync/push paths consult, not just
+ * flip an isolated flag.
+ */
+import { describe, expect, it } from "vitest";
+
+import { hasEnabledPlannedSessionImportRoute } from "../../application/coaching/planned-session-import-route";
+import {
+  executeWorkoutPush,
+  NoActiveExportRouteError,
+} from "../../application/export/execute-workout-push";
+import { createInMemoryPersistence } from "../../test-utils/in-memory-persistence";
+import { doSetDataRoute } from "./do-set-data-route";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("doSetDataRoute — enable_route / disable_route", () => {
+  it("should resolve the chat-facing integration id to the storage bridge id", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = (await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "enable_route",
+      dataType: "planned-session",
+      integrationId: "train2go",
+      direction: "import",
+    })) as { enabled: boolean; mode: string };
+
+    // Assert
+    expect(result).toMatchObject({ enabled: true, mode: "auto" });
+    const stored = await persistence.integrationPolicy.findByNaturalKey({
+      profileId: PROFILE_ID,
+      dataType: "planned-session",
+      direction: "import",
+      bridgeId: "train2go-bridge",
+    });
+    expect(stored?.enabled).toBe(true);
+  });
+
+  it("should preserve an existing route's mode when toggling enabled", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    await persistence.integrationPolicy.put({
+      id: "existing",
+      profileId: PROFILE_ID,
+      dataType: "planned-session",
+      bridgeId: "train2go-bridge",
+      direction: "import",
+      mode: "manual",
+      enabled: false,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    });
+
+    // Act
+    const result = (await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "enable_route",
+      dataType: "planned-session",
+      integrationId: "train2go",
+      direction: "import",
+    })) as { mode: string };
+
+    // Assert
+    expect(result.mode).toBe("manual");
+  });
+
+  it("should return an error for an integration with no bridge to route", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "enable_route",
+      dataType: "sleep",
+      integrationId: "manual",
+      direction: "import",
+    });
+
+    // Assert
+    expect(result).toEqual({
+      error: "integration_not_bridged",
+      integrationId: "manual",
+    });
+  });
+
+  it("should cut the real Train2Go sync gate when planned-session import is disabled via chat (kill test)", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    await persistence.integrationPolicy.put({
+      id: "existing",
+      profileId: PROFILE_ID,
+      dataType: "planned-session",
+      bridgeId: "train2go-bridge",
+      direction: "import",
+      mode: "auto",
+      enabled: true,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    });
+    expect(
+      await hasEnabledPlannedSessionImportRoute(
+        persistence.integrationPolicy,
+        PROFILE_ID
+      )
+    ).toBe(true);
+
+    // Act
+    await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "disable_route",
+      dataType: "planned-session",
+      integrationId: "train2go",
+      direction: "import",
+    });
+
+    // Assert
+    expect(
+      await hasEnabledPlannedSessionImportRoute(
+        persistence.integrationPolicy,
+        PROFILE_ID
+      )
+    ).toBe(false);
+  });
+
+  it("should block the real Garmin push gate when the workout export route is disabled via chat (kill test)", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+    await persistence.integrationPolicy.put({
+      id: "existing",
+      profileId: PROFILE_ID,
+      dataType: "workout",
+      bridgeId: "garmin-bridge",
+      direction: "export",
+      mode: "manual",
+      enabled: true,
+      updatedAt: "2026-07-01T00:00:00.000Z",
+    });
+
+    // Act
+    await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "disable_route",
+      dataType: "workout",
+      integrationId: "garmin",
+      direction: "export",
+    });
+
+    // Assert
+    await expect(
+      executeWorkoutPush(
+        {
+          policyRepo: persistence.integrationPolicy,
+          ledgerRepo: {} as never,
+        },
+        {
+          profileId: PROFILE_ID,
+          kaiordRecordId: "w1",
+          destinationBridgeId: "garmin-bridge",
+          payload: {},
+          pushFn: async () => ({ externalId: "ext-1" }),
+        }
+      )
+    ).rejects.toBeInstanceOf(NoActiveExportRouteError);
+  });
+});
+
+describe("doSetDataRoute — set_source_policy", () => {
+  it("should resolve a single-source priority order (read only from that source)", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "set_source_policy",
+      dataType: "sleep",
+      mode: "priority",
+      sourceOrder: ["whoop"],
+    });
+
+    // Assert
+    expect(result).toEqual({
+      dataType: "sleep",
+      mode: "priority",
+      sourceOrder: ["whoop-bridge"],
+    });
+    const stored = await persistence.dataTypeSourcePolicy.findByProfileAndType({
+      profileId: PROFILE_ID,
+      dataType: "sleep",
+    });
+    expect(stored).toMatchObject({
+      mode: "priority",
+      sourceOrder: ["whoop-bridge"],
+    });
+  });
+
+  it("should keep the 'manual' source key unresolved (not a bridge id)", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "set_source_policy",
+      dataType: "weight",
+      mode: "priority",
+      sourceOrder: ["manual", "garmin"],
+    });
+
+    // Assert
+    expect(result).toEqual({
+      dataType: "weight",
+      mode: "priority",
+      sourceOrder: ["manual", "garmin-bridge"],
+    });
+  });
+
+  it("should clear the source order when switching to union", async () => {
+    // Arrange
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "set_source_policy",
+      dataType: "sleep",
+      mode: "union",
+      sourceOrder: ["whoop"],
+    });
+
+    // Assert
+    expect(result).toEqual({
+      dataType: "sleep",
+      mode: "union",
+      sourceOrder: [],
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.ts
@@ -1,0 +1,42 @@
+/**
+ * Applies the three `set_data_route` actions and returns the resulting
+ * persisted state so the assistant can confirm it in natural language.
+ */
+import type { SetDataRouteInput } from "../../application/chat/tools/chat-tool-deps";
+import type { PersistencePort } from "../../ports/persistence-port";
+import { applyRouteToggle } from "./apply-route-toggle";
+import { resolveSourceKey } from "./resolve-integration-key";
+
+type SourcePolicyInput = Extract<
+  SetDataRouteInput,
+  { action: "set_source_policy" }
+>;
+
+const applySourcePolicy = async (
+  persistence: PersistencePort,
+  profileId: string,
+  input: SourcePolicyInput
+): Promise<unknown> => {
+  const sourceOrder =
+    input.mode === "priority"
+      ? (input.sourceOrder ?? [])
+          .map(resolveSourceKey)
+          .filter((id): id is string => id !== undefined)
+      : [];
+  await persistence.dataTypeSourcePolicy.put({
+    profileId,
+    dataType: input.dataType,
+    mode: input.mode,
+    sourceOrder,
+  });
+  return { dataType: input.dataType, mode: input.mode, sourceOrder };
+};
+
+export const doSetDataRoute = (
+  persistence: PersistencePort,
+  profileId: string,
+  input: SetDataRouteInput
+): Promise<unknown> =>
+  input.action === "set_source_policy"
+    ? applySourcePolicy(persistence, profileId, input)
+    : applyRouteToggle(persistence, profileId, input);

--- a/packages/workout-spa-editor/src/hooks/chat/resolve-integration-key.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/resolve-integration-key.ts
@@ -1,0 +1,22 @@
+/**
+ * Resolves the chat-facing INTEGRATION_REGISTRY id (e.g. "whoop") to the
+ * IntegrationPolicy/DataTypeSourcePolicy storage key (the bridge id, e.g.
+ * "whoop-bridge") used by `set_data_route`.
+ */
+import { INTEGRATION_REGISTRY } from "../../integrations/integration-registry";
+
+const MANUAL_SOURCE_ID = "manual";
+
+/** IntegrationPolicy rows only exist for real bridges — manual is always
+    active by product decision and has no route to toggle (F1.0/F4.1). */
+export const resolveBridgeId = (integrationId: string): string | undefined =>
+  INTEGRATION_REGISTRY.find((entry) => entry.id === integrationId)?.bridgeId ??
+  undefined;
+
+/** DataTypeSourcePolicy.sourceOrder additionally accepts "manual" — the
+    always-on source key resolveEffectiveSource exempts from the
+    enabled-import-policy filter (F3.2 reconciliation invariant). */
+export const resolveSourceKey = (integrationId: string): string | undefined =>
+  integrationId === MANUAL_SOURCE_ID
+    ? MANUAL_SOURCE_ID
+    : resolveBridgeId(integrationId);

--- a/packages/workout-spa-editor/src/hooks/data-hub/use-data-hub-matrix.ts
+++ b/packages/workout-spa-editor/src/hooks/data-hub/use-data-hub-matrix.ts
@@ -20,8 +20,11 @@ import { usePersistence } from "../../contexts/persistence-context";
 import { INTEGRATION_REGISTRY } from "../../integrations/integration-registry";
 import { useConnectionStatus } from "../use-connection-status";
 import { useDiscoveredBridges } from "../use-discovered-bridges";
+import { useSourceSyncState } from "./use-source-sync-state";
 
 const TRAIN2GO = "train2go";
+const GARMIN = "garmin";
+const GARMIN_BRIDGE = "garmin-bridge";
 
 export const useDataHubMatrix = (profileId: string | null): DataHubRow[] => {
   const connections = useConnectionStatus(profileId);
@@ -29,6 +32,11 @@ export const useDataHubMatrix = (profileId: string | null): DataHubRow[] => {
   const { byDataType } = useDataFlows(profileId ?? "");
   const persistence = usePersistence();
   const train2goSyncedAt = useTrain2GoSyncState(persistence, profileId ?? "");
+  const garminSyncedAt = useSourceSyncState(
+    persistence,
+    GARMIN_BRIDGE,
+    profileId
+  );
 
   return useMemo(
     () =>
@@ -42,7 +50,12 @@ export const useDataHubMatrix = (profileId: string | null): DataHubRow[] => {
           (byDataType.get(dataType)?.[direction] ?? []).some(
             (p) => p.bridgeId === bridgeId && p.enabled
           ),
-        lastSyncedAt: (id) => (id === TRAIN2GO ? train2goSyncedAt : undefined),
+        lastSyncedAt: (id) =>
+          id === TRAIN2GO
+            ? train2goSyncedAt
+            : id === GARMIN
+              ? garminSyncedAt
+              : undefined,
         findRoute: (dataType, direction, bridgeId) => {
           const match = (byDataType.get(dataType)?.[direction] ?? []).find(
             (p) => p.bridgeId === bridgeId
@@ -50,6 +63,6 @@ export const useDataHubMatrix = (profileId: string | null): DataHubRow[] => {
           return match ? { id: match.id, mode: match.mode } : undefined;
         },
       }),
-    [connections, discovered, byDataType, train2goSyncedAt]
+    [connections, discovered, byDataType, train2goSyncedAt, garminSyncedAt]
   );
 };

--- a/packages/workout-spa-editor/src/hooks/data-hub/use-source-sync-state.ts
+++ b/packages/workout-spa-editor/src/hooks/data-hub/use-source-sync-state.ts
@@ -1,0 +1,24 @@
+/**
+ * useSourceSyncState — live `lastSyncedAt` for a (source, profile)
+ * `coachingSyncState` row. Backs the Data Hub matrix freshness for any
+ * import source that records a sync timestamp (train2go planned sessions,
+ * garmin-bridge activities) without a per-source bespoke hook.
+ */
+import { useLiveQuery } from "dexie-react-hooks";
+
+import type { PersistencePort } from "../../ports/persistence-port";
+
+export const useSourceSyncState = (
+  persistence: PersistencePort,
+  source: string,
+  profileId: string | null
+): string | undefined => {
+  const row = useLiveQuery(() => {
+    if (!profileId) return Promise.resolve(undefined);
+    return persistence.coachingSyncState.getBySourceAndProfile(
+      source,
+      profileId
+    );
+  }, [source, profileId]);
+  return row?.lastSyncedAt;
+};

--- a/packages/workout-spa-editor/src/hooks/use-calendar-activities.ts
+++ b/packages/workout-spa-editor/src/hooks/use-calendar-activities.ts
@@ -1,0 +1,43 @@
+/**
+ * useCalendarActivities — live read of the v27 `activities` (executed
+ * sessions) for the visible calendar week, grouped by day.
+ *
+ * Backs the calendar's native activity render (GATE A1): the flat list feeds
+ * the executed-match auto hook and the by-day map feeds the bucket builder.
+ * One `useLiveQuery` over the `[profileId+date]` index keeps the read budget
+ * bounded, mirroring `useCoachingActivities`.
+ */
+import { useLiveQuery } from "dexie-react-hooks";
+import { useMemo } from "react";
+
+import { usePersistence } from "../contexts/persistence-context";
+import type { ActivityRecord } from "../types/activity-record";
+
+export type CalendarActivities = {
+  activities: ActivityRecord[];
+  byDay: Record<string, ActivityRecord[]>;
+};
+
+export const useCalendarActivities = (
+  profileId: string | null,
+  days: string[]
+): CalendarActivities => {
+  const persistence = usePersistence();
+  const start = days[0] ?? "";
+  const end = days[days.length - 1] ?? "";
+  const rows = useLiveQuery(() => {
+    if (!profileId || !start || !end) return Promise.resolve([]);
+    return persistence.activities.getByProfileAndDateRange(
+      profileId,
+      start,
+      end
+    );
+  }, [profileId, start, end]);
+
+  return useMemo(() => {
+    const activities = rows ?? [];
+    const byDay: Record<string, ActivityRecord[]> = {};
+    for (const a of activities) (byDay[a.date] ??= []).push(a);
+    return { activities, byDay };
+  }, [rows]);
+};

--- a/packages/workout-spa-editor/src/hooks/use-calendar-executed.ts
+++ b/packages/workout-spa-editor/src/hooks/use-calendar-executed.ts
@@ -1,0 +1,29 @@
+/**
+ * useCalendarExecuted — groups the calendar's executed-activity plumbing:
+ * pull Garmin activities (governed), read the visible week's activities, and
+ * auto-match them into existing sessions. Returns the by-day activities for
+ * the bucket builder's native render. Extracted so `useCalendarPage` stays
+ * under its line cap.
+ */
+import type { ActivityRecord } from "../types/activity-record";
+import type { WorkoutRecord } from "../types/calendar-record";
+import { useCalendarActivities } from "./use-calendar-activities";
+import { useExecutedMatchAutoForCalendar } from "./use-executed-match-auto";
+import { useGarminActivitiesPull } from "./use-garmin-activities-pull";
+import type { MatchedSessionWithMetadata } from "./use-matched-sessions";
+
+export type CalendarExecutedData = {
+  days: string[];
+  workoutsByDay: Readonly<Record<string, WorkoutRecord[]>>;
+};
+
+export const useCalendarExecuted = (
+  profileId: string | null,
+  rawMatched: readonly MatchedSessionWithMetadata[] | undefined,
+  data: CalendarExecutedData
+): Record<string, ActivityRecord[]> => {
+  useGarminActivitiesPull(profileId);
+  const { activities, byDay } = useCalendarActivities(profileId, data.days);
+  useExecutedMatchAutoForCalendar(rawMatched, data.workoutsByDay, activities);
+  return byDay;
+};

--- a/packages/workout-spa-editor/src/hooks/use-chat-action-ops.ts
+++ b/packages/workout-spa-editor/src/hooks/use-chat-action-ops.ts
@@ -9,23 +9,17 @@
  */
 import { useCallback, useMemo } from "react";
 
-import { bridgeDiscovery } from "../adapters/bridge/bridge-discovery";
-import { createTrain2GoCoachingTransport } from "../adapters/train2go/train2go-coaching-transport";
 import type {
   ChatActionOps,
   CreateWorkoutInput,
-  LogHealthMetricInput,
-  LogIntakeInput,
 } from "../application/chat/tools/chat-tool-deps";
 import { usePersistence } from "../contexts/persistence-context";
 import type { LlmProviderConfig } from "../store/ai-store-types";
-import {
-  doCreateWorkout,
-  doLogHealthMetric,
-  doSyncCoaching,
-} from "./chat/chat-action-ops-impl";
-import { doLogIntake } from "./chat/do-log-intake";
+import { doCreateWorkout, doSyncCoaching } from "./chat/chat-action-ops-impl";
+import { useLogOps } from "./use-log-ops";
 import { usePushToGarminOp } from "./use-push-to-garmin-op";
+import { useSetDataRouteOp } from "./use-set-data-route-op";
+import { useTrain2GoCoachingTransport } from "./use-train2go-coaching-transport";
 
 const requireProfile = (profileId: string | null): string => {
   if (!profileId) throw new Error("No active profile");
@@ -43,13 +37,9 @@ export const useChatActionOps = (
 ): ChatActionOps => {
   const persistence = usePersistence();
   const pushToGarmin = usePushToGarminOp();
-  const transport = useMemo(
-    () =>
-      createTrain2GoCoachingTransport(
-        () => bridgeDiscovery.getExtensionId("train2go-bridge") ?? ""
-      ),
-    []
-  );
+  const setDataRoute = useSetDataRouteOp(profileId);
+  const { logHealthMetric, logIntake } = useLogOps(profileId);
+  const transport = useTrain2GoCoachingTransport();
 
   const syncCoaching = useCallback(
     () => doSyncCoaching(persistence, transport, requireProfile(profileId)),
@@ -69,16 +59,6 @@ export const useChatActionOps = (
     },
     [persistence, profileId, provider, modelId]
   );
-  const logHealthMetric = useCallback(
-    (input: LogHealthMetricInput) =>
-      doLogHealthMetric(persistence, requireProfile(profileId), input),
-    [persistence, profileId]
-  );
-  const logIntake = useCallback(
-    (input: LogIntakeInput) =>
-      doLogIntake(persistence, requireProfile(profileId), input),
-    [persistence, profileId]
-  );
 
   return useMemo(
     () => ({
@@ -87,7 +67,15 @@ export const useChatActionOps = (
       logHealthMetric,
       logIntake,
       pushToGarmin,
+      setDataRoute,
     }),
-    [syncCoaching, createWorkout, logHealthMetric, logIntake, pushToGarmin]
+    [
+      syncCoaching,
+      createWorkout,
+      logHealthMetric,
+      logIntake,
+      pushToGarmin,
+      setDataRoute,
+    ]
   );
 };

--- a/packages/workout-spa-editor/src/hooks/use-executed-match-auto.ts
+++ b/packages/workout-spa-editor/src/hooks/use-executed-match-auto.ts
@@ -16,6 +16,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { matchExecutedWorkouts } from "../application/coaching/match-executed-workouts";
 import { usePersistence } from "../contexts/persistence-context";
 import { canonicalizeSport } from "../lib/canonicalize-sport";
+import type { ActivityRecord } from "../types/activity-record";
 import type { WorkoutRecord } from "../types/calendar-record";
 import type { SessionMatch } from "../types/session-match";
 import { logger } from "../utils/logger";
@@ -44,7 +45,8 @@ const fireAppend = (
 
 export const useExecutedMatchAutoForCalendar = (
   rawMatched: readonly MatchedSessionWithMetadata[] | undefined,
-  workoutsByDay: Readonly<Record<string, WorkoutRecord[]>>
+  workoutsByDay: Readonly<Record<string, WorkoutRecord[]>>,
+  activities: readonly ActivityRecord[]
 ): void => {
   const matches = useMemo(
     () => (rawMatched ?? []).map((m) => m.match),
@@ -54,22 +56,25 @@ export const useExecutedMatchAutoForCalendar = (
     () => Object.values(workoutsByDay).flat(),
     [workoutsByDay]
   );
-  useExecutedMatchAuto(matches, workouts);
+  useExecutedMatchAuto(matches, workouts, activities);
 };
 
 export const useExecutedMatchAuto = (
   matches: readonly SessionMatch[] | null,
-  workouts: readonly WorkoutRecord[] | null
+  workouts: readonly WorkoutRecord[] | null,
+  activities: readonly ActivityRecord[] = []
 ): void => {
   const persistence = usePersistence();
   const firedRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
-    if (!matches || matches.length === 0 || !workouts || workouts.length === 0)
-      return;
+    if (!matches || matches.length === 0) return;
+    const hasExecuted = (workouts?.length ?? 0) > 0 || activities.length > 0;
+    if (!hasExecuted) return;
     const appends = matchExecutedWorkouts({
       sessionMatches: matches,
-      workouts,
+      workouts: workouts ?? [],
+      activities,
       canonicalSport: canonicalizeSport,
     });
     for (const { matchId, toAppend } of appends) {
@@ -85,5 +90,5 @@ export const useExecutedMatchAuto = (
         firedRef
       );
     }
-  }, [matches, workouts, persistence]);
+  }, [matches, workouts, activities, persistence]);
 };

--- a/packages/workout-spa-editor/src/hooks/use-garmin-activities-pull.ts
+++ b/packages/workout-spa-editor/src/hooks/use-garmin-activities-pull.ts
@@ -1,0 +1,42 @@
+/**
+ * useGarminActivitiesPull — live, once-per-mount governed pull of executed
+ * Garmin activities into the v27 `activities` store (F5.3).
+ *
+ * Mirrors the zones auto-import lifecycle: gates on a discovered garmin-bridge
+ * and defers all governance (route-inactive → no fetch) to the pure
+ * `pullGarminActivities` use case. Errors are swallowed so a failed pull never
+ * breaks the calendar mount. The `firedRef` guard keeps it single-shot per
+ * profile so re-renders never re-fire the network call.
+ */
+import { useEffect, useRef } from "react";
+
+import { bridgeDiscovery } from "../adapters/bridge/bridge-discovery";
+import { readGarminActivities } from "../adapters/bridge/garmin-activities-transport";
+import { pullGarminActivities } from "../application/import/pull-garmin-activities.use-case";
+import { usePersistence } from "../contexts/persistence-context";
+import { useDiscoveredBridges } from "./use-discovered-bridges";
+
+const GARMIN_BRIDGE_ID = "garmin-bridge";
+
+export const useGarminActivitiesPull = (profileId: string | null): void => {
+  const persistence = usePersistence();
+  const discovered = useDiscoveredBridges();
+  const firedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!profileId || firedRef.current === profileId) return;
+    if (!discovered.some((d) => d.bridgeId === GARMIN_BRIDGE_ID)) return;
+    const extensionId = bridgeDiscovery.getExtensionId(GARMIN_BRIDGE_ID);
+    if (!extensionId) return;
+    firedRef.current = profileId;
+    void pullGarminActivities(
+      {
+        policyRepo: persistence.integrationPolicy,
+        activities: persistence.activities,
+        coachingSyncState: persistence.coachingSyncState,
+        readActivities: () => readGarminActivities(extensionId),
+      },
+      profileId
+    ).catch(() => undefined);
+  }, [profileId, discovered, persistence]);
+};

--- a/packages/workout-spa-editor/src/hooks/use-log-ops.ts
+++ b/packages/workout-spa-editor/src/hooks/use-log-ops.ts
@@ -1,0 +1,33 @@
+import { useCallback } from "react";
+
+import type {
+  LogHealthMetricInput,
+  LogIntakeInput,
+} from "../application/chat/tools/chat-tool-deps";
+import { usePersistence } from "../contexts/persistence-context";
+import { doLogHealthMetric } from "./chat/chat-action-ops-impl";
+import { doLogIntake } from "./chat/do-log-intake";
+
+export type LogOps = {
+  logHealthMetric: (input: LogHealthMetricInput) => Promise<unknown>;
+  logIntake: (input: LogIntakeInput) => Promise<unknown>;
+};
+
+export const useLogOps = (profileId: string | null): LogOps => {
+  const persistence = usePersistence();
+  const logHealthMetric = useCallback(
+    (input: LogHealthMetricInput) => {
+      if (!profileId) throw new Error("No active profile");
+      return doLogHealthMetric(persistence, profileId, input);
+    },
+    [persistence, profileId]
+  );
+  const logIntake = useCallback(
+    (input: LogIntakeInput) => {
+      if (!profileId) throw new Error("No active profile");
+      return doLogIntake(persistence, profileId, input);
+    },
+    [persistence, profileId]
+  );
+  return { logHealthMetric, logIntake };
+};

--- a/packages/workout-spa-editor/src/hooks/use-set-data-route-op.ts
+++ b/packages/workout-spa-editor/src/hooks/use-set-data-route-op.ts
@@ -1,0 +1,20 @@
+import { useCallback } from "react";
+
+import type { SetDataRouteInput } from "../application/chat/tools/chat-tool-deps";
+import { usePersistence } from "../contexts/persistence-context";
+import { doSetDataRoute } from "./chat/do-set-data-route";
+
+/**
+ * Binds the confirmation-gated set_data_route chat action: contexts are
+ * touched only here, then injected into the plain `doSetDataRoute`.
+ */
+export const useSetDataRouteOp = (profileId: string | null) => {
+  const persistence = usePersistence();
+  return useCallback(
+    (input: SetDataRouteInput) => {
+      if (!profileId) throw new Error("No active profile");
+      return doSetDataRoute(persistence, profileId, input);
+    },
+    [persistence, profileId]
+  );
+};

--- a/packages/workout-spa-editor/src/hooks/use-train2go-coaching-transport.ts
+++ b/packages/workout-spa-editor/src/hooks/use-train2go-coaching-transport.ts
@@ -1,0 +1,14 @@
+import { useMemo } from "react";
+
+import { bridgeDiscovery } from "../adapters/bridge/bridge-discovery";
+import { createTrain2GoCoachingTransport } from "../adapters/train2go/train2go-coaching-transport";
+import type { CoachingTransport } from "../application/coaching/coaching-transport-port";
+
+export const useTrain2GoCoachingTransport = (): CoachingTransport =>
+  useMemo(
+    () =>
+      createTrain2GoCoachingTransport(
+        () => bridgeDiscovery.getExtensionId("train2go-bridge") ?? ""
+      ),
+    []
+  );

--- a/packages/workout-spa-editor/src/ports/activity-repository.ts
+++ b/packages/workout-spa-editor/src/ports/activity-repository.ts
@@ -14,4 +14,13 @@ export type ActivityRepository = {
    * Returns `{ created: false }` on a dedup hit (no second write).
    */
   upsertByExternalId: (record: ActivityRecord) => Promise<{ created: boolean }>;
+  /**
+   * All executed activities for a profile within an inclusive date range —
+   * backs the calendar's native activity render (`[profileId+date]` index).
+   */
+  getByProfileAndDateRange: (
+    profileId: string,
+    start: string,
+    end: string
+  ) => Promise<ActivityRecord[]>;
 };

--- a/packages/workout-spa-editor/src/test-utils/in-memory-activity-repository.ts
+++ b/packages/workout-spa-editor/src/test-utils/in-memory-activity-repository.ts
@@ -14,4 +14,9 @@ export const createInMemoryActivityRepository = (
     store.set(key, record);
     return { created: true };
   },
+
+  getByProfileAndDateRange: async (profileId, start, end) =>
+    [...store.values()].filter(
+      (a) => a.profileId === profileId && a.date >= start && a.date <= end
+    ),
 });

--- a/packages/workout-spa-editor/src/types/activity-record.ts
+++ b/packages/workout-spa-editor/src/types/activity-record.ts
@@ -65,3 +65,34 @@ export const buildActivityRecord = (
     createdAt: new Date().toISOString(),
   };
 };
+
+export type BuildSourceActivityRecordInput = {
+  profileId: string;
+  date: string;
+  sport: string;
+  sourceBridgeId: string;
+  externalId: string;
+  durationSeconds?: number;
+  distanceMeters?: number;
+};
+
+/**
+ * Build a summary-only ActivityRecord for a source pull (e.g. Garmin): no
+ * recorded KRD and no twin WorkoutRecord (`linkedWorkoutId: null`). The
+ * calendar renders it natively from the summary fields.
+ */
+export const buildSourceActivityRecord = (
+  input: BuildSourceActivityRecordInput
+): ActivityRecord => ({
+  id: crypto.randomUUID(),
+  profileId: input.profileId,
+  date: input.date,
+  sport: input.sport,
+  sourceBridgeId: input.sourceBridgeId,
+  externalId: input.externalId,
+  durationSeconds: input.durationSeconds,
+  distanceMeters: input.distanceMeters,
+  linkedWorkoutId: null,
+  krd: null,
+  createdAt: new Date().toISOString(),
+});


### PR DESCRIPTION
## Summary

Stacked on #855 (Data Hub V1). Completes the program: executions become real, governed data.

- **Garmin activities pull (F5)**: `read:activities` announced in lockstep in both garmin-bridge announcers; read-only activities handler with kill-switch, 30s throttle and retry-backoff (raw feed; domain mapping SPA-side with Zod — unknown fields, including GPS, are stripped at the edge). The pull is governed by the `activity ← garmin` route (no enabled route ⇒ no bridge call) and stamps `garmin-bridge` provenance; freshness feeds the Data Hub matrix cell. New routes start as "available" — the user opts in via the matrix.
- **Live activities (gate A1 closed)**: activities feed the auto-match hook and render natively on the calendar via a read-side projection (`activityToWorkoutRecord`); the transitional dual-write and the legacy `source !== "train2go"` heuristic are retired. Projected cards open a read-only execution preview (never the editor) and are not draggable; pre-existing executions keep rendering and persisted matches survive.
- **Conversational hub tools (F6)**: `get_data_routes` (auto-exec read tool: routes, multi-source semantics, freshness, effective source) and `set_data_route` (confirmation-gated action tool: enable/disable route, set union/priority + source order) reusing the matrix derivation and the real governance gates. Eval harness added (`pnpm --filter @kaiord/ai eval:chat-tools`; assertion tests run without LLM).
- **SessionMatch foundational scenario E2E**: planned-session←train2go + activity←garmin linked, with the extended kill test (disabling the route stops the pull).
- Docs: worktree-hygiene rule added to AGENTS.md.

## Validation

- Full monorepo build + all package suites green (5273 SPA tests + guards 513/513 at HEAD).
- Independent review: security APPROVED (LOW — narrow endpoint allowlist verified, Zod at the edge, confirmation gate architectural, no PII in telemetry/errors) and architecture/quality APPROVED after one blocker was found and fixed (projected-card click used to hang the editor; now covered by click tests in Calendar and Daily).

## Pending manual smokes (Pablo)

- Live Garmin activities pull with a real session (can't run headless).
- Live chat-tool eval (`ANTHROPIC_API_KEY` required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)