### PR TITLE
test(spa-editor): stabilize lab-entry save-toast assertion on mobile CI

### DIFF
--- a/packages/workout-spa-editor/e2e/lab-entry.spec.ts
+++ b/packages/workout-spa-editor/e2e/lab-entry.spec.ts
@@ -124,7 +124,11 @@ test.describe("Lab analytics entry (DoD-1)", () => {
       await fillRow(page, i, PARAMS[i]);
     }
     await page.getByRole("button", { name: "Save" }).click();
-    await expect(page.getByText("Lab report saved")).toBeVisible();
+    // Saving ~10 parameters + toast can exceed the 10s default on the loaded
+    // mobile CI runners; give it generous headroom (passes in ~8s locally).
+    await expect(page.getByText("Lab report saved")).toBeVisible({
+      timeout: 20_000,
+    });
     await page.reload();
     await page.waitForFunction(
       () =>


### PR DESCRIPTION
The main-only cross-browser workflow (Workout SPA Editor E2E Tests) failed on **Mobile Chrome** for lab-entry.spec.ts:127 — the 'Lab report saved' toast timed out after saving ~10 parameters. Root cause: **flaky under CI load**, not a product bug. The test passes deterministically on Mobile Chrome locally (~8s); the 10s default was just tight on the loaded emulated-mobile runner (the whole suite took 14 min). #863's slightly longer English labels nudged it over the edge. Fix: give the toast assertion a 20s timeout. Verified locally on chromium (2.8s) and Mobile Chrome (8.0s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)