### PR TITLE
feat(spa-editor): localize shared app-shell atoms & molecules (common namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/atoms/BackButton/BackButton.tsx
+++ b/packages/workout-spa-editor/src/components/atoms/BackButton/BackButton.tsx
@@ -1,16 +1,19 @@
 import { ArrowLeft } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
+
 export type BackButtonProps = {
   readonly onClick: () => void;
   readonly testId?: string;
 };
 
 export function BackButton({ onClick, testId }: BackButtonProps) {
+  const t = useTranslate("common");
   return (
     <button
       type="button"
       onClick={onClick}
-      aria-label="Back"
+      aria-label={t("actions.back")}
       data-testid={testId ?? "back-button"}
       className="inline-flex h-9 w-9 items-center justify-center rounded-md text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
     >

--- a/packages/workout-spa-editor/src/components/atoms/ErrorMessage/ErrorActions.tsx
+++ b/packages/workout-spa-editor/src/components/atoms/ErrorMessage/ErrorActions.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../Button/Button";
 
 type ErrorActionsProps = {
@@ -6,6 +7,7 @@ type ErrorActionsProps = {
 };
 
 export const ErrorActions = ({ onRetry, onDismiss }: ErrorActionsProps) => {
+  const t = useTranslate("common");
   if (!onRetry && !onDismiss) return null;
 
   return (
@@ -17,7 +19,7 @@ export const ErrorActions = ({ onRetry, onDismiss }: ErrorActionsProps) => {
           size="sm"
           className="text-red-700 hover:bg-red-100 dark:text-red-300 dark:hover:bg-red-900"
         >
-          Try Again
+          {t("actions.tryAgain")}
         </Button>
       )}
       {onDismiss && (
@@ -27,7 +29,7 @@ export const ErrorActions = ({ onRetry, onDismiss }: ErrorActionsProps) => {
           size="sm"
           className="text-red-700 hover:bg-red-100 dark:text-red-300 dark:hover:bg-red-900"
         >
-          Dismiss
+          {t("actions.dismiss")}
         </Button>
       )}
     </div>

--- a/packages/workout-spa-editor/src/components/atoms/RouteSpinner.tsx
+++ b/packages/workout-spa-editor/src/components/atoms/RouteSpinner.tsx
@@ -1,12 +1,15 @@
+import { useTranslate } from "../../i18n/use-translate";
+
 /**
  * RouteSpinner - Loading fallback for lazy-loaded routes.
  */
 export function RouteSpinner() {
+  const t = useTranslate("common");
   return (
     <div
       className="flex items-center justify-center p-12"
       role="status"
-      aria-label="Loading page"
+      aria-label={t("a11y.loadingPage")}
     >
       <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
     </div>

--- a/packages/workout-spa-editor/src/components/atoms/ThemeToggle/ThemeToggle.tsx
+++ b/packages/workout-spa-editor/src/components/atoms/ThemeToggle/ThemeToggle.tsx
@@ -1,6 +1,7 @@
 import { Moon, Sun } from "lucide-react";
 
 import { useTheme } from "../../../contexts/ThemeContext";
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../Button/Button";
 import { Icon } from "../Icon/Icon";
 
@@ -15,6 +16,7 @@ import { Icon } from "../Icon/Icon";
  */
 export const ThemeToggle = () => {
   const { theme, resolvedTheme, setTheme } = useTheme();
+  const t = useTranslate("common");
 
   const handleToggle = () => {
     // Cycle through themes: light → dark → light
@@ -31,7 +33,9 @@ export const ThemeToggle = () => {
   // Determine icon and label based on resolved theme
   const currentIcon = resolvedTheme === "dark" ? Moon : Sun;
   const ariaLabel =
-    resolvedTheme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+    resolvedTheme === "dark"
+      ? t("a11y.switchToLightMode")
+      : t("a11y.switchToDarkMode");
 
   return (
     <Button

--- a/packages/workout-spa-editor/src/components/atoms/Toast/Toast.tsx
+++ b/packages/workout-spa-editor/src/components/atoms/Toast/Toast.tsx
@@ -2,6 +2,7 @@ import * as ToastPrimitive from "@radix-ui/react-toast";
 import { X } from "lucide-react";
 import { forwardRef } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { baseToastStyles, variantStyles } from "./Toast.styles";
 import type { ToastProps } from "./Toast.types";
 
@@ -29,6 +30,7 @@ export const Toast = forwardRef<HTMLLIElement, ToastProps>(
     },
     ref
   ) => {
+    const t = useTranslate("common");
     return (
       <ToastPrimitive.Root
         ref={ref}
@@ -51,13 +53,17 @@ export const Toast = forwardRef<HTMLLIElement, ToastProps>(
           )}
         </div>
         {action && (
-          <ToastPrimitive.Action altText="Action" className="shrink-0" asChild>
+          <ToastPrimitive.Action
+            altText={t("actions.action")}
+            className="shrink-0"
+            asChild
+          >
             {action}
           </ToastPrimitive.Action>
         )}
         <ToastPrimitive.Close
           className="absolute right-2 top-2 rounded-md p-1 opacity-0 transition-opacity hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100"
-          aria-label="Close"
+          aria-label={t("actions.close")}
         >
           <X className="h-4 w-4" />
         </ToastPrimitive.Close>

--- a/packages/workout-spa-editor/src/components/molecules/BottomNav/BottomNav.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/BottomNav/BottomNav.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { BAR_STYLE, FAB_NOTCH_WIDTH } from "./bottom-nav-styles";
 import { BOTTOM_NAV_TABS, isTabActive } from "./bottom-nav-tabs";
 import { BottomNavFab } from "./BottomNavFab";
@@ -17,9 +18,10 @@ const NOTCH_INDEX = 3;
  */
 export function BottomNav() {
   const [location, navigate] = useLocation();
+  const t = useTranslate("common");
   return (
     <nav
-      aria-label="Primary"
+      aria-label={t("a11y.primary")}
       data-testid="bottom-nav"
       style={BAR_STYLE}
       className="fixed inset-x-[14px] bottom-[14px] z-30 mx-auto flex max-w-md items-stretch rounded-[24px] border border-slate-700/60 md:hidden"

--- a/packages/workout-spa-editor/src/components/molecules/BottomNav/BottomNavFab.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/BottomNav/BottomNavFab.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 import { FAB_ICON_SIZE, FAB_STYLE } from "./bottom-nav-styles";
 
@@ -9,10 +10,11 @@ type BottomNavFabProps = {
  * Raised gradient action button centered over the bar notch.
  */
 export function BottomNavFab({ onActivate }: BottomNavFabProps) {
+  const t = useTranslate("common");
   return (
     <button
       type="button"
-      aria-label="Create workout"
+      aria-label={t("a11y.createWorkout")}
       onClick={onActivate}
       style={FAB_STYLE}
       className="absolute -top-[18px] left-1/2 flex -translate-x-1/2 items-center justify-center rounded-[20px] text-white"

--- a/packages/workout-spa-editor/src/components/molecules/BottomNav/bottom-nav-tabs.ts
+++ b/packages/workout-spa-editor/src/components/molecules/BottomNav/bottom-nav-tabs.ts
@@ -4,7 +4,6 @@ import type { IconName } from "../../atoms/Icon";
 export type BottomNavTab = {
   /** Nav-destination id; also the `nav` i18n key for the tab label. */
   id: string;
-  label: string;
   icon: IconName;
   path: string;
 };
@@ -22,7 +21,6 @@ export const BOTTOM_NAV_TABS: readonly BottomNavTab[] = NAV_DESTINATIONS.filter(
   (destination) => destination.surfaces.bottomNav
 ).map((destination) => ({
   id: destination.id,
-  label: destination.labelKey,
   icon: destination.icon,
   path: destination.path,
 }));

--- a/packages/workout-spa-editor/src/components/molecules/StatusHeader/ProfileEntryButton.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StatusHeader/ProfileEntryButton.tsx
@@ -2,16 +2,18 @@ import { User } from "lucide-react";
 import { useLocation } from "wouter";
 
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button/Button";
 
 export function ProfileEntryButton() {
   const [, navigate] = useLocation();
+  const t = useTranslate("common");
   const activeProfile = useActiveProfileLive()?.profile ?? null;
-  const label = activeProfile?.name ?? "No profile";
+  const label = activeProfile?.name ?? t("status.noProfile");
 
   const ariaLabel = activeProfile
-    ? `Open athlete profile (active profile: ${activeProfile.name})`
-    : "Open athlete profile (no active profile)";
+    ? t("a11y.openAthleteProfile", { name: activeProfile.name })
+    : t("a11y.openAthleteProfileEmpty");
 
   return (
     <Button

--- a/packages/workout-spa-editor/src/components/molecules/StatusHeader/StatusEntryButtons.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StatusHeader/StatusEntryButtons.tsx
@@ -1,6 +1,7 @@
 import { HelpCircle } from "lucide-react";
 import { useLocation } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button/Button";
 import { ProfileEntryButton } from "./ProfileEntryButton";
 import { isEntryActive } from "./status-entry-active";
@@ -14,6 +15,7 @@ type StatusEntryButtonsProps = {
 
 export function StatusEntryButtons({ onHelpClick }: StatusEntryButtonsProps) {
   const [location, navigate] = useLocation();
+  const t = useTranslate("common");
   // Athlete is reachable through ProfileEntryButton below, and settings
   // renders in its dedicated trailing slot — rendering either here would
   // duplicate the destination in the same bar.
@@ -49,12 +51,12 @@ export function StatusEntryButtons({ onHelpClick }: StatusEntryButtonsProps) {
         variant="tertiary"
         size="sm"
         onClick={onHelpClick}
-        aria-label="Open help"
-        title="Help (?)"
+        aria-label={t("a11y.openHelp")}
+        title={t("help.hint")}
         data-testid="status-header-help-button"
       >
         <HelpCircle className="h-4 w-4" />
-        <span className="hidden sm:inline">Help</span>
+        <span className="hidden sm:inline">{t("actions.help")}</span>
       </Button>
     </>
   );

--- a/packages/workout-spa-editor/src/components/molecules/StatusHeader/StatusHeader.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StatusHeader/StatusHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { ThemeToggle } from "../../atoms/ThemeToggle";
 import { StatusEntryButtons } from "./StatusEntryButtons";
 
@@ -6,9 +7,10 @@ type StatusHeaderProps = {
 };
 
 export function StatusHeader({ onHelpClick }: StatusHeaderProps) {
+  const t = useTranslate("common");
   return (
     <nav
-      aria-label="Main navigation"
+      aria-label={t("a11y.mainNavigation")}
       className="flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-sm sm:justify-end"
       data-testid="status-header"
     >

--- a/packages/workout-spa-editor/src/components/molecules/StatusHeader/StatusIndicators.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StatusHeader/StatusIndicators.tsx
@@ -1,19 +1,21 @@
 import { useGarminBridge } from "../../../contexts/garmin-bridge-context";
 import { useTrain2GoZonesSync } from "../../../contexts/train2go-zones-sync-context";
+import { useTranslate } from "../../../i18n/use-translate";
 import { useTrain2GoStore } from "../../../store/train2go-store";
-
-const garminLabel = (sessionActive: boolean) =>
-  sessionActive ? "Connected" : "Offline";
 
 const garminTone = (sessionActive: boolean) =>
   sessionActive ? "text-green-600 dark:text-green-400" : "text-gray-500";
 
 export function StatusIndicators() {
+  const t = useTranslate("common");
   const garmin = useGarminBridge();
   const sync = useTrain2GoZonesSync();
   const train2goInstalled = useTrain2GoStore((s) => s.extensionInstalled);
 
-  const syncLabel = sync.pending ? "Conflict" : "Synced";
+  const garminLabel = t(
+    garmin.sessionActive ? "status.connected" : "status.offline"
+  );
+  const syncLabel = t(sync.pending ? "status.conflict" : "status.synced");
   const syncTone = sync.pending
     ? "text-amber-600 dark:text-amber-400"
     : "text-gray-500";
@@ -25,12 +27,12 @@ export function StatusIndicators() {
           className={garminTone(garmin.sessionActive)}
           data-testid="status-header-garmin"
         >
-          Garmin: {garminLabel(garmin.sessionActive)}
+          {t("bridge.garmin", { label: garminLabel })}
         </span>
       )}
       {train2goInstalled && (
         <span className={syncTone} data-testid="status-header-sync">
-          Train2Go: {syncLabel}
+          {t("bridge.train2go", { label: syncLabel })}
         </span>
       )}
     </>

--- a/packages/workout-spa-editor/src/components/molecules/StatusHeader/status-entry-defs.ts
+++ b/packages/workout-spa-editor/src/components/molecules/StatusHeader/status-entry-defs.ts
@@ -6,7 +6,6 @@ import { ICON_MAP } from "../../atoms/Icon/icon-map";
 export type EntryDef = {
   id: string;
   icon: ComponentType<{ className?: string }>;
-  label: string;
   ariaLabel?: string;
   to: string;
   variant?: "primary" | "tertiary";
@@ -29,7 +28,6 @@ export const ENTRY_DEFS: ReadonlyArray<EntryDef> = NAV_DESTINATIONS.filter(
 ).map((destination) => ({
   id: destination.id,
   icon: ICON_MAP[destination.icon],
-  label: destination.labelKey,
   ariaLabel: destination.ariaLabel,
   to: destination.path,
   variant: PRIMARY_VARIANT_IDS.has(destination.id) ? "primary" : undefined,

--- a/packages/workout-spa-editor/src/components/templates/MainLayout/components/HelpDialog.tsx
+++ b/packages/workout-spa-editor/src/components/templates/MainLayout/components/HelpDialog.tsx
@@ -7,6 +7,7 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { HelpSection } from "../../../pages/HelpSection/HelpSection";
 
 type HelpDialogProps = {
@@ -20,6 +21,7 @@ export function HelpDialog({
   onOpenChange,
   onReplayTutorial,
 }: HelpDialogProps) {
+  const t = useTranslate("common");
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
@@ -30,12 +32,12 @@ export function HelpDialog({
         >
           <div className="mb-4 flex items-center justify-between">
             <Dialog.Title className="text-2xl font-bold text-gray-900 dark:text-white">
-              Help & Documentation
+              {t("help.documentation")}
             </Dialog.Title>
             <Dialog.Close asChild>
               <button
                 className="rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-gray-100 dark:ring-offset-gray-950 dark:focus:ring-primary-400 dark:data-[state=open]:bg-gray-800"
-                aria-label="Close"
+                aria-label={t("actions.close")}
               >
                 <X className="h-4 w-4" />
               </button>

--- a/packages/workout-spa-editor/src/i18n/locales/en/common.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/common.json
@@ -4,5 +4,39 @@
     "auto": "Auto",
     "en": "English",
     "es": "Spanish"
+  },
+  "actions": {
+    "close": "Close",
+    "action": "Action",
+    "tryAgain": "Try Again",
+    "dismiss": "Dismiss",
+    "back": "Back",
+    "help": "Help"
+  },
+  "status": {
+    "connected": "Connected",
+    "offline": "Offline",
+    "conflict": "Conflict",
+    "synced": "Synced",
+    "noProfile": "No profile"
+  },
+  "a11y": {
+    "mainNavigation": "Main navigation",
+    "primary": "Primary",
+    "createWorkout": "Create workout",
+    "loadingPage": "Loading page",
+    "switchToLightMode": "Switch to light mode",
+    "switchToDarkMode": "Switch to dark mode",
+    "openHelp": "Open help",
+    "openAthleteProfile": "Open athlete profile (active profile: {{name}})",
+    "openAthleteProfileEmpty": "Open athlete profile (no active profile)"
+  },
+  "help": {
+    "documentation": "Help & Documentation",
+    "hint": "Help (?)"
+  },
+  "bridge": {
+    "garmin": "Garmin: {{label}}",
+    "train2go": "Train2Go: {{label}}"
   }
 }

--- a/packages/workout-spa-editor/src/i18n/locales/es/common.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/common.json
@@ -4,5 +4,39 @@
     "auto": "Automático",
     "en": "Inglés",
     "es": "Español"
+  },
+  "actions": {
+    "close": "Cerrar",
+    "action": "Acción",
+    "tryAgain": "Reintentar",
+    "dismiss": "Descartar",
+    "back": "Atrás",
+    "help": "Ayuda"
+  },
+  "status": {
+    "connected": "Conectado",
+    "offline": "Sin conexión",
+    "conflict": "Conflicto",
+    "synced": "Sincronizado",
+    "noProfile": "Sin perfil"
+  },
+  "a11y": {
+    "mainNavigation": "Navegación principal",
+    "primary": "Principal",
+    "createWorkout": "Crear entreno",
+    "loadingPage": "Cargando página",
+    "switchToLightMode": "Cambiar a modo claro",
+    "switchToDarkMode": "Cambiar a modo oscuro",
+    "openHelp": "Abrir ayuda",
+    "openAthleteProfile": "Abrir perfil de atleta (perfil activo: {{name}})",
+    "openAthleteProfileEmpty": "Abrir perfil de atleta (sin perfil activo)"
+  },
+  "help": {
+    "documentation": "Ayuda y documentación",
+    "hint": "Ayuda (?)"
+  },
+  "bridge": {
+    "garmin": "Garmin: {{label}}",
+    "train2go": "Train2Go: {{label}}"
   }
 }


### PR DESCRIPTION
## What

Fourth SPA i18n migration PR (after #876 nav, #877 settings, #879 daily). Localizes the **shared app shell** — atoms/molecules that appear on every screen — by extending the existing `common` namespace.

- New `common.*` groups: `actions` (Close/Action/Try Again/Dismiss/Back/Help), `status` (Connected/Offline/Conflict/Synced/No profile), `a11y` (Main navigation/Primary/Create workout/Loading page/theme toggles/help/profile aria), `help` (Help & Documentation), `bridge` (`Garmin: {{label}}` / `Train2Go: {{label}}`).
- Migrated via `useTranslate("common")`: `Toast`, `ErrorActions`, `ThemeToggle`, `BackButton`, `RouteSpinner`, `HelpDialog`, `BottomNav` + `BottomNavFab`, and `StatusHeader` (`StatusIndicators`, `ProfileEntryButton`, `StatusEntryButtons`, `StatusHeader`).
- **PII-safe interpolation**: the bridge status labels and the profile aria-label use `{{...}}` params so dynamic/PII values never appear as a guard-checked toast/aria literal.
- **Dead-code cleanup**: removed the now-unused `label` fields from `bottom-nav-tabs.ts` and `status-entry-defs.ts` (nav display keys off `id` since #876).
- Establishes the shared vocabulary later batches reference instead of duplicating literals.

## Invariants preserved

- **en-default byte-identical** — no component test needed editing.
- **en/es key parity** enforced by `resource-parity.test.ts`.
- All `data-testid`s untouched.

## Verification

- Touched-dir + i18n suites: **1331/1331 passed** (atoms + molecules + templates + i18n).
- `tsc --noEmit` clean · eslint clean · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)