### PR TITLE
test(spa-editor): stabilize flaky LabDashboardSection multi-card test

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/health/labs/dashboard/LabDashboardSection.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/dashboard/LabDashboardSection.test.tsx
@@ -17,9 +17,10 @@ vi.mock("../../../../charts/uplot-base/uplot-chart", () => ({
 
 const PROFILE_ID = "p1";
 const NOW = "2026-07-07T12:00:00.000Z";
-// Pinning several parameters fires one Dexie live query per card; under full-
-// suite CPU contention their re-renders can exceed the 1s waitFor default.
-const CHART_RENDER_TIMEOUT_MS = 4000;
+// Pinning parameters chains Dexie writes → live-query re-renders → per-card
+// live queries; under CI CPU contention this can outrun a short waitFor, so
+// use the repo's Dexie-slow budget (matches playwright/expect 10s).
+const CHART_RENDER_TIMEOUT_MS = 10_000;
 
 const wrap = ({ children }: { children: ReactNode }) => (
   <PersistenceProvider persistence={createDexiePersistence(db)}>
@@ -126,11 +127,19 @@ describe("LabDashboardSection", () => {
     // Arrange
     render(<LabDashboardSection profileId={PROFILE_ID} />, { wrapper: wrap });
     const user = userEvent.setup();
-    const items = await screen.findAllByTestId("lab-parameter-item");
+    const total = (await screen.findAllByTestId("lab-parameter-item")).length;
 
     // Act
-    for (const item of items) {
-      await user.click(within(item).getByTestId("lab-parameter-select"));
+
+    // Pin each row, re-querying fresh every iteration: the list is driven by
+    // `summaries` (stable order across pins), but an awaited click triggers a
+    // re-render that can detach a previously-captured node, so a reused
+    // reference would silently click a stale element and skip the pin.
+    for (let i = 0; i < total; i += 1) {
+      const rows = await screen.findAllByTestId("lab-parameter-item");
+      const row = rows[i];
+      if (!row) throw new Error(`lab-parameter-item ${i} disappeared`);
+      await user.click(within(row).getByTestId("lab-parameter-select"));
     }
 
     // Assert
@@ -139,7 +148,7 @@ describe("LabDashboardSection", () => {
       () =>
         expect(
           within(grid).getAllByTestId("lab-parameter-chart-card")
-        ).toHaveLength(items.length),
+        ).toHaveLength(total),
       { timeout: CHART_RENDER_TIMEOUT_MS }
     );
   });


### PR DESCRIPTION
The multi-pin test in `LabDashboardSection.test.tsx` flaked on main's `test-frontend (22.18.0)` after #871 merged (it passed on the PR run) — "expected length 2 but got 1".

**Root cause:** the test captured the parameter rows once, then clicked each row's select in a loop. Each awaited click re-renders the section (the pinned grid appears / rows re-highlight); a reused, now-detached node reference makes the second click a no-op, so only one parameter ever gets pinned and the grid never reaches 2 chart cards.

**Fix:** re-query the rows fresh on each iteration (the list is `summaries`-driven, so its order is stable across pins) and raise the card-render `waitFor` to the repo's 10s Dexie-slow budget. Verified 8/8 locally + typecheck/lint clean.

Follow-up to #871; unblocks main's CI (test-frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)