### PR TITLE
feat(spa-editor): localize workout detail, stats & list a11y (workout-detail namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/WorkoutPreview/WorkoutPreview.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/WorkoutPreview/WorkoutPreview.tsx
@@ -7,6 +7,7 @@
 
 import React, { useMemo } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { flattenWorkoutSteps } from "./flatten-steps";
 import type { PreviewBar, WorkoutPreviewProps } from "./workout-preview-types";
 import { WorkoutPreviewBar } from "./WorkoutPreviewBar";
@@ -53,6 +54,7 @@ export const WorkoutPreview: React.FC<WorkoutPreviewProps> = ({
   className = "",
   height = 80,
 }) => {
+  const t = useTranslate("workout-detail");
   const layout = useMemo(() => {
     const bars = flattenWorkoutSteps(workout);
     const total = bars.reduce((s, b) => s + b.durationSeconds, 0);
@@ -66,7 +68,7 @@ export const WorkoutPreview: React.FC<WorkoutPreviewProps> = ({
     <div
       className={`overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-800 ${className}`}
       role="region"
-      aria-label="Workout preview"
+      aria-label={t("preview.region")}
       data-testid="workout-preview"
     >
       <svg
@@ -75,7 +77,7 @@ export const WorkoutPreview: React.FC<WorkoutPreviewProps> = ({
         viewBox={`0 0 ${VIEWBOX_WIDTH} ${height}`}
         preserveAspectRatio="none"
         role="group"
-        aria-label="Workout step bars"
+        aria-label={t("preview.bars")}
       >
         {layout.map((bar) => (
           <WorkoutPreviewBar

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutList/WorkoutList.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutList/WorkoutList.tsx
@@ -4,7 +4,8 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 
-import { dndAnnouncements } from "./dnd-announcements";
+import { useTranslate } from "../../../i18n/use-translate";
+import { createDndAnnouncements } from "./dnd-announcements";
 import { useWorkoutListDnd } from "./hooks/use-workout-list-dnd";
 import type { WorkoutListProps } from "./WorkoutList.types";
 import { WorkoutListContent } from "./WorkoutListContent";
@@ -15,6 +16,7 @@ export type { WorkoutListProps };
 export const WorkoutList = (props: WorkoutListProps) => {
   const { workout, className = "", onStepReorder } = props;
 
+  const t = useTranslate("workout-detail");
   const baseClasses = "flex flex-col gap-4";
   const classes = [baseClasses, className].filter(Boolean).join(" ");
   const dnd = useWorkoutListDnd(workout, onStepReorder);
@@ -25,13 +27,13 @@ export const WorkoutList = (props: WorkoutListProps) => {
       collisionDetection={dnd.collisionDetection}
       onDragStart={dnd.handleDragStart}
       onDragEnd={dnd.handleDragEnd}
-      accessibility={{ announcements: dndAnnouncements }}
+      accessibility={{ announcements: createDndAnnouncements(t) }}
     >
       <SortableContext
         items={dnd.sortableIds}
         strategy={verticalListSortingStrategy}
       >
-        <div className={classes} role="list" aria-label="Workout steps">
+        <div className={classes} role="list" aria-label={t("list.steps")}>
           <WorkoutListContent
             workout={workout}
             selectedStepId={props.selectedStepId}

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutList/dnd-announcements.ts
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutList/dnd-announcements.ts
@@ -1,27 +1,31 @@
 import type { Announcements } from "@dnd-kit/core";
 
+import { getTranslate, type Translate } from "../../../i18n/use-translate";
+
 /**
  * Accessibility announcements for drag-and-drop operations
  * Provides screen reader feedback during drag interactions
  * Requirement 3: Visual feedback and accessibility for step reordering
  */
-export const dndAnnouncements: Announcements = {
+export const createDndAnnouncements = (
+  t: Translate = getTranslate("workout-detail")
+): Announcements => ({
   onDragStart({ active }) {
-    return `Picked up draggable item ${active.id}. Press arrow keys to move, space to drop.`;
+    return t("dnd.picked", { id: active.id });
   },
   onDragOver({ active, over }) {
     if (over) {
-      return `Draggable item ${active.id} was moved over droppable area ${over.id}.`;
+      return t("dnd.movedOver", { id: active.id, over: over.id });
     }
-    return `Draggable item ${active.id} is no longer over a droppable area.`;
+    return t("dnd.noLongerOver", { id: active.id });
   },
   onDragEnd({ active, over }) {
     if (over) {
-      return `Draggable item ${active.id} was dropped over droppable area ${over.id}.`;
+      return t("dnd.dropped", { id: active.id, over: over.id });
     }
-    return `Draggable item ${active.id} was dropped.`;
+    return t("dnd.droppedNoTarget", { id: active.id });
   },
   onDragCancel({ active }) {
-    return `Dragging was cancelled. Draggable item ${active.id} was dropped.`;
+    return t("dnd.cancelled", { id: active.id });
   },
-};
+});

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutStats/StatValue.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutStats/StatValue.tsx
@@ -6,6 +6,8 @@
 
 import React from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
+
 export type StatValueProps = {
   value: string | number | null;
   hasEstimate?: boolean;
@@ -17,6 +19,7 @@ export const StatValue: React.FC<StatValueProps> = ({
   hasEstimate = false,
   emptyText = "—",
 }) => {
+  const t = useTranslate("workout-detail");
   if (value === null || value === undefined) {
     return <span className="text-gray-500">{emptyText}</span>;
   }
@@ -27,7 +30,7 @@ export const StatValue: React.FC<StatValueProps> = ({
       {hasEstimate && (
         <span
           className="ml-1 text-xs text-gray-500"
-          title="Estimate due to open-ended steps"
+          title={t("stats.estimateIndicatorTitle")}
         >
           *
         </span>

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutStats/StatsContent.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutStats/StatsContent.tsx
@@ -6,6 +6,7 @@
 
 import React from "react";
 
+import { type Translate, useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutStats } from "../../../utils/workout-stats";
 import { formatDistance, formatDuration } from "./format-helpers";
 import { StatRow } from "./StatRow";
@@ -15,9 +16,12 @@ export type StatsContentProps = {
   stats: WorkoutStats;
 };
 
-const DurationRow: React.FC<{ stats: WorkoutStats }> = ({ stats }) => (
+const DurationRow: React.FC<{ stats: WorkoutStats; t: Translate }> = ({
+  stats,
+  t,
+}) => (
   <StatRow
-    label="Total Duration:"
+    label={t("stats.totalDuration")}
     value={
       <StatValue
         value={
@@ -31,9 +35,12 @@ const DurationRow: React.FC<{ stats: WorkoutStats }> = ({ stats }) => (
   />
 );
 
-const DistanceRow: React.FC<{ stats: WorkoutStats }> = ({ stats }) => (
+const DistanceRow: React.FC<{ stats: WorkoutStats; t: Translate }> = ({
+  stats,
+  t,
+}) => (
   <StatRow
-    label="Total Distance:"
+    label={t("stats.totalDistance")}
     value={
       <StatValue
         value={
@@ -47,26 +54,37 @@ const DistanceRow: React.FC<{ stats: WorkoutStats }> = ({ stats }) => (
   />
 );
 
-export const StatsContent: React.FC<StatsContentProps> = ({ stats }) => (
-  <>
-    <DurationRow stats={stats} />
-    <DistanceRow stats={stats} />
-    <StatRow
-      label="Total Steps:"
-      value={`${stats.stepCount} ${stats.stepCount === 1 ? "step" : "steps"}`}
-    />
-    {stats.repetitionCount > 0 && (
+export const StatsContent: React.FC<StatsContentProps> = ({ stats }) => {
+  const t = useTranslate("workout-detail");
+  return (
+    <>
+      <DurationRow stats={stats} t={t} />
+      <DistanceRow stats={stats} t={t} />
       <StatRow
-        label="Repetition Blocks:"
-        value={`${stats.repetitionCount} ${stats.repetitionCount === 1 ? "repetition" : "repetitions"}`}
+        label={t("stats.totalSteps")}
+        value={t(
+          stats.stepCount === 1 ? "stats.steps_one" : "stats.steps_other",
+          {
+            n: stats.stepCount,
+          }
+        )}
       />
-    )}
-    {stats.hasOpenSteps && (
-      <div className="mt-3 border-t border-gray-200 pt-2">
-        <p className="text-xs text-gray-500">
-          * Totals are estimates due to open-ended or conditional steps
-        </p>
-      </div>
-    )}
-  </>
-);
+      {stats.repetitionCount > 0 && (
+        <StatRow
+          label={t("stats.repetitionBlocks")}
+          value={t(
+            stats.repetitionCount === 1
+              ? "stats.repetitions_one"
+              : "stats.repetitions_other",
+            { n: stats.repetitionCount }
+          )}
+        />
+      )}
+      {stats.hasOpenSteps && (
+        <div className="mt-3 border-t border-gray-200 pt-2">
+          <p className="text-xs text-gray-500">{t("stats.estimateNote")}</p>
+        </div>
+      )}
+    </>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/WorkoutStats/WorkoutStats.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/WorkoutStats/WorkoutStats.tsx
@@ -9,6 +9,7 @@
 
 import React, { useMemo } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { Workout } from "../../../types/krd";
 import { calculateWorkoutStats } from "../../../utils/workout-stats";
 import { StatsContent } from "./StatsContent";
@@ -32,6 +33,7 @@ export const WorkoutStats: React.FC<WorkoutStatsProps> = ({
 }) => {
   // Calculate stats (memoized for performance - Requirement 9.5)
   const stats = useMemo(() => calculateWorkoutStats(workout), [workout]);
+  const t = useTranslate("workout-detail");
 
   // Don't render if no workout
   if (!workout) {
@@ -42,10 +44,10 @@ export const WorkoutStats: React.FC<WorkoutStatsProps> = ({
     <div
       className={`rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800 ${className}`}
       role="region"
-      aria-label="Workout statistics"
+      aria-label={t("stats.region")}
     >
       <h2 className="mb-3 text-lg font-semibold text-gray-900">
-        Workout Stats
+        {t("stats.heading")}
       </h2>
       <div className="space-y-2">
         <StatsContent stats={stats} />

--- a/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailFooter.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailFooter.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { adjustWithAiHref } from "../../../routing/adjust-with-ai-href";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import { Button } from "../../atoms/Button";
@@ -16,12 +17,13 @@ export function WorkoutDetailFooter({
   workout,
   onEdit,
 }: WorkoutDetailFooterProps) {
+  const t = useTranslate("workout-detail");
   const [, navigate] = useLocation();
   return (
     <div className="sticky bottom-0 -mx-4 flex gap-3 border-t border-slate-800 bg-surface-deep px-4 py-3">
       <Button variant="ghost" onClick={onEdit}>
         <Icon icon={ICON_MAP.edit} size="sm" color="inherit" />
-        Edit
+        {t("footer.edit")}
       </Button>
       {workout && (
         <Button
@@ -29,7 +31,7 @@ export function WorkoutDetailFooter({
           onClick={() => navigate(adjustWithAiHref(workout))}
         >
           <Icon icon={ICON_MAP.chat} size="sm" color="inherit" />
-          Adjust with AI
+          {t("footer.adjustWithAi")}
         </Button>
       )}
       <div className="flex-1">

--- a/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { ROUTE_HEADING_ATTR } from "../../../routing/constants";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
@@ -7,12 +8,13 @@ export type WorkoutDetailHeaderProps = {
 
 /** Sheet header: back chevron, the route-heading title, and an inert dots menu. */
 export function WorkoutDetailHeader({ onBack }: WorkoutDetailHeaderProps) {
+  const t = useTranslate("workout-detail");
   return (
     <div className="flex items-center justify-between">
       <button
         type="button"
         onClick={onBack}
-        aria-label="Back"
+        aria-label={t("header.back")}
         data-testid="workout-detail-back"
         className="inline-flex h-9 w-9 items-center justify-center rounded-md text-slate-300 hover:bg-white/5"
       >
@@ -23,11 +25,11 @@ export function WorkoutDetailHeader({ onBack }: WorkoutDetailHeaderProps) {
         {...{ [ROUTE_HEADING_ATTR]: "" }}
         className="text-[15px] font-semibold text-slate-200"
       >
-        Workout
+        {t("header.title")}
       </h1>
       <button
         type="button"
-        aria-label="More options"
+        aria-label={t("header.moreOptions")}
         disabled
         className="inline-flex h-9 w-9 items-center justify-center rounded-md text-slate-500"
       >

--- a/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailNotFound.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailNotFound.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { ROUTE_HEADING_ATTR } from "../../../routing/constants";
 import { Button } from "../../atoms/Button";
 
@@ -7,6 +8,7 @@ export type WorkoutDetailNotFoundProps = {
 
 /** Empty state shown when no workout matches the route id. */
 export function WorkoutDetailNotFound({ onBack }: WorkoutDetailNotFoundProps) {
+  const t = useTranslate("workout-detail");
   return (
     <div className="mx-auto flex min-h-screen w-full max-w-md flex-col items-center justify-center gap-4 bg-surface-deep p-4 text-center">
       <h1
@@ -14,10 +16,10 @@ export function WorkoutDetailNotFound({ onBack }: WorkoutDetailNotFoundProps) {
         {...{ [ROUTE_HEADING_ATTR]: "" }}
         className="text-[18px] font-semibold text-slate-200"
       >
-        Workout not found
+        {t("notFound.title")}
       </h1>
       <Button variant="ghost" onClick={onBack}>
-        Back to calendar
+        {t("notFound.backToCalendar")}
       </Button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailStructure.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailStructure.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { ReviewModel } from "../../../lib/workout-review";
 import { Card } from "../../atoms/Card";
 import { ZoneDist } from "../../molecules/ZoneDist";
@@ -15,10 +16,11 @@ export function WorkoutDetailStructure({
   dist,
   steps,
 }: WorkoutDetailStructureProps) {
+  const t = useTranslate("workout-detail");
   return (
     <Card className="border-slate-800 bg-surface p-4">
       <p className="mb-3 text-[12px] font-semibold uppercase tracking-[0.08em] text-slate-500">
-        Structure · time in zone
+        {t("structure.eyebrow")}
       </p>
       <ZoneDist dist={dist} height={ZONE_BAR_HEIGHT} className="mb-3" />
       <StepList steps={steps} />

--- a/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailTitle.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailTitle.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import {
   Icon,
   ICON_MAP,
@@ -5,11 +6,11 @@ import {
   SPORT_ICON_NAME,
 } from "../../atoms/Icon";
 
-const SPORT_LABELS: Record<string, string> = {
-  cycling: "Cycling",
-  running: "Running",
-  swimming: "Swimming",
-  strength: "Strength",
+const SPORT_LABEL_KEYS: Record<string, string> = {
+  cycling: "sport.cycling",
+  running: "sport.running",
+  swimming: "sport.swimming",
+  strength: "sport.strength",
 };
 
 const TILE_SIZE = 52;
@@ -23,14 +24,15 @@ export type WorkoutDetailTitleProps = {
 const sportIcon = (sport: string): IconName =>
   SPORT_ICON_NAME[sport as keyof typeof SPORT_ICON_NAME] ?? "zap";
 
-const sportLabel = (sport: string): string => SPORT_LABELS[sport] ?? "Workout";
-
 /** Sport icon tile + title + "`${SportLabel} · ${tag||'Planned'}`" subtitle. */
 export function WorkoutDetailTitle({
   sport,
   title,
   tag,
 }: WorkoutDetailTitleProps) {
+  const t = useTranslate("workout-detail");
+  const labelKey = SPORT_LABEL_KEYS[sport];
+  const sportLabel = labelKey ? t(labelKey) : t("fallbackTitle");
   return (
     <div className="flex items-center gap-3">
       <div
@@ -44,7 +46,7 @@ export function WorkoutDetailTitle({
           {title}
         </div>
         <p className="text-[12.5px] text-slate-500">
-          {sportLabel(sport)} · {tag || "Planned"}
+          {sportLabel} · {tag || t("title.planned")}
         </p>
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailView.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutDetail/WorkoutDetailView.tsx
@@ -1,3 +1,4 @@
+import { type Translate, useTranslate } from "../../../i18n/use-translate";
 import type { ReviewModel } from "../../../lib/workout-review";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import { SummaryStrip } from "../../molecules/SummaryStrip";
@@ -13,10 +14,14 @@ export type WorkoutDetailViewProps = {
   onEdit: () => void;
 };
 
-const buildSummary = (model: ReviewModel) => [
-  { icon: "clock" as const, value: model.duration, label: "Duration" },
-  { icon: "flame" as const, value: String(model.tss), label: "TSS" },
-  { icon: "zap" as const, value: model.load, label: "Load" },
+const buildSummary = (model: ReviewModel, t: Translate) => [
+  {
+    icon: "clock" as const,
+    value: model.duration,
+    label: t("summary.duration"),
+  },
+  { icon: "flame" as const, value: String(model.tss), label: t("summary.tss") },
+  { icon: "zap" as const, value: model.load, label: t("summary.load") },
 ];
 
 /** Read-only workout detail sheet with header, summary, structure, and footer. */
@@ -26,8 +31,9 @@ export function WorkoutDetailView({
   onBack,
   onEdit,
 }: WorkoutDetailViewProps) {
+  const t = useTranslate("workout-detail");
   const tag = record.tags[0];
-  const title = model?.title ?? "Workout";
+  const title = model?.title ?? t("fallbackTitle");
 
   return (
     <div className="mx-auto flex min-h-screen w-full max-w-md flex-col gap-4 bg-surface-deep p-4">
@@ -35,7 +41,7 @@ export function WorkoutDetailView({
       <WorkoutDetailTitle sport={record.sport} title={title} tag={tag} />
       {model && (
         <>
-          <SummaryStrip items={buildSummary(model)} />
+          <SummaryStrip items={buildSummary(model, t)} />
           <WorkoutDetailStructure dist={model.dist} steps={model.steps} />
         </>
       )}

--- a/packages/workout-spa-editor/src/components/pages/WorkoutDetail/use-workout-detail-model.ts
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutDetail/use-workout-detail-model.ts
@@ -1,12 +1,11 @@
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { thresholdsForSport } from "../../../lib/athlete";
 import {
   buildReviewModel,
   type ReviewModel,
 } from "../../../lib/workout-review";
 import type { WorkoutRecord } from "../../../types/calendar-record";
-
-const FALLBACK_TITLE = "Workout";
 
 /**
  * Derives the read-only review view-model for a workout record, selecting the
@@ -16,13 +15,14 @@ const FALLBACK_TITLE = "Workout";
 export function useWorkoutDetailModel(
   record: WorkoutRecord | undefined
 ): ReviewModel | null {
+  const t = useTranslate("workout-detail");
   const profile = useActiveProfileLive()?.profile;
   if (!record?.krd) return null;
 
   const thresholds = thresholdsForSport(profile, record.sport);
   const fallback =
     (record.raw as { description?: string } | null)?.description ??
-    FALLBACK_TITLE;
+    t("fallbackTitle");
 
   return buildReviewModel(record.krd, thresholds, fallback);
 }

--- a/packages/workout-spa-editor/src/i18n/locales/en/workout-detail.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/workout-detail.json
@@ -1,0 +1,62 @@
+{
+  "header": {
+    "back": "Back",
+    "title": "Workout",
+    "moreOptions": "More options"
+  },
+  "notFound": {
+    "title": "Workout not found",
+    "backToCalendar": "Back to calendar"
+  },
+  "structure": {
+    "eyebrow": "Structure · time in zone"
+  },
+  "sport": {
+    "cycling": "Cycling",
+    "running": "Running",
+    "swimming": "Swimming",
+    "strength": "Strength"
+  },
+  "title": {
+    "planned": "Planned"
+  },
+  "footer": {
+    "edit": "Edit",
+    "adjustWithAi": "Adjust with AI"
+  },
+  "summary": {
+    "duration": "Duration",
+    "tss": "TSS",
+    "load": "Load"
+  },
+  "fallbackTitle": "Workout",
+  "stats": {
+    "region": "Workout statistics",
+    "heading": "Workout Stats",
+    "totalDuration": "Total Duration:",
+    "totalDistance": "Total Distance:",
+    "totalSteps": "Total Steps:",
+    "repetitionBlocks": "Repetition Blocks:",
+    "steps_one": "{{n}} step",
+    "steps_other": "{{n}} steps",
+    "repetitions_one": "{{n}} repetition",
+    "repetitions_other": "{{n}} repetitions",
+    "estimateNote": "* Totals are estimates due to open-ended or conditional steps",
+    "estimateIndicatorTitle": "Estimate due to open-ended steps"
+  },
+  "list": {
+    "steps": "Workout steps"
+  },
+  "dnd": {
+    "picked": "Picked up draggable item {{id}}. Press arrow keys to move, space to drop.",
+    "movedOver": "Draggable item {{id}} was moved over droppable area {{over}}.",
+    "noLongerOver": "Draggable item {{id}} is no longer over a droppable area.",
+    "dropped": "Draggable item {{id}} was dropped over droppable area {{over}}.",
+    "droppedNoTarget": "Draggable item {{id}} was dropped.",
+    "cancelled": "Dragging was cancelled. Draggable item {{id}} was dropped."
+  },
+  "preview": {
+    "region": "Workout preview",
+    "bars": "Workout step bars"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/workout-detail.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/workout-detail.json
@@ -1,0 +1,62 @@
+{
+  "header": {
+    "back": "Atrás",
+    "title": "Entrenamiento",
+    "moreOptions": "Más opciones"
+  },
+  "notFound": {
+    "title": "Entrenamiento no encontrado",
+    "backToCalendar": "Volver al calendario"
+  },
+  "structure": {
+    "eyebrow": "Estructura · tiempo en zona"
+  },
+  "sport": {
+    "cycling": "Ciclismo",
+    "running": "Carrera",
+    "swimming": "Natación",
+    "strength": "Fuerza"
+  },
+  "title": {
+    "planned": "Planificado"
+  },
+  "footer": {
+    "edit": "Editar",
+    "adjustWithAi": "Ajustar con IA"
+  },
+  "summary": {
+    "duration": "Duración",
+    "tss": "TSS",
+    "load": "Carga"
+  },
+  "fallbackTitle": "Entrenamiento",
+  "stats": {
+    "region": "Estadísticas del entrenamiento",
+    "heading": "Estadísticas del entrenamiento",
+    "totalDuration": "Duración total:",
+    "totalDistance": "Distancia total:",
+    "totalSteps": "Pasos totales:",
+    "repetitionBlocks": "Bloques de repetición:",
+    "steps_one": "{{n}} paso",
+    "steps_other": "{{n}} pasos",
+    "repetitions_one": "{{n}} repetición",
+    "repetitions_other": "{{n}} repeticiones",
+    "estimateNote": "* Los totales son estimaciones debido a pasos abiertos o condicionales",
+    "estimateIndicatorTitle": "Estimación debido a pasos abiertos"
+  },
+  "list": {
+    "steps": "Pasos del entrenamiento"
+  },
+  "dnd": {
+    "picked": "Elemento arrastrable {{id}} seleccionado. Pulsa las flechas para mover y espacio para soltar.",
+    "movedOver": "El elemento arrastrable {{id}} se movió sobre el área {{over}}.",
+    "noLongerOver": "El elemento arrastrable {{id}} ya no está sobre un área de destino.",
+    "dropped": "El elemento arrastrable {{id}} se soltó sobre el área {{over}}.",
+    "droppedNoTarget": "El elemento arrastrable {{id}} se soltó.",
+    "cancelled": "Se canceló el arrastre. El elemento arrastrable {{id}} se soltó."
+  },
+  "preview": {
+    "region": "Vista previa del entrenamiento",
+    "bars": "Barras de pasos del entrenamiento"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -19,6 +19,7 @@ import enLibrary from "./locales/en/library.json";
 import enNav from "./locales/en/nav.json";
 import enSettings from "./locales/en/settings.json";
 import enTargets from "./locales/en/targets.json";
+import enWorkoutDetail from "./locales/en/workout-detail.json";
 import esCalendar from "./locales/es/calendar.json";
 import esCommon from "./locales/es/common.json";
 import esCreateWorkout from "./locales/es/create-workout.json";
@@ -31,6 +32,7 @@ import esLibrary from "./locales/es/library.json";
 import esNav from "./locales/es/nav.json";
 import esSettings from "./locales/es/settings.json";
 import esTargets from "./locales/es/targets.json";
+import esWorkoutDetail from "./locales/es/workout-detail.json";
 
 export const NAMESPACES = [
   "calendar",
@@ -45,6 +47,7 @@ export const NAMESPACES = [
   "nav",
   "settings",
   "targets",
+  "workout-detail",
 ] as const;
 
 export const DEFAULT_NAMESPACE = "common";
@@ -63,6 +66,7 @@ export const resources: LocaleResources = {
     nav: enNav,
     settings: enSettings,
     targets: enTargets,
+    "workout-detail": enWorkoutDetail,
   },
   es: {
     calendar: esCalendar,
@@ -77,5 +81,6 @@ export const resources: LocaleResources = {
     nav: esNav,
     settings: esSettings,
     targets: esTargets,
+    "workout-detail": esWorkoutDetail,
   },
 };


### PR DESCRIPTION
## What

Eleventh SPA i18n PR. New `workout-detail` namespace.

- Detail header/title/structure/footer, not-found state, `WorkoutStats` (with singular/plural step & repetition counts), `WorkoutList` drag-and-drop aria announcements, `WorkoutPreview`.
- Resolves the **workout-review fallback title deferred from the Daily PR**: `use-workout-detail-model` now renders `t("fallbackTitle")` (byte-identical "Workout") instead of a hardcoded const.
- dnd announcements + summary/sport labels use interpolation and stable config keys.

## Verification

- WorkoutDetail + WorkoutStats + WorkoutList + WorkoutPreview + i18n suites: **148/148**.
- `tsc --noEmit` clean · eslint clean · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized workout detail content across the header, footer, stats, preview, empty state, and workout title/summary sections.
  * Added Spanish and English translations for workout detail screens.
  * Improved drag-and-drop accessibility messages with translated announcements.

* **Bug Fixes**
  * Replaced remaining hardcoded English labels and accessibility text with translated strings for a more consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->