### PR TITLE
feat(spa-editor): localize the workout editor shell & actions (editor namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/EmptyWorkoutState/EmptyWorkoutState.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/EmptyWorkoutState/EmptyWorkoutState.tsx
@@ -1,5 +1,6 @@
 import { ListPlus } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button/Button";
 
 export type EmptyWorkoutStateProps = {
@@ -7,6 +8,7 @@ export type EmptyWorkoutStateProps = {
 };
 
 export function EmptyWorkoutState({ onAddStep }: EmptyWorkoutStateProps) {
+  const t = useTranslate("editor");
   return (
     <div
       className="flex flex-col items-center justify-center py-12 text-center"
@@ -17,19 +19,19 @@ export function EmptyWorkoutState({ onAddStep }: EmptyWorkoutStateProps) {
         aria-hidden="true"
       />
       <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-        Add your first step
+        {t("empty.title")}
       </h3>
       <p className="mt-1 mb-6 text-sm text-gray-500 dark:text-gray-400">
-        Start building your workout by adding steps
+        {t("empty.description")}
       </p>
       <Button
         variant="primary"
         onClick={onAddStep}
-        aria-label="Add first step to workout"
+        aria-label={t("empty.addFirstStepAria")}
         data-testid="add-first-step-button"
       >
         <ListPlus className="mr-2 h-4 w-4" aria-hidden="true" />
-        Add Step
+        {t("actions.addStep")}
       </Button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/CommentSelector.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/CommentSelector.tsx
@@ -4,6 +4,7 @@
  * Pre-selects comments before noon on workout date.
  */
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutComment } from "../../../types/calendar-fragments";
 
 export type CommentSelectorProps = {
@@ -17,16 +18,17 @@ export function CommentSelector({
   selected,
   onToggle,
 }: CommentSelectorProps) {
+  const t = useTranslate("editor");
   if (comments.length === 0) {
     return (
-      <p className="text-xs text-muted-foreground">No comments available.</p>
+      <p className="text-xs text-muted-foreground">{t("raw.noComments")}</p>
     );
   }
 
   return (
     <div className="space-y-2" data-testid="comment-selector">
       <p className="text-xs font-medium text-muted-foreground">
-        Include comments:
+        {t("raw.includeComments")}
       </p>
       {comments.map((c, i) => (
         <label key={i} className="flex items-start gap-2 text-sm">

--- a/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/RawWorkoutActions.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/RawWorkoutActions.tsx
@@ -4,6 +4,7 @@
 
 import { Bot, PenLine, SkipForward, Undo2 } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import { ActionBtn } from "./ActionBtn";
 
@@ -26,20 +27,21 @@ export function RawWorkoutActions({
   onManual,
   disabled = false,
 }: RawWorkoutActionsProps) {
+  const t = useTranslate("editor");
   return (
     <div className="flex flex-wrap gap-2 pt-2">
       {workout.state === "raw" && (
         <>
           <ActionBtn
             icon={Bot}
-            label="Process with AI"
+            label={t("raw.processWithAi")}
             onClick={() => onProcess(workout.id, Array.from(selected))}
             primary
             disabled={disabled}
           />
           <ActionBtn
             icon={SkipForward}
-            label="Skip"
+            label={t("raw.skip")}
             onClick={() => onSkip(workout.id)}
             disabled={disabled}
           />
@@ -48,14 +50,14 @@ export function RawWorkoutActions({
       {workout.state === "skipped" && (
         <ActionBtn
           icon={Undo2}
-          label="Un-skip"
+          label={t("raw.unskip")}
           onClick={() => onUnskip(workout.id)}
           disabled={disabled}
         />
       )}
       <ActionBtn
         icon={PenLine}
-        label="Create workout"
+        label={t("raw.createWorkout")}
         onClick={onManual}
         disabled={disabled}
       />

--- a/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/RawWorkoutDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/RawWorkoutDialog.tsx
@@ -6,6 +6,7 @@
 
 import * as Dialog from "@radix-ui/react-dialog";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import { RawWorkoutContent } from "./RawWorkoutContent";
 
@@ -26,6 +27,7 @@ export function RawWorkoutDialog({
   onUnskip,
   isSubmitting = false,
 }: RawWorkoutDialogProps) {
+  const t = useTranslate("editor");
   return (
     <Dialog.Root
       open={workout !== null}
@@ -35,8 +37,7 @@ export function RawWorkoutDialog({
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
         <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800">
           <Dialog.Description className="sr-only">
-            Raw workout details with coach description, comment selection, and
-            actions to process or skip.
+            {t("raw.dialogDescription")}
           </Dialog.Description>
           {workout && (
             <RawWorkoutContent

--- a/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/RawWorkoutHeader.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/RawWorkoutDialog/RawWorkoutHeader.tsx
@@ -5,16 +5,23 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
+
 export type RawWorkoutHeaderProps = {
   title: string;
 };
 
 export function RawWorkoutHeader({ title }: RawWorkoutHeaderProps) {
+  const tc = useTranslate("common");
   return (
     <div className="flex items-center justify-between">
       <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
       <Dialog.Close asChild>
-        <button type="button" aria-label="Close" className="rounded p-1">
+        <button
+          type="button"
+          aria-label={tc("actions.close")}
+          className="rounded p-1"
+        >
           <X className="h-4 w-4" />
         </button>
       </Dialog.Close>

--- a/packages/workout-spa-editor/src/components/molecules/SaveButton/ProgressBar.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SaveButton/ProgressBar.tsx
@@ -1,6 +1,9 @@
+import { useTranslate } from "../../../i18n/use-translate";
+
 type ProgressBarProps = { progress: number };
 
 export function ProgressBar({ progress }: ProgressBarProps) {
+  const t = useTranslate("editor");
   return (
     <div className="w-full bg-gray-200 rounded-full h-2 dark:bg-gray-700">
       <div
@@ -10,7 +13,7 @@ export function ProgressBar({ progress }: ProgressBarProps) {
         aria-valuenow={progress}
         aria-valuemin={0}
         aria-valuemax={100}
-        aria-label={`Export progress: ${progress}%`}
+        aria-label={t("save.exportProgress", { progress })}
       />
     </div>
   );

--- a/packages/workout-spa-editor/src/components/molecules/SaveButton/SaveButton.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SaveButton/SaveButton.tsx
@@ -12,6 +12,7 @@
 
 import { Download } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { KRD } from "../../../types/krd";
 import { Button } from "../../atoms/Button/Button";
 import { ExportFormatSelector } from "../ExportFormatSelector/ExportFormatSelector";
@@ -27,6 +28,7 @@ export type SaveButtonProps = {
 };
 
 export function SaveButton({ workout, disabled, className }: SaveButtonProps) {
+  const t = useTranslate("editor");
   const {
     saveErrors,
     isSaving,
@@ -65,7 +67,7 @@ export function SaveButton({ workout, disabled, className }: SaveButtonProps) {
           className="w-full sm:w-auto"
         >
           {icon}
-          {isSaving ? "Saving..." : "Save Workout"}
+          {isSaving ? t("save.saving") : t("save.saveWorkout")}
         </Button>
       </div>
 

--- a/packages/workout-spa-editor/src/components/molecules/SaveButton/save-handler.ts
+++ b/packages/workout-spa-editor/src/components/molecules/SaveButton/save-handler.ts
@@ -1,3 +1,4 @@
+import { getTranslate, type Translate } from "../../../i18n/use-translate";
 import type { KRD, ValidationError } from "../../../types/krd";
 import { downloadWorkout, exportWorkout } from "../../../utils/export-workout";
 import type { WorkoutFileFormat } from "../../../utils/file-format-detector";
@@ -12,7 +13,8 @@ export function createSaveHandler(
   setExportProgress: (progress: number) => void,
   success: (title: string, description: string) => void,
   showError: (title: string, description: string) => void,
-  onExported?: (format: string) => void
+  onExported?: (format: string) => void,
+  t: Translate = getTranslate("editor")
 ) {
   return async () => {
     setIsSaving(true);
@@ -36,14 +38,14 @@ export function createSaveHandler(
       const workoutName = getStructuredWorkout(workout)?.name || "workout";
       const formatLabel = selectedFormat.toUpperCase();
       success(
-        "Workout Saved",
-        `"${workoutName}" has been saved as ${formatLabel}`
+        t("save.savedTitle"),
+        t("save.savedDescription", { name: workoutName, format: formatLabel })
       );
       onExported?.(selectedFormat);
     } catch (err) {
       const errorMessage =
-        err instanceof Error ? err.message : "Failed to export workout";
-      showError("Export Failed", errorMessage);
+        err instanceof Error ? err.message : t("save.exportFailedFallback");
+      showError(t("save.exportFailedTitle"), errorMessage);
       setSaveErrors([
         {
           path: ["export"],

--- a/packages/workout-spa-editor/src/components/molecules/SaveButton/use-save-workout.ts
+++ b/packages/workout-spa-editor/src/components/molecules/SaveButton/use-save-workout.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 
 import { useAnalytics } from "../../../contexts";
 import { useToast } from "../../../hooks/use-toast";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { KRD, ValidationError } from "../../../types/krd";
 import type { WorkoutFileFormat } from "../../../utils/file-format-detector";
 import { createSaveHandler } from "./save-handler";
@@ -20,6 +21,7 @@ export function useSaveWorkout(workout: KRD) {
   const toast = useToast();
   const { success, error: showError } = toast;
   const analytics = useAnalytics();
+  const t = useTranslate("editor");
 
   const handleSave = createSaveHandler(
     workout,
@@ -29,7 +31,8 @@ export function useSaveWorkout(workout: KRD) {
     setExportProgress,
     success,
     showError,
-    (format) => analytics.event("workout-exported", { format })
+    (format) => analytics.event("workout-exported", { format }),
+    t
   );
 
   const clearErrors = () => setSaveErrors(null);

--- a/packages/workout-spa-editor/src/components/molecules/SaveErrorDialog/SaveErrorDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SaveErrorDialog/SaveErrorDialog.tsx
@@ -10,6 +10,7 @@
 
 import { AlertCircle, X } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { ValidationError } from "../../../types/krd";
 import { Button } from "../../atoms/Button/Button";
 
@@ -23,18 +24,20 @@ export type SaveErrorDialogProps = {
  * Dialog header with title and close button
  */
 function DialogHeader({ onClose }: { onClose: () => void }) {
+  const t = useTranslate("editor");
+  const tc = useTranslate("common");
   return (
     <div className="flex items-center justify-between border-b border-gray-200 p-4 dark:border-gray-700">
       <div className="flex items-center gap-2">
         <AlertCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
         <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-          Save Failed
+          {t("saveError.title")}
         </h2>
       </div>
       <button
         onClick={onClose}
         className="rounded-lg p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700 dark:hover:text-gray-300"
-        aria-label="Close"
+        aria-label={tc("actions.close")}
       >
         <X className="h-5 w-5" />
       </button>
@@ -74,6 +77,8 @@ export function SaveErrorDialog({
   onClose,
   onRetry,
 }: SaveErrorDialogProps) {
+  const t = useTranslate("editor");
+  const tc = useTranslate("common");
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
       <div className="w-full max-w-md rounded-lg bg-white shadow-xl dark:bg-gray-800">
@@ -81,18 +86,17 @@ export function SaveErrorDialog({
 
         <div className="p-4">
           <p className="mb-4 text-sm text-gray-600 dark:text-gray-400">
-            The workout could not be saved due to validation errors. Please fix
-            the following issues and try again:
+            {t("saveError.body")}
           </p>
           <ErrorList errors={errors} />
         </div>
 
         <div className="flex justify-end gap-2 border-t border-gray-200 p-4 dark:border-gray-700">
           <Button variant="secondary" onClick={onClose}>
-            Close
+            {tc("actions.close")}
           </Button>
           <Button variant="primary" onClick={onRetry}>
-            Fix and Retry
+            {t("saveError.fixAndRetry")}
           </Button>
         </div>
       </div>

--- a/packages/workout-spa-editor/src/components/molecules/UndoRedoButtons/UndoRedoButtons.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/UndoRedoButtons/UndoRedoButtons.tsx
@@ -1,5 +1,6 @@
 import { Redo2, Undo2 } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button/Button";
 import { Tooltip } from "../../atoms/Tooltip/Tooltip";
 
@@ -16,32 +17,33 @@ export function UndoRedoButtons({
   onUndo,
   onRedo,
 }: UndoRedoButtonsProps) {
+  const t = useTranslate("editor");
   return (
     <div
       className="flex w-full gap-1 sm:w-auto"
       role="group"
-      aria-label="History controls"
+      aria-label={t("history.controlsAria")}
     >
-      <Tooltip content="Undo (Ctrl+Z)" disabled={!canUndo}>
+      <Tooltip content={t("history.undoTooltip")} disabled={!canUndo}>
         <Button
           variant="secondary"
           size="sm"
           onClick={onUndo}
           disabled={!canUndo}
-          aria-label="Undo last action"
+          aria-label={t("history.undoAria")}
           data-testid="undo-button"
           className="w-full sm:w-auto"
         >
           <Undo2 className="h-4 w-4" aria-hidden="true" />
         </Button>
       </Tooltip>
-      <Tooltip content="Redo (Ctrl+Y)" disabled={!canRedo}>
+      <Tooltip content={t("history.redoTooltip")} disabled={!canRedo}>
         <Button
           variant="secondary"
           size="sm"
           onClick={onRedo}
           disabled={!canRedo}
-          aria-label="Redo last action"
+          aria-label={t("history.redoAria")}
           data-testid="redo-button"
           className="w-full sm:w-auto"
         >

--- a/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/EditActions.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/EditActions.tsx
@@ -1,6 +1,7 @@
 import * as ContextMenu from "@radix-ui/react-context-menu";
 import { ClipboardCopy, ClipboardPaste, Scissors, Trash } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import {
   ariaModifier,
   deleteSymbol,
@@ -22,45 +23,48 @@ type Props = Pick<
   | "onDelete"
 >;
 
-export const EditActions = (p: Props) => (
-  <>
-    {p.showCut && (
-      <EditorMenuItem
-        onSelect={p.onCut}
-        aria={`${ariaModifier}+X`}
-        icon={Scissors}
-        label="Cut"
-        hint={`${modifierSymbol}X`}
-      />
-    )}
-    {p.showCopy && (
-      <EditorMenuItem
-        onSelect={p.onCopy}
-        aria={`${ariaModifier}+C`}
-        icon={ClipboardCopy}
-        label="Copy"
-        hint={`${modifierSymbol}C`}
-      />
-    )}
-    {p.showPaste && (
-      <EditorMenuItem
-        onSelect={p.onPaste}
-        aria={`${ariaModifier}+V`}
-        icon={ClipboardPaste}
-        label="Paste"
-        hint={`${modifierSymbol}V`}
-      />
-    )}
-    {p.showDelete && (
-      <ContextMenu.Item
-        className={deleteItemClass}
-        onSelect={p.onDelete}
-        aria-keyshortcuts="Delete"
-      >
-        <Trash className="h-4 w-4" />
-        <span>Delete</span>
-        <span className={shortcutClass}>{deleteSymbol}</span>
-      </ContextMenu.Item>
-    )}
-  </>
-);
+export const EditActions = (p: Props) => {
+  const t = useTranslate("editor");
+  return (
+    <>
+      {p.showCut && (
+        <EditorMenuItem
+          onSelect={p.onCut}
+          aria={`${ariaModifier}+X`}
+          icon={Scissors}
+          label={t("contextMenu.cut")}
+          hint={`${modifierSymbol}X`}
+        />
+      )}
+      {p.showCopy && (
+        <EditorMenuItem
+          onSelect={p.onCopy}
+          aria={`${ariaModifier}+C`}
+          icon={ClipboardCopy}
+          label={t("contextMenu.copy")}
+          hint={`${modifierSymbol}C`}
+        />
+      )}
+      {p.showPaste && (
+        <EditorMenuItem
+          onSelect={p.onPaste}
+          aria={`${ariaModifier}+V`}
+          icon={ClipboardPaste}
+          label={t("contextMenu.paste")}
+          hint={`${modifierSymbol}V`}
+        />
+      )}
+      {p.showDelete && (
+        <ContextMenu.Item
+          className={deleteItemClass}
+          onSelect={p.onDelete}
+          aria-keyshortcuts="Delete"
+        >
+          <Trash className="h-4 w-4" />
+          <span>{t("contextMenu.delete")}</span>
+          <span className={shortcutClass}>{deleteSymbol}</span>
+        </ContextMenu.Item>
+      )}
+    </>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/EditorContextMenu.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/EditorContextMenu.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { useRef } from "react";
 
 import { useEditorContextMenu } from "../../../hooks/use-editor-context-menu";
+import { useTranslate } from "../../../i18n/use-translate";
 import { EditorContextMenuContent } from "./EditorContextMenuContent";
 
 type EditorContextMenuProps = {
@@ -10,6 +11,7 @@ type EditorContextMenuProps = {
 };
 
 export const EditorContextMenu = ({ children }: EditorContextMenuProps) => {
+  const t = useTranslate("editor");
   const ctx = useEditorContextMenu();
   const targetStepId = useRef<string | null>(null);
 
@@ -40,7 +42,7 @@ export const EditorContextMenu = ({ children }: EditorContextMenuProps) => {
     <ContextMenu.Root onOpenChange={handleOpen}>
       <ContextMenu.Trigger
         asChild
-        aria-label="Workout editor actions"
+        aria-label={t("contextMenu.actionsAria")}
         onContextMenu={handleContextMenu}
       >
         {children}

--- a/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/StructuralActions.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/StructuralActions.tsx
@@ -1,5 +1,6 @@
 import { CheckSquare, Group, Ungroup } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import {
   ariaModifier,
   modifierSymbol,
@@ -18,34 +19,37 @@ type Props = Pick<
   | "onUngroup"
 >;
 
-export const StructuralActions = (p: Props) => (
-  <>
-    {p.showSelectAll && (
-      <EditorMenuItem
-        onSelect={p.onSelectAll}
-        aria={`${ariaModifier}+A`}
-        icon={CheckSquare}
-        label="Select All"
-        hint={`${modifierSymbol}A`}
-      />
-    )}
-    {p.showGroup && (
-      <EditorMenuItem
-        onSelect={p.onGroup}
-        aria={`${ariaModifier}+G`}
-        icon={Group}
-        label="Group"
-        hint={`${modifierSymbol}G`}
-      />
-    )}
-    {p.showUngroup && (
-      <EditorMenuItem
-        onSelect={p.onUngroup}
-        aria={`Shift+${ariaModifier}+G`}
-        icon={Ungroup}
-        label="Ungroup"
-        hint={`${shiftSymbol}${modifierSymbol}G`}
-      />
-    )}
-  </>
-);
+export const StructuralActions = (p: Props) => {
+  const t = useTranslate("editor");
+  return (
+    <>
+      {p.showSelectAll && (
+        <EditorMenuItem
+          onSelect={p.onSelectAll}
+          aria={`${ariaModifier}+A`}
+          icon={CheckSquare}
+          label={t("contextMenu.selectAll")}
+          hint={`${modifierSymbol}A`}
+        />
+      )}
+      {p.showGroup && (
+        <EditorMenuItem
+          onSelect={p.onGroup}
+          aria={`${ariaModifier}+G`}
+          icon={Group}
+          label={t("contextMenu.group")}
+          hint={`${modifierSymbol}G`}
+        />
+      )}
+      {p.showUngroup && (
+        <EditorMenuItem
+          onSelect={p.onUngroup}
+          aria={`Shift+${ariaModifier}+G`}
+          icon={Ungroup}
+          label={t("contextMenu.ungroup")}
+          hint={`${shiftSymbol}${modifierSymbol}G`}
+        />
+      )}
+    </>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchEditorSurface.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchEditorSurface.tsx
@@ -1,87 +1,35 @@
-import { useEffect, useRef } from "react";
-
-import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import { useAppHandlers } from "../../../hooks/use-app-handlers";
-import { useSetUserPreferenceFields } from "../../../hooks/use-set-user-preference-fields";
-import { useUserPreferences } from "../../../hooks/use-user-preferences";
-import {
-  useCreateEmptyWorkout,
-  useCurrentWorkout,
-} from "../../../store/selectors";
+import { useTranslate } from "../../../i18n/use-translate";
+import { useCurrentWorkout } from "../../../store/selectors";
 import { useWorkoutStore } from "../../../store/workout-store";
 import type { Workout } from "../../../types/krd";
-import type { Sport } from "../../../types/krd-core";
 import { todayIsoDate } from "../../../utils/today-iso-date";
 import { AiBanner } from "../../molecules/AiBanner/AiBanner";
 import { useCoachingSidebar } from "../../organisms/CoachingSidebar/use-coaching-sidebar";
 import { EditorBody } from "../../pages/EditorBody";
 import { WorkoutSection } from "../../pages/WorkoutSection/WorkoutSection";
 import { ScratchScheduleButton } from "./ScratchScheduleButton";
-
-const DEFAULT_SCRATCH_SPORT: Sport = "cycling";
-const DEFAULT_SCRATCH_NAME = "Untitled workout";
+import { useScratchAutoSeed } from "./use-scratch-auto-seed";
 
 /**
  * Editor canvas for `/workout/new?source=scratch`.
  *
- * Composes the collapsed `AiBanner` above the editor body. The mount
- * effect seeds an empty in-memory workout via `createEmptyWorkout`
- * ONLY when `currentWorkout === null` — this guard prevents the
- * auto-init from overwriting a template just written by `LibraryPage`
- * before its `navigate("/workout/new?source=scratch")` (see plan A8).
- *
- * `startInEditMode` is wired to `autoCreatedRef`: only the auto-init
- * path opens `WorkoutHeader.MetadataEditMode` so a fresh scratch user
- * commits sport/name inline. Pre-populated workouts (library template
- * load, e2e seeds) already have sport/name and render in view mode.
- *
- * The initial sport is sourced from `userPreferences.lastScratchSport`
- * for the active profile when set; the on-save effect writes the
- * current sport back so the next scratch session pre-selects it.
- * Both reads/writes are gated on `autoCreatedRef.current` so library
- * / e2e-seeded workouts never leak into the preference.
+ * Composes the collapsed `AiBanner` above the editor body. The scratch
+ * auto-init lifecycle (mount seeding + sport-preference writeback) lives in
+ * `useScratchAutoSeed`, which returns `startInEditMode` for the auto-init path.
  */
 export function ScratchEditorSurface({ date }: { date: string | null }) {
+  const t = useTranslate("editor");
   const currentWorkout = useCurrentWorkout();
-  const createEmpty = useCreateEmptyWorkout();
   const selectedStepId = useWorkoutStore((s) => s.selectedStepId);
   const reorderStep = useWorkoutStore((s) => s.reorderStep);
   const reorderStepsInBlock = useWorkoutStore((s) => s.reorderStepsInBlock);
   const { handleStepSelect } = useAppHandlers();
   const sidebarData = useCoachingSidebar(null, undefined);
-  const autoCreatedRef = useRef(false);
-  const activeProfile = useActiveProfileLive();
-  const profileId = activeProfile?.id ?? null;
-  const prefs = useUserPreferences({ profileId, defaultView: "grid" });
-  const setPrefs = useSetUserPreferenceFields(profileId);
-  const initialSportRef = useRef<Sport | null>(null);
-
-  useEffect(() => {
-    if (currentWorkout !== null) return;
-    // Wait for the active-profile live query to resolve. Then, when a
-    // profile is active, also wait for its userPreferences row so the
-    // seed picks `lastScratchSport`. With no active profile the prefs
-    // query returns undefined permanently — fall through to the
-    // hard-coded default so the editor still mounts.
-    if (activeProfile === undefined) return;
-    if (profileId !== null && prefs === undefined) return;
-    autoCreatedRef.current = true;
-    const sport = prefs?.lastScratchSport ?? DEFAULT_SCRATCH_SPORT;
-    initialSportRef.current = sport;
-    createEmpty(DEFAULT_SCRATCH_NAME, sport);
-  }, [currentWorkout, createEmpty, prefs, profileId, activeProfile]);
+  const { startInEditMode } = useScratchAutoSeed(t);
 
   const workout = currentWorkout?.extensions?.structured_workout as
     Workout | undefined;
-  const currentSport = workout?.sport;
-
-  useEffect(() => {
-    if (!autoCreatedRef.current) return;
-    if (!currentSport) return;
-    if (currentSport === initialSportRef.current) return;
-    initialSportRef.current = currentSport;
-    void setPrefs({ lastScratchSport: currentSport });
-  }, [currentSport, setPrefs]);
 
   return (
     <div className="space-y-6">
@@ -96,7 +44,7 @@ export function ScratchEditorSurface({ date }: { date: string | null }) {
             onStepSelect={handleStepSelect}
             onStepReorder={reorderStep}
             onReorderStepsInBlock={reorderStepsInBlock}
-            startInEditMode={autoCreatedRef.current}
+            startInEditMode={startInEditMode}
           />
         </EditorBody>
       )}

--- a/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchScheduleButton.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/ScratchScheduleButton.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button/Button";
 import { usePersistScratch } from "./use-persist-scratch";
 
@@ -10,6 +11,7 @@ export type ScratchScheduleButtonProps = { date: string };
  * active and a workout is loaded; the click is the only persist trigger.
  */
 export function ScratchScheduleButton({ date }: ScratchScheduleButtonProps) {
+  const t = useTranslate("editor");
   const { canSchedule, schedule } = usePersistScratch(date);
 
   return (
@@ -19,7 +21,7 @@ export function ScratchScheduleButton({ date }: ScratchScheduleButtonProps) {
       onClick={() => void schedule()}
       data-testid="scratch-schedule-button"
     >
-      Save &amp; schedule
+      {t("scratch.saveAndSchedule")}
     </Button>
   );
 }

--- a/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/use-persist-scratch.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/use-persist-scratch.ts
@@ -3,17 +3,12 @@ import { useLocation } from "wouter";
 import { usePersistence } from "../../../contexts/persistence-context";
 import { useToastContext } from "../../../contexts/ToastContext";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { calendarWeekHref } from "../../../routing/calendar-week-href";
 import { useCurrentWorkout } from "../../../store/selectors/workout-selectors";
 import type { Workout } from "../../../types/krd";
 import { isValidCalendarDate } from "../../../utils/is-valid-calendar-date";
 import { persistScratchWorkout } from "./persist-scratch-workout";
-
-const INVALID_TITLE = "Invalid date";
-const INVALID_DESC =
-  "Could not schedule — the date is not a valid calendar day.";
-const SAVE_FAIL_TITLE = "Save failed";
-const SAVE_FAIL_DESC = "Could not schedule the workout — please retry.";
 
 const DEFAULT_SPORT = "cycling";
 
@@ -29,6 +24,7 @@ export type UsePersistScratch = {
  * D6-rejects calendar-impossible dates (toast, no persist/nav).
  */
 export function usePersistScratch(date: string): UsePersistScratch {
+  const t = useTranslate("editor");
   const currentWorkout = useCurrentWorkout();
   const profileId = useActiveProfileLive()?.id ?? null;
   const persistence = usePersistence();
@@ -40,7 +36,7 @@ export function usePersistScratch(date: string): UsePersistScratch {
   const schedule = async (): Promise<void> => {
     if (!currentWorkout || !profileId) return;
     if (!isValidCalendarDate(date)) {
-      toast.error(INVALID_TITLE, INVALID_DESC);
+      toast.error(t("scratch.invalidTitle"), t("scratch.invalidDescription"));
       return;
     }
     const workout = currentWorkout.extensions?.structured_workout as
@@ -55,7 +51,10 @@ export function usePersistScratch(date: string): UsePersistScratch {
       });
       navigate(calendarWeekHref(date));
     } catch {
-      toast.error(SAVE_FAIL_TITLE, SAVE_FAIL_DESC);
+      toast.error(
+        t("scratch.saveFailedTitle"),
+        t("scratch.saveFailedDescription")
+      );
     }
   };
 

--- a/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/use-scratch-auto-seed.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ScratchEditorSurface/use-scratch-auto-seed.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from "react";
+
+import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useSetUserPreferenceFields } from "../../../hooks/use-set-user-preference-fields";
+import { useUserPreferences } from "../../../hooks/use-user-preferences";
+import type { Translate } from "../../../i18n/use-translate";
+import {
+  useCreateEmptyWorkout,
+  useCurrentWorkout,
+} from "../../../store/selectors";
+import type { Workout } from "../../../types/krd";
+import type { Sport } from "../../../types/krd-core";
+
+const DEFAULT_SCRATCH_SPORT: Sport = "cycling";
+
+/**
+ * Owns the scratch auto-init lifecycle for `ScratchEditorSurface`.
+ *
+ * The mount effect seeds an empty in-memory workout via `createEmptyWorkout`
+ * ONLY when `currentWorkout === null` — this guard prevents the auto-init from
+ * overwriting a template just written by `LibraryPage` before its
+ * `navigate("/workout/new?source=scratch")` (see plan A8).
+ *
+ * The returned `startInEditMode` is wired to `autoCreatedRef`: only the
+ * auto-init path opens `WorkoutHeader.MetadataEditMode` so a fresh scratch
+ * user commits sport/name inline. Pre-populated workouts (library template
+ * load, e2e seeds) already have sport/name and render in view mode.
+ *
+ * The initial sport is sourced from `userPreferences.lastScratchSport` for the
+ * active profile when set; the on-save effect writes the current sport back so
+ * the next scratch session pre-selects it. Both reads/writes are gated on
+ * `autoCreatedRef.current` so library / e2e-seeded workouts never leak.
+ */
+export function useScratchAutoSeed(t: Translate): { startInEditMode: boolean } {
+  const currentWorkout = useCurrentWorkout();
+  const createEmpty = useCreateEmptyWorkout();
+  const activeProfile = useActiveProfileLive();
+  const profileId = activeProfile?.id ?? null;
+  const prefs = useUserPreferences({ profileId, defaultView: "grid" });
+  const setPrefs = useSetUserPreferenceFields(profileId);
+  const autoCreatedRef = useRef(false);
+  const initialSportRef = useRef<Sport | null>(null);
+  const untitledName = t("scratch.untitledName");
+
+  useEffect(() => {
+    if (currentWorkout !== null) return;
+    // Wait for the active-profile live query to resolve. Then, when a
+    // profile is active, also wait for its userPreferences row so the
+    // seed picks `lastScratchSport`. With no active profile the prefs
+    // query returns undefined permanently — fall through to the
+    // hard-coded default so the editor still mounts.
+    if (activeProfile === undefined) return;
+    if (profileId !== null && prefs === undefined) return;
+    autoCreatedRef.current = true;
+    const sport = prefs?.lastScratchSport ?? DEFAULT_SCRATCH_SPORT;
+    initialSportRef.current = sport;
+    createEmpty(untitledName, sport);
+  }, [
+    currentWorkout,
+    createEmpty,
+    prefs,
+    profileId,
+    activeProfile,
+    untitledName,
+  ]);
+
+  const currentSport = (
+    currentWorkout?.extensions?.structured_workout as Workout | undefined
+  )?.sport;
+
+  useEffect(() => {
+    if (!autoCreatedRef.current) return;
+    if (!currentSport) return;
+    if (currentSport === initialSportRef.current) return;
+    initialSportRef.current = currentSport;
+    void setPrefs({ lastScratchSport: currentSport });
+  }, [currentSport, setPrefs]);
+
+  return { startInEditMode: autoCreatedRef.current };
+}

--- a/packages/workout-spa-editor/src/components/pages/EditorLoadingState.tsx
+++ b/packages/workout-spa-editor/src/components/pages/EditorLoadingState.tsx
@@ -6,22 +6,24 @@
 
 import { Link } from "wouter";
 
+import { useTranslate } from "../../i18n/use-translate";
+
 export function EditorLoading() {
+  const t = useTranslate("editor");
   return (
     <div className="flex items-center justify-center py-16 text-muted-foreground">
-      Loading workout...
+      {t("loading.loadingWorkout")}
     </div>
   );
 }
 
 export function EditorNoData() {
+  const t = useTranslate("editor");
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center">
-      <p className="text-muted-foreground">
-        This workout has no structured data yet.
-      </p>
+      <p className="text-muted-foreground">{t("loading.noStructuredData")}</p>
       <Link href="/daily" className="text-primary underline mt-2">
-        Go to Daily
+        {t("loading.goToDaily")}
       </Link>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/EditorPageHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/EditorPageHeader.tsx
@@ -1,5 +1,6 @@
 import { PenLine } from "lucide-react";
 
+import { useTranslate } from "../../i18n/use-translate";
 import { ROUTE_HEADING_ATTR } from "../../routing/constants";
 import { BackButton } from "../atoms/BackButton/BackButton";
 
@@ -10,16 +11,17 @@ export type EditorPageHeaderProps = {
 
 const COPY = {
   new: {
-    title: "New workout",
-    description: "Create from scratch, generate with AI, or import a file.",
+    title: "pageHeader.newTitle",
+    description: "pageHeader.newDescription",
   },
   edit: {
-    title: "Edit workout",
-    description: "Refine steps, intervals, and targets.",
+    title: "pageHeader.editTitle",
+    description: "pageHeader.editDescription",
   },
 } as const;
 
 export function EditorPageHeader({ mode, onBack }: EditorPageHeaderProps) {
+  const t = useTranslate("editor");
   const { title, description } = COPY[mode];
 
   return (
@@ -32,10 +34,12 @@ export function EditorPageHeader({ mode, onBack }: EditorPageHeaderProps) {
           {...{ [ROUTE_HEADING_ATTR]: "" }}
           className="text-xl font-semibold text-gray-900 dark:text-white"
         >
-          {title}
+          {t(title)}
         </h1>
       </div>
-      <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        {t(description)}
+      </p>
     </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/EditorWorkflowBar.tsx
+++ b/packages/workout-spa-editor/src/components/pages/EditorWorkflowBar.tsx
@@ -6,6 +6,7 @@
 
 import { Check, Upload } from "lucide-react";
 
+import { useTranslate } from "../../i18n/use-translate";
 import type { WorkoutState } from "../../types/calendar-enums";
 import { Button } from "../atoms/Button/Button";
 import { ModifiedIndicator } from "../molecules/ModifiedIndicator";
@@ -23,12 +24,13 @@ export function EditorWorkflowBar({
   onPush,
   onRepush,
 }: EditorWorkflowBarProps) {
+  const t = useTranslate("editor");
   if (state === "structured") {
     return (
       <div className="flex items-center gap-3" data-testid="workflow-bar">
         <Button onClick={onAccept}>
           <Check className="mr-2 h-4 w-4" />
-          Accept Workout
+          {t("workflow.acceptWorkout")}
         </Button>
       </div>
     );
@@ -39,7 +41,7 @@ export function EditorWorkflowBar({
       <div className="flex items-center gap-3" data-testid="workflow-bar">
         <Button onClick={onPush}>
           <Upload className="mr-2 h-4 w-4" />
-          Push to Garmin
+          {t("workflow.pushToGarmin")}
         </Button>
       </div>
     );

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../i18n/use-translate";
 import { humanizeSport } from "../../lib/format-sport";
 import type { Workout } from "../../types/krd";
 import { WorkoutList } from "../organisms/WorkoutList/WorkoutList";
@@ -13,15 +14,16 @@ export function WorkoutSection({
   selectedStepId,
   onStepSelect,
 }: WorkoutSectionProps) {
+  const t = useTranslate("editor");
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <div className="mb-6 flex items-center justify-between">
         <div>
           <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-            {workout.name || "Untitled Workout"}
+            {workout.name || t("section.untitledWorkout")}
           </h2>
           <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-            Sport: {humanizeSport(workout.sport)}
+            {t("section.sport")} {humanizeSport(workout.sport)}
             {workout.subSport && ` • ${humanizeSport(workout.subSport)}`}
           </p>
         </div>

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/MetadataEditMode.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/MetadataEditMode.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { KRD } from "../../../types/krd";
 import { WorkoutMetadataEditor } from "../../molecules/WorkoutMetadataEditor/WorkoutMetadataEditor";
 
@@ -12,10 +13,11 @@ export function MetadataEditMode({
   onSave,
   onCancel,
 }: MetadataEditModeProps) {
+  const t = useTranslate("editor");
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <h3 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
-        Edit Workout Metadata
+        {t("section.editMetadataTitle")}
       </h3>
       <WorkoutMetadataEditor krd={krd} onSave={onSave} onCancel={onCancel} />
     </div>

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/SelectionHints.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/SelectionHints.tsx
@@ -1,5 +1,6 @@
 import { Repeat } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button/Button";
 
 type MultiSelectionHintProps = {
@@ -11,22 +12,23 @@ export function MultiSelectionHint({
   selectedStepCount,
   onCreateRepetitionBlock,
 }: MultiSelectionHintProps) {
+  const t = useTranslate("editor");
   return (
     <div className="flex flex-col items-center gap-1 sm:flex-row sm:gap-2">
       <Button
         variant="primary"
         onClick={onCreateRepetitionBlock}
-        aria-label="Create repetition block from selected steps"
+        aria-label={t("selection.createBlockAria")}
         data-testid="create-repetition-block-button"
         className="w-full sm:w-auto"
       >
         <Repeat className="mr-2 h-4 w-4" aria-hidden="true" />
-        Create Repetition Block ({selectedStepCount} steps)
+        {t("selection.createBlock", { count: selectedStepCount })}
       </Button>
       <span className="text-xs text-gray-500 dark:text-gray-400">
-        or press{" "}
+        {t("selection.orPress")}{" "}
         <kbd className="rounded bg-gray-100 px-1 py-0.5 text-xs dark:bg-gray-700">
-          Ctrl+G
+          {t("selection.ctrlG")}
         </kbd>
       </span>
     </div>
@@ -34,12 +36,13 @@ export function MultiSelectionHint({
 }
 
 export function SingleSelectionHint() {
+  const t = useTranslate("editor");
   return (
     <p
       className="text-xs text-gray-500 dark:text-gray-400"
       data-testid="selection-hint"
     >
-      Ctrl+click another step to create a repetition block
+      {t("selection.ctrlClickHint")}
     </p>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutActions.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutActions.tsx
@@ -1,6 +1,7 @@
 import { Trash2 } from "lucide-react";
 
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { KRD } from "../../../types/krd";
 import { Button } from "../../atoms/Button/Button";
 import { GarminPushButton } from "../../molecules/GarminPushButton";
@@ -25,6 +26,7 @@ export function WorkoutActions({
   onRedo,
   onDiscard,
 }: WorkoutActionsProps) {
+  const t = useTranslate("editor");
   // Restore the policy-gated push: GarminPushButton resolves export
   // policies by profile, so without the active profile id it always
   // renders null (AC-5 gating was dead after the redesign).
@@ -43,12 +45,12 @@ export function WorkoutActions({
       <Button
         variant="tertiary"
         onClick={onDiscard}
-        aria-label="Discard workout and return to welcome screen"
+        aria-label={t("actions.discardAria")}
         data-testid="discard-workout-button"
         className="text-red-600 hover:bg-red-50 hover:text-red-700 dark:text-red-400 dark:hover:bg-red-900/20 dark:hover:text-red-300"
       >
         <Trash2 className="mr-2 h-4 w-4" />
-        Discard
+        {t("actions.discard")}
       </Button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutStepsListActions.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutStepsListActions.tsx
@@ -1,6 +1,7 @@
 import { Plus, Repeat } from "lucide-react";
 import type { RefObject } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button/Button";
 import { PasteButton } from "../../molecules/PasteButton";
 import { MultiSelectionHint, SingleSelectionHint } from "./SelectionHints";
@@ -30,6 +31,7 @@ export function WorkoutStepsListActions({
   onPasteStep,
   addStepButtonRef,
 }: WorkoutStepsListActionsProps) {
+  const t = useTranslate("editor");
   const hasSingleSelection = selectedStepCount === 1;
 
   return (
@@ -45,23 +47,23 @@ export function WorkoutStepsListActions({
         <Button
           variant="secondary"
           onClick={onCreateEmptyRepetitionBlock}
-          aria-label="Add repetition block"
+          aria-label={t("actions.addRepetitionAria")}
           data-testid="create-empty-repetition-block-button"
           className="w-full sm:w-auto"
         >
           <Repeat className="mr-2 h-4 w-4" aria-hidden="true" />
-          Add Repetition
+          {t("actions.addRepetition")}
         </Button>
         <Button
           ref={addStepButtonRef}
           variant="secondary"
           onClick={onAddStep}
-          aria-label="Add new step to workout"
+          aria-label={t("actions.addStepAria")}
           data-testid="add-step-button"
           className="w-full sm:w-auto"
         >
           <Plus className="mr-2 h-4 w-4" aria-hidden="true" />
-          Add Step
+          {t("actions.addStep")}
         </Button>
         {onPasteStep && (
           <PasteButton onPaste={onPasteStep} className="w-full sm:w-auto" />

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutTitle.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/WorkoutTitle.tsx
@@ -1,6 +1,7 @@
 import { Edit2 } from "lucide-react";
 import type { RefObject } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { humanizeSport } from "../../../lib/format-sport";
 import type { Workout } from "../../../types/krd";
 import { Button } from "../../atoms/Button/Button";
@@ -17,6 +18,7 @@ type WorkoutTitleProps = {
 };
 
 export function WorkoutTitle({ workout, onEdit, titleRef }: WorkoutTitleProps) {
+  const t = useTranslate("editor");
   return (
     <div className="min-w-0 flex-1 text-left">
       <div className="flex items-center gap-2">
@@ -25,13 +27,13 @@ export function WorkoutTitle({ workout, onEdit, titleRef }: WorkoutTitleProps) {
           tabIndex={-1}
           className="text-2xl font-bold text-gray-900 focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:text-white dark:focus-visible:ring-offset-gray-800"
         >
-          {workout.name || "Untitled Workout"}
+          {workout.name || t("section.untitledWorkout")}
         </h2>
         <Button
           variant="tertiary"
           size="sm"
           onClick={onEdit}
-          aria-label="Edit workout metadata"
+          aria-label={t("section.editMetadata")}
           data-testid="edit-metadata-button"
           className="h-8 w-8 p-0"
         >
@@ -39,7 +41,7 @@ export function WorkoutTitle({ workout, onEdit, titleRef }: WorkoutTitleProps) {
         </Button>
       </div>
       <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-        Sport: {humanizeSport(workout.sport)}
+        {t("section.sport")} {humanizeSport(workout.sport)}
         {workout.subSport && ` • ${humanizeSport(workout.subSport)}`}
       </p>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/delete-block-with-toast.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/delete-block-with-toast.tsx
@@ -6,6 +6,7 @@
  */
 
 import type { useToastContext } from "../../../contexts/ToastContext";
+import { getTranslate, type Translate } from "../../../i18n/use-translate";
 import { UNDO_DELETE_WINDOW_MS } from "../../../store/actions/delete-undo-constants";
 import { useWorkoutStore } from "../../../store/workout-store";
 
@@ -13,7 +14,8 @@ export function executeDeleteWithToast(
   blockId: string,
   deleteAction: (blockId: string) => void,
   toast: ReturnType<typeof useToastContext>["toast"],
-  undoDelete: (timestamp: number) => void
+  undoDelete: (timestamp: number) => void,
+  t: Translate = getTranslate("editor")
 ) {
   deleteAction(blockId);
   setTimeout(() => {
@@ -21,7 +23,7 @@ export function executeDeleteWithToast(
     const mostRecentDelete = deletedSteps[deletedSteps.length - 1];
     if (mostRecentDelete) {
       toast({
-        title: "Repetition block deleted",
+        title: t("deleteBlock.toastTitle"),
         variant: "info",
         duration: UNDO_DELETE_WINDOW_MS,
         action: (
@@ -30,7 +32,7 @@ export function executeDeleteWithToast(
             className="px-3 py-1 text-sm font-medium rounded-md bg-white/10 hover:bg-white/20 transition-colors"
             data-testid="undo-delete-block-button"
           >
-            Undo
+            {t("actions.undo")}
           </button>
         ),
       });

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-delete-step-with-toast.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-delete-step-with-toast.tsx
@@ -8,11 +8,13 @@
 import { useCallback } from "react";
 
 import { useToastContext } from "../../../contexts/ToastContext";
+import { useTranslate } from "../../../i18n/use-translate";
 import { UNDO_DELETE_WINDOW_MS } from "../../../store/actions/delete-undo-constants";
 import { useDeleteStep, useUndoDelete } from "../../../store/selectors";
 import { useWorkoutStore } from "../../../store/workout-store";
 
 export function useDeleteStepWithToast() {
+  const t = useTranslate("editor");
   const storeDeleteStep = useDeleteStep();
   const undoDelete = useUndoDelete();
   const { toast } = useToastContext();
@@ -27,8 +29,8 @@ export function useDeleteStepWithToast() {
 
         if (mostRecentDelete) {
           toast({
-            title: "Step deleted",
-            description: "The step has been removed from your workout.",
+            title: t("deleteStep.toastTitle"),
+            description: t("deleteStep.toastDescription"),
             variant: "info",
             duration: UNDO_DELETE_WINDOW_MS,
             action: (
@@ -37,13 +39,13 @@ export function useDeleteStepWithToast() {
                 data-testid="undo-delete-button"
                 className="inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-transparent bg-transparent px-3 text-sm font-medium transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/20 disabled:pointer-events-none disabled:opacity-50"
               >
-                Undo
+                {t("actions.undo")}
               </button>
             ),
           });
         }
       }, 0);
     },
-    [storeDeleteStep, undoDelete, toast]
+    [storeDeleteStep, undoDelete, toast, t]
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-discard-confirmation.ts
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-discard-confirmation.ts
@@ -1,16 +1,8 @@
 import { useCallback } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { useClearWorkout } from "../../../store";
 import { useShowConfirmationModal } from "../../../store/selectors";
-
-const DISCARD_MODAL_CONFIG = {
-  title: "Discard Workout",
-  message:
-    "Are you sure you want to discard the current workout? This action cannot be undone.",
-  confirmLabel: "Discard",
-  cancelLabel: "Cancel",
-  variant: "destructive" as const,
-};
 
 /**
  * Returns the open-the-discard-modal handler.
@@ -22,16 +14,33 @@ const DISCARD_MODAL_CONFIG = {
  * callbacks would create a new memoized handler on every parent render.
  */
 export function useDiscardConfirmation(onAfterConfirm?: () => void) {
+  const t = useTranslate("editor");
   const clearWorkout = useClearWorkout();
   const showConfirmationModal = useShowConfirmationModal();
+  const title = t("discard.title");
+  const message = t("discard.message");
+  const confirmLabel = t("discard.confirmLabel");
+  const cancelLabel = t("discard.cancelLabel");
 
   return useCallback(() => {
     showConfirmationModal({
-      ...DISCARD_MODAL_CONFIG,
+      title,
+      message,
+      confirmLabel,
+      cancelLabel,
+      variant: "destructive",
       onConfirm: () => {
         clearWorkout();
         onAfterConfirm?.();
       },
     });
-  }, [clearWorkout, showConfirmationModal, onAfterConfirm]);
+  }, [
+    clearWorkout,
+    showConfirmationModal,
+    onAfterConfirm,
+    title,
+    message,
+    confirmLabel,
+    cancelLabel,
+  ]);
 }

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-repetition-block-handlers.helpers.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-repetition-block-handlers.helpers.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 
 import { useToastContext } from "../../../contexts/ToastContext";
+import { useTranslate } from "../../../i18n/use-translate";
 import { findById } from "../../../store/find-by-id";
 import {
   useDeleteRepetitionBlock,
@@ -29,6 +30,7 @@ export function extractStepIndices(
 }
 
 export function useDeleteWithConfirmation() {
+  const t = useTranslate("editor");
   const deleteAction = useDeleteRepetitionBlock();
   const undoDelete = useUndoDelete();
   const showModal = useShowConfirmationModal();
@@ -37,18 +39,17 @@ export function useDeleteWithConfirmation() {
   return useCallback(
     (blockId: string) => {
       showModal({
-        title: "Delete Repetition Block",
-        message:
-          "Are you sure you want to delete this repetition block? This action can be undone.",
-        confirmLabel: "Delete",
-        cancelLabel: "Cancel",
+        title: t("deleteBlock.title"),
+        message: t("deleteBlock.message"),
+        confirmLabel: t("deleteBlock.confirmLabel"),
+        cancelLabel: t("deleteBlock.cancelLabel"),
         variant: "destructive",
         onConfirm: () => {
-          executeDeleteWithToast(blockId, deleteAction, toast, undoDelete);
+          executeDeleteWithToast(blockId, deleteAction, toast, undoDelete, t);
         },
       });
     },
-    [deleteAction, toast, undoDelete, showModal]
+    [deleteAction, toast, undoDelete, showModal, t]
   );
 }
 

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/useCopyStep.ts
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/useCopyStep.ts
@@ -1,16 +1,15 @@
 import { useCallback } from "react";
 
 import { useToastContext } from "../../../contexts/ToastContext";
+import { useTranslate } from "../../../i18n/use-translate";
 import { useWorkoutStore } from "../../../store/workout-store";
-
-const COPY_SUCCESS_TOAST = "Step copied to clipboard";
-const COPY_FAILURE_TOAST = "Failed to copy step";
 
 /**
  * Hook for copying a step to clipboard with toast notification
  * Requirement 39.2: Copy step data as JSON to clipboard and show notification
  */
 export function useCopyStep() {
+  const t = useTranslate("editor");
   const copyStep = useWorkoutStore((state) => state.copyStep);
   const { success, error } = useToastContext();
 
@@ -19,11 +18,11 @@ export function useCopyStep() {
       const result = await copyStep(stepIndex);
 
       if (result.success) {
-        success(COPY_SUCCESS_TOAST);
+        success(t("clipboard.copySuccess"));
       } else {
-        error(COPY_FAILURE_TOAST);
+        error(t("clipboard.copyFailure"));
       }
     },
-    [copyStep, success, error]
+    [copyStep, success, error, t]
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/usePasteStep.ts
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/usePasteStep.ts
@@ -1,20 +1,15 @@
 import { useCallback } from "react";
 
 import { useToastContext } from "../../../contexts/ToastContext";
+import { useTranslate } from "../../../i18n/use-translate";
 import { useWorkoutStore } from "../../../store/workout-store";
-
-const PASTE_SUCCESS_TOAST = "Step pasted successfully";
-// Most paste failures mean the clipboard is empty or holds something
-// that isn't a recognised step payload. The text matches the e2e
-// regex spanning empty-clipboard, no-valid-step, and invalid-content
-// branches without requiring multiple constants.
-const PASTE_FAILURE_TOAST = "Clipboard does not contain a valid step";
 
 /**
  * Hook for pasting a step from clipboard with toast notification
  * Requirement 39.2: Read step data from clipboard and show notification
  */
 export function usePasteStep() {
+  const t = useTranslate("editor");
   const pasteStep = useWorkoutStore((state) => state.pasteStep);
   const { success, error } = useToastContext();
 
@@ -23,11 +18,14 @@ export function usePasteStep() {
       const result = await pasteStep(insertIndex);
 
       if (result.success) {
-        success(PASTE_SUCCESS_TOAST);
+        success(t("clipboard.pasteSuccess"));
       } else {
-        error(PASTE_FAILURE_TOAST);
+        // The failure copy (editor.clipboard.pasteFailure = "Clipboard does
+        // not contain a valid step") matches the e2e regex spanning the
+        // empty-clipboard, no-valid-step, and invalid-content branches.
+        error(t("clipboard.pasteFailure"));
       }
     },
-    [pasteStep, success, error]
+    [pasteStep, success, error, t]
   );
 }

--- a/packages/workout-spa-editor/src/i18n/locales/en/editor.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/editor.json
@@ -1,0 +1,115 @@
+{
+  "loading": {
+    "loadingWorkout": "Loading workout...",
+    "noStructuredData": "This workout has no structured data yet.",
+    "goToDaily": "Go to Daily"
+  },
+  "pageHeader": {
+    "newTitle": "New workout",
+    "newDescription": "Create from scratch, generate with AI, or import a file.",
+    "editTitle": "Edit workout",
+    "editDescription": "Refine steps, intervals, and targets."
+  },
+  "workflow": {
+    "acceptWorkout": "Accept Workout",
+    "pushToGarmin": "Push to Garmin"
+  },
+  "section": {
+    "untitledWorkout": "Untitled Workout",
+    "sport": "Sport:",
+    "editMetadata": "Edit workout metadata",
+    "editMetadataTitle": "Edit Workout Metadata"
+  },
+  "actions": {
+    "discard": "Discard",
+    "discardAria": "Discard workout and return to welcome screen",
+    "addStep": "Add Step",
+    "addRepetition": "Add Repetition",
+    "addRepetitionAria": "Add repetition block",
+    "addStepAria": "Add new step to workout",
+    "undo": "Undo"
+  },
+  "selection": {
+    "createBlockAria": "Create repetition block from selected steps",
+    "createBlock": "Create Repetition Block ({{count}} steps)",
+    "orPress": "or press",
+    "ctrlG": "Ctrl+G",
+    "ctrlClickHint": "Ctrl+click another step to create a repetition block"
+  },
+  "discard": {
+    "title": "Discard Workout",
+    "message": "Are you sure you want to discard the current workout? This action cannot be undone.",
+    "confirmLabel": "Discard",
+    "cancelLabel": "Cancel"
+  },
+  "deleteBlock": {
+    "title": "Delete Repetition Block",
+    "message": "Are you sure you want to delete this repetition block? This action can be undone.",
+    "confirmLabel": "Delete",
+    "cancelLabel": "Cancel",
+    "toastTitle": "Repetition block deleted"
+  },
+  "deleteStep": {
+    "toastTitle": "Step deleted",
+    "toastDescription": "The step has been removed from your workout."
+  },
+  "clipboard": {
+    "copySuccess": "Step copied to clipboard",
+    "copyFailure": "Failed to copy step",
+    "pasteSuccess": "Step pasted successfully",
+    "pasteFailure": "Clipboard does not contain a valid step"
+  },
+  "contextMenu": {
+    "actionsAria": "Workout editor actions",
+    "cut": "Cut",
+    "copy": "Copy",
+    "paste": "Paste",
+    "delete": "Delete",
+    "selectAll": "Select All",
+    "group": "Group",
+    "ungroup": "Ungroup"
+  },
+  "empty": {
+    "title": "Add your first step",
+    "description": "Start building your workout by adding steps",
+    "addFirstStepAria": "Add first step to workout"
+  },
+  "history": {
+    "controlsAria": "History controls",
+    "undoTooltip": "Undo (Ctrl+Z)",
+    "undoAria": "Undo last action",
+    "redoTooltip": "Redo (Ctrl+Y)",
+    "redoAria": "Redo last action"
+  },
+  "save": {
+    "saveWorkout": "Save Workout",
+    "saving": "Saving...",
+    "exportProgress": "Export progress: {{progress}}%",
+    "savedTitle": "Workout Saved",
+    "savedDescription": "\"{{name}}\" has been saved as {{format}}",
+    "exportFailedTitle": "Export Failed",
+    "exportFailedFallback": "Failed to export workout"
+  },
+  "saveError": {
+    "title": "Save Failed",
+    "body": "The workout could not be saved due to validation errors. Please fix the following issues and try again:",
+    "fixAndRetry": "Fix and Retry"
+  },
+  "scratch": {
+    "untitledName": "Untitled workout",
+    "saveAndSchedule": "Save & schedule",
+    "invalidTitle": "Invalid date",
+    "invalidDescription": "Could not schedule — the date is not a valid calendar day.",
+    "saveFailedTitle": "Save failed",
+    "saveFailedDescription": "Could not schedule the workout — please retry."
+  },
+  "raw": {
+    "dialogDescription": "Raw workout details with coach description, comment selection, and actions to process or skip.",
+    "processWithAi": "Process with AI",
+    "skip": "Skip",
+    "unskip": "Un-skip",
+    "createWorkout": "Create workout",
+    "noComments": "No comments available.",
+    "includeComments": "Include comments:"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/editor.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/editor.json
@@ -1,0 +1,115 @@
+{
+  "loading": {
+    "loadingWorkout": "Cargando entreno...",
+    "noStructuredData": "Este entreno aún no tiene datos estructurados.",
+    "goToDaily": "Ir a diario"
+  },
+  "pageHeader": {
+    "newTitle": "Nuevo entreno",
+    "newDescription": "Crea desde cero, genera con IA o importa un archivo.",
+    "editTitle": "Editar entreno",
+    "editDescription": "Ajusta pasos, intervalos y objetivos."
+  },
+  "workflow": {
+    "acceptWorkout": "Aceptar entreno",
+    "pushToGarmin": "Enviar a Garmin"
+  },
+  "section": {
+    "untitledWorkout": "Entreno sin título",
+    "sport": "Deporte:",
+    "editMetadata": "Editar metadatos del entreno",
+    "editMetadataTitle": "Editar metadatos del entreno"
+  },
+  "actions": {
+    "discard": "Descartar",
+    "discardAria": "Descartar el entreno y volver a la pantalla de bienvenida",
+    "addStep": "Añadir paso",
+    "addRepetition": "Añadir repetición",
+    "addRepetitionAria": "Añadir bloque de repetición",
+    "addStepAria": "Añadir un nuevo paso al entreno",
+    "undo": "Deshacer"
+  },
+  "selection": {
+    "createBlockAria": "Crear bloque de repetición con los pasos seleccionados",
+    "createBlock": "Crear bloque de repetición ({{count}} pasos)",
+    "orPress": "o pulsa",
+    "ctrlG": "Ctrl+G",
+    "ctrlClickHint": "Ctrl+clic en otro paso para crear un bloque de repetición"
+  },
+  "discard": {
+    "title": "Descartar entreno",
+    "message": "¿Seguro que quieres descartar el entreno actual? Esta acción no se puede deshacer.",
+    "confirmLabel": "Descartar",
+    "cancelLabel": "Cancelar"
+  },
+  "deleteBlock": {
+    "title": "Eliminar bloque de repetición",
+    "message": "¿Seguro que quieres eliminar este bloque de repetición? Esta acción se puede deshacer.",
+    "confirmLabel": "Eliminar",
+    "cancelLabel": "Cancelar",
+    "toastTitle": "Bloque de repetición eliminado"
+  },
+  "deleteStep": {
+    "toastTitle": "Paso eliminado",
+    "toastDescription": "El paso se ha eliminado de tu entreno."
+  },
+  "clipboard": {
+    "copySuccess": "Paso copiado al portapapeles",
+    "copyFailure": "No se pudo copiar el paso",
+    "pasteSuccess": "Paso pegado correctamente",
+    "pasteFailure": "El portapapeles no contiene un paso válido"
+  },
+  "contextMenu": {
+    "actionsAria": "Acciones del editor de entrenos",
+    "cut": "Cortar",
+    "copy": "Copiar",
+    "paste": "Pegar",
+    "delete": "Eliminar",
+    "selectAll": "Seleccionar todo",
+    "group": "Agrupar",
+    "ungroup": "Desagrupar"
+  },
+  "empty": {
+    "title": "Añade tu primer paso",
+    "description": "Empieza a construir tu entreno añadiendo pasos",
+    "addFirstStepAria": "Añadir el primer paso al entreno"
+  },
+  "history": {
+    "controlsAria": "Controles de historial",
+    "undoTooltip": "Deshacer (Ctrl+Z)",
+    "undoAria": "Deshacer la última acción",
+    "redoTooltip": "Rehacer (Ctrl+Y)",
+    "redoAria": "Rehacer la última acción"
+  },
+  "save": {
+    "saveWorkout": "Guardar entreno",
+    "saving": "Guardando...",
+    "exportProgress": "Progreso de exportación: {{progress}}%",
+    "savedTitle": "Entreno guardado",
+    "savedDescription": "«{{name}}» se ha guardado como {{format}}",
+    "exportFailedTitle": "Error de exportación",
+    "exportFailedFallback": "No se pudo exportar el entreno"
+  },
+  "saveError": {
+    "title": "Error al guardar",
+    "body": "El entreno no se pudo guardar debido a errores de validación. Corrige los siguientes problemas e inténtalo de nuevo:",
+    "fixAndRetry": "Corregir y reintentar"
+  },
+  "scratch": {
+    "untitledName": "Entreno sin título",
+    "saveAndSchedule": "Guardar y programar",
+    "invalidTitle": "Fecha no válida",
+    "invalidDescription": "No se pudo programar — la fecha no es un día válido del calendario.",
+    "saveFailedTitle": "Error al guardar",
+    "saveFailedDescription": "No se pudo programar el entreno — inténtalo de nuevo."
+  },
+  "raw": {
+    "dialogDescription": "Detalles del entreno en bruto con la descripción del entrenador, la selección de comentarios y acciones para procesar o saltar.",
+    "processWithAi": "Procesar con IA",
+    "skip": "Saltar",
+    "unskip": "Deshacer salto",
+    "createWorkout": "Crear entreno",
+    "noComments": "No hay comentarios disponibles.",
+    "includeComments": "Incluir comentarios:"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -9,12 +9,14 @@ import type { LocaleResources } from "@kaiord/i18n";
 
 import enCommon from "./locales/en/common.json";
 import enDaily from "./locales/en/daily.json";
+import enEditor from "./locales/en/editor.json";
 import enErrors from "./locales/en/errors.json";
 import enLabs from "./locales/en/labs.json";
 import enNav from "./locales/en/nav.json";
 import enSettings from "./locales/en/settings.json";
 import esCommon from "./locales/es/common.json";
 import esDaily from "./locales/es/daily.json";
+import esEditor from "./locales/es/editor.json";
 import esErrors from "./locales/es/errors.json";
 import esLabs from "./locales/es/labs.json";
 import esNav from "./locales/es/nav.json";
@@ -23,6 +25,7 @@ import esSettings from "./locales/es/settings.json";
 export const NAMESPACES = [
   "common",
   "daily",
+  "editor",
   "errors",
   "labs",
   "nav",
@@ -35,6 +38,7 @@ export const resources: LocaleResources = {
   en: {
     common: enCommon,
     daily: enDaily,
+    editor: enEditor,
     errors: enErrors,
     labs: enLabs,
     nav: enNav,
@@ -43,6 +47,7 @@ export const resources: LocaleResources = {
   es: {
     common: esCommon,
     daily: esDaily,
+    editor: esEditor,
     errors: esErrors,
     labs: esLabs,
     nav: esNav,


### PR DESCRIPTION
## What

Fifth SPA i18n PR (after #876 nav, #877 settings, #879 daily, #880 common). Localizes the **workout editor** — the primary product surface — under a new `editor` namespace.

- Editor page header / loading / workflow bar, `WorkoutSection` (title, actions, metadata edit, selection hints, step-list actions), `EditorContextMenu` (cut/copy/paste/delete/select-all/group/ungroup + shortcut hints), `StepList`, `EmptyWorkoutState`, `UndoRedoButtons`, `SaveButton` + `SaveErrorDialog`, `RawWorkoutDialog`, `ScratchEditorSurface`.
- **Toasts** route through `t("literal.key")` (PII-guard-allowed); `save-handler` interpolates `{name, format}`; pure helpers take an optional `t` defaulting to English (byte-identical unit tests).
- The **e2e-asserted** paste-failure copy is kept byte-identical.
- Extracted `use-scratch-auto-seed` from `ScratchEditorSurface` to stay under the 80-line cap.

## Verification

- Touched-dir + i18n suites: **2285/2285 passed** (pages + organisms + molecules + i18n).
- Full SPA suite: 5437/5438 — the one failure is the pre-existing flaky `LabDashboardSection` chart test (labs, untouched here; passes in isolation, sharded-green in CI).
- `tsc --noEmit` clean · eslint clean (incl. line caps) · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)