### PR TITLE
feat(spa-editor): localize the chat & coaching sidebar (chat namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatComposer.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatComposer.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button";
 
 export type ChatComposerProps = {
@@ -15,6 +16,7 @@ export function ChatComposer({
   disabled,
   initialText,
 }: ChatComposerProps) {
+  const t = useTranslate("chat");
   const [text, setText] = useState(initialText ?? "");
 
   const submit = () => {
@@ -27,7 +29,7 @@ export function ChatComposer({
   return (
     <div className="flex items-end gap-2">
       <textarea
-        aria-label="Message"
+        aria-label={t("composer.messageLabel")}
         rows={2}
         value={text}
         disabled={disabled}
@@ -38,11 +40,11 @@ export function ChatComposer({
             submit();
           }
         }}
-        placeholder="Ask about your training or health…"
+        placeholder={t("composer.placeholder")}
         className="flex-1 resize-none rounded-2xl border border-slate-700 bg-surface-deep px-3 py-2 text-[14px] text-slate-50 placeholder:text-slate-500"
       />
       <Button onClick={submit} disabled={disabled || text.trim() === ""}>
-        Send
+        {t("composer.send")}
       </Button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatErrorNotice.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatErrorNotice.tsx
@@ -1,20 +1,25 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button";
 
 export type ChatErrorNoticeProps = {
-  message: string;
+  category: string;
   onRetry: () => void;
 };
 
-/** In-conversation error entry with a retry affordance. `message` is a
- * fixed category string (never conversation content), per the PII guard. */
-export function ChatErrorNotice({ message, onRetry }: ChatErrorNoticeProps) {
+/** In-conversation error entry with a retry affordance. `category` is a stable
+ * error-category key (never conversation content), localized here by that key
+ * so raw error text is never rendered, per the PII guard. */
+export function ChatErrorNotice({ category, onRetry }: ChatErrorNoticeProps) {
+  const t = useTranslate("chat");
   return (
     <div
       role="alert"
       className="flex items-center justify-between gap-3 rounded-2xl border border-rose-600/40 bg-rose-950/20 px-3 py-2"
     >
-      <span className="text-[13px] text-rose-200">{message}</span>
-      <Button onClick={onRetry}>Retry</Button>
+      <span className="text-[13px] text-rose-200">
+        {t(`errors.${category}`)}
+      </span>
+      <Button onClick={onRetry}>{t("errors.retry")}</Button>
     </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatHeader.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { ROUTE_HEADING_ATTR } from "../../../routing/constants";
 
 /**
@@ -6,6 +7,7 @@ import { ROUTE_HEADING_ATTR } from "../../../routing/constants";
  * eagerly, like LibraryHeader, so focus survives loading→loaded swaps).
  */
 export function ChatHeader() {
+  const t = useTranslate("chat");
   return (
     <div className="mb-1">
       <h1
@@ -13,10 +15,10 @@ export function ChatHeader() {
         {...{ [ROUTE_HEADING_ATTR]: "" }}
         className="m-0 text-[26px] font-extrabold tracking-[-0.02em] text-slate-50"
       >
-        Assistant
+        {t("header.title")}
       </h1>
       <p className="mt-1 text-[13.5px] text-slate-400">
-        Ask about your training and health history, or run an action.
+        {t("header.subtitle")}
       </p>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatLoading.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatLoading.tsx
@@ -1,0 +1,11 @@
+import { useTranslate } from "../../../i18n/use-translate";
+
+/** Centered loading placeholder shown while the provider list resolves. */
+export function ChatLoading() {
+  const t = useTranslate("chat");
+  return (
+    <div className="flex items-center justify-center p-8 text-slate-400">
+      {t("page.loading")}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatMessageList.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatMessageList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { ChatMessageRecord } from "../../../types/chat/chat-message-record";
 import { buildToolResultLinks } from "./build-tool-result-links";
 import { ToolResultLinks } from "./ToolResultLinks";
@@ -10,10 +11,10 @@ const ROLE_STYLE: Record<string, string> = {
   tool: "self-start bg-slate-900 text-slate-400 italic",
 };
 
-const ROLE_LABEL: Record<string, string> = {
-  user: "You",
-  assistant: "Assistant",
-  tool: "Action",
+const ROLE_LABEL_KEY: Record<string, string> = {
+  user: "role.user",
+  assistant: "role.assistant",
+  tool: "role.tool",
 };
 
 export type ChatMessageListProps = {
@@ -28,6 +29,7 @@ export function ChatMessageList({
   messages,
   focusMessageId,
 }: ChatMessageListProps) {
+  const t = useTranslate("chat");
   const focusedRef = useRef<HTMLLIElement | null>(null);
 
   useEffect(() => {
@@ -38,7 +40,7 @@ export function ChatMessageList({
   if (messages.length === 0) {
     return (
       <p className="p-8 text-center text-[13px] text-slate-500">
-        Start a conversation — ask about your recent workouts or sleep.
+        {t("empty.startConversation")}
       </p>
     );
   }
@@ -47,6 +49,7 @@ export function ChatMessageList({
     <ul className="flex flex-col gap-3" data-testid="chat-messages">
       {messages.map((m) => {
         const focused = m.id === focusMessageId;
+        const roleKey = ROLE_LABEL_KEY[m.role];
         return (
           <li
             key={m.id}
@@ -55,10 +58,10 @@ export function ChatMessageList({
             className={`max-w-[80%] whitespace-pre-wrap rounded-2xl px-3 py-2 text-[14px] ${ROLE_STYLE[m.role] ?? ROLE_STYLE.assistant} ${focused ? "ring-2 ring-yellow-300" : ""}`}
           >
             <span className="mb-0.5 block text-[11px] font-semibold opacity-70">
-              {ROLE_LABEL[m.role] ?? m.role}
+              {roleKey ? t(roleKey) : m.role}
             </span>
             {m.content}
-            <ToolResultLinks links={buildToolResultLinks(m)} />
+            <ToolResultLinks links={buildToolResultLinks(m, t)} />
           </li>
         );
       })}

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatModelPicker.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatModelPicker.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { LlmProviderConfig } from "../../../store/ai-store-types";
 
 export type ChatModelPickerProps = {
@@ -13,6 +14,7 @@ export function ChatModelPicker({
   value,
   onChange,
 }: ChatModelPickerProps) {
+  const t = useTranslate("chat");
   if (providers.length === 0) return null;
   const current =
     value ?? providers.find((p) => p.isDefault)?.id ?? providers[0]!.id;
@@ -22,7 +24,7 @@ export function ChatModelPicker({
         htmlFor="chat-model-select"
         className="mb-1 block text-xs font-medium text-slate-400"
       >
-        Model
+        {t("model.label")}
       </label>
       <select
         id="chat-model-select"

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatSearchBox.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatSearchBox.tsx
@@ -1,3 +1,5 @@
+import { useTranslate } from "../../../i18n/use-translate";
+
 export type ChatSearchBoxProps = {
   value: string;
   onChange: (value: string) => void;
@@ -5,21 +7,22 @@ export type ChatSearchBoxProps = {
 
 /** Search input for the conversation sidebar, with a clear affordance. */
 export function ChatSearchBox({ value, onChange }: ChatSearchBoxProps) {
+  const t = useTranslate("chat");
   return (
     <div className="flex items-center gap-1 rounded-md border border-slate-700 px-2 py-1">
       <input
         type="search"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Search chats…"
-        aria-label="Search chats"
+        placeholder={t("search.placeholder")}
+        aria-label={t("search.label")}
         data-testid="chat-search-input"
         className="w-full bg-transparent text-sm text-slate-100 placeholder:text-slate-500 focus:outline-none"
       />
       {value && (
         <button
           type="button"
-          aria-label="Clear search"
+          aria-label={t("search.clear")}
           className="shrink-0 px-1 text-slate-500 hover:text-slate-200"
           onClick={() => onChange("")}
         >

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatSearchResults.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatSearchResults.tsx
@@ -1,4 +1,5 @@
 import type { ChatSearchResult } from "../../../application/chat/search-conversations";
+import { useTranslate } from "../../../i18n/use-translate";
 import { SnippetText } from "./SnippetText";
 
 export type ChatSearchResultsProps = {
@@ -17,13 +18,14 @@ export function ChatSearchResults({
   onSelect,
   onResultSelect,
 }: ChatSearchResultsProps) {
+  const t = useTranslate("chat");
   if (results.length === 0) {
     return (
       <p
         data-testid="chat-search-empty"
         className="px-2 py-4 text-sm text-slate-400"
       >
-        No matches.
+        {t("search.noMatches")}
       </p>
     );
   }

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatTurnExtras.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatTurnExtras.tsx
@@ -39,7 +39,7 @@ export function ChatTurnExtras({
           busy={busy}
         />
       )}
-      {error !== null && <ChatErrorNotice message={error} onRetry={onRetry} />}
+      {error !== null && <ChatErrorNotice category={error} onRetry={onRetry} />}
     </>
   );
 }

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ChatWorkspace.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ChatWorkspace.tsx
@@ -1,5 +1,6 @@
 import { useChatPrefill } from "../../../hooks/use-chat-prefill";
 import type { UseChatSearchPanel } from "../../../hooks/use-chat-search-panel";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { LlmProviderConfig } from "../../../store/ai-store-types";
 import type { ChatConversationRecord } from "../../../types/chat/chat-conversation-record";
 import type { ChatMessageRecord } from "../../../types/chat/chat-message-record";
@@ -28,6 +29,7 @@ export type ChatWorkspaceProps = {
 /** Two-column chat surface: the conversation list and the active thread (or a
  * prompt to pick/start one when no thread is selected). */
 export function ChatWorkspace(props: ChatWorkspaceProps) {
+  const t = useTranslate("chat");
   const prefill = useChatPrefill();
   return (
     <div className="grid gap-4 md:grid-cols-[240px_1fr]">
@@ -64,7 +66,7 @@ export function ChatWorkspace(props: ChatWorkspaceProps) {
           />
         ) : (
           <p className="p-4 text-sm text-slate-400">
-            Select a conversation or start a new one.
+            {t("workspace.selectOrStart")}
           </p>
         )}
       </div>

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ConversationList.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ConversationList.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { ChatConversationRecord } from "../../../types/chat/chat-conversation-record";
 import { ConversationListItem } from "./ConversationListItem";
 
@@ -20,9 +21,10 @@ export function ConversationList({
   onRename,
   onDelete,
 }: ConversationListProps) {
+  const t = useTranslate("chat");
   return (
     <nav
-      aria-label="Conversations"
+      aria-label={t("list.ariaLabel")}
       className="flex w-full flex-col gap-1"
       data-testid="conversation-list"
     >
@@ -31,7 +33,7 @@ export function ConversationList({
         className="mb-1 rounded-md border border-slate-700 px-2 py-1.5 text-sm font-medium text-slate-200 hover:bg-slate-800"
         onClick={onNew}
       >
-        + New conversation
+        {t("list.newConversation")}
       </button>
       {conversations.map((c) => (
         <ConversationListItem

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ConversationListItem.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ConversationListItem.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { ChatConversationRecord } from "../../../types/chat/chat-conversation-record";
 import { ConversationTitleInput } from "./ConversationTitleInput";
 
@@ -19,6 +20,7 @@ export function ConversationListItem({
   onRename,
   onDelete,
 }: ConversationListItemProps) {
+  const t = useTranslate("chat");
   const [editing, setEditing] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
 
@@ -50,7 +52,7 @@ export function ConversationListItem({
       </button>
       <button
         type="button"
-        aria-label="Rename conversation"
+        aria-label={t("item.rename")}
         className="shrink-0 px-1 text-slate-500 hover:text-slate-200"
         onClick={() => setEditing(true)}
       >
@@ -58,7 +60,7 @@ export function ConversationListItem({
       </button>
       <button
         type="button"
-        aria-label={confirmDelete ? "Confirm delete" : "Delete conversation"}
+        aria-label={confirmDelete ? t("item.confirmDelete") : t("item.delete")}
         className="shrink-0 px-1 text-slate-500 hover:text-red-400"
         onClick={() =>
           confirmDelete ? onDelete(conversation.id) : setConfirmDelete(true)

--- a/packages/workout-spa-editor/src/components/organisms/Chat/ConversationTitleInput.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/ConversationTitleInput.tsx
@@ -1,5 +1,7 @@
 import { useRef, useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
+
 export type ConversationTitleInputProps = {
   initialTitle: string;
   onCommit: (title: string) => void;
@@ -13,13 +15,14 @@ export function ConversationTitleInput({
   onCommit,
   onCancel,
 }: ConversationTitleInputProps) {
+  const t = useTranslate("chat");
   const [draft, setDraft] = useState(initialTitle);
   // Escape sets this so the trailing blur (focus loss on unmount) does not
   // commit. Enter blurs to commit exactly once via onBlur.
   const suppressBlurCommitRef = useRef(false);
   return (
     <input
-      aria-label="Conversation title"
+      aria-label={t("titleInput.label")}
       className="w-full rounded-md bg-slate-800 px-2 py-1 text-sm text-slate-100"
       value={draft}
       autoFocus

--- a/packages/workout-spa-editor/src/components/organisms/Chat/PendingActionCard.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/PendingActionCard.tsx
@@ -1,11 +1,12 @@
 import type { PendingAction } from "@kaiord/ai";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button";
 
-const ACTION_LABEL: Record<string, string> = {
-  sync_coaching: "Sync coaching activities",
-  create_workout: "Create a workout",
-  log_health_metric: "Log a health metric",
+const ACTION_LABEL_KEY: Record<string, string> = {
+  sync_coaching: "action.sync_coaching",
+  create_workout: "action.create_workout",
+  log_health_metric: "action.log_health_metric",
 };
 
 export type PendingActionCardProps = {
@@ -23,17 +24,20 @@ export function PendingActionCard({
   onDeny,
   busy,
 }: PendingActionCardProps) {
+  const t = useTranslate("chat");
+  const actionKey = ACTION_LABEL_KEY[action.toolName];
+  const label = actionKey ? t(actionKey) : action.toolName;
   return (
     <div className="rounded-2xl border border-amber-600/40 bg-amber-950/20 p-3">
       <p className="text-[13px] font-semibold text-amber-200">
-        Confirm: {ACTION_LABEL[action.toolName] ?? action.toolName}
+        {t("pendingAction.confirm", { action: label })}
       </p>
       <pre className="my-2 overflow-x-auto rounded-lg bg-slate-900 p-2 text-[12px] text-slate-300">
         {JSON.stringify(action.input, null, 2)}
       </pre>
       <div className="flex gap-2">
         <Button onClick={onApprove} disabled={busy}>
-          Approve
+          {t("pendingAction.approve")}
         </Button>
         <button
           type="button"
@@ -41,7 +45,7 @@ export function PendingActionCard({
           disabled={busy}
           className="rounded-xl px-3 py-1.5 text-[13px] text-slate-300 hover:text-slate-100 disabled:opacity-50"
         >
-          Decline
+          {t("pendingAction.decline")}
         </button>
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/Chat/build-tool-result-links.ts
+++ b/packages/workout-spa-editor/src/components/organisms/Chat/build-tool-result-links.ts
@@ -4,6 +4,7 @@
  * result: a link to the workout and, when dated, to its calendar week.
  * Any other tool, or a failed run with no `toolResult`, yields no links.
  */
+import { getTranslate, type Translate } from "../../../i18n/use-translate";
 import { calendarWeekHref } from "../../../routing/calendar-week-href";
 import { withOrigin } from "../../../routing/with-origin";
 import type { ChatMessageRecord } from "../../../types/chat/chat-message-record";
@@ -24,7 +25,8 @@ function isWorkoutToolResult(value: unknown): value is WorkoutToolResult {
 }
 
 export function buildToolResultLinks(
-  message: ChatMessageRecord
+  message: ChatMessageRecord,
+  t: Translate = getTranslate("chat")
 ): ToolResultLink[] {
   if (!message.toolName || !LINKABLE_TOOLS.has(message.toolName)) return [];
   if (!isWorkoutToolResult(message.toolResult)) return [];
@@ -33,10 +35,13 @@ export function buildToolResultLinks(
   const links: ToolResultLink[] = [
     {
       href: withOrigin(`/workout/view/${workoutId}`, "chat"),
-      label: "View workout",
+      label: t("toolLinks.viewWorkout"),
     },
   ];
   if (date)
-    links.push({ href: calendarWeekHref(date), label: "View on calendar" });
+    links.push({
+      href: calendarWeekHref(date),
+      label: t("toolLinks.viewCalendar"),
+    });
   return links;
 }

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/CoachingDescription.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/CoachingDescription.tsx
@@ -6,6 +6,7 @@
  * `dangerouslySetInnerHTML` so the sidebar is safe even if the
  * upstream description carries unexpected markup.
  */
+import { useTranslate } from "../../../i18n/use-translate";
 import { renderCoachingInline } from "./coaching-inline";
 import { formatCoachingDescription } from "./format-coaching-description";
 
@@ -14,13 +15,14 @@ export type CoachingDescriptionProps = {
 };
 
 export function CoachingDescription({ description }: CoachingDescriptionProps) {
+  const t = useTranslate("chat");
   if (!description) {
     return (
       <p
         data-testid="coaching-sidebar-empty"
         className="text-xs italic text-slate-500 dark:text-slate-400"
       >
-        No description provided.
+        {t("coaching.noDescription")}
       </p>
     );
   }

--- a/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/CoachingSidebar.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CoachingSidebar/CoachingSidebar.tsx
@@ -11,14 +11,15 @@
 import { ChevronLeft, ChevronRight } from "lucide-react";
 
 import { toCoachingActivity } from "../../../adapters/train2go/coaching-record-to-activity.converter";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { CoachingActivityRecord } from "../../../types/coaching-activity-record";
 import { CoachingDescription } from "./CoachingDescription";
 import { useSidebarCollapse } from "./use-sidebar-collapse";
 
-const STATUS_LABEL: Record<string, string> = {
-  pending: "Pending",
-  completed: "Completed",
-  skipped: "Skipped",
+const STATUS_LABEL_KEY: Record<string, string> = {
+  pending: "status.pending",
+  completed: "status.completed",
+  skipped: "status.skipped",
 };
 
 export type CoachingSidebarProps = {
@@ -26,6 +27,7 @@ export type CoachingSidebarProps = {
 };
 
 export function CoachingSidebar({ activity }: CoachingSidebarProps) {
+  const t = useTranslate("chat");
   const { collapsed, toggle } = useSidebarCollapse();
   if (collapsed) {
     return (
@@ -36,13 +38,14 @@ export function CoachingSidebar({ activity }: CoachingSidebarProps) {
         className="flex items-center gap-1 rounded-md border border-slate-300 px-2 py-1 text-xs text-slate-600 hover:bg-slate-100 dark:border-slate-700 dark:text-slate-300 dark:hover:bg-slate-800"
       >
         <ChevronRight className="h-3 w-3" aria-hidden="true" />
-        Coach
+        {t("coaching.coach")}
       </button>
     );
   }
   const view = toCoachingActivity(activity);
   const sport = view.sport;
-  const status = STATUS_LABEL[activity.status] ?? activity.status;
+  const statusKey = STATUS_LABEL_KEY[activity.status];
+  const status = statusKey ? t(statusKey) : activity.status;
   return (
     <aside
       data-testid="coaching-sidebar"
@@ -59,7 +62,7 @@ export function CoachingSidebar({ activity }: CoachingSidebarProps) {
           type="button"
           data-testid="coaching-sidebar-collapse"
           onClick={toggle}
-          aria-label="Collapse coach sidebar"
+          aria-label={t("coaching.collapse")}
           className="rounded p-1 text-slate-500 hover:bg-slate-200 dark:text-slate-400 dark:hover:bg-slate-800"
         >
           <ChevronLeft className="h-4 w-4" aria-hidden="true" />

--- a/packages/workout-spa-editor/src/components/pages/ChatPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/ChatPage.tsx
@@ -19,6 +19,7 @@ import { useChatModelSelection } from "../../hooks/use-chat-model-selection";
 import { useChatSearchPanel } from "../../hooks/use-chat-search-panel";
 import { useAiRuntimeStore } from "../../store/ai-runtime-store";
 import { ChatHeader } from "../organisms/Chat/ChatHeader";
+import { ChatLoading } from "../organisms/Chat/ChatLoading";
 import { ChatWorkspace } from "../organisms/Chat/ChatWorkspace";
 import { CreateProvidersEmpty } from "./CreateWorkout/CreateProvidersEmpty";
 import { resolveActiveChatModel } from "./resolve-active-chat-model";
@@ -62,9 +63,7 @@ export default function ChatPage({ conversationId }: ChatPageProps) {
     <div className="space-y-4 p-4" data-testid="chat-page">
       <ChatHeader />
       {providers === undefined ? (
-        <div className="flex items-center justify-center p-8 text-slate-400">
-          Loading…
-        </div>
+        <ChatLoading />
       ) : providers.length === 0 ? (
         <CreateProvidersEmpty />
       ) : (

--- a/packages/workout-spa-editor/src/components/pages/CoachingDraftSurface.tsx
+++ b/packages/workout-spa-editor/src/components/pages/CoachingDraftSurface.tsx
@@ -8,6 +8,7 @@
  * persisted SessionMatch that does not exist for a draft.
  */
 import { useAppHandlers } from "../../hooks/use-app-handlers";
+import { useTranslate } from "../../i18n/use-translate";
 import { useCurrentWorkout } from "../../store/selectors/workout-selectors";
 import { useWorkoutStore } from "../../store/workout-store";
 import type { Workout } from "../../types/krd";
@@ -28,6 +29,7 @@ export function CoachingDraftSurface({
   coachingDraftId,
   onBack,
 }: CoachingDraftSurfaceProps) {
+  const t = useTranslate("chat");
   const { activity, noStructured } = useCoachingDraft(coachingDraftId);
   const { canSave, save } = useCoachingDraftSave(activity);
   const currentWorkout = useCurrentWorkout();
@@ -50,7 +52,7 @@ export function CoachingDraftSurface({
           onClick={() => void save()}
           data-testid="coaching-draft-save-button"
         >
-          Save workout
+          {t("draft.saveWorkout")}
         </Button>
       )}
       {workout && currentWorkout && (

--- a/packages/workout-spa-editor/src/hooks/chat/chat-error.test.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/chat-error.test.ts
@@ -11,9 +11,7 @@ describe("categorizeChatError", () => {
     const category = categorizeChatError(error);
 
     // Assert
-    expect(category).toBe(
-      "Authentication failed — check your API key in settings."
-    );
+    expect(category).toBe("auth");
   });
 
   it("should map rate/quota failures to a fixed category", () => {
@@ -24,7 +22,7 @@ describe("categorizeChatError", () => {
     const category = categorizeChatError(error);
 
     // Assert
-    expect(category).toContain("Rate limit");
+    expect(category).toBe("rate");
   });
 
   it("should map network failures to a fixed category", () => {
@@ -35,7 +33,7 @@ describe("categorizeChatError", () => {
     const category = categorizeChatError(error);
 
     // Assert
-    expect(category).toContain("Network error");
+    expect(category).toBe("network");
   });
 
   it("should fall back to a generic category for unknown errors", () => {
@@ -46,7 +44,7 @@ describe("categorizeChatError", () => {
     const category = categorizeChatError(error);
 
     // Assert
-    expect(category).toBe("The assistant hit an error. Try again.");
+    expect(category).toBe("generic");
   });
 
   it("should never leak the original message into the category", () => {

--- a/packages/workout-spa-editor/src/hooks/chat/chat-error.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/chat-error.ts
@@ -1,20 +1,16 @@
 /**
- * Maps a provider/tool failure to a fixed, user-safe category string.
+ * Maps a provider/tool failure to a stable, user-safe error-category key.
  *
- * Returns ONLY static literals — never interpolates the error message or any
- * conversation content — so the PII guard holds when this is rendered or
- * (optionally) toasted.
+ * Returns ONLY a fixed enum key — never the error message or any conversation
+ * content — so the PII guard holds when the value is rendered (localized by
+ * category key at the display boundary) or (optionally) toasted.
  */
-export const categorizeChatError = (error: unknown): string => {
+export type ChatErrorCategory = "auth" | "rate" | "network" | "generic";
+
+export const categorizeChatError = (error: unknown): ChatErrorCategory => {
   const message = error instanceof Error ? error.message : String(error);
-  if (/401|unauthor|api[_\s-]?key/i.test(message)) {
-    return "Authentication failed — check your API key in settings.";
-  }
-  if (/429|rate|quota|overload/i.test(message)) {
-    return "Rate limit or quota reached — try again shortly.";
-  }
-  if (/network|fetch|cors|timeout/i.test(message)) {
-    return "Network error reaching the provider — try again.";
-  }
-  return "The assistant hit an error. Try again.";
+  if (/401|unauthor|api[_\s-]?key/i.test(message)) return "auth";
+  if (/429|rate|quota|overload/i.test(message)) return "rate";
+  if (/network|fetch|cors|timeout/i.test(message)) return "network";
+  return "generic";
 };

--- a/packages/workout-spa-editor/src/hooks/chat/chat-turn-runner.test.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/chat-turn-runner.test.ts
@@ -188,6 +188,6 @@ describe("chat-turn-runner", () => {
 
     // Assert
     expect(states.at(-1)).toBe("error");
-    expect(errors.at(-1)).toContain("Authentication failed");
+    expect(errors.at(-1)).toBe("auth");
   });
 });

--- a/packages/workout-spa-editor/src/i18n/locales/en/chat.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/chat.json
@@ -1,0 +1,80 @@
+{
+  "page": {
+    "loading": "Loading…"
+  },
+  "header": {
+    "title": "Assistant",
+    "subtitle": "Ask about your training and health history, or run an action."
+  },
+  "composer": {
+    "messageLabel": "Message",
+    "placeholder": "Ask about your training or health…",
+    "send": "Send"
+  },
+  "empty": {
+    "startConversation": "Start a conversation — ask about your recent workouts or sleep."
+  },
+  "role": {
+    "user": "You",
+    "assistant": "Assistant",
+    "tool": "Action"
+  },
+  "model": {
+    "label": "Model"
+  },
+  "search": {
+    "placeholder": "Search chats…",
+    "label": "Search chats",
+    "clear": "Clear search",
+    "noMatches": "No matches."
+  },
+  "workspace": {
+    "selectOrStart": "Select a conversation or start a new one."
+  },
+  "list": {
+    "ariaLabel": "Conversations",
+    "newConversation": "+ New conversation"
+  },
+  "item": {
+    "rename": "Rename conversation",
+    "delete": "Delete conversation",
+    "confirmDelete": "Confirm delete"
+  },
+  "titleInput": {
+    "label": "Conversation title"
+  },
+  "pendingAction": {
+    "confirm": "Confirm: {{action}}",
+    "approve": "Approve",
+    "decline": "Decline"
+  },
+  "action": {
+    "sync_coaching": "Sync coaching activities",
+    "create_workout": "Create a workout",
+    "log_health_metric": "Log a health metric"
+  },
+  "toolLinks": {
+    "viewWorkout": "View workout",
+    "viewCalendar": "View on calendar"
+  },
+  "errors": {
+    "retry": "Retry",
+    "auth": "Authentication failed — check your API key in settings.",
+    "rate": "Rate limit or quota reached — try again shortly.",
+    "network": "Network error reaching the provider — try again.",
+    "generic": "The assistant hit an error. Try again."
+  },
+  "draft": {
+    "saveWorkout": "Save workout"
+  },
+  "coaching": {
+    "noDescription": "No description provided.",
+    "coach": "Coach",
+    "collapse": "Collapse coach sidebar"
+  },
+  "status": {
+    "pending": "Pending",
+    "completed": "Completed",
+    "skipped": "Skipped"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/chat.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/chat.json
@@ -1,0 +1,80 @@
+{
+  "page": {
+    "loading": "Cargando…"
+  },
+  "header": {
+    "title": "Asistente",
+    "subtitle": "Pregunta sobre tu entrenamiento y tu historial de salud, o ejecuta una acción."
+  },
+  "composer": {
+    "messageLabel": "Mensaje",
+    "placeholder": "Pregunta sobre tu entrenamiento o tu salud…",
+    "send": "Enviar"
+  },
+  "empty": {
+    "startConversation": "Inicia una conversación: pregunta por tus entrenamientos recientes o tu sueño."
+  },
+  "role": {
+    "user": "Tú",
+    "assistant": "Asistente",
+    "tool": "Acción"
+  },
+  "model": {
+    "label": "Modelo"
+  },
+  "search": {
+    "placeholder": "Buscar chats…",
+    "label": "Buscar chats",
+    "clear": "Borrar búsqueda",
+    "noMatches": "Sin coincidencias."
+  },
+  "workspace": {
+    "selectOrStart": "Selecciona una conversación o inicia una nueva."
+  },
+  "list": {
+    "ariaLabel": "Conversaciones",
+    "newConversation": "+ Nueva conversación"
+  },
+  "item": {
+    "rename": "Renombrar conversación",
+    "delete": "Eliminar conversación",
+    "confirmDelete": "Confirmar eliminación"
+  },
+  "titleInput": {
+    "label": "Título de la conversación"
+  },
+  "pendingAction": {
+    "confirm": "Confirmar: {{action}}",
+    "approve": "Aprobar",
+    "decline": "Rechazar"
+  },
+  "action": {
+    "sync_coaching": "Sincronizar actividades del entrenador",
+    "create_workout": "Crear un entrenamiento",
+    "log_health_metric": "Registrar una métrica de salud"
+  },
+  "toolLinks": {
+    "viewWorkout": "Ver entrenamiento",
+    "viewCalendar": "Ver en el calendario"
+  },
+  "errors": {
+    "retry": "Reintentar",
+    "auth": "Error de autenticación: comprueba tu clave de API en los ajustes.",
+    "rate": "Se alcanzó el límite de peticiones o la cuota: inténtalo de nuevo en breve.",
+    "network": "Error de red al contactar con el proveedor: inténtalo de nuevo.",
+    "generic": "El asistente tuvo un error. Inténtalo de nuevo."
+  },
+  "draft": {
+    "saveWorkout": "Guardar entrenamiento"
+  },
+  "coaching": {
+    "noDescription": "No se proporcionó descripción.",
+    "coach": "Entrenador",
+    "collapse": "Contraer barra del entrenador"
+  },
+  "status": {
+    "pending": "Pendiente",
+    "completed": "Completado",
+    "skipped": "Omitido"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -8,6 +8,7 @@
 import type { LocaleResources } from "@kaiord/i18n";
 
 import enCalendar from "./locales/en/calendar.json";
+import enChat from "./locales/en/chat.json";
 import enCommon from "./locales/en/common.json";
 import enCreateWorkout from "./locales/en/create-workout.json";
 import enDaily from "./locales/en/daily.json";
@@ -21,6 +22,7 @@ import enSettings from "./locales/en/settings.json";
 import enTargets from "./locales/en/targets.json";
 import enWorkoutDetail from "./locales/en/workout-detail.json";
 import esCalendar from "./locales/es/calendar.json";
+import esChat from "./locales/es/chat.json";
 import esCommon from "./locales/es/common.json";
 import esCreateWorkout from "./locales/es/create-workout.json";
 import esDaily from "./locales/es/daily.json";
@@ -36,6 +38,7 @@ import esWorkoutDetail from "./locales/es/workout-detail.json";
 
 export const NAMESPACES = [
   "calendar",
+  "chat",
   "common",
   "create-workout",
   "daily",
@@ -55,6 +58,7 @@ export const DEFAULT_NAMESPACE = "common";
 export const resources: LocaleResources = {
   en: {
     calendar: enCalendar,
+    chat: enChat,
     common: enCommon,
     "create-workout": enCreateWorkout,
     daily: enDaily,
@@ -70,6 +74,7 @@ export const resources: LocaleResources = {
   },
   es: {
     calendar: esCalendar,
+    chat: esChat,
     common: esCommon,
     "create-workout": esCreateWorkout,
     daily: esDaily,


### PR DESCRIPTION
## What

Twelfth SPA i18n PR. New `chat` namespace across chat + coaching sidebar UI.

- Chat page/workspace, composer, header, message list, model picker, search, conversation list, pending-action card, coaching sidebar. Only static UI chrome is localized — conversation content and user-typed titles are left untouched.
- **Failure-semantics refactor for chat errors**: `categorizeChatError` now returns a stable `ChatErrorCategory` (`"auth"`/`"rate"`/`"network"`/`"generic"`) instead of an English message, and `ChatErrorNotice` localizes by that category key at the display boundary. Rendered English is byte-identical (`errors.auth` = "Authentication failed — check your API key in settings.", etc.).
- The two chat-error tests were updated to assert the **category** (the function's return type legitimately changed).
- Config maps (role/action/status/tool-links) keep stable keys; `ChatLoading` extracted from `ChatPage` for the 80-line cap.

## Verification

- pages + Chat + CoachingSidebar + hooks/chat + i18n suites: **662/662**.
- `tsc --noEmit` clean (prop-type change propagated) · eslint clean · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)