### PR TITLE
fix(spa-editor): surface Language in the settings index

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsPage.test.tsx
@@ -121,6 +121,20 @@ describe("SettingsPage", () => {
         expect(memory.history.at(-1)).toBe("/settings/preferences");
       });
     });
+
+    it("should surface a Language row that opens the preferences tab", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const { memory } = renderAtPath("/settings");
+
+      // Act
+      await user.click(screen.getByTestId("settings-row-Language"));
+
+      // Assert
+      await waitFor(() => {
+        expect(memory.history.at(-1)).toBe("/settings/preferences");
+      });
+    });
   });
 
   describe("routing", () => {

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-groups.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-groups.ts
@@ -41,6 +41,7 @@ export const SETTINGS_GROUPS: ReadonlyArray<SettingsGroupDef> = [
     eyebrow: "Preferences",
     rows: [
       { icon: "target", label: "Units", to: "/settings/preferences" },
+      { icon: "chat", label: "Language", to: "/settings/preferences" },
       { icon: "bell", label: "Notifications", to: "/settings/preferences" },
     ],
   },

--- a/packages/workout-spa-editor/src/i18n/locale-switch.integration.test.tsx
+++ b/packages/workout-spa-editor/src/i18n/locale-switch.integration.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { useTranslation } from "react-i18next";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { appI18n } from "./i18n";
+import { LocaleProvider, useActiveLocale } from "./LocaleProvider";
+
+const prefsMock = vi.hoisted(() => ({ locale: "en" as string | undefined }));
+
+vi.mock("../hooks/use-active-profile-live", () => ({
+  useActiveProfileLive: () => ({ id: "p1", profile: null }),
+}));
+
+vi.mock("../hooks/use-user-preferences", () => ({
+  useUserPreferences: () => ({
+    profileId: "p1",
+    calendarView: "grid",
+    locale: prefsMock.locale,
+  }),
+}));
+
+const Probe = () => {
+  const { t } = useTranslation("common");
+  return (
+    <div>
+      <span data-testid="t">{t("language.label")}</span>
+      <span data-testid="loc">{useActiveLocale()}</span>
+    </div>
+  );
+};
+
+afterEach(async () => {
+  await appI18n.changeLanguage("en");
+});
+
+describe("locale switch propagation", () => {
+  it("should flip t() copy and the active locale when the preference becomes es", async () => {
+    // Arrange
+    prefsMock.locale = "en";
+    const { rerender } = render(
+      <LocaleProvider>
+        <Probe />
+      </LocaleProvider>
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("t")).toHaveTextContent("Language");
+      expect(screen.getByTestId("loc")).toHaveTextContent("en");
+    });
+
+    // Act
+    prefsMock.locale = "es";
+    rerender(
+      <LocaleProvider>
+        <Probe />
+      </LocaleProvider>
+    );
+
+    // Assert
+    await waitFor(() => {
+      expect(screen.getByTestId("t")).toHaveTextContent("Idioma");
+      expect(screen.getByTestId("loc")).toHaveTextContent("es");
+    });
+  });
+});


### PR DESCRIPTION
**Reported:** the language selector felt "buried inside Units", and switching to Spanish "didn't change anything".

**Diagnosis:**
1. The switcher was added to the Preferences tab (#871) but the settings *home* index (`SETTINGS_GROUPS`) never got a matching row, so Language was only reachable by opening Preferences via the Units/Notifications row — hence "inside Units". **Fix:** add a dedicated **Language** row to the Preferences group (→ /settings/preferences).
2. "Switching does nothing" is **not a switch bug** — the added `locale-switch.integration.test` proves that changing the persisted preference flips both a `t()` consumer and `useActiveLocale` from `en` to `es`. The reason little visibly changes is that only a thin slice of the UI is translated so far (labs names, dates, validation/AI errors, and the switcher's own labels). Translating the rest of the SPA is the separate `add-spa-i18n-dictionaries` follow-up.

Verified: SettingsPage 16/16, locale-switch + PreferencesTab green; typecheck/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a **Language** option in Settings under Preferences, making it easier to open language-related settings.

* **Bug Fixes**
  * Improved locale switching behavior so translated text and the active language update consistently.

* **Tests**
  * Added coverage for navigating from the Settings list to the Preferences tab.
  * Added an integration test for language preference changes and UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->