### PR TITLE
feat(spa-editor): localize the Daily page (daily namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/Daily/DailyHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/DailyHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { ROUTE_HEADING_ATTR } from "../../../routing/constants";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
@@ -19,9 +20,10 @@ export function DailyHeader({
   isFocusToday,
   onBackToToday,
 }: DailyHeaderProps) {
+  const t = useTranslate("daily");
   const eyebrow = focusDate.toLocaleDateString(undefined, DATE_OPTIONS);
   const title = isFocusToday
-    ? "Today"
+    ? t("header.today")
     : focusDate.toLocaleDateString(undefined, TITLE_OPTIONS);
 
   return (
@@ -43,13 +45,13 @@ export function DailyHeader({
             onClick={onBackToToday}
             className="mt-1 rounded-md text-[13px] font-semibold text-sky-400 transition-colors hover:text-sky-300"
           >
-            ← Back to Today
+            {t("header.backToToday")}
           </button>
         )}
       </div>
       <button
         type="button"
-        aria-label="Notifications"
+        aria-label={t("header.notifications")}
         className="flex h-10 w-10 items-center justify-center rounded-full bg-white/5 text-slate-300"
       >
         <Icon icon={ICON_MAP.bell} size="md" color="inherit" />

--- a/packages/workout-spa-editor/src/components/pages/Daily/EnergyBalanceCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/EnergyBalanceCard.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Link } from "wouter";
 
 import { useDayEnergyBalance } from "../../../hooks/energy/use-day-energy-balance";
+import { useTranslate } from "../../../i18n/use-translate";
 import { Card } from "../../atoms/Card";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 import { GoalSetupDialog } from "../../molecules/GoalSetupDialog/GoalSetupDialog";
@@ -25,6 +26,7 @@ export type EnergyBalanceCardProps = {
  * BMR inputs are missing for an uncovered day.
  */
 export function EnergyBalanceCard({ profileId, date }: EnergyBalanceCardProps) {
+  const t = useTranslate("daily");
   const [goalOpen, setGoalOpen] = useState(false);
   const result = useDayEnergyBalance(profileId, date);
   if (result === undefined) return null;
@@ -42,7 +44,7 @@ export function EnergyBalanceCard({ profileId, date }: EnergyBalanceCardProps) {
       <div className="flex items-center gap-3">
         <Icon icon={ICON_MAP.flame} size="md" color="inherit" />
         <p className="text-[15px] font-semibold text-slate-100 m-0">
-          Energy balance
+          {t("energyBalance.title")}
         </p>
         {profileId && (
           <button
@@ -51,7 +53,7 @@ export function EnergyBalanceCard({ profileId, date }: EnergyBalanceCardProps) {
             data-testid="energy-balance-set-goal"
             className="ml-auto text-[13px] font-semibold text-blue-400"
           >
-            Set goal
+            {t("energyBalance.setGoal")}
           </button>
         )}
       </div>
@@ -70,7 +72,7 @@ export function EnergyBalanceCard({ profileId, date }: EnergyBalanceCardProps) {
         data-testid="energy-balance-nutrition-link"
         className="mt-3 block text-[13px] font-semibold text-blue-400"
       >
-        Log nutrition
+        {t("energyBalance.logNutrition")}
       </Link>
       {profileId && (
         <GoalSetupDialog

--- a/packages/workout-spa-editor/src/components/pages/Daily/EnergyBalanceGated.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/EnergyBalanceGated.tsx
@@ -1,5 +1,6 @@
 import { Link } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Card } from "../../atoms/Card";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
@@ -11,6 +12,7 @@ const PROFILE_HREF = "/settings/profile";
  * their profile rather than displaying a basal-derived number.
  */
 export function EnergyBalanceGated() {
+  const t = useTranslate("daily");
   return (
     <Link
       href={PROFILE_HREF}
@@ -22,10 +24,10 @@ export function EnergyBalanceGated() {
           <Icon icon={ICON_MAP.flame} size="md" color="inherit" />
           <div className="min-w-0 flex-1">
             <p className="text-[15px] font-semibold text-slate-100 m-0">
-              Energy balance
+              {t("energyBalance.title")}
             </p>
             <p className="text-[13px] text-slate-400 m-0 mt-0.5">
-              Complete your profile to estimate energy
+              {t("energyBalance.gatedPrompt")}
             </p>
           </div>
           <Icon icon={ICON_MAP.chevR} size="sm" color="inherit" />

--- a/packages/workout-spa-editor/src/components/pages/Daily/EnergyBalanceStats.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/EnergyBalanceStats.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { EnergyBalanceViewModel } from "./energy-balance-view-model";
 
 const NET_TONE_CLASS: Record<EnergyBalanceViewModel["netTone"], string> = {
@@ -25,17 +26,20 @@ function Stat({ label, value, valueClass = "text-slate-50" }: StatProps) {
 export type EnergyBalanceStatsProps = { vm: EnergyBalanceViewModel };
 
 export function EnergyBalanceStats({ vm }: EnergyBalanceStatsProps) {
+  const t = useTranslate("daily");
   return (
     <>
       <div className="mt-4 flex gap-2 border-t border-slate-800 pt-4">
         <Stat label={vm.expenditureLabel} value={vm.expenditure} />
-        <Stat label="Intake" value={vm.intake} />
+        <Stat label={t("energyBalance.intake")} value={vm.intake} />
         <Stat
-          label="Net"
+          label={t("energyBalance.net")}
           value={vm.net}
           valueClass={NET_TONE_CLASS[vm.netTone]}
         />
-        {vm.target !== null && <Stat label="Target" value={vm.target} />}
+        {vm.target !== null && (
+          <Stat label={t("energyBalance.target")} value={vm.target} />
+        )}
       </div>
       {vm.capWarning !== null && (
         <p

--- a/packages/workout-spa-editor/src/components/pages/Daily/PlannedEmpty.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/PlannedEmpty.tsx
@@ -1,20 +1,22 @@
 import { useLocation } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { withOrigin } from "../../../routing/with-origin";
 import { Button } from "../../atoms/Button";
 import { Card } from "../../atoms/Card";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
 export function PlannedEmpty() {
+  const t = useTranslate("daily");
   const [, navigate] = useLocation();
 
   return (
     <Card className="bg-primary-900 border-slate-800 p-6 text-center">
       <p className="text-[15px] font-semibold text-slate-300 m-0">
-        Nothing planned today
+        {t("planned.emptyTitle")}
       </p>
       <p className="text-[13px] text-slate-500 m-0 mt-1">
-        Create a workout to fill your day.
+        {t("planned.emptyBody")}
       </p>
       <Button
         variant="primary"
@@ -22,7 +24,7 @@ export function PlannedEmpty() {
         onClick={() => navigate(withOrigin("/workout/new", "daily"))}
       >
         <Icon icon={ICON_MAP.plus} size="sm" color="inherit" />
-        Plan a session
+        {t("planned.planSession")}
       </Button>
     </Card>
   );

--- a/packages/workout-spa-editor/src/components/pages/Daily/PlannedSession.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/PlannedSession.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 import { SectionHead } from "../../molecules/SectionHead";
@@ -18,9 +19,10 @@ export function PlannedSession({
   onWorkoutClick,
   onActivityClick,
 }: PlannedSessionProps) {
+  const t = useTranslate("daily");
   return (
     <section data-testid="daily-planned-session">
-      <SectionHead title="Planned" />
+      <SectionHead title={t("planned.title")} />
       {todayBucketsEmpty(buckets) ? (
         <PlannedEmpty />
       ) : (

--- a/packages/workout-spa-editor/src/components/pages/Daily/ReadinessCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/ReadinessCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Card } from "../../atoms/Card";
 import { ReadinessRing } from "../../molecules/ReadinessRing";
 import { ReadinessStat } from "./ReadinessStat";
@@ -7,9 +8,8 @@ export type ReadinessCardProps = {
   readiness: ReadinessModel;
 };
 
-const NO_DATA_LABEL = "NO DATA";
-
 export function ReadinessCard({ readiness }: ReadinessCardProps) {
+  const t = useTranslate("daily");
   const { score, headline, rationale, hrv, sleep, battery } = readiness;
 
   return (
@@ -17,7 +17,7 @@ export function ReadinessCard({ readiness }: ReadinessCardProps) {
       <div className="flex items-center gap-4">
         <ReadinessRing
           score={score ?? 0}
-          label={score === null ? NO_DATA_LABEL : "READY"}
+          label={score === null ? t("readiness.noData") : t("readiness.ready")}
         />
         <div className="min-w-0">
           <p className="text-[16px] font-bold text-slate-50 m-0">{headline}</p>

--- a/packages/workout-spa-editor/src/components/pages/Daily/TrendsCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/TrendsCard.tsx
@@ -1,9 +1,11 @@
 import { Link } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Card } from "../../atoms/Card";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
 export function TrendsCard() {
+  const t = useTranslate("daily");
   return (
     <Link href="/health" data-testid="daily-trends-card" className="block">
       <Card className="bg-primary-900 border-slate-800 p-4 transition-colors hover:border-slate-700">
@@ -11,10 +13,10 @@ export function TrendsCard() {
           <Icon icon={ICON_MAP.trend} size="md" color="inherit" />
           <div className="min-w-0 flex-1">
             <p className="text-[15px] font-semibold text-slate-100 m-0">
-              Trends
+              {t("trends.title")}
             </p>
             <p className="text-[13px] text-slate-400 m-0 mt-0.5">
-              See your wellness history
+              {t("trends.subtitle")}
             </p>
           </div>
           <Icon icon={ICON_MAP.chevR} size="sm" color="inherit" />

--- a/packages/workout-spa-editor/src/components/pages/Daily/WeekStrip.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/WeekStrip.tsx
@@ -1,5 +1,6 @@
 import { Link } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { calendarWeekHref } from "../../../routing/calendar-week-href";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 import type { DaySummary, WeekSummary } from "./build-week-summary";
@@ -26,6 +27,7 @@ const EMPTY: DaySummary = {
 };
 
 export function WeekStrip(props: WeekStripProps) {
+  const t = useTranslate("daily");
   const { days, weekSummary, onSelectDay } = props;
   const calendarHref =
     days.length > 0 ? calendarWeekHref(days[0]!.iso) : "/calendar";
@@ -38,7 +40,7 @@ export function WeekStrip(props: WeekStripProps) {
       <div className="flex items-center gap-1.5">
         <button
           type="button"
-          aria-label="Previous day"
+          aria-label={t("weekStrip.previousDay")}
           onClick={props.onPrev}
           className={ARROW}
         >
@@ -54,7 +56,7 @@ export function WeekStrip(props: WeekStripProps) {
         ))}
         <button
           type="button"
-          aria-label="Next day"
+          aria-label={t("weekStrip.nextDay")}
           onClick={props.onNext}
           className={ARROW}
         >
@@ -64,11 +66,11 @@ export function WeekStrip(props: WeekStripProps) {
       <div className="mt-2 flex justify-end">
         <Link
           href={calendarHref}
-          aria-label="Open week in calendar"
+          aria-label={t("weekStrip.openInCalendar")}
           className="flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-semibold text-slate-400 transition-colors hover:bg-slate-800"
         >
           <Icon icon={ICON_MAP.calendar} size="sm" color="inherit" />
-          Calendar
+          {t("weekStrip.calendar")}
         </Link>
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/Daily/today-readiness.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/today-readiness.ts
@@ -11,6 +11,7 @@
  */
 import type { HrvSummary, SleepRecord, StressEpisode } from "@kaiord/core";
 
+import { getTranslate, type Translate } from "../../../i18n/use-translate";
 import {
   batteryValue,
   compositeScore,
@@ -20,14 +21,18 @@ import {
   sleepValue,
 } from "./readiness-metrics";
 
-const HEADLINE_PUSH_TODAY = "Good to push today";
-const HEADLINE_PUSH = "Good to push";
-const HEADLINE_EASY_TODAY = "Take it easy today";
-const HEADLINE_EASY = "Take it easy";
-
-function readyHeadline(ready: boolean, isFocusToday: boolean): string {
-  if (ready) return isFocusToday ? HEADLINE_PUSH_TODAY : HEADLINE_PUSH;
-  return isFocusToday ? HEADLINE_EASY_TODAY : HEADLINE_EASY;
+function readyHeadline(
+  ready: boolean,
+  isFocusToday: boolean,
+  t: Translate
+): string {
+  if (ready)
+    return t(
+      isFocusToday ? "readiness.headlinePushToday" : "readiness.headlinePush"
+    );
+  return t(
+    isFocusToday ? "readiness.headlineEasyToday" : "readiness.headlineEasy"
+  );
 }
 
 export type ReadinessMetric = {
@@ -61,7 +66,8 @@ export function buildReadinessModel(
   stress: StressEpisode[] | undefined,
   isFocusToday: boolean,
   hrvSource?: ReadinessMetricSource,
-  sleepSource?: ReadinessMetricSource
+  sleepSource?: ReadinessMetricSource,
+  t: Translate = getTranslate("daily")
 ): ReadinessModel {
   const score = compositeScore(hrv, sleep);
   const ready = score !== null && score >= SCORE_MAX / 2;
@@ -69,25 +75,25 @@ export function buildReadinessModel(
     score,
     headline:
       score === null
-        ? "No readiness data yet"
-        : readyHeadline(ready, isFocusToday),
+        ? t("readiness.noDataYet")
+        : readyHeadline(ready, isFocusToday, t),
     rationale:
       score === null
-        ? "Connect Garmin to sync HRV and sleep."
-        : "Based on your overnight HRV and sleep.",
+        ? t("readiness.rationaleNoData")
+        : t("readiness.rationale"),
     hrv: {
-      label: "HRV",
+      label: t("readiness.hrv"),
       value: hrv ? `${Math.round(hrv.rMSSD)}` : EM_DASH,
       trend: hrvTrend(hrv),
       source: hrvSource?.sourceBridgeId,
       usedFallback: hrvSource?.usedFallback,
     },
     sleep: {
-      label: "Sleep",
+      label: t("readiness.sleep"),
       value: sleepValue(sleep),
       source: sleepSource?.sourceBridgeId,
       usedFallback: sleepSource?.usedFallback,
     },
-    battery: { label: "Battery", value: batteryValue(stress) },
+    battery: { label: t("readiness.battery"), value: batteryValue(stress) },
   };
 }

--- a/packages/workout-spa-editor/src/components/pages/Daily/use-today-data.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/use-today-data.ts
@@ -1,23 +1,21 @@
 /**
  * Aggregates every reactive source the Today page renders: the active
- * profile, this week's workouts, and today's Garmin health metrics (HRV,
- * sleep, stress). View-model derivation stays in the pure `today-*` helpers.
+ * profile, this week's workouts, and today's readiness. View-model
+ * derivation stays in the pure `today-*` helpers; readiness resolution
+ * lives in `use-today-readiness`.
  */
-import type { HrvSummary, SleepRecord } from "@kaiord/core";
 import { useMemo } from "react";
 
-import { useEffectiveHealthRecordLive } from "../../../hooks/health/use-effective-health-record-live";
-import { useHealthStressDayLive } from "../../../hooks/health/use-health-stress-day-live";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 import type { Profile } from "../../../types/profile";
 import type { TodayBuckets } from "./build-today-buckets";
 import type { WeekSummary } from "./build-week-summary";
-import { pickEffectiveHealthRecord } from "./pick-effective-health-record";
 import { toIsoDate, type WeekDay, weekDays } from "./today-dates";
-import { buildReadinessModel, type ReadinessModel } from "./today-readiness";
+import type { ReadinessModel } from "./today-readiness";
 import { useTodayPlannedBuckets } from "./use-today-planned-buckets";
+import { useTodayReadiness } from "./use-today-readiness";
 import { useWeekWorkoutsLive } from "./use-today-workouts-live";
 
 export type TodayData = {
@@ -45,43 +43,15 @@ export function useTodayData(focusDate: Date, realTodayIso: string): TodayData {
   );
   const dayIsos = useMemo(() => days.map((d) => d.iso), [days]);
   const focusIso = toIsoDate(focusDate);
+  const isFocusToday = focusIso === realTodayIso;
   const start = days[0]!.iso;
   const end = days[days.length - 1]!.iso;
 
   const weekWorkouts = useWeekWorkoutsLive(profileId, start, end);
-  // F3.2/F3.3: HRV/sleep resolve through the multi-source resolver
-  // instead of reading the table directly — same single-day scope as
-  // before, but the "winning" record is now a governed choice (union
-  // default today; priority + fallback once F3.1's companion table
-  // exists), not just the query's last row.
-  const hrvResult = useEffectiveHealthRecordLive<HrvSummary>(
-    profileId ?? "",
-    "hrv",
-    focusIso
-  );
-  const sleepResult = useEffectiveHealthRecordLive<SleepRecord>(
-    profileId ?? "",
-    "sleep",
-    focusIso
-  );
-  const stressRecords = useHealthStressDayLive(profileId ?? "", focusIso);
-  const hrvPick = pickEffectiveHealthRecord(hrvResult);
-  const sleepPick = pickEffectiveHealthRecord(sleepResult);
+  const readiness = useTodayReadiness(profileId, focusIso, isFocusToday);
 
   const { planned, weekSummary, coachingByDay, expandActivity } =
     useTodayPlannedBuckets(profileId, dayIsos, focusIso, weekWorkouts, profile);
-  const isFocusToday = focusIso === realTodayIso;
-  // hrvPick/sleepPick already carry {sourceBridgeId, usedFallback} (plus
-  // `record`, structurally ignored here) — passed straight through as the
-  // source-meta args, no need to reshape into ReadinessMetricSource.
-  const readiness = buildReadinessModel(
-    hrvPick.record,
-    sleepPick.record,
-    stressRecords?.map((record) => record.krd),
-    isFocusToday,
-    hrvPick,
-    sleepPick
-  );
 
   return {
     profile,

--- a/packages/workout-spa-editor/src/components/pages/Daily/use-today-readiness.ts
+++ b/packages/workout-spa-editor/src/components/pages/Daily/use-today-readiness.ts
@@ -1,0 +1,42 @@
+/**
+ * Resolves the Today page readiness model. HRV/sleep resolve through the
+ * multi-source resolver (a governed "winning" record, not the query's last
+ * row); the model's copy is localized via the active-locale translator.
+ */
+import type { HrvSummary, SleepRecord } from "@kaiord/core";
+
+import { useEffectiveHealthRecordLive } from "../../../hooks/health/use-effective-health-record-live";
+import { useHealthStressDayLive } from "../../../hooks/health/use-health-stress-day-live";
+import { useTranslate } from "../../../i18n/use-translate";
+import { pickEffectiveHealthRecord } from "./pick-effective-health-record";
+import { buildReadinessModel, type ReadinessModel } from "./today-readiness";
+
+export function useTodayReadiness(
+  profileId: string | null,
+  focusIso: string,
+  isFocusToday: boolean
+): ReadinessModel {
+  const t = useTranslate("daily");
+  const hrvResult = useEffectiveHealthRecordLive<HrvSummary>(
+    profileId ?? "",
+    "hrv",
+    focusIso
+  );
+  const sleepResult = useEffectiveHealthRecordLive<SleepRecord>(
+    profileId ?? "",
+    "sleep",
+    focusIso
+  );
+  const stressRecords = useHealthStressDayLive(profileId ?? "", focusIso);
+  const hrvPick = pickEffectiveHealthRecord(hrvResult);
+  const sleepPick = pickEffectiveHealthRecord(sleepResult);
+  return buildReadinessModel(
+    hrvPick.record,
+    sleepPick.record,
+    stressRecords?.map((record) => record.krd),
+    isFocusToday,
+    hrvPick,
+    sleepPick,
+    t
+  );
+}

--- a/packages/workout-spa-editor/src/i18n/locales/en/daily.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/daily.json
@@ -1,0 +1,46 @@
+{
+  "header": {
+    "today": "Today",
+    "backToToday": "← Back to Today",
+    "notifications": "Notifications"
+  },
+  "readiness": {
+    "ready": "READY",
+    "noData": "NO DATA",
+    "noDataYet": "No readiness data yet",
+    "rationaleNoData": "Connect Garmin to sync HRV and sleep.",
+    "rationale": "Based on your overnight HRV and sleep.",
+    "headlinePushToday": "Good to push today",
+    "headlinePush": "Good to push",
+    "headlineEasyToday": "Take it easy today",
+    "headlineEasy": "Take it easy",
+    "hrv": "HRV",
+    "sleep": "Sleep",
+    "battery": "Battery"
+  },
+  "energyBalance": {
+    "title": "Energy balance",
+    "setGoal": "Set goal",
+    "logNutrition": "Log nutrition",
+    "gatedPrompt": "Complete your profile to estimate energy",
+    "intake": "Intake",
+    "net": "Net",
+    "target": "Target"
+  },
+  "weekStrip": {
+    "previousDay": "Previous day",
+    "nextDay": "Next day",
+    "openInCalendar": "Open week in calendar",
+    "calendar": "Calendar"
+  },
+  "trends": {
+    "title": "Trends",
+    "subtitle": "See your wellness history"
+  },
+  "planned": {
+    "title": "Planned",
+    "emptyTitle": "Nothing planned today",
+    "emptyBody": "Create a workout to fill your day.",
+    "planSession": "Plan a session"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/daily.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/daily.json
@@ -1,0 +1,46 @@
+{
+  "header": {
+    "today": "Hoy",
+    "backToToday": "← Volver a hoy",
+    "notifications": "Notificaciones"
+  },
+  "readiness": {
+    "ready": "LISTO",
+    "noData": "SIN DATOS",
+    "noDataYet": "Aún no hay datos de preparación",
+    "rationaleNoData": "Conecta Garmin para sincronizar la VFC y el sueño.",
+    "rationale": "Según tu VFC nocturna y tu sueño.",
+    "headlinePushToday": "Buen día para exigirte",
+    "headlinePush": "Bien para exigirte",
+    "headlineEasyToday": "Tómatelo con calma hoy",
+    "headlineEasy": "Tómatelo con calma",
+    "hrv": "VFC",
+    "sleep": "Sueño",
+    "battery": "Batería"
+  },
+  "energyBalance": {
+    "title": "Balance energético",
+    "setGoal": "Definir objetivo",
+    "logNutrition": "Registrar nutrición",
+    "gatedPrompt": "Completa tu perfil para estimar la energía",
+    "intake": "Ingesta",
+    "net": "Neto",
+    "target": "Objetivo"
+  },
+  "weekStrip": {
+    "previousDay": "Día anterior",
+    "nextDay": "Día siguiente",
+    "openInCalendar": "Abrir la semana en el calendario",
+    "calendar": "Calendario"
+  },
+  "trends": {
+    "title": "Tendencias",
+    "subtitle": "Consulta tu historial de bienestar"
+  },
+  "planned": {
+    "title": "Planificado",
+    "emptyTitle": "Nada planificado hoy",
+    "emptyBody": "Crea un entreno para llenar tu día.",
+    "planSession": "Planificar sesión"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -8,11 +8,13 @@
 import type { LocaleResources } from "@kaiord/i18n";
 
 import enCommon from "./locales/en/common.json";
+import enDaily from "./locales/en/daily.json";
 import enErrors from "./locales/en/errors.json";
 import enLabs from "./locales/en/labs.json";
 import enNav from "./locales/en/nav.json";
 import enSettings from "./locales/en/settings.json";
 import esCommon from "./locales/es/common.json";
+import esDaily from "./locales/es/daily.json";
 import esErrors from "./locales/es/errors.json";
 import esLabs from "./locales/es/labs.json";
 import esNav from "./locales/es/nav.json";
@@ -20,6 +22,7 @@ import esSettings from "./locales/es/settings.json";
 
 export const NAMESPACES = [
   "common",
+  "daily",
   "errors",
   "labs",
   "nav",
@@ -31,6 +34,7 @@ export const DEFAULT_NAMESPACE = "common";
 export const resources: LocaleResources = {
   en: {
     common: enCommon,
+    daily: enDaily,
     errors: enErrors,
     labs: enLabs,
     nav: enNav,
@@ -38,6 +42,7 @@ export const resources: LocaleResources = {
   },
   es: {
     common: esCommon,
+    daily: esDaily,
     errors: esErrors,
     labs: esLabs,
     nav: esNav,

--- a/packages/workout-spa-editor/src/i18n/use-translate.ts
+++ b/packages/workout-spa-editor/src/i18n/use-translate.ts
@@ -43,11 +43,24 @@ const interpolate = (value: string, params?: TranslateParams): string =>
 
 export type Translate = (key: string, params?: TranslateParams) => string;
 
-export function useTranslate(ns: string): Translate {
-  const locale = useActiveLocale();
+/**
+ * Non-hook translator for a namespace at an explicit locale. Pure
+ * presentation-logic (view-model builders, formatters) that produces
+ * user-facing copy takes a `Translate` argument defaulting to this at
+ * `DEFAULT_LOCALE`, so their existing English-asserting unit tests stay
+ * byte-identical while hook callers thread a locale-aware translator.
+ */
+export function getTranslate(
+  ns: string,
+  locale: Locale = DEFAULT_LOCALE
+): Translate {
   return (key, params) =>
     interpolate(
       lookup(locale, ns, key) ?? lookup(DEFAULT_LOCALE, ns, key) ?? key,
       params
     );
+}
+
+export function useTranslate(ns: string): Translate {
+  return getTranslate(ns, useActiveLocale());
 }


### PR DESCRIPTION
## What

Third SPA i18n migration PR (after #876 nav, #877 settings). Localizes the **Daily / Today** page — the default landing view.

- New `daily` namespace (`en`/`es`): header (Today / back-to-today / notifications), week strip aria-labels + calendar link, planned/empty states, energy-balance labels, trends card, and the **readiness** headline / rationale / stat labels.
- Introduces a reusable seam for pure presentation-logic: a non-hook **`getTranslate(ns, locale)`** factory. `buildReadinessModel` now takes an optional `Translate` param **defaulting to the English translator**, so its unit tests (which pass no `t`) stay byte-identical while the `use-today-data` hook threads a locale-aware translator.
- Extracted the readiness derivation into a new **`use-today-readiness`** hook (owns `useTranslate` + `buildReadinessModel`), keeping `use-today-data` under the 80-line SPA cap.

## Deferred (tracked, cross-cutting)

Two shared string sources stay English in this PR and land with their owning batches:
- `energy-balance-view-model.ts` (`Measured`/`Predicted`/`Mixed`, `deficit`/`surplus`/`balanced`, `Untracked`, cap warnings) — **shared with the Nutrition page** → `nutrition`/`energy` batch.
- `workout-review` `FALLBACK_TITLE` ("Workout"/"AI session") — **shared with WorkoutDetail + CreateWorkout** → workout-review batch.

The default-en `Translate` pattern introduced here is exactly what those batches will use to thread locale through the shared pure functions.

## Invariants preserved

- **en-default byte-identical**: every English value equals the original literal; no component/logic test needed editing.
- **en/es key parity** enforced by `resource-parity.test.ts`.
- testids/keys untouched.

## Verification

- Full SPA suite: **5438/5438 passed** (786 files, exit 0).
- `tsc --noEmit` clean · eslint clean · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)