### PR TITLE
feat(spa-editor): localize the app navigation (i18n migration 1)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/BottomNav/BottomNavTab.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/BottomNav/BottomNavTab.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 import {
   ACTIVE_STROKE_WIDTH,
@@ -13,6 +14,7 @@ type BottomNavTabProps = {
 };
 
 export function BottomNavTab({ tab, active, onActivate }: BottomNavTabProps) {
+  const t = useTranslate("nav");
   const color = active ? "text-sky-400" : "text-slate-500";
   return (
     <button
@@ -27,7 +29,7 @@ export function BottomNavTab({ tab, active, onActivate }: BottomNavTabProps) {
         strokeWidth={active ? ACTIVE_STROKE_WIDTH : INACTIVE_STROKE_WIDTH}
         style={{ width: TAB_ICON_SIZE, height: TAB_ICON_SIZE }}
       />
-      <span className="text-[10.5px] font-semibold">{tab.label}</span>
+      <span className="text-[10.5px] font-semibold">{t(tab.id)}</span>
     </button>
   );
 }

--- a/packages/workout-spa-editor/src/components/molecules/BottomNav/bottom-nav-tabs.ts
+++ b/packages/workout-spa-editor/src/components/molecules/BottomNav/bottom-nav-tabs.ts
@@ -2,6 +2,8 @@ import { NAV_DESTINATIONS } from "../../../routing/nav-destinations";
 import type { IconName } from "../../atoms/Icon";
 
 export type BottomNavTab = {
+  /** Nav-destination id; also the `nav` i18n key for the tab label. */
+  id: string;
   label: string;
   icon: IconName;
   path: string;
@@ -19,6 +21,7 @@ export type BottomNavTab = {
 export const BOTTOM_NAV_TABS: readonly BottomNavTab[] = NAV_DESTINATIONS.filter(
   (destination) => destination.surfaces.bottomNav
 ).map((destination) => ({
+  id: destination.id,
   label: destination.labelKey,
   icon: destination.icon,
   path: destination.path,

--- a/packages/workout-spa-editor/src/components/molecules/StatusHeader/status-entry-button.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StatusHeader/status-entry-button.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button/Button";
 import type { EntryDef } from "./status-entry-defs";
 
@@ -12,6 +13,7 @@ type EntryButtonProps = {
 };
 
 export function EntryButton({ entry, active, onClick }: EntryButtonProps) {
+  const t = useTranslate("nav");
   const classes =
     [
       active ? ACTIVE_ENTRY_CLASS : undefined,
@@ -26,14 +28,14 @@ export function EntryButton({ entry, active, onClick }: EntryButtonProps) {
       variant={entry.variant ?? "tertiary"}
       size="sm"
       onClick={onClick}
-      aria-label={entry.ariaLabel}
+      aria-label={entry.ariaLabel ? t(`aria.${entry.id}`) : undefined}
       aria-current={active ? "page" : undefined}
       className={classes}
       data-testid={`status-header-${entry.id}-button`}
     >
       <entry.icon className="h-4 w-4" />
       <span className={entry.id === "new" ? "" : "hidden sm:inline"}>
-        {entry.label}
+        {t(entry.id)}
       </span>
     </Button>
   );

--- a/packages/workout-spa-editor/src/i18n/locales/en/nav.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/nav.json
@@ -1,0 +1,23 @@
+{
+  "daily": "Daily",
+  "calendar": "Calendar",
+  "library": "Library",
+  "nutrition": "Nutrition",
+  "athlete": "Athlete",
+  "trends": "Trends",
+  "labs": "Labs",
+  "chat": "Chat",
+  "new": "New workout",
+  "settings": "Settings",
+  "aria": {
+    "daily": "Go to daily",
+    "calendar": "Go to calendar",
+    "library": "Open workout library",
+    "nutrition": "Open nutrition",
+    "athlete": "Open athlete profile",
+    "trends": "Open wellness trends",
+    "labs": "Open lab analytics",
+    "chat": "Open chat assistant",
+    "settings": "Open settings"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/nav.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/nav.json
@@ -1,0 +1,23 @@
+{
+  "daily": "Diario",
+  "calendar": "Calendario",
+  "library": "Biblioteca",
+  "nutrition": "Nutrición",
+  "athlete": "Atleta",
+  "trends": "Tendencias",
+  "labs": "Laboratorio",
+  "chat": "Chat",
+  "new": "Nuevo entreno",
+  "settings": "Ajustes",
+  "aria": {
+    "daily": "Ir a diario",
+    "calendar": "Ir a calendario",
+    "library": "Abrir biblioteca de entrenos",
+    "nutrition": "Abrir nutrición",
+    "athlete": "Abrir perfil de atleta",
+    "trends": "Abrir tendencias de bienestar",
+    "labs": "Abrir analíticas de laboratorio",
+    "chat": "Abrir asistente de chat",
+    "settings": "Abrir ajustes"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -10,15 +10,17 @@ import type { LocaleResources } from "@kaiord/i18n";
 import enCommon from "./locales/en/common.json";
 import enErrors from "./locales/en/errors.json";
 import enLabs from "./locales/en/labs.json";
+import enNav from "./locales/en/nav.json";
 import esCommon from "./locales/es/common.json";
 import esErrors from "./locales/es/errors.json";
 import esLabs from "./locales/es/labs.json";
+import esNav from "./locales/es/nav.json";
 
-export const NAMESPACES = ["common", "errors", "labs"] as const;
+export const NAMESPACES = ["common", "errors", "labs", "nav"] as const;
 
 export const DEFAULT_NAMESPACE = "common";
 
 export const resources: LocaleResources = {
-  en: { common: enCommon, errors: enErrors, labs: enLabs },
-  es: { common: esCommon, errors: esErrors, labs: esLabs },
+  en: { common: enCommon, errors: enErrors, labs: enLabs, nav: enNav },
+  es: { common: esCommon, errors: esErrors, labs: esLabs, nav: esNav },
 };

--- a/packages/workout-spa-editor/src/i18n/use-translate.test.tsx
+++ b/packages/workout-spa-editor/src/i18n/use-translate.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { LocaleProvider } from "./LocaleProvider";
+import { useTranslate } from "./use-translate";
+
+const prefsMock = vi.hoisted(() => ({ locale: "es" as string | undefined }));
+
+vi.mock("../hooks/use-active-profile-live", () => ({
+  useActiveProfileLive: () => ({ id: "p1", profile: null }),
+}));
+
+vi.mock("../hooks/use-user-preferences", () => ({
+  useUserPreferences: () => ({
+    profileId: "p1",
+    calendarView: "grid",
+    locale: prefsMock.locale,
+  }),
+}));
+
+const Probe = ({ k }: { k: string }) => {
+  const t = useTranslate("nav");
+  return <span data-testid="out">{t(k)}</span>;
+};
+
+describe("useTranslate", () => {
+  it("should default to the English value outside a provider", () => {
+    // Arrange
+    const key = "daily";
+
+    // Act
+    render(<Probe k={key} />);
+
+    // Assert
+    expect(screen.getByTestId("out")).toHaveTextContent("Daily");
+  });
+
+  it("should return the Spanish value under an es locale provider", () => {
+    // Arrange
+    prefsMock.locale = "es";
+
+    // Act
+    render(
+      <LocaleProvider>
+        <Probe k="daily" />
+      </LocaleProvider>
+    );
+
+    // Assert
+    expect(screen.getByTestId("out")).toHaveTextContent("Diario");
+  });
+
+  it("should fall back to the key when it is missing", () => {
+    // Arrange
+    const key = "does.not.exist";
+
+    // Act
+    render(<Probe k={key} />);
+
+    // Assert
+    expect(screen.getByTestId("out")).toHaveTextContent("does.not.exist");
+  });
+});

--- a/packages/workout-spa-editor/src/i18n/use-translate.ts
+++ b/packages/workout-spa-editor/src/i18n/use-translate.ts
@@ -1,0 +1,53 @@
+/**
+ * Pure, dictionary-backed translator for a namespace. Reads the active locale
+ * from `useActiveLocale` (which defaults to English outside a `LocaleProvider`,
+ * so the thousands of component tests that render unwrapped stay in `en` and
+ * their English assertions keep passing). Resolves a dotted key against the
+ * active locale, falls back to the English value, then to the key itself; no
+ * react-i18next dependency, so no `I18nextProvider` is required to render.
+ *
+ * This is the seam used to migrate hardcoded UI strings: replace a literal
+ * with `t("key")` and add the English value verbatim to the namespace JSON so
+ * `en`-mode output is byte-identical.
+ */
+import { DEFAULT_LOCALE, type Locale } from "@kaiord/i18n";
+
+import { useActiveLocale } from "./LocaleProvider";
+import { resources } from "./resources";
+
+type TranslateParams = Record<string, string | number>;
+
+const lookup = (
+  locale: Locale,
+  ns: string,
+  key: string
+): string | undefined => {
+  const namespaces = resources[locale] ?? resources[DEFAULT_LOCALE];
+  let current: unknown = namespaces[ns];
+  for (const segment of key.split(".")) {
+    if (current && typeof current === "object") {
+      current = (current as Record<string, unknown>)[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return typeof current === "string" ? current : undefined;
+};
+
+const interpolate = (value: string, params?: TranslateParams): string =>
+  params === undefined
+    ? value
+    : value.replace(/\{\{(\w+)\}\}/g, (_match, key: string) =>
+        key in params ? String(params[key]) : `{{${key}}}`
+      );
+
+export type Translate = (key: string, params?: TranslateParams) => string;
+
+export function useTranslate(ns: string): Translate {
+  const locale = useActiveLocale();
+  return (key, params) =>
+    interpolate(
+      lookup(locale, ns, key) ?? lookup(DEFAULT_LOCALE, ns, key) ?? key,
+      params
+    );
+}


### PR DESCRIPTION
First string-migration PR of the full i18n program (option B). Makes the app navigation switch language.

- Adds a pure, dictionary-backed **`useTranslate`** hook — reads `useActiveLocale`, defaults to English outside a `LocaleProvider`, falls back en → key. This is the seam for the whole migration: no `I18nextProvider` needed, so the thousands of unwrapped component tests keep passing in `en`.
- Adds a **`nav`** namespace (en/es). Header entries and bottom-nav tabs render label + aria-label via `useTranslate` by destination id → switching to Español flips the nav to **Diario / Calendario / Biblioteca / Nutrición / Atleta / Tendencias / Laboratorio / Chat / Nuevo entreno / Ajustes**.
- English output byte-identical → full SPA suite green (5,438), no test rewrites.

Next in the program: settings + common, editor / library / coaching / help, then landing, cli, mcp, extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)