### PR TITLE
feat(spa-editor): localize the calendar (calendar namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/AddEntryChooser/AddEntryChooser.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/AddEntryChooser/AddEntryChooser.tsx
@@ -11,6 +11,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useId } from "react";
 
 import { useActiveLocale } from "../../../i18n/LocaleProvider";
+import { useTranslate } from "../../../i18n/use-translate";
 import {
   DIALOG_CONTENT_CLASSES,
   DIALOG_OVERLAY_CLASSES,
@@ -35,11 +36,12 @@ export function AddEntryChooser({
   date,
   onChoose,
 }: AddEntryChooserProps) {
+  const t = useTranslate("calendar");
   const titleId = useId();
   const dateLabel = formatDateLabel(date, useActiveLocale());
   const titleText = dateLabel
-    ? `Add to ${dateLabel}`
-    : "What do you want to add?";
+    ? t("addEntry.addTo", { date: dateLabel })
+    : t("addEntry.title");
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -64,7 +66,7 @@ export function AddEntryChooser({
               className={TILE_CLASSES}
               onClick={() => onChoose("workout")}
             >
-              Workout
+              {t("addEntry.workout")}
             </button>
             <button
               type="button"
@@ -72,7 +74,7 @@ export function AddEntryChooser({
               className={TILE_CLASSES}
               onClick={() => onChoose("wellness")}
             >
-              Wellness
+              {t("addEntry.wellness")}
             </button>
           </div>
         </Dialog.Content>

--- a/packages/workout-spa-editor/src/components/molecules/CalendarViewToggle/CalendarViewToggle.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CalendarViewToggle/CalendarViewToggle.tsx
@@ -10,6 +10,7 @@
 
 import { LayoutGrid, List } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { CalendarView } from "../../../types/user-preferences";
 
 export type CalendarViewToggleProps = {
@@ -31,8 +32,12 @@ export function CalendarViewToggle({
   view,
   onToggle,
 }: CalendarViewToggleProps) {
+  const t = useTranslate("calendar");
   const next = nextView(view);
-  const label = `Switch to ${next} view`;
+  const label =
+    next === "grid"
+      ? t("viewToggle.switchToGridView")
+      : t("viewToggle.switchToListView");
   const Icon = next === "grid" ? LayoutGrid : List;
   const handleClick = () => {
     // View-write failure is non-fatal whether it surfaces synchronously

--- a/packages/workout-spa-editor/src/components/pages/CalendarPageView.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarPageView.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../i18n/use-translate";
 import { ROUTE_HEADING_ATTR } from "../../routing/constants";
 import { todayIsoDate } from "../../utils/today-iso-date";
 import { AutoMatchBanner } from "../organisms/AutoMatchBanner/AutoMatchBanner";
@@ -19,11 +20,12 @@ export function CalendarPageView({
   bannerActions,
   wellnessByDay,
 }: CalendarPageReadyState) {
+  const t = useTranslate("calendar");
   const todayDate = todayIsoDate();
   return (
     <div className="space-y-4" data-testid="calendar-page">
       <h1 tabIndex={-1} {...{ [ROUTE_HEADING_ATTR]: "" }} className="sr-only">
-        Calendar
+        {t("page.heading")}
       </h1>
       <CalendarHeader
         state={s}

--- a/packages/workout-spa-editor/src/components/pages/CalendarWeekGridHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarWeekGridHeader.tsx
@@ -7,7 +7,11 @@
  * scrolls a tall column body.
  */
 
-const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+import type { Locale } from "@kaiord/i18n";
+
+import { useActiveLocale } from "../../i18n/LocaleProvider";
+import { useTranslate } from "../../i18n/use-translate";
+import { shortWeekdayName } from "./calendar-day-labels";
 
 const TODAY_TINT = "bg-primary-50/40 dark:bg-primary-900/20";
 const TODAY_PILL =
@@ -15,13 +19,13 @@ const TODAY_PILL =
 
 const MULTI_WORKOUT_THRESHOLD = 3;
 
-const getDayLabel = (date: string): { name: string; num: number } => {
-  const d = new Date(date + "T12:00:00Z");
-  return {
-    name: DAY_NAMES[(d.getUTCDay() + 6) % 7] ?? "",
-    num: d.getUTCDate(),
-  };
-};
+const getDayLabel = (
+  date: string,
+  locale: Locale
+): { name: string; num: number } => ({
+  name: shortWeekdayName(date, locale),
+  num: new Date(date + "T12:00:00Z").getUTCDate(),
+});
 
 export type CalendarWeekGridHeaderProps = {
   days: string[];
@@ -34,13 +38,15 @@ export function CalendarWeekGridHeader({
   todayDate,
   countFor,
 }: CalendarWeekGridHeaderProps) {
+  const t = useTranslate("calendar");
+  const locale = useActiveLocale();
   return (
     <div
       data-testid="calendar-week-grid-header"
       className="sticky top-0 z-10 mb-2 hidden bg-background sm:grid sm:grid-cols-7 sm:gap-2"
     >
       {days.map((date) => {
-        const label = getDayLabel(date);
+        const label = getDayLabel(date, locale);
         const isToday = date === todayDate;
         const count = countFor(date);
         return (
@@ -55,13 +61,15 @@ export function CalendarWeekGridHeader({
             <span className={isToday ? TODAY_PILL : ""}>
               {label.name} {label.num}
             </span>
-            {isToday && <span className="sr-only"> (today)</span>}
+            {isToday && (
+              <span className="sr-only">{t("gridHeader.todaySuffix")}</span>
+            )}
             {count >= MULTI_WORKOUT_THRESHOLD && (
               <span
                 data-testid={`multi-workout-badge-${date}`}
                 className="ml-auto rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-200"
               >
-                {count} activities
+                {t("gridHeader.activities", { count })}
               </span>
             )}
           </div>

--- a/packages/workout-spa-editor/src/components/pages/CalendarWeekList.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarWeekList.tsx
@@ -4,17 +4,7 @@ import type { MatchedSessionWithMetadata } from "../../hooks/use-matched-session
 import type { WorkoutRecord } from "../../types/calendar-record";
 import type { CoachingActivity } from "../../types/coaching-activity";
 import type { DayWellness } from "../../types/health/day-wellness";
-import { renderDayCards } from "../molecules/WorkoutCard/day-column-cards";
-import { WellnessBand } from "../molecules/WorkoutCard/WellnessBand/WellnessBand";
-
-const DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-// prettier-ignore
-const MONTH_NAMES = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
-
-const formatHeading = (date: string): string => {
-  const d = new Date(date + "T12:00:00Z");
-  return `${DAY_NAMES[(d.getUTCDay() + 6) % 7] ?? ""} ${MONTH_NAMES[d.getUTCMonth()] ?? ""} ${d.getUTCDate()}`;
-};
+import { CalendarWeekListDay } from "./CalendarWeekListDay";
 
 export type CalendarWeekListProps = {
   days: string[];
@@ -41,49 +31,21 @@ export function CalendarWeekList({
 }: CalendarWeekListProps) {
   return (
     <div data-testid="calendar-week-list" className="flex flex-col gap-3">
-      {days.map((date) => {
-        const matched = matchedByDay[date] ?? [];
-        const plans = soloPlansByDay[date] ?? [];
-        const actuals = soloActualsByDay[date] ?? [];
-        const isToday = date === todayDate;
-        return (
-          <section
-            key={date}
-            data-testid={`calendar-list-day-${date}`}
-            data-today={isToday ? "true" : undefined}
-            aria-current={isToday ? "date" : undefined}
-            className="rounded-lg border p-3"
-          >
-            <h2 className="mb-2 text-sm font-semibold text-muted-foreground">
-              {formatHeading(date)}
-              {isToday && <span className="sr-only"> (today)</span>}
-            </h2>
-            <WellnessBand
-              wellness={wellnessByDay?.[date]}
-              resolved={wellnessByDay !== undefined}
-            />
-            <div className="flex flex-col gap-2">
-              {renderDayCards({
-                matchedSessions: matched,
-                soloPlans: plans,
-                soloActuals: actuals,
-                view: "list",
-                onWorkoutClick,
-                onActivityClick,
-              })}
-            </div>
-            <button
-              type="button"
-              data-testid={`calendar-list-add-${date}`}
-              aria-label={`Add to ${formatHeading(date)}`}
-              onClick={() => onAddClick(date)}
-              className="mt-2 w-full rounded border border-dashed border-gray-300 px-3 py-2 text-xs text-muted-foreground transition-colors hover:border-primary-400 hover:text-primary-600 dark:border-gray-600"
-            >
-              + Add
-            </button>
-          </section>
-        );
-      })}
+      {days.map((date) => (
+        <CalendarWeekListDay
+          key={date}
+          date={date}
+          matched={matchedByDay[date] ?? []}
+          plans={soloPlansByDay[date] ?? []}
+          actuals={soloActualsByDay[date] ?? []}
+          isToday={date === todayDate}
+          wellness={wellnessByDay?.[date]}
+          wellnessResolved={wellnessByDay !== undefined}
+          onWorkoutClick={onWorkoutClick}
+          onAddClick={onAddClick}
+          onActivityClick={onActivityClick}
+        />
+      ))}
     </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/CalendarWeekListDay.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CalendarWeekListDay.tsx
@@ -1,0 +1,83 @@
+/** A single day section within the calendar week List view. */
+
+import type { Locale } from "@kaiord/i18n";
+
+import type { MatchedSessionWithMetadata } from "../../hooks/use-matched-sessions";
+import { useActiveLocale } from "../../i18n/LocaleProvider";
+import { useTranslate } from "../../i18n/use-translate";
+import type { WorkoutRecord } from "../../types/calendar-record";
+import type { CoachingActivity } from "../../types/coaching-activity";
+import type { DayWellness } from "../../types/health/day-wellness";
+import { renderDayCards } from "../molecules/WorkoutCard/day-column-cards";
+import { WellnessBand } from "../molecules/WorkoutCard/WellnessBand/WellnessBand";
+import { shortMonthName, shortWeekdayName } from "./calendar-day-labels";
+
+const formatHeading = (date: string, locale: Locale): string => {
+  const d = new Date(date + "T12:00:00Z");
+  return `${shortWeekdayName(date, locale)} ${shortMonthName(date, locale)} ${d.getUTCDate()}`;
+};
+
+export type CalendarWeekListDayProps = {
+  date: string;
+  matched: MatchedSessionWithMetadata[];
+  plans: CoachingActivity[];
+  actuals: WorkoutRecord[];
+  isToday: boolean;
+  wellness?: DayWellness;
+  wellnessResolved: boolean;
+  onWorkoutClick: (workout: WorkoutRecord) => void;
+  onAddClick: (date: string) => void;
+  onActivityClick?: (activity: CoachingActivity) => void;
+};
+
+export function CalendarWeekListDay({
+  date,
+  matched,
+  plans,
+  actuals,
+  isToday,
+  wellness,
+  wellnessResolved,
+  onWorkoutClick,
+  onAddClick,
+  onActivityClick,
+}: CalendarWeekListDayProps) {
+  const t = useTranslate("calendar");
+  const locale = useActiveLocale();
+  const heading = formatHeading(date, locale);
+  return (
+    <section
+      data-testid={`calendar-list-day-${date}`}
+      data-today={isToday ? "true" : undefined}
+      aria-current={isToday ? "date" : undefined}
+      className="rounded-lg border p-3"
+    >
+      <h2 className="mb-2 text-sm font-semibold text-muted-foreground">
+        {heading}
+        {isToday && (
+          <span className="sr-only">{t("weekList.todaySuffix")}</span>
+        )}
+      </h2>
+      <WellnessBand wellness={wellness} resolved={wellnessResolved} />
+      <div className="flex flex-col gap-2">
+        {renderDayCards({
+          matchedSessions: matched,
+          soloPlans: plans,
+          soloActuals: actuals,
+          view: "list",
+          onWorkoutClick,
+          onActivityClick,
+        })}
+      </div>
+      <button
+        type="button"
+        data-testid={`calendar-list-add-${date}`}
+        aria-label={t("weekList.addTo", { date: heading })}
+        onClick={() => onAddClick(date)}
+        className="mt-2 w-full rounded border border-dashed border-gray-300 px-3 py-2 text-xs text-muted-foreground transition-colors hover:border-primary-400 hover:text-primary-600 dark:border-gray-600"
+      >
+        {t("weekList.add")}
+      </button>
+    </section>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/DateBanner.tsx
+++ b/packages/workout-spa-editor/src/components/pages/DateBanner.tsx
@@ -7,12 +7,14 @@
  */
 
 import { useActiveLocale } from "../../i18n/LocaleProvider";
+import { useTranslate } from "../../i18n/use-translate";
 
 export type DateBannerProps = {
   date: string;
 };
 
 export function DateBanner({ date }: DateBannerProps) {
+  const t = useTranslate("calendar");
   const locale = useActiveLocale();
   const parsed = new Date(date + "T12:00:00Z");
   if (isNaN(parsed.getTime())) return null;
@@ -26,7 +28,7 @@ export function DateBanner({ date }: DateBannerProps) {
 
   return (
     <p data-testid="date-banner" className="text-sm text-muted-foreground">
-      Creating workout for {formatted}
+      {t("dateBanner.creatingWorkoutFor", { date: formatted })}
     </p>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/calendar-day-labels.ts
+++ b/packages/workout-spa-editor/src/components/pages/calendar-day-labels.ts
@@ -1,0 +1,31 @@
+/**
+ * Locale-aware short weekday / month names for the calendar week views.
+ *
+ * Derives names from `Intl.DateTimeFormat` at the active locale instead of
+ * hardcoded English arrays, so day/month labels localize automatically. The
+ * ISO date is anchored at noon UTC and formatted in UTC so the weekday and
+ * month match the calendar's date-only semantics regardless of the viewer's
+ * timezone.
+ */
+
+import { DEFAULT_LOCALE, type Locale } from "@kaiord/i18n";
+
+const noonUtc = (date: string): Date => new Date(`${date}T12:00:00Z`);
+
+export const shortWeekdayName = (
+  date: string,
+  locale: Locale = DEFAULT_LOCALE
+): string =>
+  new Intl.DateTimeFormat(locale, {
+    weekday: "short",
+    timeZone: "UTC",
+  }).format(noonUtc(date));
+
+export const shortMonthName = (
+  date: string,
+  locale: Locale = DEFAULT_LOCALE
+): string =>
+  new Intl.DateTimeFormat(locale, {
+    month: "short",
+    timeZone: "UTC",
+  }).format(noonUtc(date));

--- a/packages/workout-spa-editor/src/components/pages/calendar-dnd/use-grid-reschedule.ts
+++ b/packages/workout-spa-editor/src/components/pages/calendar-dnd/use-grid-reschedule.ts
@@ -6,8 +6,8 @@
  *
  * Failures are non-fatal: the optimistic UI reverts via the underlying
  * `useLiveQuery` re-fetch, and a static error toast surfaces a single
- * line of feedback. The toast first argument is the bare module-top
- * constant `TOAST_MOVE_WORKOUT_FAILED` so the `R-PIIInterpolation`
+ * line of feedback. The toast first argument is a static translation
+ * key (`t("reschedule.moveFailed")`) so the `R-PIIInterpolation`
  * mechanical guard stays green.
  */
 
@@ -17,21 +17,21 @@ import { db } from "../../../adapters/dexie/dexie-database";
 import { createDexieWorkoutRepository } from "../../../adapters/dexie/dexie-workout-repository";
 import { rescheduleWorkout } from "../../../application/reschedule-workout";
 import { useToastContext } from "../../../contexts/ToastContext";
+import { useTranslate } from "../../../i18n/use-translate";
 import { usePointerDrag } from "./use-pointer-drag";
 
-const TOAST_MOVE_WORKOUT_FAILED = "Could not move workout";
-
 export function useGridReschedule() {
+  const t = useTranslate("calendar");
   const toast = useToastContext();
 
   const onDrop = useCallback(
     (workoutId: string, targetDayISO: string): void => {
       const repo = createDexieWorkoutRepository(db);
       rescheduleWorkout(repo, workoutId, targetDayISO).catch(() => {
-        toast.error(TOAST_MOVE_WORKOUT_FAILED);
+        toast.error(t("reschedule.moveFailed"));
       });
     },
-    [toast]
+    [toast, t]
   );
 
   return usePointerDrag({ onDrop });

--- a/packages/workout-spa-editor/src/components/pages/use-batch-runner.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-batch-runner.ts
@@ -3,6 +3,7 @@ import { useCallback, useRef, useState } from "react";
 import { db } from "../../adapters/dexie/dexie-database";
 import type { BatchProgress } from "../../application/batch-processor";
 import { processBatch } from "../../application/batch-processor";
+import { useTranslate } from "../../i18n/use-translate";
 import { createProcessOne } from "./batch-process-one";
 import type { BatchPending } from "./use-batch-state";
 
@@ -10,6 +11,7 @@ export function useBatchRunner(
   setMessage: (msg: string | null) => void,
   onSuccess?: (count: number) => void
 ) {
+  const t = useTranslate("calendar");
   const [progress, setProgress] = useState<BatchProgress | null>(null);
   const [isProcessing, setIsProcessing] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
@@ -34,12 +36,12 @@ export function useBatchRunner(
         // this hook free of React-context coupling.
         onSuccess?.(batch.workouts.length);
       } catch {
-        setMessage("Batch processing encountered an unexpected error.");
+        setMessage(t("batch.error"));
       } finally {
         setIsProcessing(false);
       }
     },
-    [setMessage, onSuccess]
+    [setMessage, onSuccess, t]
   );
 
   const cancel = useCallback(() => {

--- a/packages/workout-spa-editor/src/components/pages/use-batch-state.ts
+++ b/packages/workout-spa-editor/src/components/pages/use-batch-state.ts
@@ -12,6 +12,7 @@ import { useCallback, useState } from "react";
 
 import { db } from "../../adapters/dexie/dexie-database";
 import { useToastContext } from "../../contexts/ToastContext";
+import { useTranslate } from "../../i18n/use-translate";
 import type { LlmProviderConfig } from "../../store/ai-store-types";
 import type { WorkoutRecord } from "../../types/calendar-record";
 import { prepareBatch } from "./batch-prepare";
@@ -24,20 +25,23 @@ export type BatchPending = {
 };
 
 export function useBatchState(weekStart: string, weekEnd: string) {
+  const t = useTranslate("calendar");
   const [message, setMessage] = useState<string | null>(null);
   const [pending, setPending] = useState<BatchPending | null>(null);
   const { success: showSuccess } = useToastContext();
-  // Static title satisfies the R-PIIInterpolation guard; the dynamic
-  // count flows through the description field.
+  // The static translation-key title satisfies the R-PIIInterpolation
+  // guard; the dynamic count flows through the description field.
   const runner = useBatchRunner(setMessage, (count) =>
-    showSuccess("Batch processed", `${count} workouts`, { duration: 3000 })
+    showSuccess(t("batch.processed"), t("batch.workoutsProcessed", { count }), {
+      duration: 3000,
+    })
   );
 
   const providerCount = useLiveQuery(() => db.table("aiProviders").count(), []);
 
   const requestStart = useCallback(async () => {
     if (!providerCount || providerCount === 0) {
-      setMessage("Configure an AI provider in Settings to process workouts.");
+      setMessage(t("batch.noProvider"));
       return;
     }
     const prep = await prepareBatch(weekStart, weekEnd);
@@ -51,7 +55,7 @@ export function useBatchState(weekStart: string, weekEnd: string) {
       modelId: prep.modelId,
       workouts: prep.workouts,
     });
-  }, [weekStart, weekEnd, providerCount]);
+  }, [weekStart, weekEnd, providerCount, t]);
 
   const confirmStart = useCallback(async () => {
     const staged = pending;

--- a/packages/workout-spa-editor/src/i18n/locales/en/calendar.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/calendar.json
@@ -1,0 +1,36 @@
+{
+  "page": {
+    "heading": "Calendar"
+  },
+  "gridHeader": {
+    "todaySuffix": " (today)",
+    "activities": "{{count}} activities"
+  },
+  "weekList": {
+    "todaySuffix": " (today)",
+    "addTo": "Add to {{date}}",
+    "add": "+ Add"
+  },
+  "viewToggle": {
+    "switchToGridView": "Switch to grid view",
+    "switchToListView": "Switch to list view"
+  },
+  "addEntry": {
+    "title": "What do you want to add?",
+    "addTo": "Add to {{date}}",
+    "workout": "Workout",
+    "wellness": "Wellness"
+  },
+  "dateBanner": {
+    "creatingWorkoutFor": "Creating workout for {{date}}"
+  },
+  "batch": {
+    "processed": "Batch processed",
+    "workoutsProcessed": "{{count}} workouts",
+    "noProvider": "Configure an AI provider in Settings to process workouts.",
+    "error": "Batch processing encountered an unexpected error."
+  },
+  "reschedule": {
+    "moveFailed": "Could not move workout"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/calendar.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/calendar.json
@@ -1,0 +1,36 @@
+{
+  "page": {
+    "heading": "Calendario"
+  },
+  "gridHeader": {
+    "todaySuffix": " (hoy)",
+    "activities": "{{count}} actividades"
+  },
+  "weekList": {
+    "todaySuffix": " (hoy)",
+    "addTo": "Añadir a {{date}}",
+    "add": "+ Añadir"
+  },
+  "viewToggle": {
+    "switchToGridView": "Cambiar a vista de cuadrícula",
+    "switchToListView": "Cambiar a vista de lista"
+  },
+  "addEntry": {
+    "title": "¿Qué quieres añadir?",
+    "addTo": "Añadir a {{date}}",
+    "workout": "Entrenamiento",
+    "wellness": "Bienestar"
+  },
+  "dateBanner": {
+    "creatingWorkoutFor": "Creando entrenamiento para el {{date}}"
+  },
+  "batch": {
+    "processed": "Lote procesado",
+    "workoutsProcessed": "{{count}} entrenamientos",
+    "noProvider": "Configura un proveedor de IA en Ajustes para procesar entrenamientos.",
+    "error": "El procesamiento por lotes encontró un error inesperado."
+  },
+  "reschedule": {
+    "moveFailed": "No se pudo mover el entrenamiento"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -7,6 +7,7 @@
 
 import type { LocaleResources } from "@kaiord/i18n";
 
+import enCalendar from "./locales/en/calendar.json";
 import enCommon from "./locales/en/common.json";
 import enDaily from "./locales/en/daily.json";
 import enEditor from "./locales/en/editor.json";
@@ -16,6 +17,7 @@ import enLabs from "./locales/en/labs.json";
 import enNav from "./locales/en/nav.json";
 import enSettings from "./locales/en/settings.json";
 import enTargets from "./locales/en/targets.json";
+import esCalendar from "./locales/es/calendar.json";
 import esCommon from "./locales/es/common.json";
 import esDaily from "./locales/es/daily.json";
 import esEditor from "./locales/es/editor.json";
@@ -27,6 +29,7 @@ import esSettings from "./locales/es/settings.json";
 import esTargets from "./locales/es/targets.json";
 
 export const NAMESPACES = [
+  "calendar",
   "common",
   "daily",
   "editor",
@@ -42,6 +45,7 @@ export const DEFAULT_NAMESPACE = "common";
 
 export const resources: LocaleResources = {
   en: {
+    calendar: enCalendar,
     common: enCommon,
     daily: enDaily,
     editor: enEditor,
@@ -53,6 +57,7 @@ export const resources: LocaleResources = {
     targets: enTargets,
   },
   es: {
+    calendar: esCalendar,
     common: esCommon,
     daily: esDaily,
     editor: esEditor,


### PR DESCRIPTION
## What

Eighth SPA i18n PR. New `calendar` namespace for the Calendar page.

- Week/grid views, view toggle, add-entry chooser, date banner, batch-processing status, DnD reschedule messages.
- **DAY_NAMES/MONTH_NAMES**: replaced the two duplicated English arrays with one locale-aware `Intl.DateTimeFormat` helper (`calendar-day-labels`), so weekday/month names localize automatically (EN output identical to the old arrays — tests confirm).
- Toast/status strings via `t("literal.key")`; word-order-unsafe concatenations restructured into single interpolated keys.
- Extracted `CalendarWeekListDay` to hold the 80-line cap.

## Verification

- Touched-dir + i18n suites (incl. all calendar page tests): **1724/1724**.
- `tsc --noEmit` clean · eslint clean · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar screens and actions are now localized in English and Spanish.
  * Added translated labels for calendar headings, add-entry choices, view toggle text, and status messages.

* **Bug Fixes**
  * Improved date and day labels so calendar text follows the selected locale consistently.
  * Error and success messages in calendar workflows now display translated, clearer wording.
  * Week list view was reorganized for more consistent day-by-day rendering and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->