### PR TITLE
feat(spa-editor): localize the create-workout & AI input flow (create-workout namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/AiBanner/AiBanner.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/AiBanner/AiBanner.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, Sparkles } from "lucide-react";
 import { lazy, Suspense } from "react";
 import { useLocation } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { useAiBannerState } from "./use-ai-banner-state";
 
 const AiWorkoutInput = lazy(() =>
@@ -19,6 +20,7 @@ const AiWorkoutInput = lazy(() =>
  * and runs the one-shot auto-collapse-on-first-success rule.
  */
 export function AiBanner() {
+  const t = useTranslate("create-workout");
   const [, navigate] = useLocation();
   const { open, toggle } = useAiBannerState();
 
@@ -36,7 +38,7 @@ export function AiBanner() {
       >
         <span className="flex items-center gap-2 text-sm font-semibold text-blue-700 dark:text-blue-300">
           <Sparkles className="h-4 w-4" />
-          Generate with AI
+          {t("banner.toggle")}
         </span>
         <ChevronDown
           className={`h-4 w-4 text-blue-600 transition-transform dark:text-blue-400 ${open ? "rotate-180" : ""}`}

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiWorkoutForm.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiWorkoutForm.tsx
@@ -2,6 +2,7 @@ import type { Sport } from "@kaiord/core";
 import { Sparkles } from "lucide-react";
 import { useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { useAiRuntimeStore } from "../../../store/ai-runtime-store";
 import { Button } from "../../atoms/Button";
 import { AiSuccessActionsContainer } from "./AiSuccessActionsContainer";
@@ -11,6 +12,7 @@ import { useAiGeneration } from "./useAiGeneration";
 import { ZoneIndicator } from "./ZoneIndicator";
 
 export const AiWorkoutForm: React.FC = () => {
+  const t = useTranslate("create-workout");
   const [text, setText] = useState("");
   const [sport, setSport] = useState("");
   const generation = useAiRuntimeStore((s) => s.generation);
@@ -26,15 +28,15 @@ export const AiWorkoutForm: React.FC = () => {
   return (
     <div className="space-y-4">
       <label htmlFor="ai-workout-description" className="sr-only">
-        Workout description
+        {t("form.descriptionLabel")}
       </label>
       <textarea
         id="ai-workout-description"
-        aria-label="Workout description"
+        aria-label={t("form.descriptionLabel")}
         className="w-full rounded-lg border border-blue-200 bg-white p-4 text-sm shadow-inner placeholder:text-gray-400 focus:border-blue-400 focus:ring-2 focus:ring-blue-200 dark:border-blue-700 dark:bg-gray-800 dark:text-white dark:placeholder:text-gray-500 dark:focus:ring-blue-800"
         rows={4}
         maxLength={2000}
-        placeholder="e.g., '45min sweet spot cycling: 10min warmup, 3x10min at 90% FTP with 2min recovery, 5min cooldown'"
+        placeholder={t("form.placeholder")}
         value={text}
         onChange={(e) => setText(e.target.value)}
         disabled={isLoading}
@@ -50,7 +52,7 @@ export const AiWorkoutForm: React.FC = () => {
           className="bg-blue-600 hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600"
         >
           <Sparkles className="mr-1.5 h-4 w-4" />
-          Generate Workout
+          {t("form.generate")}
         </Button>
       </div>
       {generation.status === "error" && (

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiWorkoutInput.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiWorkoutInput.tsx
@@ -1,6 +1,7 @@
 import { Sparkles } from "lucide-react";
 
 import { useAiProvidersLive } from "../../../hooks/use-ai-providers-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { AiWorkoutForm } from "./AiWorkoutForm";
 import { AiWorkoutInputEmpty } from "./AiWorkoutInputEmpty";
 
@@ -11,6 +12,7 @@ type AiWorkoutInputProps = {
 export const AiWorkoutInput: React.FC<AiWorkoutInputProps> = ({
   onSettingsClick,
 }) => {
+  const t = useTranslate("create-workout");
   const providers = useAiProvidersLive();
 
   // `undefined` is the loading phase. Render nothing so the gradient
@@ -23,11 +25,11 @@ export const AiWorkoutInput: React.FC<AiWorkoutInputProps> = ({
       <div className="mb-3 flex items-center gap-2">
         <Sparkles className="h-6 w-6 text-blue-600 dark:text-blue-400" />
         <h2 className="text-xl font-bold text-gray-900 dark:text-white">
-          AI Workout Generator
+          {t("generator.title")}
         </h2>
       </div>
       <p className="mb-5 text-sm text-gray-600 dark:text-gray-400">
-        Describe your workout in natural language and let AI create it.
+        {t("generator.subtitle")}
       </p>
       {providers.length === 0 ? (
         <AiWorkoutInputEmpty onSettingsClick={onSettingsClick} />

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiWorkoutInputEmpty.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/AiWorkoutInputEmpty.tsx
@@ -1,5 +1,6 @@
 import { Settings } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button";
 
 type AiWorkoutInputEmptyProps = {
@@ -8,17 +9,20 @@ type AiWorkoutInputEmptyProps = {
 
 export const AiWorkoutInputEmpty = ({
   onSettingsClick,
-}: AiWorkoutInputEmptyProps) => (
-  <div className="rounded-lg border border-dashed border-blue-300 bg-white/60 p-5 text-center dark:border-blue-700 dark:bg-gray-800/60">
-    <p className="mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">
-      Configure an AI provider to get started
-    </p>
-    <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
-      Supports Anthropic (Claude), OpenAI (GPT), and Google (Gemini)
-    </p>
-    <Button size="sm" onClick={onSettingsClick}>
-      <Settings className="mr-1.5 h-3.5 w-3.5" />
-      Open Settings
-    </Button>
-  </div>
-);
+}: AiWorkoutInputEmptyProps) => {
+  const t = useTranslate("create-workout");
+  return (
+    <div className="rounded-lg border border-dashed border-blue-300 bg-white/60 p-5 text-center dark:border-blue-700 dark:bg-gray-800/60">
+      <p className="mb-1 text-sm font-medium text-gray-700 dark:text-gray-300">
+        {t("providersEmpty.title")}
+      </p>
+      <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
+        {t("empty.supports")}
+      </p>
+      <Button size="sm" onClick={onSettingsClick}>
+        <Settings className="mr-1.5 h-3.5 w-3.5" />
+        {t("empty.openSettings")}
+      </Button>
+    </div>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/ModelSelector.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/ModelSelector.tsx
@@ -1,7 +1,9 @@
 import { useAiProvidersLive } from "../../../hooks/use-ai-providers-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { useAiRuntimeStore } from "../../../store/ai-runtime-store";
 
 export const ModelSelector: React.FC = () => {
+  const t = useTranslate("create-workout");
   const providers = useAiProvidersLive();
   const selectedProviderId = useAiRuntimeStore((s) => s.selectedProviderId);
   const selectForGeneration = useAiRuntimeStore((s) => s.selectForGeneration);
@@ -19,7 +21,7 @@ export const ModelSelector: React.FC = () => {
         htmlFor="ai-model-select"
         className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300"
       >
-        Model
+        {t("model.label")}
       </label>
       <select
         id="ai-model-select"

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/SportSelect.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/SportSelect.tsx
@@ -1,9 +1,11 @@
+import { useTranslate } from "../../../i18n/use-translate";
+
 const SPORT_OPTIONS = [
-  { value: "", label: "Auto-detect" },
-  { value: "cycling", label: "Cycling" },
-  { value: "running", label: "Running" },
-  { value: "swimming", label: "Swimming" },
-  { value: "generic", label: "Generic" },
+  { value: "", labelKey: "sportOptions.autoDetect" },
+  { value: "cycling", labelKey: "sportOptions.cycling" },
+  { value: "running", labelKey: "sportOptions.running" },
+  { value: "swimming", labelKey: "sportOptions.swimming" },
+  { value: "generic", labelKey: "sportOptions.generic" },
 ];
 
 type SportSelectProps = {
@@ -11,25 +13,28 @@ type SportSelectProps = {
   onChange: (value: string) => void;
 };
 
-export const SportSelect = ({ value, onChange }: SportSelectProps) => (
-  <div className="w-full">
-    <label
-      htmlFor="ai-sport-select"
-      className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300"
-    >
-      Sport
-    </label>
-    <select
-      id="ai-sport-select"
-      className="w-full rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-    >
-      {SPORT_OPTIONS.map((o) => (
-        <option key={o.value} value={o.value}>
-          {o.label}
-        </option>
-      ))}
-    </select>
-  </div>
-);
+export const SportSelect = ({ value, onChange }: SportSelectProps) => {
+  const t = useTranslate("create-workout");
+  return (
+    <div className="w-full">
+      <label
+        htmlFor="ai-sport-select"
+        className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300"
+      >
+        {t("sport")}
+      </label>
+      <select
+        id="ai-sport-select"
+        className="w-full rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {SPORT_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {t(o.labelKey)}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/ZoneIndicator.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AiWorkoutInput/ZoneIndicator.tsx
@@ -5,6 +5,7 @@
  */
 
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { SportKey } from "../../../types/sport-zones";
 import { formatThresholdSummary } from "./zone-indicator-helpers";
 
@@ -13,6 +14,7 @@ type ZoneIndicatorProps = {
 };
 
 export function ZoneIndicator({ sport }: ZoneIndicatorProps) {
+  const t = useTranslate("create-workout");
   // Live read of the active profile via the Dexie singleton (D1).
   // `undefined` while loading collapses to `null` so the "No profile
   // selected" branch renders during the initial paint, matching the
@@ -22,7 +24,7 @@ export function ZoneIndicator({ sport }: ZoneIndicatorProps) {
   if (!profile) {
     return (
       <p className="text-xs text-gray-400 dark:text-gray-500">
-        No profile selected. Set up a profile to include training zones.
+        {t("zoneIndicator.noProfile")}
       </p>
     );
   }
@@ -33,14 +35,14 @@ export function ZoneIndicator({ sport }: ZoneIndicatorProps) {
   if (sportKey && !config) {
     return (
       <p className="text-xs text-amber-600 dark:text-amber-400">
-        No {sportKey} zones configured for {profile.name}.
+        {t("zoneIndicator.noZones", { sport: sportKey, name: profile.name })}
       </p>
     );
   }
 
   const summary = config
     ? formatThresholdSummary(config.thresholds)
-    : `Profile: ${profile.name}`;
+    : t("zoneIndicator.profile", { name: profile.name });
 
   return (
     <p className="text-xs text-gray-600 dark:text-gray-400">

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateGeneratingPhase.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateGeneratingPhase.tsx
@@ -1,11 +1,14 @@
+import { useTranslate } from "../../../i18n/use-translate";
+
 const SKELETON_ROWS = [0, 1, 2, 3];
 
 /** Loading phase: spinner-style heading plus shimmering skeleton rows. */
 export function CreateGeneratingPhase() {
+  const t = useTranslate("create-workout");
   return (
     <div className="flex flex-col gap-4">
       <p className="text-center text-[16px] font-semibold text-slate-200">
-        Designing your session…
+        {t("generating.title")}
       </p>
       <div className="flex flex-col gap-3">
         {SKELETON_ROWS.map((row) => (

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateInputHero.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateInputHero.tsx
@@ -1,5 +1,6 @@
 import type { ChangeEvent } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 import { Pill } from "../../atoms/Pill";
@@ -21,6 +22,7 @@ export function CreateInputHero({
   onPromptChange,
   onGenerate,
 }: CreateInputHeroProps) {
+  const t = useTranslate("create-workout");
   const canGenerate = promptText.trim().length > 0;
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) =>
     onPromptChange(e.target.value);
@@ -30,26 +32,29 @@ export function CreateInputHero({
       <div className="mb-3 flex items-center gap-2">
         <Icon icon={ICON_MAP.sparkle} size="sm" className="text-sky-400" />
         <span className="text-[15px] font-semibold text-slate-50">
-          Describe it in plain words
+          {t("hero.describe")}
         </span>
       </div>
       <textarea
         rows={3}
         value={promptText}
         onChange={handleChange}
-        placeholder="e.g. 4×4 VO₂ max intervals with a long warm-up…"
+        placeholder={t("hero.placeholder")}
         className={TEXTAREA_CLASS}
       />
       <div className="mt-3 flex flex-wrap gap-2">
-        {EXAMPLE_PROMPTS.map((prompt) => (
-          <button
-            key={prompt}
-            type="button"
-            onClick={() => onPromptChange(prompt)}
-          >
-            <Pill tone="neutral">{prompt}</Pill>
-          </button>
-        ))}
+        {EXAMPLE_PROMPTS.map((prompt) => {
+          const label = t(prompt.label);
+          return (
+            <button
+              key={prompt.key}
+              type="button"
+              onClick={() => onPromptChange(label)}
+            >
+              <Pill tone="neutral">{label}</Pill>
+            </button>
+          );
+        })}
       </div>
       <Button
         className={`mt-4 w-full ${canGenerate ? "" : "opacity-50"}`}
@@ -57,10 +62,10 @@ export function CreateInputHero({
         onClick={onGenerate}
       >
         <Icon icon={ICON_MAP.sparkle} size="sm" color="inherit" />
-        Generate workout
+        {t("hero.generate")}
       </Button>
       <p className="mt-2 text-center text-[12.5px] text-slate-500">
-        Built around your {sportLabel} zones
+        {t("hero.builtAround", { sport: sportLabel })}
       </p>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateInputPhase.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateInputPhase.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { ActiveSport } from "../../../lib/athlete";
 import { ATHLETE_SPORTS } from "../../../lib/athlete";
 import type { LlmProviderConfig } from "../../../store/ai-store-types";
@@ -34,18 +35,19 @@ export function CreateInputPhase({
   onGenerate,
   onClose,
 }: CreateInputPhaseProps) {
+  const t = useTranslate("create-workout");
   const [, navigate] = useLocation();
   const sportLabel =
     SPORT_OPTIONS.find((o) => o.value === sport)?.label.toLowerCase() ?? "";
 
   return (
     <div className="flex flex-col gap-4">
-      <CreateSheetHeader title="New session" onClose={onClose} />
+      <CreateSheetHeader title={t("sheet.newSession")} onClose={onClose} />
       <Segmented
         options={SPORT_OPTIONS}
         value={sport}
         onChange={onSportChange}
-        ariaLabel="Sport"
+        ariaLabel={t("sport")}
       />
       {provider ? (
         <CreateInputHero

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateProvidersEmpty.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateProvidersEmpty.tsx
@@ -1,10 +1,12 @@
 import { useLocation } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
 /** Empty state shown when no AI provider is configured. */
 export function CreateProvidersEmpty() {
+  const t = useTranslate("create-workout");
   const [, navigate] = useLocation();
 
   return (
@@ -15,14 +17,14 @@ export function CreateProvidersEmpty() {
         className="mx-auto mb-3 text-sky-400"
       />
       <p className="mb-1 text-[15px] font-semibold text-slate-50">
-        Configure an AI provider to get started
+        {t("providersEmpty.title")}
       </p>
       <p className="mb-4 text-[12.5px] text-slate-500">
-        Supports Anthropic, OpenAI, and Google
+        {t("providersEmpty.supports")}
       </p>
       <Button onClick={() => navigate("/settings/ai")}>
         <Icon icon={ICON_MAP.gear} size="sm" color="inherit" />
-        Open AI settings
+        {t("providersEmpty.openSettings")}
       </Button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateResultHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateResultHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { ActiveSport } from "../../../lib/athlete";
 import { Icon, ICON_MAP, SPORT_ICON_NAME } from "../../atoms/Icon";
 import { Pill } from "../../atoms/Pill";
@@ -9,6 +10,7 @@ export type CreateResultHeaderProps = {
 
 /** Generated-session header: sport tile, title, AI provenance pill. */
 export function CreateResultHeader({ sport, title }: CreateResultHeaderProps) {
+  const t = useTranslate("create-workout");
   return (
     <div className="flex items-center gap-3">
       <div className="flex h-11 w-11 items-center justify-center rounded-[14px] bg-surface-deep">
@@ -20,12 +22,10 @@ export function CreateResultHeader({ sport, title }: CreateResultHeaderProps) {
             {title}
           </span>
           <Pill tone="accent" icon="sparkle">
-            AI
+            {t("result.aiBadge")}
           </Pill>
         </div>
-        <p className="text-[12.5px] text-slate-500">
-          Tap any step to fine-tune
-        </p>
+        <p className="text-[12.5px] text-slate-500">{t("result.tapToTune")}</p>
       </div>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateResultPhase.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateResultPhase.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { ActiveSport } from "../../../lib/athlete";
 import type { ReviewModel } from "../../../lib/workout-review";
 import { Button } from "../../atoms/Button";
@@ -27,20 +28,29 @@ export function CreateResultPhase({
   onSave,
   onClose,
 }: CreateResultPhaseProps) {
+  const t = useTranslate("create-workout");
   const summary = [
-    { icon: "clock" as const, value: model.duration, label: "Duration" },
-    { icon: "flame" as const, value: String(model.tss), label: "TSS" },
-    { icon: "zap" as const, value: model.load, label: "Load" },
+    {
+      icon: "clock" as const,
+      value: model.duration,
+      label: t("summary.duration"),
+    },
+    {
+      icon: "flame" as const,
+      value: String(model.tss),
+      label: t("summary.tss"),
+    },
+    { icon: "zap" as const, value: model.load, label: t("summary.load") },
   ];
 
   return (
     <div className="flex flex-col gap-4">
-      <CreateSheetHeader title="Review session" onClose={onClose} />
+      <CreateSheetHeader title={t("sheet.reviewSession")} onClose={onClose} />
       <CreateResultHeader sport={sport} title={model.title} />
       <SummaryStrip items={summary} />
       <div className="rounded-[16px] border border-slate-800 bg-surface p-4">
         <p className="mb-3 text-[12px] font-semibold uppercase tracking-[0.08em] text-slate-500">
-          Time in zone
+          {t("result.timeInZone")}
         </p>
         <ZoneDist dist={model.dist} height={ZONE_BAR_HEIGHT} className="mb-3" />
         <StepList steps={model.steps} />
@@ -48,11 +58,11 @@ export function CreateResultPhase({
       <div className="flex gap-3">
         <Button variant="ghost" onClick={onRedo}>
           <Icon icon={ICON_MAP.sync} size="sm" color="inherit" />
-          Redo
+          {t("result.redo")}
         </Button>
         <Button className="flex-grow" loading={saving} onClick={onSave}>
           <Icon icon={ICON_MAP.check} size="sm" color="inherit" />
-          Save & push
+          {t("result.savePush")}
         </Button>
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateSheetHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateSheetHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
 export type CreateSheetHeaderProps = {
@@ -7,12 +8,13 @@ export type CreateSheetHeaderProps = {
 
 /** Full-width sheet header with a title and a close button. */
 export function CreateSheetHeader({ title, onClose }: CreateSheetHeaderProps) {
+  const t = useTranslate("common");
   return (
     <div className="mb-4 flex items-center justify-between">
       <h2 className="text-[19px] font-bold text-slate-50">{title}</h2>
       <button
         type="button"
-        aria-label="Close"
+        aria-label={t("actions.close")}
         onClick={onClose}
         className="rounded-full p-1.5 text-slate-400 transition-colors hover:bg-white/5 hover:text-slate-200"
       >

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateStartFrom.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateStartFrom.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Icon, ICON_MAP, type IconName } from "../../atoms/Icon";
 
 export type CreateStartFromProps = {
@@ -16,10 +17,26 @@ export function CreateStartFrom({
   onBlank,
   onImport,
 }: CreateStartFromProps) {
+  const t = useTranslate("create-workout");
   const tiles: Tile[] = [
-    { key: "template", label: "Template", icon: "cards", onClick: onTemplate },
-    { key: "blank", label: "Blank", icon: "plus", onClick: onBlank },
-    { key: "import", label: "Import file", icon: "upload", onClick: onImport },
+    {
+      key: "template",
+      label: t("startFrom.template"),
+      icon: "cards",
+      onClick: onTemplate,
+    },
+    {
+      key: "blank",
+      label: t("startFrom.blank"),
+      icon: "plus",
+      onClick: onBlank,
+    },
+    {
+      key: "import",
+      label: t("startFrom.import"),
+      icon: "upload",
+      onClick: onImport,
+    },
   ];
 
   return (
@@ -27,7 +44,7 @@ export function CreateStartFrom({
       <div className="my-5 flex items-center gap-3">
         <span className="h-px flex-1 bg-slate-800" />
         <span className="text-[12px] font-semibold uppercase tracking-[0.08em] text-slate-500">
-          or start from
+          {t("startFrom.divider")}
         </span>
         <span className="h-px flex-1 bg-slate-800" />
       </div>

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateWorkout.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/CreateWorkout.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { thresholdsForSport } from "../../../lib/athlete";
 import { buildReviewModel } from "../../../lib/workout-review";
 import { ROUTE_HEADING_ATTR } from "../../../routing/constants";
@@ -6,8 +7,6 @@ import { CreateInputPhase } from "./CreateInputPhase";
 import { CreateResultPhase } from "./CreateResultPhase";
 import { useCreateSave } from "./use-create-save";
 import { useCreateWorkout } from "./use-create-workout";
-
-const FALLBACK_TITLE = "AI session";
 
 export type CreateWorkoutProps = {
   onClose: () => void;
@@ -19,6 +18,8 @@ export default function CreateWorkout({
   onClose,
   onSaved,
 }: CreateWorkoutProps) {
+  const t = useTranslate("create-workout");
+  const FALLBACK_TITLE = t("fallbackTitle");
   const create = useCreateWorkout();
   const { phase, sport, profile, activeProfileId, generatedKrd, promptText } =
     create;
@@ -50,7 +51,7 @@ export default function CreateWorkout({
           heading — exposes a focus target for useFocusOnRouteChange. Copy is
           stable across phases; phase-specific titles live in CreateSheetHeader. */}
       <h1 tabIndex={-1} {...{ [ROUTE_HEADING_ATTR]: "" }} className="sr-only">
-        New session
+        {t("sheet.newSession")}
       </h1>
       {phase === "input" && (
         <CreateInputPhase

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/example-prompts.ts
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/example-prompts.ts
@@ -1,7 +1,17 @@
-/** Tap-to-fill prompt suggestions shown on the Create input phase. */
-export const EXAMPLE_PROMPTS: readonly string[] = [
-  "45 min Z2 endurance ride",
-  "4×4 VO₂ max intervals",
-  "Sweet spot 3×12 @ 90%",
-  "10k tempo run with strides",
+/**
+ * Tap-to-fill prompt suggestions shown on the Create input phase. `key` is the
+ * stable React key and the i18n key selector; `label` is the dotted
+ * `create-workout` translation key resolved at render. The visible (translated)
+ * label becomes the prompt payload when a chip is tapped.
+ */
+export type ExamplePrompt = {
+  key: string;
+  label: string;
+};
+
+export const EXAMPLE_PROMPTS: readonly ExamplePrompt[] = [
+  { key: "enduranceRide", label: "examples.enduranceRide" },
+  { key: "vo2Intervals", label: "examples.vo2Intervals" },
+  { key: "sweetSpot", label: "examples.sweetSpot" },
+  { key: "tempoRun", label: "examples.tempoRun" },
 ];

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/use-create-workout.ts
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/use-create-workout.ts
@@ -8,14 +8,13 @@ import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import { useAiCustomPromptLive } from "../../../hooks/use-ai-custom-prompt-live";
 import { useAiModelBindingsLive } from "../../../hooks/use-ai-model-bindings-live";
 import { useAiProvidersLive } from "../../../hooks/use-ai-providers-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { ActiveSport } from "../../../lib/athlete";
 import { ATHLETE_SPORTS } from "../../../lib/athlete";
 import { generateWorkoutKrd } from "../../../lib/generate-workout";
 import { formatZonesContext } from "../../organisms/AiWorkoutInput/zones-formatter";
 
 export type CreatePhase = "input" | "generating" | "result";
-
-const GENERATION_FAILED = "Workout generation failed";
 
 export function useCreateWorkout() {
   const [phase, setPhase] = useState<CreatePhase>("input");
@@ -28,6 +27,7 @@ export function useCreateWorkout() {
   const bindings = useAiModelBindingsLive(active?.id ?? null);
   const customPrompt = useAiCustomPromptLive();
   const toast = useToastContext();
+  const t = useTranslate("create-workout");
   const search = useSearch();
   const dateParam = new URLSearchParams(search).get("date");
 
@@ -58,9 +58,9 @@ export function useCreateWorkout() {
       setPhase("result");
     } catch {
       setPhase("input");
-      toast.error(GENERATION_FAILED);
+      toast.error(t("toast.generationFailed"));
     }
-  }, [promptText, resolved, active, sport, customPrompt, toast]);
+  }, [promptText, resolved, active, sport, customPrompt, toast, t]);
 
   return {
     phase,

--- a/packages/workout-spa-editor/src/components/pages/CreateWorkout/use-save-and-push.ts
+++ b/packages/workout-spa-editor/src/components/pages/CreateWorkout/use-save-and-push.ts
@@ -3,11 +3,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { db } from "../../../adapters/dexie/dexie-database";
 import { useGarminBridge } from "../../../contexts";
 import { useToastContext } from "../../../contexts/ToastContext";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import { useGarminPush } from "../../molecules/GarminPushButton/useGarminPush";
-
-const SAVED_AND_PUSHED = "Saved & pushed to Garmin";
-const SAVED_ONLY = "Workout saved";
 
 export type SaveAndPushInput = {
   buildRecord: () => Promise<WorkoutRecord>;
@@ -25,6 +23,7 @@ export function useSaveAndPush({ buildRecord, onDone }: SaveAndPushInput) {
   const [saving, setSaving] = useState(false);
   const { sessionActive } = useGarminBridge();
   const toast = useToastContext();
+  const t = useTranslate("create-workout");
   const { push } = useGarminPush(record);
   const pendingRef = useRef(false);
 
@@ -42,14 +41,14 @@ export function useSaveAndPush({ buildRecord, onDone }: SaveAndPushInput) {
     void (async () => {
       if (sessionActive) {
         await push();
-        toast.success(SAVED_AND_PUSHED);
+        toast.success(t("toast.savedAndPushed"));
       } else {
-        toast.success(SAVED_ONLY);
+        toast.success(t("toast.savedOnly"));
       }
       setSaving(false);
       onDone(record);
     })();
-  }, [record, sessionActive, push, toast, onDone]);
+  }, [record, sessionActive, push, toast, onDone, t]);
 
   return { save, saving };
 }

--- a/packages/workout-spa-editor/src/i18n/locales/en/create-workout.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/create-workout.json
@@ -1,0 +1,82 @@
+{
+  "sheet": {
+    "newSession": "New session",
+    "reviewSession": "Review session"
+  },
+  "sport": "Sport",
+  "hero": {
+    "describe": "Describe it in plain words",
+    "placeholder": "e.g. 4×4 VO₂ max intervals with a long warm-up…",
+    "generate": "Generate workout",
+    "builtAround": "Built around your {{sport}} zones"
+  },
+  "examples": {
+    "enduranceRide": "45 min Z2 endurance ride",
+    "vo2Intervals": "4×4 VO₂ max intervals",
+    "sweetSpot": "Sweet spot 3×12 @ 90%",
+    "tempoRun": "10k tempo run with strides"
+  },
+  "generating": {
+    "title": "Designing your session…"
+  },
+  "result": {
+    "aiBadge": "AI",
+    "tapToTune": "Tap any step to fine-tune",
+    "timeInZone": "Time in zone",
+    "redo": "Redo",
+    "savePush": "Save & push"
+  },
+  "summary": {
+    "duration": "Duration",
+    "tss": "TSS",
+    "load": "Load"
+  },
+  "startFrom": {
+    "divider": "or start from",
+    "template": "Template",
+    "blank": "Blank",
+    "import": "Import file"
+  },
+  "providersEmpty": {
+    "title": "Configure an AI provider to get started",
+    "supports": "Supports Anthropic, OpenAI, and Google",
+    "openSettings": "Open AI settings"
+  },
+  "fallbackTitle": "AI session",
+  "generator": {
+    "title": "AI Workout Generator",
+    "subtitle": "Describe your workout in natural language and let AI create it."
+  },
+  "form": {
+    "descriptionLabel": "Workout description",
+    "placeholder": "e.g., '45min sweet spot cycling: 10min warmup, 3x10min at 90% FTP with 2min recovery, 5min cooldown'",
+    "generate": "Generate Workout"
+  },
+  "empty": {
+    "supports": "Supports Anthropic (Claude), OpenAI (GPT), and Google (Gemini)",
+    "openSettings": "Open Settings"
+  },
+  "model": {
+    "label": "Model"
+  },
+  "sportOptions": {
+    "autoDetect": "Auto-detect",
+    "cycling": "Cycling",
+    "running": "Running",
+    "swimming": "Swimming",
+    "generic": "Generic"
+  },
+  "zoneIndicator": {
+    "noProfile": "No profile selected. Set up a profile to include training zones.",
+    "noZones": "No {{sport}} zones configured for {{name}}.",
+    "profile": "Profile: {{name}}"
+  },
+  "banner": {
+    "toggle": "Generate with AI"
+  },
+  "toast": {
+    "generationFailed": "Workout generation failed",
+    "savedAndPushed": "Saved & pushed to Garmin",
+    "savedOnly": "Workout saved"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/create-workout.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/create-workout.json
@@ -1,0 +1,82 @@
+{
+  "sheet": {
+    "newSession": "Nueva sesión",
+    "reviewSession": "Revisar sesión"
+  },
+  "sport": "Deporte",
+  "hero": {
+    "describe": "Descríbelo con tus palabras",
+    "placeholder": "p. ej. 4×4 intervalos de VO₂ máx con un calentamiento largo…",
+    "generate": "Generar entreno",
+    "builtAround": "Basado en tus zonas de {{sport}}"
+  },
+  "examples": {
+    "enduranceRide": "Rodaje de resistencia Z2 de 45 min",
+    "vo2Intervals": "4×4 intervalos de VO₂ máx",
+    "sweetSpot": "Sweet spot 3×12 al 90%",
+    "tempoRun": "Carrera tempo de 10k con rectas"
+  },
+  "generating": {
+    "title": "Diseñando tu sesión…"
+  },
+  "result": {
+    "aiBadge": "IA",
+    "tapToTune": "Toca cualquier paso para ajustarlo",
+    "timeInZone": "Tiempo en zona",
+    "redo": "Rehacer",
+    "savePush": "Guardar y enviar"
+  },
+  "summary": {
+    "duration": "Duración",
+    "tss": "TSS",
+    "load": "Carga"
+  },
+  "startFrom": {
+    "divider": "o empieza desde",
+    "template": "Plantilla",
+    "blank": "En blanco",
+    "import": "Importar archivo"
+  },
+  "providersEmpty": {
+    "title": "Configura un proveedor de IA para empezar",
+    "supports": "Compatible con Anthropic, OpenAI y Google",
+    "openSettings": "Abrir ajustes de IA"
+  },
+  "fallbackTitle": "Sesión de IA",
+  "generator": {
+    "title": "Generador de entrenos con IA",
+    "subtitle": "Describe tu entreno en lenguaje natural y deja que la IA lo cree."
+  },
+  "form": {
+    "descriptionLabel": "Descripción del entreno",
+    "placeholder": "p. ej., '45min sweet spot ciclismo: 10min calentamiento, 3x10min al 90% FTP con 2min recuperación, 5min enfriamiento'",
+    "generate": "Generar entreno"
+  },
+  "empty": {
+    "supports": "Compatible con Anthropic (Claude), OpenAI (GPT) y Google (Gemini)",
+    "openSettings": "Abrir ajustes"
+  },
+  "model": {
+    "label": "Modelo"
+  },
+  "sportOptions": {
+    "autoDetect": "Detección automática",
+    "cycling": "Ciclismo",
+    "running": "Carrera",
+    "swimming": "Natación",
+    "generic": "Genérico"
+  },
+  "zoneIndicator": {
+    "noProfile": "Ningún perfil seleccionado. Configura un perfil para incluir zonas de entrenamiento.",
+    "noZones": "No hay zonas de {{sport}} configuradas para {{name}}.",
+    "profile": "Perfil: {{name}}"
+  },
+  "banner": {
+    "toggle": "Generar con IA"
+  },
+  "toast": {
+    "generationFailed": "No se pudo generar el entreno",
+    "savedAndPushed": "Guardado y enviado a Garmin",
+    "savedOnly": "Entreno guardado"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -9,6 +9,7 @@ import type { LocaleResources } from "@kaiord/i18n";
 
 import enCalendar from "./locales/en/calendar.json";
 import enCommon from "./locales/en/common.json";
+import enCreateWorkout from "./locales/en/create-workout.json";
 import enDaily from "./locales/en/daily.json";
 import enEditor from "./locales/en/editor.json";
 import enErrors from "./locales/en/errors.json";
@@ -20,6 +21,7 @@ import enSettings from "./locales/en/settings.json";
 import enTargets from "./locales/en/targets.json";
 import esCalendar from "./locales/es/calendar.json";
 import esCommon from "./locales/es/common.json";
+import esCreateWorkout from "./locales/es/create-workout.json";
 import esDaily from "./locales/es/daily.json";
 import esEditor from "./locales/es/editor.json";
 import esErrors from "./locales/es/errors.json";
@@ -33,6 +35,7 @@ import esTargets from "./locales/es/targets.json";
 export const NAMESPACES = [
   "calendar",
   "common",
+  "create-workout",
   "daily",
   "editor",
   "errors",
@@ -50,6 +53,7 @@ export const resources: LocaleResources = {
   en: {
     calendar: enCalendar,
     common: enCommon,
+    "create-workout": enCreateWorkout,
     daily: enDaily,
     editor: enEditor,
     errors: enErrors,
@@ -63,6 +67,7 @@ export const resources: LocaleResources = {
   es: {
     calendar: esCalendar,
     common: esCommon,
+    "create-workout": esCreateWorkout,
     daily: esDaily,
     editor: esEditor,
     errors: esErrors,


### PR DESCRIPTION
## What

Tenth SPA i18n PR. New `create-workout` namespace for the primary create flow.

- Create phases (input hero, generating, result), start-from options, providers-empty, and the AI workout input (sport select, model selector, zone indicator, AiBanner).
- **LLM-prompt builders** (`zone-indicator-helpers`, `zones-formatter`) intentionally **left English** — they feed the model, not the user.
- `example-prompts` split into `{key, label}`: stable key for React/i18n, translated label both renders and seeds the tap payload (Spanish user → Spanish example → Spanish generation).
- Special chars (×, ₂, …) byte-identical; toasts via `t("literal.key")`; duplicate "configure AI provider" copy consolidated to one key.

## Verification

- CreateWorkout + AiWorkoutInput + AiBanner + i18n suites: **58/58**.
- `tsc --noEmit` clean · eslint clean · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)