### PR TITLE
test(spa-editor): stabilize lab save-toast assertions on mobile cross-browser CI

### DIFF
--- a/packages/workout-spa-editor/e2e/lab-dod-journey.spec.ts
+++ b/packages/workout-spa-editor/e2e/lab-dod-journey.spec.ts
@@ -151,8 +151,13 @@ test.describe("Lab analytics DoD journey (F5.2 cohesion)", () => {
     await row.getByLabel("Value").fill("90");
     await page.getByRole("button", { name: "Save" }).click();
 
-    // Assert — DoD-1: the new report persisted.
-    await expect(page.getByText("Lab report saved")).toBeVisible();
+    // Assert — DoD-1: the new report persisted. Use .first() + generous
+    // timeout: on loaded mobile CI runners Radix pauses toast auto-dismiss
+    // (see ToastProvider note), so a prior toast can still be mounted and the
+    // bare getByText would hit a strict-mode "2 elements" violation.
+    await expect(page.getByText("Lab report saved").first()).toBeVisible({
+      timeout: 20_000,
+    });
 
     // Assert — DoD-4: ferritin (recorded only in the old report) is still
     // surfaced and flagged out-of-range in the latest-values list.

--- a/packages/workout-spa-editor/e2e/lab-entry.spec.ts
+++ b/packages/workout-spa-editor/e2e/lab-entry.spec.ts
@@ -126,7 +126,9 @@ test.describe("Lab analytics entry (DoD-1)", () => {
     await page.getByRole("button", { name: "Save" }).click();
     // Saving ~10 parameters + toast can exceed the 10s default on the loaded
     // mobile CI runners; give it generous headroom (passes in ~8s locally).
-    await expect(page.getByText("Lab report saved")).toBeVisible({
+    // .first(): mobile runners can keep a prior toast mounted (paused
+    // auto-dismiss), so match the first rather than fail strict mode.
+    await expect(page.getByText("Lab report saved").first()).toBeVisible({
       timeout: 20_000,
     });
     await page.reload();


### PR DESCRIPTION
Follow-up to #865. After raising the toast timeout, the main-only cross-browser Mobile Chrome job surfaced the *next* fragility in the same assertion: **strict-mode violation** — getByText('Lab report saved') resolved to **2 elements** in lab-dod-journey.spec.ts:155. Root cause is documented in ToastProvider: on webkit/mobile Radix pauses toast auto-dismiss, so a prior 'Lab report saved' toast stays mounted while the next one appears → two identical toasts. **Not a product bug** (the report persists). Fix: use `.first()` + a 20s timeout on both lab save-toast assertions (lab-entry + lab-dod-journey), tolerating 1-or-2 stacked toasts and mobile latency. Verified locally on chromium and Mobile Chrome (6 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Made the lab report save toast checks more reliable in end-to-end tests.
  * Updated assertions to handle duplicate toast elements and wait appropriately for visibility, reducing flaky failures in CI and mobile runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->