### PR TITLE
feat(spa-editor): localize the coaching banners (coaching namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/BatchMessage.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/BatchMessage.tsx
@@ -1,3 +1,5 @@
+import { useTranslate } from "../../../i18n/use-translate";
+
 export function BatchMessage({
   message,
   onDismiss,
@@ -5,11 +7,12 @@ export function BatchMessage({
   message: string;
   onDismiss: () => void;
 }) {
+  const t = useTranslate("coaching");
   return (
     <div className="flex items-center gap-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-900 dark:bg-amber-950">
       <span className="flex-1">{message}</span>
       <button type="button" onClick={onDismiss} className="text-xs underline">
-        Dismiss
+        {t("batch.dismiss")}
       </button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/BatchProcessingBanner.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/BatchProcessingBanner.tsx
@@ -9,6 +9,7 @@
 import { Bot } from "lucide-react";
 
 import type { BatchProgress } from "../../../application/batch-processor";
+import { useTranslate } from "../../../i18n/use-translate";
 import { ProcessingStatus } from "./ProcessingStatus";
 
 export type BatchProcessingBannerProps = {
@@ -50,17 +51,20 @@ function IdleStatus({
   rawCount: number;
   onProcess: () => void;
 }) {
+  const t = useTranslate("coaching");
   return (
     <>
       <span className="flex-1 text-sm">
-        {rawCount} raw workout{rawCount !== 1 ? "s" : ""} this week
+        {t(rawCount === 1 ? "batch.rawCount_one" : "batch.rawCount_other", {
+          count: rawCount,
+        })}
       </span>
       <button
         type="button"
         onClick={onProcess}
         className="rounded-md bg-primary-600 px-3 py-1 text-sm text-white hover:bg-primary-700"
       >
-        Process all with AI
+        {t("batch.processAll")}
       </button>
     </>
   );

--- a/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/ProcessingStatus.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/BatchProcessingBanner/ProcessingStatus.tsx
@@ -1,6 +1,7 @@
 import { X } from "lucide-react";
 
 import type { BatchProgress } from "../../../application/batch-processor";
+import { useTranslate } from "../../../i18n/use-translate";
 
 function deriveCounts(progress: BatchProgress) {
   // Back-compat: `counts` is the spec-required shape but legacy emit
@@ -23,31 +24,39 @@ export function ProcessingStatus({
   onCancel: () => void;
 }) {
   const counts = deriveCounts(progress);
+  const t = useTranslate("coaching");
 
   return (
     <>
       <div className="flex-1 text-sm">
         <div data-testid="batch-progress">
-          Processing {progress.processed} of {progress.total}
+          {t("batch.progress", {
+            processed: progress.processed,
+            total: progress.total,
+          })}
         </div>
         <div
           data-testid="batch-progress-breakdown"
           className="mt-0.5 flex gap-3 text-xs text-gray-600 dark:text-gray-400"
         >
-          <span data-testid="batch-count-queued">Queued {counts.queued}</span>
+          <span data-testid="batch-count-queued">
+            {t("batch.queued", { n: counts.queued })}
+          </span>
           <span data-testid="batch-count-processing">
-            Processing {counts.processing}
+            {t("batch.processing", { n: counts.processing })}
           </span>
           <span data-testid="batch-count-succeeded">
-            Succeeded {counts.succeeded}
+            {t("batch.succeeded", { n: counts.succeeded })}
           </span>
-          <span data-testid="batch-count-failed">Failed {counts.failed}</span>
+          <span data-testid="batch-count-failed">
+            {t("batch.failed", { n: counts.failed })}
+          </span>
         </div>
       </div>
       <button
         type="button"
         onClick={onCancel}
-        aria-label="Cancel batch processing"
+        aria-label={t("batch.cancelAria")}
         className="rounded p-1 hover:bg-yellow-100 dark:hover:bg-yellow-900"
       >
         <X className="h-4 w-4" />

--- a/packages/workout-spa-editor/src/components/organisms/AutoMatchBanner/AutoMatchBanner.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AutoMatchBanner/AutoMatchBanner.tsx
@@ -12,6 +12,7 @@
 import { useState } from "react";
 
 import type { MatchSuggestion } from "../../../application/match-suggestion";
+import { type Translate, useTranslate } from "../../../i18n/use-translate";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 import { AutoMatchBannerHeader } from "./AutoMatchBannerHeader";
 import { AutoMatchSuggestionRow } from "./AutoMatchSuggestionRow";
@@ -26,10 +27,12 @@ export type AutoMatchBannerProps = {
 
 const VISIBLE_ROW_CAP = 2;
 
-const remainingMessage = (verb: string, after: number): string =>
-  after === 0
-    ? `${verb}. No suggestions remaining.`
-    : `${verb}. ${after} suggestions remaining.`;
+const statusMessage = (t: Translate, verbKey: string, after: number): string =>
+  `${t(verbKey)} ${
+    after === 0
+      ? t("suggestion.noneRemaining")
+      : t("suggestion.nRemaining", { count: after })
+  }`;
 
 export function AutoMatchBanner({
   suggestions,
@@ -38,6 +41,7 @@ export function AutoMatchBanner({
   resolveActivity,
   resolveWorkoutTitle,
 }: AutoMatchBannerProps) {
+  const t = useTranslate("coaching");
   const [expanded, setExpanded] = useState(false);
   const [status, setStatus] = useState("");
 
@@ -46,20 +50,21 @@ export function AutoMatchBanner({
     ? suggestions
     : suggestions.slice(0, VISIBLE_ROW_CAP);
   const overflow = suggestions.length > VISIBLE_ROW_CAP;
+  const after = suggestions.length - 1;
 
   const onAcceptRow = async (s: MatchSuggestion) => {
     await onAccept(s);
-    setStatus(remainingMessage("Session matched", suggestions.length - 1));
+    setStatus(statusMessage(t, "suggestion.sessionMatched", after));
   };
   const onRejectRow = async (s: MatchSuggestion) => {
     await onReject(s);
-    setStatus(remainingMessage("Suggestion dismissed", suggestions.length - 1));
+    setStatus(statusMessage(t, "suggestion.suggestionDismissed", after));
   };
 
   return (
     <section
       role="region"
-      aria-label="Auto-match suggestions"
+      aria-label={t("banner.ariaLabel")}
       data-testid="auto-match-banner"
       className={`overflow-y-auto rounded-md border border-slate-200 bg-slate-50 p-2 text-sm dark:border-slate-700 dark:bg-slate-900 ${expanded ? "max-h-64" : "max-h-32"}`}
     >

--- a/packages/workout-spa-editor/src/components/organisms/AutoMatchBanner/AutoMatchBannerHeader.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AutoMatchBanner/AutoMatchBannerHeader.tsx
@@ -6,6 +6,8 @@
  * to override.
  */
 
+import { useTranslate } from "../../../i18n/use-translate";
+
 export type AutoMatchBannerHeaderProps = {
   total: number;
   expanded: boolean;
@@ -19,9 +21,10 @@ export function AutoMatchBannerHeader({
   overflow,
   onToggleExpanded,
 }: AutoMatchBannerHeaderProps) {
+  const t = useTranslate("coaching");
   return (
     <div className="mb-2 flex items-center justify-between">
-      <span className="font-medium">Auto-match suggestions ({total})</span>
+      <span className="font-medium">{t("banner.title", { total })}</span>
       {overflow && (
         <button
           type="button"
@@ -29,7 +32,7 @@ export function AutoMatchBannerHeader({
           onClick={onToggleExpanded}
           className="text-xs text-primary-600 hover:underline"
         >
-          {expanded ? "Collapse" : `view all (${total})`}
+          {expanded ? t("banner.collapse") : t("banner.viewAll", { total })}
         </button>
       )}
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/AutoMatchBanner/AutoMatchSuggestionRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/AutoMatchBanner/AutoMatchSuggestionRow.tsx
@@ -6,6 +6,7 @@
 import { Check, X } from "lucide-react";
 
 import type { MatchSuggestion } from "../../../application/match-suggestion";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 
 const formatPercent = (score: number | null): string =>
@@ -26,6 +27,7 @@ export function AutoMatchSuggestionRow({
   resolveActivity,
   resolveWorkoutTitle,
 }: AutoMatchSuggestionRowProps) {
+  const t = useTranslate("coaching");
   const activity = resolveActivity?.(suggestion.activityId);
   const workoutTitle = resolveWorkoutTitle?.(suggestion.workoutId);
   return (
@@ -40,7 +42,7 @@ export function AutoMatchSuggestionRow({
       </span>
       <button
         type="button"
-        aria-label="Accept suggestion"
+        aria-label={t("suggestion.accept")}
         onClick={onAccept}
         className="rounded p-1 text-emerald-600 hover:bg-emerald-50"
       >
@@ -48,7 +50,7 @@ export function AutoMatchSuggestionRow({
       </button>
       <button
         type="button"
-        aria-label="Reject suggestion"
+        aria-label={t("suggestion.reject")}
         onClick={onReject}
         className="rounded p-1 text-slate-500 hover:bg-slate-100"
       >

--- a/packages/workout-spa-editor/src/components/organisms/BatchCostConfirmation/BatchCostConfirmationPanel.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/BatchCostConfirmation/BatchCostConfirmationPanel.tsx
@@ -6,6 +6,7 @@
 import * as Dialog from "@radix-ui/react-dialog";
 
 import type { BatchCostEstimate } from "../../../hooks/use-batch-cost-estimate";
+import { useTranslate } from "../../../i18n/use-translate";
 import { BatchCostEstimateList } from "./BatchCostEstimateList";
 
 export type BatchCostConfirmationPanelProps = {
@@ -21,18 +22,21 @@ export function BatchCostConfirmationPanel({
   onConfirm,
   onCancel,
 }: BatchCostConfirmationPanelProps) {
+  const t = useTranslate("coaching");
   return (
     <div className="p-6">
       <Dialog.Title className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-        Process {workoutCount} workout{workoutCount !== 1 ? "s" : ""} with AI?
+        {t(
+          workoutCount === 1 ? "batchCost.title_one" : "batchCost.title_other",
+          { count: workoutCount }
+        )}
       </Dialog.Title>
       <Dialog.Description className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-        Review the estimate before dispatching the batch.
+        {t("batchCost.description")}
       </Dialog.Description>
       <BatchCostEstimateList estimate={estimate} />
       <p className="mt-4 text-xs text-gray-500 dark:text-gray-400">
-        This is an estimate — actual usage may differ. Real cost is recorded per
-        run in Settings → Usage.
+        {t("batchCost.estimateNote")}
       </p>
       <div className="mt-6 flex justify-end gap-2">
         <button
@@ -41,7 +45,7 @@ export function BatchCostConfirmationPanel({
           data-testid="batch-cost-cancel"
           className="rounded-md border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
         >
-          Cancel
+          {t("batchCost.cancel")}
         </button>
         <button
           type="button"
@@ -50,7 +54,7 @@ export function BatchCostConfirmationPanel({
           disabled={estimate.providerLabel === null}
           className="rounded-md bg-primary-600 px-4 py-2 text-sm text-white hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          Confirm
+          {t("batchCost.confirm")}
         </button>
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/BatchCostConfirmation/BatchCostEstimateList.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/BatchCostConfirmation/BatchCostEstimateList.tsx
@@ -4,6 +4,7 @@
  */
 
 import type { BatchCostEstimate } from "../../../hooks/use-batch-cost-estimate";
+import { useTranslate } from "../../../i18n/use-translate";
 
 export type BatchCostEstimateListProps = {
   estimate: BatchCostEstimate;
@@ -12,29 +13,36 @@ export type BatchCostEstimateListProps = {
 export function BatchCostEstimateList({
   estimate,
 }: BatchCostEstimateListProps) {
+  const t = useTranslate("coaching");
   return (
     <dl className="mt-4 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
-      <dt className="text-gray-500 dark:text-gray-400">Provider</dt>
+      <dt className="text-gray-500 dark:text-gray-400">
+        {t("batchCost.provider")}
+      </dt>
       <dd
         data-testid="batch-cost-provider"
         className="font-medium text-gray-900 dark:text-gray-100"
       >
-        {estimate.providerLabel ?? "No provider selected"}
+        {estimate.providerLabel ?? t("batchCost.noProvider")}
       </dd>
-      <dt className="text-gray-500 dark:text-gray-400">Estimated tokens</dt>
+      <dt className="text-gray-500 dark:text-gray-400">
+        {t("batchCost.tokens")}
+      </dt>
       <dd
         data-testid="batch-cost-tokens"
         className="font-medium text-gray-900 dark:text-gray-100"
       >
         {estimate.tokens.toLocaleString()}
       </dd>
-      <dt className="text-gray-500 dark:text-gray-400">Estimated cost</dt>
+      <dt className="text-gray-500 dark:text-gray-400">
+        {t("batchCost.cost")}
+      </dt>
       <dd
         data-testid="batch-cost-usd"
         className="font-medium text-gray-900 dark:text-gray-100"
       >
         {estimate.costUsd !== null
-          ? `$${estimate.costUsd.toFixed(4)} USD`
+          ? t("batchCost.costValue", { amount: estimate.costUsd.toFixed(4) })
           : "—"}
       </dd>
     </dl>

--- a/packages/workout-spa-editor/src/i18n/locales/en/coaching.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/coaching.json
@@ -1,0 +1,41 @@
+{
+  "banner": {
+    "title": "Auto-match suggestions ({{total}})",
+    "ariaLabel": "Auto-match suggestions",
+    "collapse": "Collapse",
+    "viewAll": "view all ({{total}})"
+  },
+  "suggestion": {
+    "accept": "Accept suggestion",
+    "reject": "Reject suggestion",
+    "sessionMatched": "Session matched.",
+    "suggestionDismissed": "Suggestion dismissed.",
+    "noneRemaining": "No suggestions remaining.",
+    "nRemaining": "{{count}} suggestions remaining."
+  },
+  "batchCost": {
+    "title_one": "Process {{count}} workout with AI?",
+    "title_other": "Process {{count}} workouts with AI?",
+    "description": "Review the estimate before dispatching the batch.",
+    "estimateNote": "This is an estimate — actual usage may differ. Real cost is recorded per run in Settings → Usage.",
+    "cancel": "Cancel",
+    "confirm": "Confirm",
+    "provider": "Provider",
+    "noProvider": "No provider selected",
+    "tokens": "Estimated tokens",
+    "cost": "Estimated cost",
+    "costValue": "${{amount}} USD"
+  },
+  "batch": {
+    "dismiss": "Dismiss",
+    "rawCount_one": "{{count}} raw workout this week",
+    "rawCount_other": "{{count}} raw workouts this week",
+    "processAll": "Process all with AI",
+    "progress": "Processing {{processed}} of {{total}}",
+    "queued": "Queued {{n}}",
+    "processing": "Processing {{n}}",
+    "succeeded": "Succeeded {{n}}",
+    "failed": "Failed {{n}}",
+    "cancelAria": "Cancel batch processing"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/coaching.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/coaching.json
@@ -1,0 +1,41 @@
+{
+  "banner": {
+    "title": "Sugerencias de emparejamiento ({{total}})",
+    "ariaLabel": "Sugerencias de emparejamiento",
+    "collapse": "Contraer",
+    "viewAll": "ver todas ({{total}})"
+  },
+  "suggestion": {
+    "accept": "Aceptar sugerencia",
+    "reject": "Rechazar sugerencia",
+    "sessionMatched": "Sesión emparejada.",
+    "suggestionDismissed": "Sugerencia descartada.",
+    "noneRemaining": "No quedan sugerencias.",
+    "nRemaining": "Quedan {{count}} sugerencias."
+  },
+  "batchCost": {
+    "title_one": "¿Procesar {{count}} entreno con IA?",
+    "title_other": "¿Procesar {{count}} entrenos con IA?",
+    "description": "Revisa la estimación antes de lanzar el lote.",
+    "estimateNote": "Es una estimación — el uso real puede variar. El coste real se registra por ejecución en Ajustes → Uso.",
+    "cancel": "Cancelar",
+    "confirm": "Confirmar",
+    "provider": "Proveedor",
+    "noProvider": "Ningún proveedor seleccionado",
+    "tokens": "Tokens estimados",
+    "cost": "Coste estimado",
+    "costValue": "${{amount}} USD"
+  },
+  "batch": {
+    "dismiss": "Descartar",
+    "rawCount_one": "{{count}} entreno sin procesar esta semana",
+    "rawCount_other": "{{count}} entrenos sin procesar esta semana",
+    "processAll": "Procesar todo con IA",
+    "progress": "Procesando {{processed}} de {{total}}",
+    "queued": "En cola {{n}}",
+    "processing": "Procesando {{n}}",
+    "succeeded": "Completados {{n}}",
+    "failed": "Fallidos {{n}}",
+    "cancelAria": "Cancelar el procesamiento por lotes"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -9,6 +9,7 @@ import type { LocaleResources } from "@kaiord/i18n";
 
 import enCalendar from "./locales/en/calendar.json";
 import enChat from "./locales/en/chat.json";
+import enCoaching from "./locales/en/coaching.json";
 import enCommon from "./locales/en/common.json";
 import enCreateWorkout from "./locales/en/create-workout.json";
 import enDaily from "./locales/en/daily.json";
@@ -23,6 +24,7 @@ import enTargets from "./locales/en/targets.json";
 import enWorkoutDetail from "./locales/en/workout-detail.json";
 import esCalendar from "./locales/es/calendar.json";
 import esChat from "./locales/es/chat.json";
+import esCoaching from "./locales/es/coaching.json";
 import esCommon from "./locales/es/common.json";
 import esCreateWorkout from "./locales/es/create-workout.json";
 import esDaily from "./locales/es/daily.json";
@@ -36,29 +38,13 @@ import esSettings from "./locales/es/settings.json";
 import esTargets from "./locales/es/targets.json";
 import esWorkoutDetail from "./locales/es/workout-detail.json";
 
-export const NAMESPACES = [
-  "calendar",
-  "chat",
-  "common",
-  "create-workout",
-  "daily",
-  "editor",
-  "errors",
-  "labs",
-  "labImport",
-  "library",
-  "nav",
-  "settings",
-  "targets",
-  "workout-detail",
-] as const;
-
 export const DEFAULT_NAMESPACE = "common";
 
 export const resources: LocaleResources = {
   en: {
     calendar: enCalendar,
     chat: enChat,
+    coaching: enCoaching,
     common: enCommon,
     "create-workout": enCreateWorkout,
     daily: enDaily,
@@ -75,6 +61,7 @@ export const resources: LocaleResources = {
   es: {
     calendar: esCalendar,
     chat: esChat,
+    coaching: esCoaching,
     common: esCommon,
     "create-workout": esCreateWorkout,
     daily: esDaily,
@@ -89,3 +76,6 @@ export const resources: LocaleResources = {
     "workout-detail": esWorkoutDetail,
   },
 };
+
+/** Namespace list for i18next, derived from the resource tree (single source). */
+export const NAMESPACES = Object.keys(resources.en);


### PR DESCRIPTION
## What

Thirteenth SPA i18n PR. New `coaching` namespace for the coaching **banners** (the CoachingCard subtree is a follow-up).

- Auto-match suggestion banner (title, view-all/collapse, accept/reject aria, sr-only status), batch cost-confirmation dialog, and the batch-processing banner (raw count, per-count queued/processing/succeeded/failed breakdown, cancel).
- Manual singular/plural (`title_one`/`_other`, `rawCount_one`/`_other`) matches the original; the sr-only remaining-suggestions status is rebuilt from **complete sentences** so Spanish word order holds; the `"$X USD"` cost keeps its byte-identical format.
- **Also**: derive `NAMESPACES` from the resource map so `resources.ts` stays under the line cap as namespaces keep growing (single source of truth).

## Verification

- AutoMatchBanner + BatchCostConfirmation + BatchProcessingBanner + i18n suites: **41/41**.
- `tsc --noEmit` clean · eslint clean · prettier clean.

Note: done directly (not via a subagent) due to transient API overload on subagent spawns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized coaching and batch-processing text across banners, dialogs, status messages, and action buttons.
  * Introduced Spanish translations alongside English for the coaching experience.
  * Improved pluralized wording for counts and estimates, including clearer messaging for processing progress and batch costs.
* **Accessibility**
  * Updated button and status labels so screen readers announce localized text consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->