### PR TITLE
feat(spa-editor): localize the settings surface (settings namespace)

### DIFF
--- a/packages/workout-spa-editor/e2e/ai-generate-workout.spec.ts
+++ b/packages/workout-spa-editor/e2e/ai-generate-workout.spec.ts
@@ -99,7 +99,7 @@ async function addTestProvider(
 ): Promise<void> {
   await openHeaderAction(page, /open settings/i);
   await page.waitForURL(/\/settings$/);
-  await page.getByTestId("settings-row-Provider").click();
+  await page.getByTestId("settings-row-provider").click();
   await page.waitForURL(/\/settings\/ai/);
 
   const settingsPage = page.getByTestId("settings-page");

--- a/packages/workout-spa-editor/e2e/data-hub.spec.ts
+++ b/packages/workout-spa-editor/e2e/data-hub.spec.ts
@@ -175,7 +175,7 @@ test.describe("Data Hub matrix", () => {
     await page.goto("/settings");
 
     // Act
-    await page.getByTestId("settings-row-Data Hub").click();
+    await page.getByTestId("settings-row-dataHub").click();
 
     // Assert
     await expect(page).toHaveURL(/\/settings\/data-hub$/, { timeout: 8_000 });

--- a/packages/workout-spa-editor/e2e/settings.spec.ts
+++ b/packages/workout-spa-editor/e2e/settings.spec.ts
@@ -21,7 +21,7 @@ test.describe("Settings Panel", () => {
     // Open the grouped settings index, then enter the AI Provider section.
     await openHeaderAction(page, /open settings/i);
     await page.waitForURL(/\/settings$/);
-    await page.getByTestId("settings-row-Provider").click();
+    await page.getByTestId("settings-row-provider").click();
     await page.waitForURL(/\/settings\/ai/);
     const settingsPage = page.getByTestId("settings-page");
     await expect(settingsPage).toBeVisible({ timeout: 5000 });
@@ -83,7 +83,7 @@ test.describe("Settings Panel", () => {
     // its own route. Navigate to it via the grouped-list row.
     await openHeaderAction(page, /open settings/i);
     await page.waitForURL(/\/settings$/);
-    await page.getByTestId("settings-row-Extensions").click();
+    await page.getByTestId("settings-row-extensions").click();
     await page.waitForURL(/\/settings\/extensions$/);
 
     const extensionsPanel = page.getByTestId("settings-panel-extensions");

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsGroupList.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsGroupList.tsx
@@ -1,4 +1,5 @@
 import { useAiProvidersLive } from "../../../hooks/use-ai-providers-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { SectionHead } from "../../molecules/SectionHead/SectionHead";
 import {
   SETTINGS_GROUPS,
@@ -22,18 +23,20 @@ const useRowDetail = () => {
 
 export const SettingsGroupList = ({ onNavigate }: SettingsGroupListProps) => {
   const detailFor = useRowDetail();
+  const t = useTranslate("settings");
 
   return (
     <div className="space-y-6" data-testid="settings-group-list">
       {SETTINGS_GROUPS.map((group) => (
-        <section key={group.eyebrow}>
-          <SectionHead title={group.eyebrow} />
+        <section key={group.key}>
+          <SectionHead title={t(`groups.${group.key}`)} />
           <div className="overflow-hidden rounded-xl bg-white shadow-sm dark:bg-slate-900 [&>*+*]:border-t [&>*+*]:border-gray-100 dark:[&>*+*]:border-slate-800">
             {group.rows.map((row) => (
               <SettingsRow
-                key={row.label}
+                key={row.key}
                 icon={row.icon}
-                label={row.label}
+                label={t(`rows.${row.key}`)}
+                testId={row.key}
                 detail={detailFor(row)}
                 to={row.to}
                 onNavigate={row.to !== undefined ? onNavigate : undefined}

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsPage.test.tsx
@@ -100,7 +100,7 @@ describe("SettingsPage", () => {
       const { memory } = renderAtPath("/settings");
 
       // Act
-      await user.click(screen.getByTestId("settings-row-Extensions"));
+      await user.click(screen.getByTestId("settings-row-extensions"));
 
       // Assert
       await waitFor(() => {
@@ -114,7 +114,7 @@ describe("SettingsPage", () => {
       const { memory } = renderAtPath("/settings");
 
       // Act
-      await user.click(screen.getByTestId("settings-row-Units"));
+      await user.click(screen.getByTestId("settings-row-units"));
 
       // Assert
       await waitFor(() => {
@@ -128,7 +128,7 @@ describe("SettingsPage", () => {
       const { memory } = renderAtPath("/settings");
 
       // Act
-      await user.click(screen.getByTestId("settings-row-Language"));
+      await user.click(screen.getByTestId("settings-row-language"));
 
       // Assert
       await waitFor(() => {
@@ -270,7 +270,7 @@ describe("SettingsPage", () => {
       const { memory } = renderAtPath("/settings");
 
       // Act
-      await user.click(screen.getByTestId("settings-row-Manage your data"));
+      await user.click(screen.getByTestId("settings-row-manageYourData"));
 
       // Assert
       await waitFor(() => {

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsPage.tsx
@@ -1,14 +1,11 @@
 import { Redirect, useLocation, useParams } from "wouter";
 
 import { useFocusOnSectionChange } from "../../../hooks/use-focus-on-section-change";
+import { useTranslate } from "../../../i18n/use-translate";
 import { ROUTE_HEADING_ATTR } from "../../../routing/constants";
 import { Button } from "../../atoms/Button/Button";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
-import {
-  isSettingsTab,
-  SETTINGS_TAB_LABELS,
-  SETTINGS_TAB_VIEWS,
-} from "./settings-tab-views";
+import { isSettingsTab, SETTINGS_TAB_VIEWS } from "./settings-tab-views";
 import { SettingsGroupList } from "./SettingsGroupList";
 
 type SettingsPageParams = { tab?: string };
@@ -18,6 +15,7 @@ const SETTINGS_ROOT = "/settings" as const;
 export default function SettingsPage() {
   const { tab } = useParams<SettingsPageParams>();
   const [, navigate] = useLocation();
+  const t = useTranslate("settings");
   useFocusOnSectionChange();
 
   if (tab !== undefined && !isSettingsTab(tab))
@@ -25,7 +23,7 @@ export default function SettingsPage() {
 
   const ActiveView = tab === undefined ? null : SETTINGS_TAB_VIEWS[tab];
   const heading =
-    tab === undefined ? "Settings" : `Settings · ${SETTINGS_TAB_LABELS[tab]}`;
+    tab === undefined ? t("title") : `${t("title")} · ${t(`tabs.${tab}`)}`;
 
   return (
     <div className="space-y-6 p-4" data-testid="settings-page">
@@ -37,7 +35,7 @@ export default function SettingsPage() {
           data-testid="settings-back"
         >
           <Icon icon={ICON_MAP.chevL} size="sm" color="inherit" />
-          Settings
+          {t("back")}
         </Button>
       )}
       <h1

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsRow.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsRow.tsx
@@ -3,6 +3,8 @@ import { Icon, ICON_MAP, type IconName } from "../../atoms/Icon";
 export type SettingsRowProps = {
   icon: IconName;
   label: string;
+  /** Locale-independent testid suffix; falls back to the label. */
+  testId?: string;
   detail?: string;
   to?: string;
   onNavigate?: (to: string) => void;
@@ -14,11 +16,13 @@ const TILE_CLASS =
 export const SettingsRow = ({
   icon,
   label,
+  testId,
   detail,
   to,
   onNavigate,
 }: SettingsRowProps) => {
   const interactive = to !== undefined && onNavigate !== undefined;
+  const rowTestId = `settings-row-${testId ?? label}`;
 
   const body = (
     <>
@@ -42,7 +46,7 @@ export const SettingsRow = ({
 
   if (!interactive) {
     return (
-      <div className={base} data-testid={`settings-row-${label}`}>
+      <div className={base} data-testid={rowTestId}>
         {body}
       </div>
     );
@@ -53,7 +57,7 @@ export const SettingsRow = ({
       type="button"
       onClick={() => onNavigate(to)}
       className={`${base} transition-colors hover:bg-gray-50 dark:hover:bg-slate-800`}
-      data-testid={`settings-row-${label}`}
+      data-testid={rowTestId}
     >
       {body}
     </button>

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-groups.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-groups.ts
@@ -2,65 +2,67 @@ import type { IconName } from "../../atoms/Icon";
 
 export type SettingsRowDef = {
   icon: IconName;
-  label: string;
+  /** Stable identity: i18n key under `settings.rows.*`, React key, and testid. */
+  key: string;
   to?: string;
   detailKey?: "defaultProvider";
 };
 
 export type SettingsGroupDef = {
-  eyebrow: string;
+  /** Stable identity: i18n key under `settings.groups.*` and React key. */
+  key: string;
   rows: ReadonlyArray<SettingsRowDef>;
 };
 
 export const SETTINGS_GROUPS: ReadonlyArray<SettingsGroupDef> = [
   {
-    eyebrow: "AI generation",
+    key: "aiGeneration",
     rows: [
       {
         icon: "sparkle",
-        label: "Provider",
+        key: "provider",
         to: "/settings/ai?section=providers",
         detailKey: "defaultProvider",
       },
       {
         icon: "edit",
-        label: "Custom instructions",
+        key: "customInstructions",
         to: "/settings/ai?section=custom-instructions",
       },
     ],
   },
   {
-    eyebrow: "Cross-device sync",
-    rows: [{ icon: "sync", label: "Google Drive sync", to: "/settings/sync" }],
+    key: "crossDeviceSync",
+    rows: [{ icon: "sync", key: "googleDriveSync", to: "/settings/sync" }],
   },
   {
-    eyebrow: "Data routing",
-    rows: [{ icon: "route", label: "Data Hub", to: "/settings/data-hub" }],
+    key: "dataRouting",
+    rows: [{ icon: "route", key: "dataHub", to: "/settings/data-hub" }],
   },
   {
-    eyebrow: "Preferences",
+    key: "preferences",
     rows: [
-      { icon: "target", label: "Units", to: "/settings/preferences" },
-      { icon: "chat", label: "Language", to: "/settings/preferences" },
-      { icon: "bell", label: "Notifications", to: "/settings/preferences" },
+      { icon: "target", key: "units", to: "/settings/preferences" },
+      { icon: "chat", key: "language", to: "/settings/preferences" },
+      { icon: "bell", key: "notifications", to: "/settings/preferences" },
     ],
   },
   {
-    eyebrow: "Privacy & data",
+    key: "privacyData",
     rows: [
-      { icon: "shield", label: "Data & privacy", to: "/settings/privacy" },
+      { icon: "shield", key: "dataPrivacy", to: "/settings/privacy" },
       {
         icon: "shield",
-        label: "Manage your data",
+        key: "manageYourData",
         to: "/settings/privacy?section=data-management",
       },
     ],
   },
   {
-    eyebrow: "Advanced",
+    key: "advanced",
     rows: [
-      { icon: "link", label: "Extensions", to: "/settings/extensions" },
-      { icon: "trend", label: "Usage", to: "/settings/usage" },
+      { icon: "link", key: "extensions", to: "/settings/extensions" },
+      { icon: "trend", key: "usage", to: "/settings/usage" },
     ],
   },
 ];

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-tab-views.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-tab-views.tsx
@@ -17,16 +17,6 @@ const TAB_ORDER: ReadonlyArray<SettingsTab> = [
   "preferences",
 ];
 
-const TAB_LABELS: Record<SettingsTab, string> = {
-  ai: "AI",
-  sync: "Sync",
-  "data-hub": "Data Hub",
-  extensions: "Extensions",
-  usage: "Usage",
-  privacy: "Privacy",
-  preferences: "Preferences",
-};
-
 const TAB_VIEWS: Record<SettingsTab, React.FC> = {
   ai: AiTab,
   sync: SyncTab,
@@ -37,7 +27,6 @@ const TAB_VIEWS: Record<SettingsTab, React.FC> = {
   preferences: PreferencesTab,
 };
 
-export const SETTINGS_TAB_LABELS = TAB_LABELS;
 export const SETTINGS_TAB_VIEWS = TAB_VIEWS;
 export const DEFAULT_SETTINGS_TAB: SettingsTab = "ai";
 

--- a/packages/workout-spa-editor/src/i18n/locales/en/settings.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/settings.json
@@ -1,0 +1,34 @@
+{
+  "title": "Settings",
+  "back": "Settings",
+  "groups": {
+    "aiGeneration": "AI generation",
+    "crossDeviceSync": "Cross-device sync",
+    "dataRouting": "Data routing",
+    "preferences": "Preferences",
+    "privacyData": "Privacy & data",
+    "advanced": "Advanced"
+  },
+  "rows": {
+    "provider": "Provider",
+    "customInstructions": "Custom instructions",
+    "googleDriveSync": "Google Drive sync",
+    "dataHub": "Data Hub",
+    "units": "Units",
+    "language": "Language",
+    "notifications": "Notifications",
+    "dataPrivacy": "Data & privacy",
+    "manageYourData": "Manage your data",
+    "extensions": "Extensions",
+    "usage": "Usage"
+  },
+  "tabs": {
+    "ai": "AI",
+    "sync": "Sync",
+    "data-hub": "Data Hub",
+    "extensions": "Extensions",
+    "usage": "Usage",
+    "privacy": "Privacy",
+    "preferences": "Preferences"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/settings.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/settings.json
@@ -1,0 +1,34 @@
+{
+  "title": "Ajustes",
+  "back": "Ajustes",
+  "groups": {
+    "aiGeneration": "Generación con IA",
+    "crossDeviceSync": "Sincronización entre dispositivos",
+    "dataRouting": "Enrutamiento de datos",
+    "preferences": "Preferencias",
+    "privacyData": "Privacidad y datos",
+    "advanced": "Avanzado"
+  },
+  "rows": {
+    "provider": "Proveedor",
+    "customInstructions": "Instrucciones personalizadas",
+    "googleDriveSync": "Sincronización con Google Drive",
+    "dataHub": "Data Hub",
+    "units": "Unidades",
+    "language": "Idioma",
+    "notifications": "Notificaciones",
+    "dataPrivacy": "Datos y privacidad",
+    "manageYourData": "Gestiona tus datos",
+    "extensions": "Extensiones",
+    "usage": "Uso"
+  },
+  "tabs": {
+    "ai": "IA",
+    "sync": "Sincronización",
+    "data-hub": "Data Hub",
+    "extensions": "Extensiones",
+    "usage": "Uso",
+    "privacy": "Privacidad",
+    "preferences": "Preferencias"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -11,16 +11,36 @@ import enCommon from "./locales/en/common.json";
 import enErrors from "./locales/en/errors.json";
 import enLabs from "./locales/en/labs.json";
 import enNav from "./locales/en/nav.json";
+import enSettings from "./locales/en/settings.json";
 import esCommon from "./locales/es/common.json";
 import esErrors from "./locales/es/errors.json";
 import esLabs from "./locales/es/labs.json";
 import esNav from "./locales/es/nav.json";
+import esSettings from "./locales/es/settings.json";
 
-export const NAMESPACES = ["common", "errors", "labs", "nav"] as const;
+export const NAMESPACES = [
+  "common",
+  "errors",
+  "labs",
+  "nav",
+  "settings",
+] as const;
 
 export const DEFAULT_NAMESPACE = "common";
 
 export const resources: LocaleResources = {
-  en: { common: enCommon, errors: enErrors, labs: enLabs, nav: enNav },
-  es: { common: esCommon, errors: esErrors, labs: esLabs, nav: esNav },
+  en: {
+    common: enCommon,
+    errors: enErrors,
+    labs: enLabs,
+    nav: enNav,
+    settings: enSettings,
+  },
+  es: {
+    common: esCommon,
+    errors: esErrors,
+    labs: esLabs,
+    nav: esNav,
+    settings: esSettings,
+  },
 };


### PR DESCRIPTION
## What

Second SPA i18n migration PR (after #876 navigation). Localizes the **Settings** surface — the area the user opened when reporting "cambio a español y no cambia nada".

- New `settings` namespace (`en`/`es`) covering settings-home group eyebrows, row labels, tab headings, and the back button.
- Settings groups/rows, `SettingsPage` heading (`Settings · AI` → `Ajustes · IA`), and back button routed through the `useTranslate` seam.
- Replaced label-derived row testids with **stable semantic keys** (`settings-row-provider`, `settings-row-extensions`, …) so identity is locale-independent; dropped the now-redundant display `label` from `settings-groups.ts`.
- Updated the 4 unit + 3 e2e testid references to the new keys.

## Invariants preserved

- **en-default byte-identical**: every English dictionary value equals the original hardcoded string, so `en`-mode assertions stay green.
- **en/es key parity** enforced by `resource-parity.test.ts` (passing).

## Verification

- `settings` + `use-translate` unit tests: 19/19 ✓
- All i18n tests (incl. resource parity): 18/18 ✓
- Full SPA suite: 5437/5438 ✓ — the one failure is the pre-existing flaky `LabDashboardSection` chart test (passes 4/4 in isolation; times out only under full-suite CPU contention, sharded green in CI).
- `tsc --noEmit` clean · SPA build clean · eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings screens are now localized in English and Spanish.
  * Settings section, tab, row, and navigation labels now display translated text.

* **Bug Fixes**
  * Fixed settings page and E2E selectors so settings rows open reliably during navigation and testing.
  * Improved stability of settings row identification by using consistent internal keys.

* **Refactor**
  * Updated settings UI to use stable identifiers and shared translations for headings, rows, and tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->