### PR TITLE
feat(spa-editor): localize the workout library (library namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/SaveToLibraryButton.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/SaveToLibraryButton.tsx
@@ -13,6 +13,7 @@
 import { BookmarkPlus } from "lucide-react";
 import { useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { KRD } from "../../../types/krd";
 import { Button } from "../../atoms/Button/Button";
 import { SaveToLibraryDialog } from "./SaveToLibraryDialog";
@@ -31,6 +32,7 @@ export function SaveToLibraryButton({
   disabled,
   className,
 }: SaveToLibraryButtonProps) {
+  const t = useTranslate("library");
   const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
@@ -42,7 +44,7 @@ export function SaveToLibraryButton({
         className={className}
       >
         <BookmarkPlus className="h-4 w-4" />
-        Save to Library
+        {t("saveDialog.title")}
       </Button>
 
       <SaveToLibraryDialog

--- a/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/DialogActions.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/DialogActions.tsx
@@ -6,6 +6,7 @@
 
 import * as Dialog from "@radix-ui/react-dialog";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { Button } from "../../../atoms/Button/Button";
 
 type DialogActionsProps = {
@@ -19,15 +20,16 @@ export function DialogActions({
   isSaving,
   isValid,
 }: DialogActionsProps) {
+  const t = useTranslate("library");
   return (
     <div className="flex justify-end gap-3">
       <Dialog.Close asChild>
         <Button variant="secondary" disabled={isSaving}>
-          Cancel
+          {t("actions.cancel")}
         </Button>
       </Dialog.Close>
       <Button onClick={onSave} disabled={!isValid || isSaving}>
-        {isSaving ? "Saving..." : "Save"}
+        {isSaving ? t("saveDialog.saving") : t("actions.save")}
       </Button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/DialogHeader.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/DialogHeader.tsx
@@ -7,17 +7,21 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
+
 export function DialogHeader() {
+  const t = useTranslate("library");
+  const tCommon = useTranslate("common");
   return (
     <>
       <div className="flex items-center justify-between">
         <Dialog.Title className="text-lg font-semibold text-gray-900 dark:text-white">
-          Save to Library
+          {t("saveDialog.title")}
         </Dialog.Title>
         <Dialog.Close asChild>
           <button
             className="rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 disabled:pointer-events-none dark:ring-offset-gray-950"
-            aria-label="Close"
+            aria-label={tCommon("actions.close")}
           >
             <X className="h-4 w-4" />
           </button>
@@ -25,7 +29,7 @@ export function DialogHeader() {
       </div>
 
       <Dialog.Description className="text-sm text-gray-600 dark:text-gray-400">
-        Add details to organize your workout in the library.
+        {t("saveDialog.description")}
       </Dialog.Description>
     </>
   );

--- a/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/DifficultySelect.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/DifficultySelect.tsx
@@ -4,6 +4,7 @@
  * Select dropdown for workout difficulty level.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import type { DifficultyLevel } from "../../../../types/workout-library";
 
 type DifficultySelectProps = {
@@ -17,13 +18,14 @@ export function DifficultySelect({
   onChange,
   disabled,
 }: DifficultySelectProps) {
+  const t = useTranslate("library");
   return (
     <div>
       <label
         htmlFor="workout-difficulty"
         className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
       >
-        Difficulty
+        {t("saveDialog.difficulty.label")}
       </label>
       <select
         id="workout-difficulty"
@@ -32,11 +34,11 @@ export function DifficultySelect({
         className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
         disabled={disabled}
       >
-        <option value="">Select difficulty</option>
-        <option value="easy">Easy</option>
-        <option value="moderate">Moderate</option>
-        <option value="hard">Hard</option>
-        <option value="very_hard">Very Hard</option>
+        <option value="">{t("saveDialog.difficulty.placeholder")}</option>
+        <option value="easy">{t("saveDialog.difficulty.easy")}</option>
+        <option value="moderate">{t("saveDialog.difficulty.moderate")}</option>
+        <option value="hard">{t("saveDialog.difficulty.hard")}</option>
+        <option value="very_hard">{t("saveDialog.difficulty.veryHard")}</option>
       </select>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/NotesTextarea.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/NotesTextarea.tsx
@@ -4,6 +4,8 @@
  * Textarea for workout notes with character counter.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
+
 type NotesTextareaProps = {
   value: string;
   onChange: (value: string) => void;
@@ -15,26 +17,27 @@ export function NotesTextarea({
   onChange,
   disabled,
 }: NotesTextareaProps) {
+  const t = useTranslate("library");
   return (
     <div>
       <label
         htmlFor="workout-notes"
         className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
       >
-        Notes
+        {t("saveDialog.notes.label")}
       </label>
       <textarea
         id="workout-notes"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Add notes about this workout..."
+        placeholder={t("saveDialog.notes.placeholder")}
         maxLength={1000}
         rows={3}
         className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
         disabled={disabled}
       />
       <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-        {value.length}/1000 characters
+        {t("saveDialog.notes.charCount", { count: value.length })}
       </p>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/TagsInput.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/TagsInput.tsx
@@ -4,6 +4,7 @@
  * Input field for workout tags.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { Input } from "../../../atoms/Input/Input";
 
 type TagsInputProps = {
@@ -13,19 +14,20 @@ type TagsInputProps = {
 };
 
 export function TagsInput({ value, onChange, disabled }: TagsInputProps) {
+  const t = useTranslate("library");
   return (
     <div>
       <label
         htmlFor="workout-tags"
         className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
       >
-        Tags (comma-separated)
+        {t("saveDialog.tags.label")}
       </label>
       <Input
         id="workout-tags"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="e.g., intervals, endurance"
+        placeholder={t("saveDialog.tags.placeholder")}
         disabled={disabled}
       />
     </div>

--- a/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/WorkoutNameInput.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/components/WorkoutNameInput.tsx
@@ -4,6 +4,7 @@
  * Input field for workout name.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { Input } from "../../../atoms/Input/Input";
 
 type WorkoutNameInputProps = {
@@ -17,19 +18,20 @@ export function WorkoutNameInput({
   onChange,
   disabled,
 }: WorkoutNameInputProps) {
+  const t = useTranslate("library");
   return (
     <div>
       <label
         htmlFor="workout-name"
         className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
       >
-        Workout Name *
+        {t("saveDialog.name.label")}
       </label>
       <Input
         id="workout-name"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="e.g., Sweet Spot Intervals"
+        placeholder={t("saveDialog.name.placeholder")}
         maxLength={200}
         disabled={disabled}
       />

--- a/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/useSaveToLibrary.ts
+++ b/packages/workout-spa-editor/src/components/molecules/SaveToLibraryButton/useSaveToLibrary.ts
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { addTemplate } from "../../../application/library/add-template";
 import { usePersistence } from "../../../contexts/persistence-context";
 import { useToastContext } from "../../../contexts/ToastContext";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { KRD } from "../../../types/krd";
 import type { DifficultyLevel } from "../../../types/workout-library";
 import {
@@ -22,6 +23,7 @@ import {
 export function useSaveToLibrary(workout: KRD, onClose: () => void) {
   const persistence = usePersistence();
   const { success, error: showError } = useToastContext();
+  const t = useTranslate("library");
 
   const [name, setName] = useState("");
   const [tags, setTags] = useState("");
@@ -52,8 +54,8 @@ export function useSaveToLibrary(workout: KRD, onClose: () => void) {
       await addTemplate(persistence, trimmedName, sport, workout, options);
 
       success(
-        "Workout Saved",
-        `"${trimmedName}" has been added to your library`,
+        t("toast.workoutSaved"),
+        t("toast.workoutSavedDescription", { name: trimmedName }),
         { duration: 3000 }
       );
 
@@ -61,8 +63,8 @@ export function useSaveToLibrary(workout: KRD, onClose: () => void) {
       onClose();
     } catch (err) {
       showError(
-        "Save Failed",
-        err instanceof Error ? err.message : "Failed to save workout",
+        t("toast.saveFailed"),
+        err instanceof Error ? err.message : t("toast.saveFailedDescription"),
         { duration: 5000 }
       );
     } finally {

--- a/packages/workout-spa-editor/src/components/molecules/StaleConflictDialog/StaleConflictDialog.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/StaleConflictDialog/StaleConflictDialog.tsx
@@ -9,6 +9,7 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { AlertTriangle, X } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button/Button";
 
 type StaleConflictDialogProps = {
@@ -26,6 +27,8 @@ export function StaleConflictDialog({
   onKeepVersion,
   onViewDiff,
 }: StaleConflictDialogProps) {
+  const t = useTranslate("library");
+  const tCommon = useTranslate("common");
   return (
     <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
       <Dialog.Portal>
@@ -37,25 +40,24 @@ export function StaleConflictDialog({
           <div className="flex items-center justify-between mb-4">
             <Dialog.Title className="flex items-center gap-2 text-lg font-semibold">
               <AlertTriangle className="h-5 w-5 text-amber-500" />
-              Stale Workout Conflict
+              {t("staleDialog.title")}
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button aria-label="Close">
+              <button aria-label={tCommon("actions.close")}>
                 <X className="h-4 w-4" />
               </button>
             </Dialog.Close>
           </div>
           <Dialog.Description className="text-sm text-muted-foreground mb-6">
-            The source description has changed since you last edited this
-            workout. Your edits may conflict with the new content.
+            {t("staleDialog.description")}
           </Dialog.Description>
           <div className="flex flex-col gap-2">
             <Button variant="secondary" onClick={onViewDiff}>
-              View Diff
+              {t("staleDialog.viewDiff")}
             </Button>
-            <Button onClick={onReprocess}>Re-process Anyway</Button>
+            <Button onClick={onReprocess}>{t("staleDialog.reprocess")}</Button>
             <Button variant="tertiary" onClick={onKeepVersion}>
-              Keep My Version
+              {t("staleDialog.keepVersion")}
             </Button>
           </div>
         </Dialog.Content>

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardHeader.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardHeader.tsx
@@ -6,6 +6,7 @@
 
 import { Trash2 } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { Button } from "../../../atoms/Button/Button";
 
 type CardHeaderProps = {
@@ -14,6 +15,7 @@ type CardHeaderProps = {
 };
 
 export function CardHeader({ workoutName, onDelete }: CardHeaderProps) {
+  const t = useTranslate("library");
   return (
     <div className="p-4 pb-2">
       <div className="flex items-start justify-between">
@@ -23,7 +25,7 @@ export function CardHeader({ workoutName, onDelete }: CardHeaderProps) {
           size="sm"
           onClick={onDelete}
           className="opacity-0 transition-opacity group-hover:opacity-100"
-          aria-label={`Delete ${workoutName}`}
+          aria-label={t("card.deleteAria", { name: workoutName })}
         >
           <Trash2 className="h-4 w-4" />
         </Button>

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardScheduleAction.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardScheduleAction.tsx
@@ -6,6 +6,7 @@
 
 import { CalendarPlus } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { Button } from "../../../atoms/Button/Button";
 
 type CardScheduleActionProps = {
@@ -13,6 +14,7 @@ type CardScheduleActionProps = {
 };
 
 export function CardScheduleAction({ onSchedule }: CardScheduleActionProps) {
+  const t = useTranslate("library");
   return (
     <Button
       onClick={onSchedule}
@@ -21,7 +23,7 @@ export function CardScheduleAction({ onSchedule }: CardScheduleActionProps) {
       size="sm"
     >
       <CalendarPlus className="mr-2 h-4 w-4" />
-      Schedule
+      {t("card.schedule")}
     </Button>
   );
 }

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardThumbnail.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/CardThumbnail.tsx
@@ -4,6 +4,8 @@
  * Displays workout thumbnail image
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
+
 type CardThumbnailProps = {
   thumbnailData?: string;
   workoutName: string;
@@ -13,13 +15,14 @@ export function CardThumbnail({
   thumbnailData,
   workoutName,
 }: CardThumbnailProps) {
+  const t = useTranslate("library");
   if (!thumbnailData) return null;
 
   return (
     <div className="aspect-video w-full overflow-hidden bg-gray-100 dark:bg-gray-800">
       <img
         src={thumbnailData}
-        alt={`${workoutName} preview`}
+        alt={t("card.thumbnailAlt", { name: workoutName })}
         className="h-full w-full object-cover"
       />
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/DeleteWorkoutDialog.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/DeleteWorkoutDialog.tsx
@@ -6,6 +6,7 @@
 
 import * as Dialog from "@radix-ui/react-dialog";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { Button } from "../../../atoms/Button/Button";
 
 type DeleteWorkoutDialogProps = {
@@ -21,23 +22,23 @@ export function DeleteWorkoutDialog({
   onConfirm,
   onCancel,
 }: DeleteWorkoutDialogProps) {
+  const t = useTranslate("library");
   return (
     <Dialog.Root open={open} onOpenChange={(isOpen) => !isOpen && onCancel()}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/50" />
         <Dialog.Content className="fixed left-[50%] top-[50%] z-50 w-full max-w-md translate-x-[-50%] translate-y-[-50%] border border-gray-200 bg-white p-6 shadow-lg sm:rounded-lg dark:border-gray-700 dark:bg-gray-800">
           <Dialog.Title className="text-lg font-semibold text-gray-900 dark:text-white">
-            Delete Workout
+            {t("deleteDialog.title")}
           </Dialog.Title>
           <Dialog.Description className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-            Are you sure you want to delete "{workoutName}"? This action cannot
-            be undone.
+            {t("deleteDialog.description", { name: workoutName })}
           </Dialog.Description>
           <div className="mt-4 flex justify-end gap-2">
             <Button variant="secondary" onClick={onCancel}>
-              Cancel
+              {t("actions.cancel")}
             </Button>
-            <Button onClick={onConfirm}>Delete</Button>
+            <Button onClick={onConfirm}>{t("actions.delete")}</Button>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/EmptyLibrary.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/EmptyLibrary.tsx
@@ -6,6 +6,7 @@
 
 import { BookOpen } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { Button } from "../../../atoms/Button";
 
 type EmptyLibraryProps = {
@@ -17,19 +18,20 @@ export function EmptyLibrary({
   isFiltered,
   onClearFilters,
 }: EmptyLibraryProps) {
+  const t = useTranslate("library");
   if (isFiltered) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
         <BookOpen className="mb-4 h-12 w-12 text-gray-400" />
         <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
-          No workouts found
+          {t("empty.filteredTitle")}
         </h3>
         <p className="mb-4 text-gray-600 dark:text-gray-400">
-          No workouts match your current filters.
+          {t("empty.filteredMessage")}
         </p>
         {onClearFilters && (
           <Button variant="secondary" onClick={onClearFilters}>
-            Clear Filters
+            {t("filters.clearFilters")}
           </Button>
         )}
       </div>
@@ -40,10 +42,10 @@ export function EmptyLibrary({
     <div className="flex flex-col items-center justify-center py-12 text-center">
       <BookOpen className="mb-4 h-12 w-12 text-gray-400" />
       <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
-        Your library is empty
+        {t("empty.title")}
       </h3>
       <p className="mb-4 text-gray-600 dark:text-gray-400">
-        Create your first workout and save it to your library to get started.
+        {t("empty.createMessage")}
       </p>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/LibraryFilters.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/LibraryFilters.tsx
@@ -4,6 +4,7 @@
  * Provides filtering and sorting controls for the workout library.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { Button } from "../../../atoms/Button/Button";
 import { DifficultyFilter } from "./filters/DifficultyFilter";
 import { SearchInput } from "./filters/SearchInput";
@@ -41,6 +42,7 @@ export function LibraryFilters({
   onSortOrderChange,
   onClearFilters,
 }: LibraryFiltersProps) {
+  const t = useTranslate("library");
   return (
     <div className="mb-6 space-y-4">
       <SearchInput value={searchTerm} onChange={onSearchChange} />
@@ -57,7 +59,7 @@ export function LibraryFilters({
 
       <div className="flex justify-end">
         <Button variant="secondary" onClick={onClearFilters}>
-          Clear Filters
+          {t("filters.clearFilters")}
         </Button>
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/TagFilterButtons.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/TagFilterButtons.tsx
@@ -4,6 +4,8 @@
  * Interactive buttons for filtering workouts by tags.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
+
 type TagFilterButtonsProps = {
   allTags: string[];
   selectedTags: string[];
@@ -15,12 +17,13 @@ export function TagFilterButtons({
   selectedTags,
   onTagToggle,
 }: TagFilterButtonsProps) {
+  const t = useTranslate("library");
   if (allTags.length === 0) return null;
 
   return (
     <div className="mb-4 flex flex-wrap items-center gap-2">
       <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-        Tags:
+        {t("filters.tagsLabel")}
       </span>
       {allTags.map((tag) => (
         <button

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/DifficultyFilter.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/DifficultyFilter.tsx
@@ -4,6 +4,8 @@
  * Dropdown filter for difficulty level.
  */
 
+import { useTranslate } from "../../../../../i18n/use-translate";
+
 type Difficulty = "easy" | "medium" | "hard";
 
 type DifficultyFilterProps = {
@@ -12,13 +14,14 @@ type DifficultyFilterProps = {
 };
 
 export function DifficultyFilter({ value, onChange }: DifficultyFilterProps) {
+  const t = useTranslate("library");
   return (
     <div>
       <label
         htmlFor="difficulty-filter-select"
         className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
       >
-        Difficulty
+        {t("filters.difficulty.label")}
       </label>
       <select
         id="difficulty-filter-select"
@@ -26,10 +29,10 @@ export function DifficultyFilter({ value, onChange }: DifficultyFilterProps) {
         onChange={(e) => onChange(e.target.value as Difficulty | "all")}
         className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
       >
-        <option value="all">All Levels</option>
-        <option value="easy">Easy</option>
-        <option value="medium">Medium</option>
-        <option value="hard">Hard</option>
+        <option value="all">{t("filters.difficulty.all")}</option>
+        <option value="easy">{t("filters.difficulty.easy")}</option>
+        <option value="medium">{t("filters.difficulty.medium")}</option>
+        <option value="hard">{t("filters.difficulty.hard")}</option>
       </select>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SearchInput.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SearchInput.tsx
@@ -4,6 +4,7 @@
  * Search input for filtering workouts.
  */
 
+import { useTranslate } from "../../../../../i18n/use-translate";
 import { Input } from "../../../../atoms/Input/Input";
 
 type SearchInputProps = {
@@ -12,11 +13,12 @@ type SearchInputProps = {
 };
 
 export function SearchInput({ value, onChange }: SearchInputProps) {
+  const t = useTranslate("library");
   return (
     <div>
       <Input
         type="text"
-        placeholder="Search workouts..."
+        placeholder={t("search.placeholder")}
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className="w-full"

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SortBySelect.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SortBySelect.tsx
@@ -4,19 +4,22 @@
  * Dropdown for selecting sort criteria.
  */
 
+import { useTranslate } from "../../../../../i18n/use-translate";
+
 type SortBySelectProps = {
   value: "name" | "date" | "difficulty";
   onChange: (value: "name" | "date" | "difficulty") => void;
 };
 
 export function SortBySelect({ value, onChange }: SortBySelectProps) {
+  const t = useTranslate("library");
   return (
     <div>
       <label
         htmlFor="sort-by-select"
         className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
       >
-        Sort By
+        {t("filters.sortBy.label")}
       </label>
       <select
         id="sort-by-select"
@@ -26,9 +29,9 @@ export function SortBySelect({ value, onChange }: SortBySelectProps) {
         }
         className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
       >
-        <option value="name">Name</option>
-        <option value="date">Date Created</option>
-        <option value="difficulty">Difficulty</option>
+        <option value="name">{t("filters.sortBy.name")}</option>
+        <option value="date">{t("filters.sortBy.dateCreated")}</option>
+        <option value="difficulty">{t("filters.sortBy.difficulty")}</option>
       </select>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SortOrderSelect.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SortOrderSelect.tsx
@@ -4,19 +4,22 @@
  * Dropdown for selecting sort order (ascending/descending).
  */
 
+import { useTranslate } from "../../../../../i18n/use-translate";
+
 type SortOrderSelectProps = {
   value: "asc" | "desc";
   onChange: (value: "asc" | "desc") => void;
 };
 
 export function SortOrderSelect({ value, onChange }: SortOrderSelectProps) {
+  const t = useTranslate("library");
   return (
     <div>
       <label
         htmlFor="sort-order-select"
         className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
       >
-        Order
+        {t("filters.sortOrder.label")}
       </label>
       <select
         id="sort-order-select"
@@ -24,8 +27,8 @@ export function SortOrderSelect({ value, onChange }: SortOrderSelectProps) {
         onChange={(e) => onChange(e.target.value as "asc" | "desc")}
         className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
       >
-        <option value="asc">Ascending</option>
-        <option value="desc">Descending</option>
+        <option value="asc">{t("filters.sortOrder.asc")}</option>
+        <option value="desc">{t("filters.sortOrder.desc")}</option>
       </select>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SportFilter.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutLibrary/components/filters/SportFilter.tsx
@@ -4,6 +4,8 @@
  * Dropdown filter for sport type.
  */
 
+import { useTranslate } from "../../../../../i18n/use-translate";
+
 type Sport = "cycling" | "running" | "swimming" | "generic";
 
 type SportFilterProps = {
@@ -12,13 +14,14 @@ type SportFilterProps = {
 };
 
 export function SportFilter({ value, onChange }: SportFilterProps) {
+  const t = useTranslate("library");
   return (
     <div>
       <label
         htmlFor="sport-filter-select"
         className="mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300"
       >
-        Sport
+        {t("filters.sport.label")}
       </label>
       <select
         id="sport-filter-select"
@@ -26,11 +29,11 @@ export function SportFilter({ value, onChange }: SportFilterProps) {
         onChange={(e) => onChange(e.target.value as Sport | "all")}
         className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
       >
-        <option value="all">All Sports</option>
-        <option value="cycling">Cycling</option>
-        <option value="running">Running</option>
-        <option value="swimming">Swimming</option>
-        <option value="generic">Generic</option>
+        <option value="all">{t("filters.sport.all")}</option>
+        <option value="cycling">{t("filters.sport.cycling")}</option>
+        <option value="running">{t("filters.sport.running")}</option>
+        <option value="swimming">{t("filters.sport.swimming")}</option>
+        <option value="generic">{t("filters.sport.generic")}</option>
       </select>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/Library/LibraryContent.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Library/LibraryContent.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from "react";
 
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutTemplate } from "../../../types/workout-library";
 import { ConfirmationModal } from "../../molecules/ConfirmationModal";
 import { filterTemplates, type SportFilter } from "./library-filter";
@@ -24,6 +25,7 @@ export function LibraryContent({
   onSchedule,
   onDelete,
 }: LibraryContentProps) {
+  const t = useTranslate("library");
   const profile = useActiveProfileLive()?.profile ?? null;
   const [query, setQuery] = useState("");
   const [sport, setSport] = useState<SportFilter>("all");
@@ -65,10 +67,10 @@ export function LibraryContent({
       )}
       <ConfirmationModal
         isOpen={deleteTarget !== null}
-        title="Delete Workout"
-        message={`Delete "${deleteTarget?.name ?? ""}"? This cannot be undone.`}
-        confirmLabel="Delete"
-        cancelLabel="Cancel"
+        title={t("deleteDialog.title")}
+        message={t("deleteDialog.confirm", { name: deleteTarget?.name ?? "" })}
+        confirmLabel={t("actions.delete")}
+        cancelLabel={t("actions.cancel")}
         variant="destructive"
         onConfirm={confirmDelete}
         onCancel={() => setDeleteTarget(null)}

--- a/packages/workout-spa-editor/src/components/pages/Library/LibraryEmpty.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Library/LibraryEmpty.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
 export type LibraryEmptyProps = {
@@ -5,18 +6,17 @@ export type LibraryEmptyProps = {
 };
 
 export function LibraryEmpty({ isFiltered }: LibraryEmptyProps) {
+  const t = useTranslate("library");
   return (
     <div className="flex flex-col items-center justify-center py-16 text-center">
       <div className="mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-sky-500/15 text-sky-400">
         <Icon icon={ICON_MAP.library} size="lg" color="inherit" />
       </div>
       <h3 className="m-0 text-[16px] font-bold text-slate-100">
-        {isFiltered ? "No workouts found" : "Your library is empty"}
+        {isFiltered ? t("empty.filteredTitle") : t("empty.title")}
       </h3>
       <p className="mt-1 text-[13.5px] text-slate-400">
-        {isFiltered
-          ? "No workouts match your current filters."
-          : "Save a workout to your library to get started."}
+        {isFiltered ? t("empty.filteredMessage") : t("empty.message")}
       </p>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/Library/LibraryHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Library/LibraryHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { ROUTE_HEADING_ATTR } from "../../../routing/constants";
 
 export type LibraryHeaderProps = {
@@ -5,6 +6,7 @@ export type LibraryHeaderProps = {
 };
 
 export function LibraryHeader({ count }: LibraryHeaderProps) {
+  const t = useTranslate("library");
   return (
     <div className="mb-1">
       <h1
@@ -12,10 +14,10 @@ export function LibraryHeader({ count }: LibraryHeaderProps) {
         {...{ [ROUTE_HEADING_ATTR]: "" }}
         className="m-0 text-[26px] font-extrabold tracking-[-0.02em] text-slate-50"
       >
-        Library
+        {t("header.title")}
       </h1>
       <p className="mt-1 text-[13.5px] text-slate-400">
-        {count} {count === 1 ? "workout" : "workouts"}
+        {t(count === 1 ? "header.count_one" : "header.count_other", { count })}
       </p>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/Library/LibraryListRow.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Library/LibraryListRow.tsx
@@ -1,5 +1,6 @@
 import { Play } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { Profile } from "../../../types/profile";
 import type { WorkoutTemplate } from "../../../types/workout-library";
 import { Button } from "../../atoms/Button";
@@ -24,6 +25,7 @@ export function LibraryListRow({
   onSchedule,
   onDelete,
 }: LibraryListRowProps) {
+  const t = useTranslate("library");
   const model = buildLibraryCardModel(template, profile);
 
   return (
@@ -37,7 +39,7 @@ export function LibraryListRow({
           onClick={onSchedule}
         >
           <Icon icon={ICON_MAP.calendar} size="sm" color="inherit" />
-          Schedule
+          {t("card.schedule")}
         </Button>
         {hasCurrentWorkout && (
           <Button
@@ -45,18 +47,18 @@ export function LibraryListRow({
             size="sm"
             className="flex-1"
             onClick={onLoad}
-            aria-label={`Load ${template.name} into editor`}
+            aria-label={t("card.loadAria", { name: template.name })}
             data-testid="card-load-into-editor"
           >
             <Play className="h-4 w-4" />
-            Load
+            {t("card.load")}
           </Button>
         )}
         <Button
           variant="ghost"
           size="sm"
           onClick={onDelete}
-          aria-label={`Delete ${template.name}`}
+          aria-label={t("card.deleteAria", { name: template.name })}
         >
           <Icon icon={ICON_MAP.x} size="sm" color="inherit" />
         </Button>

--- a/packages/workout-spa-editor/src/components/pages/Library/LibrarySearchField.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Library/LibrarySearchField.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
 export type LibrarySearchFieldProps = {
@@ -9,6 +10,7 @@ export function LibrarySearchField({
   value,
   onChange,
 }: LibrarySearchFieldProps) {
+  const t = useTranslate("library");
   return (
     <div className="flex items-center gap-2 rounded-lg border border-slate-800 bg-primary-900 px-3 py-2">
       <Icon icon={ICON_MAP.target} size="sm" color="muted" />
@@ -16,8 +18,8 @@ export function LibrarySearchField({
         type="search"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Search workouts..."
-        aria-label="Search workouts"
+        placeholder={t("search.placeholder")}
+        aria-label={t("search.ariaLabel")}
         className="w-full bg-transparent text-[14px] text-slate-100 placeholder:text-slate-500 focus:outline-none"
       />
     </div>

--- a/packages/workout-spa-editor/src/components/pages/Library/LibrarySportChips.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Library/LibrarySportChips.tsx
@@ -1,5 +1,6 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Pill } from "../../atoms/Pill";
-import { SPORT_CHIPS, type SportFilter } from "./library-filter";
+import { getSportChips, type SportFilter } from "./library-filter";
 
 export type LibrarySportChipsProps = {
   active: SportFilter;
@@ -10,9 +11,10 @@ export function LibrarySportChips({
   active,
   onChange,
 }: LibrarySportChipsProps) {
+  const t = useTranslate("library");
   return (
     <div className="flex gap-2 overflow-x-auto pb-1">
-      {SPORT_CHIPS.map((chip) => (
+      {getSportChips(t).map((chip) => (
         <button
           key={chip.value}
           type="button"

--- a/packages/workout-spa-editor/src/components/pages/Library/library-filter.ts
+++ b/packages/workout-spa-editor/src/components/pages/Library/library-filter.ts
@@ -1,3 +1,4 @@
+import { getTranslate, type Translate } from "../../../i18n/use-translate";
 import type { WorkoutTemplate } from "../../../types/workout-library";
 
 export type SportFilter = "all" | "cycling" | "running" | "swimming";
@@ -7,12 +8,16 @@ export type SportChip = {
   label: string;
 };
 
-export const SPORT_CHIPS: SportChip[] = [
-  { value: "all", label: "All" },
-  { value: "cycling", label: "Cycling" },
-  { value: "running", label: "Running" },
-  { value: "swimming", label: "Swim" },
-];
+export function getSportChips(
+  t: Translate = getTranslate("library")
+): SportChip[] {
+  return [
+    { value: "all", label: t("sport.all") },
+    { value: "cycling", label: t("sport.cycling") },
+    { value: "running", label: t("sport.running") },
+    { value: "swimming", label: t("sport.swim") },
+  ];
+}
 
 /** Filters templates by case-insensitive title substring and sport. */
 export function filterTemplates(

--- a/packages/workout-spa-editor/src/components/pages/LibraryPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/LibraryPage.tsx
@@ -31,6 +31,7 @@ import { deleteTemplate } from "../../application/library/delete-template";
 import { usePersistence } from "../../contexts/persistence-context";
 import { useToastContext } from "../../contexts/ToastContext";
 import { useLibraryTemplatesLive } from "../../hooks/use-library-templates-live";
+import { useTranslate } from "../../i18n/use-translate";
 import { withOrigin } from "../../routing/with-origin";
 import { useCurrentWorkout, useLoadWorkout } from "../../store/selectors";
 import type { WorkoutTemplate } from "../../types/workout-library";
@@ -41,6 +42,7 @@ import { useLibrarySchedule } from "./use-library-schedule";
 import { useScheduleTemplate } from "./use-schedule-template";
 
 export default function LibraryPage() {
+  const t = useTranslate("library");
   const templates = useLibraryTemplatesLive();
   const persistence = usePersistence();
   const { error: showError, success: showSuccess } = useToastContext();
@@ -57,8 +59,8 @@ export default function LibraryPage() {
       await deleteTemplate(persistence, id);
     } catch (err) {
       showError(
-        "Delete Failed",
-        err instanceof Error ? err.message : "Failed to delete template",
+        t("toast.deleteFailed"),
+        err instanceof Error ? err.message : t("toast.deleteFailedDescription"),
         { duration: 5000 }
       );
     }
@@ -71,7 +73,7 @@ export default function LibraryPage() {
     // Title is a static literal (PII guard R-PIIInterpolation);
     // template.name flows through the description field which the
     // guard intentionally does not constrain.
-    showSuccess("Template loaded", template.name, { duration: 3000 });
+    showSuccess(t("toast.templateLoaded"), template.name, { duration: 3000 });
     // SPA navigation (no full reload) so the freshly-loaded workout
     // survives the route transition. Hard reload would drop Zustand.
     // `?source=scratch` mounts the editor directly with the
@@ -87,7 +89,7 @@ export default function LibraryPage() {
       <LibraryHeader count={templates?.length ?? 0} />
       {templates === undefined ? (
         <div className="flex items-center justify-center p-8 text-slate-400">
-          Loading library...
+          {t("page.loading")}
         </div>
       ) : (
         <>

--- a/packages/workout-spa-editor/src/i18n/locales/en/library.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/library.json
@@ -1,0 +1,116 @@
+{
+  "page": {
+    "loading": "Loading library..."
+  },
+  "header": {
+    "title": "Library",
+    "count_one": "{{count}} workout",
+    "count_other": "{{count}} workouts"
+  },
+  "search": {
+    "placeholder": "Search workouts...",
+    "ariaLabel": "Search workouts"
+  },
+  "sport": {
+    "all": "All",
+    "cycling": "Cycling",
+    "running": "Running",
+    "swim": "Swim"
+  },
+  "empty": {
+    "title": "Your library is empty",
+    "message": "Save a workout to your library to get started.",
+    "createMessage": "Create your first workout and save it to your library to get started.",
+    "filteredTitle": "No workouts found",
+    "filteredMessage": "No workouts match your current filters."
+  },
+  "card": {
+    "schedule": "Schedule",
+    "load": "Load",
+    "loadAria": "Load {{name}} into editor",
+    "deleteAria": "Delete {{name}}",
+    "thumbnailAlt": "{{name}} preview"
+  },
+  "actions": {
+    "cancel": "Cancel",
+    "delete": "Delete",
+    "save": "Save"
+  },
+  "deleteDialog": {
+    "title": "Delete Workout",
+    "confirm": "Delete \"{{name}}\"? This cannot be undone.",
+    "description": "Are you sure you want to delete \"{{name}}\"? This action cannot be undone."
+  },
+  "filters": {
+    "clearFilters": "Clear Filters",
+    "tagsLabel": "Tags:",
+    "sport": {
+      "label": "Sport",
+      "all": "All Sports",
+      "cycling": "Cycling",
+      "running": "Running",
+      "swimming": "Swimming",
+      "generic": "Generic"
+    },
+    "difficulty": {
+      "label": "Difficulty",
+      "all": "All Levels",
+      "easy": "Easy",
+      "medium": "Medium",
+      "hard": "Hard"
+    },
+    "sortBy": {
+      "label": "Sort By",
+      "name": "Name",
+      "dateCreated": "Date Created",
+      "difficulty": "Difficulty"
+    },
+    "sortOrder": {
+      "label": "Order",
+      "asc": "Ascending",
+      "desc": "Descending"
+    }
+  },
+  "saveDialog": {
+    "title": "Save to Library",
+    "description": "Add details to organize your workout in the library.",
+    "saving": "Saving...",
+    "name": {
+      "label": "Workout Name *",
+      "placeholder": "e.g., Sweet Spot Intervals"
+    },
+    "tags": {
+      "label": "Tags (comma-separated)",
+      "placeholder": "e.g., intervals, endurance"
+    },
+    "difficulty": {
+      "label": "Difficulty",
+      "placeholder": "Select difficulty",
+      "easy": "Easy",
+      "moderate": "Moderate",
+      "hard": "Hard",
+      "veryHard": "Very Hard"
+    },
+    "notes": {
+      "label": "Notes",
+      "placeholder": "Add notes about this workout...",
+      "charCount": "{{count}}/1000 characters"
+    }
+  },
+  "staleDialog": {
+    "title": "Stale Workout Conflict",
+    "description": "The source description has changed since you last edited this workout. Your edits may conflict with the new content.",
+    "viewDiff": "View Diff",
+    "reprocess": "Re-process Anyway",
+    "keepVersion": "Keep My Version"
+  },
+  "toast": {
+    "deleteFailed": "Delete Failed",
+    "deleteFailedDescription": "Failed to delete template",
+    "templateLoaded": "Template loaded",
+    "workoutSaved": "Workout Saved",
+    "workoutSavedDescription": "\"{{name}}\" has been added to your library",
+    "saveFailed": "Save Failed",
+    "saveFailedDescription": "Failed to save workout"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/library.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/library.json
@@ -1,0 +1,116 @@
+{
+  "page": {
+    "loading": "Cargando biblioteca..."
+  },
+  "header": {
+    "title": "Biblioteca",
+    "count_one": "{{count}} entrenamiento",
+    "count_other": "{{count}} entrenamientos"
+  },
+  "search": {
+    "placeholder": "Buscar entrenamientos...",
+    "ariaLabel": "Buscar entrenamientos"
+  },
+  "sport": {
+    "all": "Todos",
+    "cycling": "Ciclismo",
+    "running": "Carrera",
+    "swim": "Natación"
+  },
+  "empty": {
+    "title": "Tu biblioteca está vacía",
+    "message": "Guarda un entrenamiento en tu biblioteca para empezar.",
+    "createMessage": "Crea tu primer entrenamiento y guárdalo en tu biblioteca para empezar.",
+    "filteredTitle": "No se encontraron entrenamientos",
+    "filteredMessage": "Ningún entrenamiento coincide con tus filtros actuales."
+  },
+  "card": {
+    "schedule": "Programar",
+    "load": "Cargar",
+    "loadAria": "Cargar {{name}} en el editor",
+    "deleteAria": "Eliminar {{name}}",
+    "thumbnailAlt": "Vista previa de {{name}}"
+  },
+  "actions": {
+    "cancel": "Cancelar",
+    "delete": "Eliminar",
+    "save": "Guardar"
+  },
+  "deleteDialog": {
+    "title": "Eliminar entrenamiento",
+    "confirm": "¿Eliminar \"{{name}}\"? Esto no se puede deshacer.",
+    "description": "¿Seguro que quieres eliminar \"{{name}}\"? Esta acción no se puede deshacer."
+  },
+  "filters": {
+    "clearFilters": "Borrar filtros",
+    "tagsLabel": "Etiquetas:",
+    "sport": {
+      "label": "Deporte",
+      "all": "Todos los deportes",
+      "cycling": "Ciclismo",
+      "running": "Carrera",
+      "swimming": "Natación",
+      "generic": "Genérico"
+    },
+    "difficulty": {
+      "label": "Dificultad",
+      "all": "Todos los niveles",
+      "easy": "Fácil",
+      "medium": "Media",
+      "hard": "Difícil"
+    },
+    "sortBy": {
+      "label": "Ordenar por",
+      "name": "Nombre",
+      "dateCreated": "Fecha de creación",
+      "difficulty": "Dificultad"
+    },
+    "sortOrder": {
+      "label": "Orden",
+      "asc": "Ascendente",
+      "desc": "Descendente"
+    }
+  },
+  "saveDialog": {
+    "title": "Guardar en la biblioteca",
+    "description": "Añade detalles para organizar tu entrenamiento en la biblioteca.",
+    "saving": "Guardando...",
+    "name": {
+      "label": "Nombre del entrenamiento *",
+      "placeholder": "p. ej., Series de Sweet Spot"
+    },
+    "tags": {
+      "label": "Etiquetas (separadas por comas)",
+      "placeholder": "p. ej., series, resistencia"
+    },
+    "difficulty": {
+      "label": "Dificultad",
+      "placeholder": "Selecciona la dificultad",
+      "easy": "Fácil",
+      "moderate": "Moderada",
+      "hard": "Difícil",
+      "veryHard": "Muy difícil"
+    },
+    "notes": {
+      "label": "Notas",
+      "placeholder": "Añade notas sobre este entrenamiento...",
+      "charCount": "{{count}}/1000 caracteres"
+    }
+  },
+  "staleDialog": {
+    "title": "Conflicto de entrenamiento obsoleto",
+    "description": "La descripción de origen ha cambiado desde la última vez que editaste este entrenamiento. Tus cambios pueden entrar en conflicto con el nuevo contenido.",
+    "viewDiff": "Ver diferencias",
+    "reprocess": "Reprocesar de todos modos",
+    "keepVersion": "Mantener mi versión"
+  },
+  "toast": {
+    "deleteFailed": "Error al eliminar",
+    "deleteFailedDescription": "No se pudo eliminar la plantilla",
+    "templateLoaded": "Plantilla cargada",
+    "workoutSaved": "Entrenamiento guardado",
+    "workoutSavedDescription": "\"{{name}}\" se ha añadido a tu biblioteca",
+    "saveFailed": "Error al guardar",
+    "saveFailedDescription": "No se pudo guardar el entrenamiento"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -14,6 +14,7 @@ import enEditor from "./locales/en/editor.json";
 import enErrors from "./locales/en/errors.json";
 import enLabImport from "./locales/en/labImport.json";
 import enLabs from "./locales/en/labs.json";
+import enLibrary from "./locales/en/library.json";
 import enNav from "./locales/en/nav.json";
 import enSettings from "./locales/en/settings.json";
 import enTargets from "./locales/en/targets.json";
@@ -24,6 +25,7 @@ import esEditor from "./locales/es/editor.json";
 import esErrors from "./locales/es/errors.json";
 import esLabImport from "./locales/es/labImport.json";
 import esLabs from "./locales/es/labs.json";
+import esLibrary from "./locales/es/library.json";
 import esNav from "./locales/es/nav.json";
 import esSettings from "./locales/es/settings.json";
 import esTargets from "./locales/es/targets.json";
@@ -36,6 +38,7 @@ export const NAMESPACES = [
   "errors",
   "labs",
   "labImport",
+  "library",
   "nav",
   "settings",
   "targets",
@@ -52,6 +55,7 @@ export const resources: LocaleResources = {
     errors: enErrors,
     labs: enLabs,
     labImport: enLabImport,
+    library: enLibrary,
     nav: enNav,
     settings: enSettings,
     targets: enTargets,
@@ -64,6 +68,7 @@ export const resources: LocaleResources = {
     errors: esErrors,
     labs: esLabs,
     labImport: esLabImport,
+    library: esLibrary,
     nav: esNav,
     settings: esSettings,
     targets: esTargets,


### PR DESCRIPTION
## What

Ninth SPA i18n PR. New `library` namespace across the Library surface.

- Library page, list/card views, filters (search, sort, difficulty, sport chips, tags), empty states, Save-to-Library dialog, delete confirmation, stale-conflict dialog.
- **Plurals**: manual `count_one`/`count_other` selection matches the original's singular/plural branching.
- **Two distinct difficulty vocabularies** kept separate: filter ("All Levels"/"Medium") vs dialog ("Moderate"/"Very Hard").
- Delete/save copy interpolates the workout `{{name}}`; toasts via `t("literal.key")`.

## Verification

- Touched-dir + i18n suites (pages + organisms + molecules + i18n): **2303/2303**.
- `tsc --noEmit` clean · eslint clean · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)