### PR TITLE
feat(spa-editor): localize the coaching card dialog (coaching namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/AiErrorState.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/AiErrorState.tsx
@@ -6,19 +6,7 @@
  * points as the no-workout layout, just with the error context.
  */
 import type { AiFailureReason } from "../../../application/coaching/convert-coaching-activity-error-mapper";
-
-const REASON_TEXT: Record<
-  AiFailureReason | "not-found" | "no-provider",
-  string
-> = {
-  "ai-error": "AI returned an error",
-  "ai-cancelled": "AI request was cancelled",
-  "ai-timeout": "AI request timed out",
-  "ai-invalid-krd": "AI returned an invalid workout structure",
-  "transport-error": "Could not reach the AI service",
-  "not-found": "Coaching activity is no longer available",
-  "no-provider": "No AI provider is configured",
-};
+import { useTranslate } from "../../../i18n/use-translate";
 
 export type AiErrorStateProps = {
   reason: AiFailureReason | "not-found" | "no-provider";
@@ -30,13 +18,14 @@ export type AiErrorStateProps = {
 };
 
 export function AiErrorState(props: AiErrorStateProps) {
+  const t = useTranslate("coaching");
   return (
     <div
       data-testid="coaching-dialog-ai-error"
       className="space-y-3 rounded border border-rose-200 bg-rose-50/60 p-3 text-sm dark:border-rose-800 dark:bg-rose-950/30"
     >
       <p className="text-rose-700 dark:text-rose-300">
-        ⚠ AI processing failed: {REASON_TEXT[props.reason]}
+        ⚠ {t("aiError.heading")}: {t(`aiError.${props.reason}`)}
         {props.detail ? ` (${props.detail})` : ""}
       </p>
       <div className="flex flex-wrap justify-end gap-2">
@@ -45,21 +34,21 @@ export function AiErrorState(props: AiErrorStateProps) {
           onClick={props.onClose}
           className="rounded-md border px-3 py-1 text-xs hover:bg-gray-50 dark:hover:bg-gray-800"
         >
-          Close
+          {t("actions.close")}
         </button>
         <button
           type="button"
           onClick={props.onMatchExisting}
           className="rounded-md border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
         >
-          Match existing
+          {t("actions.matchExisting")}
         </button>
         <button
           type="button"
           onClick={props.onEditManually}
           className="rounded-md border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 dark:border-slate-700 dark:hover:bg-slate-800"
         >
-          Edit manually
+          {t("actions.editManually")}
         </button>
         <button
           type="button"
@@ -67,7 +56,7 @@ export function AiErrorState(props: AiErrorStateProps) {
           onClick={props.onRetry}
           className="rounded-md bg-rose-600 px-3 py-1 text-xs text-white hover:bg-rose-700"
         >
-          Retry AI
+          {t("actions.retryAi")}
         </button>
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialogContent.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingActivityDialogContent.tsx
@@ -10,6 +10,7 @@
  *                    contextual buttons.
  */
 
+import { useTranslate } from "../../../i18n/use-translate";
 import {
   type CoachingDialogBodyProps,
   renderMatchedBody,
@@ -19,7 +20,6 @@ import {
   DialogDescription,
   DialogHeader,
   DialogMeta,
-  STATUS_LABEL,
 } from "./coaching-dialog-parts";
 import { CoachingDayComments } from "./CoachingDayComments";
 import { useCoachingDayComments } from "./use-coaching-day-comments";
@@ -34,6 +34,7 @@ export function CoachingActivityDialogContent(
   props: CoachingActivityDialogContentProps
 ) {
   const { activity, dialogState, profileId } = props;
+  const t = useTranslate("coaching");
   const matched = dialogState?.kind === "matched" ? dialogState : null;
   const comments = useCoachingDayComments(
     profileId,
@@ -45,9 +46,7 @@ export function CoachingActivityDialogContent(
       <DialogHeader activity={activity} />
       <DialogMeta activity={activity} />
       <div className="text-xs text-muted-foreground">
-        <span className="font-medium">
-          {STATUS_LABEL[activity.status] ?? activity.status}
-        </span>
+        <span className="font-medium">{t(`status.${activity.status}`)}</span>
       </div>
       <DialogDescription activity={activity} />
       {matched

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingSyncButton.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/CoachingSyncButton.tsx
@@ -16,6 +16,7 @@
  * CoachingSyncIconButton.tsx.
  */
 
+import { useTranslate } from "../../../i18n/use-translate";
 import {
   buildSyncTooltip,
   usePrefersReducedMotion,
@@ -45,6 +46,7 @@ export function CoachingSyncButton({
   lastSyncedAt,
   routeInactive = false,
 }: CoachingSyncButtonProps) {
+  const t = useTranslate("coaching");
   const reducedMotion = usePrefersReducedMotion();
 
   if (!connected) {
@@ -55,7 +57,7 @@ export function CoachingSyncButton({
           onClick={onConnect}
           className="rounded border border-slate-300 bg-white px-3 py-1 text-sm text-slate-700 hover:bg-slate-100 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-300 dark:hover:bg-slate-800"
         >
-          Connect to {label}
+          {t("sync.connectTo", { label })}
         </button>
         {error && <span className="text-xs text-red-500">{error}</span>}
       </div>

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/LinkedWorkoutSection.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/LinkedWorkoutSection.tsx
@@ -5,6 +5,7 @@
  * flight.
  */
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import {
   formatDurationMinutes,
@@ -23,6 +24,7 @@ export function LinkedWorkoutSection({
   splitting,
   onSplit,
 }: LinkedWorkoutSectionProps) {
+  const t = useTranslate("coaching");
   const duration = formatDurationMinutes(workout.raw?.duration?.value);
   return (
     <div
@@ -30,11 +32,11 @@ export function LinkedWorkoutSection({
       className="space-y-2 rounded border border-emerald-200 bg-emerald-50/40 p-3 text-sm dark:border-emerald-800 dark:bg-emerald-950/30"
     >
       <div className="text-xs font-semibold uppercase text-slate-500 dark:text-slate-400">
-        Linked workout
+        {t("linked.heading")}
       </div>
-      <div className="font-medium">{workoutTitle(workout)}</div>
+      <div className="font-medium">{workoutTitle(workout, t)}</div>
       <div className="text-xs text-slate-600 dark:text-slate-400">
-        {sportLabel(workout.sport)}
+        {sportLabel(workout.sport, t)}
         {duration && ` · ${duration}`}
       </div>
       <div className="pt-1">
@@ -44,7 +46,7 @@ export function LinkedWorkoutSection({
           onClick={onSplit}
           className="rounded border border-slate-300 px-3 py-1 text-xs hover:bg-slate-100 disabled:opacity-50 dark:border-slate-700 dark:hover:bg-slate-800"
         >
-          {splitting ? "Splitting…" : "Split"}
+          {splitting ? t("actions.splitting") : t("actions.split")}
         </button>
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/MatchToPicker.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/MatchToPicker.tsx
@@ -16,6 +16,7 @@
 
 import { useEffect, useRef, useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 import { MatchToPickerItem } from "./MatchToPickerItem";
 
@@ -26,15 +27,18 @@ export type MatchToPickerProps = {
   onClose: () => void;
 };
 
-const Empty = () => (
-  <div
-    role="listbox"
-    aria-label="Match to workout"
-    className="rounded border border-slate-200 p-3 text-sm text-slate-500 dark:border-slate-700"
-  >
-    No same-day, same-sport workouts available to match.
-  </div>
-);
+const Empty = () => {
+  const t = useTranslate("coaching");
+  return (
+    <div
+      role="listbox"
+      aria-label={t("picker.ariaLabel")}
+      className="rounded border border-slate-200 p-3 text-sm text-slate-500 dark:border-slate-700"
+    >
+      {t("picker.empty")}
+    </div>
+  );
+};
 
 export function MatchToPicker({
   workouts,
@@ -42,6 +46,7 @@ export function MatchToPicker({
   onSelect,
   onClose,
 }: MatchToPickerProps) {
+  const t = useTranslate("coaching");
   const [focusIndex, setFocusIndex] = useState(0);
   const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
@@ -69,7 +74,7 @@ export function MatchToPicker({
   return (
     <div
       role="listbox"
-      aria-label="Match to workout"
+      aria-label={t("picker.ariaLabel")}
       onKeyDown={onKeyDown}
       className="space-y-1 rounded border border-slate-200 p-2 dark:border-slate-700"
     >

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/MatchedActions.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/MatchedActions.tsx
@@ -17,6 +17,7 @@
  * Dexie-backed `WorkoutRecord` directly (Option α) so the dialog
  * pushes the persisted state.
  */
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutRecord } from "../../../types/calendar-record";
 
 export type MatchedActionsProps = {
@@ -30,6 +31,7 @@ export type MatchedActionsProps = {
 };
 
 export function MatchedActions(props: MatchedActionsProps) {
+  const t = useTranslate("coaching");
   const state = props.workout.state;
   const showAi = state === "raw";
   const showPush = state === "structured" || state === "ready";
@@ -40,7 +42,7 @@ export function MatchedActions(props: MatchedActionsProps) {
         onClick={props.onClose}
         className="rounded-md border px-3 py-1 text-sm hover:bg-gray-50 dark:hover:bg-gray-800"
       >
-        Close
+        {t("actions.close")}
       </button>
       <button
         type="button"
@@ -49,7 +51,7 @@ export function MatchedActions(props: MatchedActionsProps) {
         onClick={props.onSplit}
         className="rounded-md border border-slate-300 px-3 py-1 text-sm hover:bg-slate-100 disabled:opacity-50 dark:border-slate-700 dark:hover:bg-slate-800"
       >
-        {props.splitting ? "Splitting…" : "Split"}
+        {props.splitting ? t("actions.splitting") : t("actions.split")}
       </button>
       {showPush && (
         <button
@@ -58,7 +60,7 @@ export function MatchedActions(props: MatchedActionsProps) {
           onClick={props.onPushToGarmin}
           className="rounded-md border border-slate-300 px-3 py-1 text-sm hover:bg-slate-100 disabled:opacity-50 dark:border-slate-700 dark:hover:bg-slate-800"
         >
-          Push to Garmin
+          {t("actions.pushToGarmin")}
         </button>
       )}
       {showAi && (
@@ -68,7 +70,7 @@ export function MatchedActions(props: MatchedActionsProps) {
           onClick={props.onAiProcess}
           className="rounded-md bg-rose-600 px-3 py-1 text-sm text-white hover:bg-rose-700"
         >
-          Process with AI
+          {t("actions.processWithAi")}
         </button>
       )}
       <button
@@ -77,7 +79,7 @@ export function MatchedActions(props: MatchedActionsProps) {
         onClick={props.onOpenEditor}
         className="rounded-md bg-slate-700 px-3 py-1 text-sm text-white hover:bg-slate-800"
       >
-        Open editor
+        {t("actions.openEditor")}
       </button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-parts.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/coaching-dialog-parts.tsx
@@ -6,28 +6,30 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 import { renderCoachingInline } from "../../organisms/CoachingSidebar/coaching-inline";
 import { formatCoachingDescription } from "../../organisms/CoachingSidebar/format-coaching-description";
 
-export const STATUS_LABEL: Record<string, string> = {
-  pending: "Pending",
-  completed: "Completed",
-  skipped: "Skipped",
+export const DialogHeader = ({ activity }: { activity: CoachingActivity }) => {
+  const t = useTranslate("coaching");
+  return (
+    <div className="flex items-center justify-between">
+      <Dialog.Title className="text-lg font-semibold">
+        {activity.title}
+      </Dialog.Title>
+      <Dialog.Close asChild>
+        <button
+          type="button"
+          aria-label={t("dialog.closeAria")}
+          className="p-1"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </Dialog.Close>
+    </div>
+  );
 };
-
-export const DialogHeader = ({ activity }: { activity: CoachingActivity }) => (
-  <div className="flex items-center justify-between">
-    <Dialog.Title className="text-lg font-semibold">
-      {activity.title}
-    </Dialog.Title>
-    <Dialog.Close asChild>
-      <button type="button" aria-label="Close" className="p-1">
-        <X className="h-4 w-4" />
-      </button>
-    </Dialog.Close>
-  </div>
-);
 
 export const DialogMeta = ({ activity }: { activity: CoachingActivity }) => (
   <div className="flex items-center gap-2 text-sm text-muted-foreground">
@@ -45,13 +47,14 @@ export const DialogDescription = ({
 }: {
   activity: CoachingActivity;
 }) => {
+  const t = useTranslate("coaching");
   if (activity.description === undefined) {
     return (
       <p
         data-testid="coaching-dialog-description-loading"
         className="text-xs italic text-muted-foreground"
       >
-        Loading description…
+        {t("dialog.loadingDescription")}
       </p>
     );
   }

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/linked-workout-utils.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/linked-workout-utils.ts
@@ -5,14 +5,8 @@
  * formatting and the per-file line caps stay satisfied.
  */
 
+import { getTranslate, type Translate } from "../../../i18n/use-translate";
 import type { WorkoutRecord } from "../../../types/calendar-record";
-
-const SPORT_LABELS: Record<string, string> = {
-  cycling: "Cycling",
-  running: "Running",
-  swimming: "Swimming",
-  strength: "Strength",
-};
 
 export const formatDurationMinutes = (seconds: number | undefined): string => {
   if (!seconds) return "";
@@ -20,12 +14,19 @@ export const formatDurationMinutes = (seconds: number | undefined): string => {
   return `${min}min`;
 };
 
-export const sportLabel = (sport: string | null | undefined): string => {
-  if (!sport) return "Workout";
-  return SPORT_LABELS[sport] ?? sport;
+export const sportLabel = (
+  sport: string | null | undefined,
+  t: Translate = getTranslate("coaching")
+): string => {
+  if (!sport) return t("linked.fallbackTitle");
+  const label = t(`linked.${sport}`);
+  return label === `linked.${sport}` ? sport : label;
 };
 
-export const workoutTitle = (workout: WorkoutRecord): string => {
+export const workoutTitle = (
+  workout: WorkoutRecord,
+  t: Translate = getTranslate("coaching")
+): string => {
   const raw = workout.raw as { title?: string; description?: string } | null;
-  return raw?.title || raw?.description?.slice(0, 60) || "Untitled workout";
+  return raw?.title || raw?.description?.slice(0, 60) || t("linked.untitled");
 };

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/no-workout-buttons.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/no-workout-buttons.tsx
@@ -5,6 +5,8 @@
  * caller passing `writeInFlight`.
  */
 
+import { useTranslate } from "../../../i18n/use-translate";
+
 export type NoWorkoutButtonsProps = {
   pickerOpen: boolean;
   writeInFlight: boolean;
@@ -16,6 +18,7 @@ export type NoWorkoutButtonsProps = {
 };
 
 export function NoWorkoutButtons(props: NoWorkoutButtonsProps) {
+  const t = useTranslate("coaching");
   return (
     <div className="flex flex-wrap justify-end gap-2">
       <button
@@ -23,7 +26,7 @@ export function NoWorkoutButtons(props: NoWorkoutButtonsProps) {
         onClick={props.onClose}
         className="rounded-md border px-3 py-1 text-sm hover:bg-gray-50 dark:hover:bg-gray-800"
       >
-        Close
+        {t("actions.close")}
       </button>
       {!props.pickerOpen && (
         <button
@@ -33,7 +36,7 @@ export function NoWorkoutButtons(props: NoWorkoutButtonsProps) {
           onClick={props.onOpenPicker}
           className="rounded-md border border-slate-300 px-3 py-1 text-sm hover:bg-slate-100 disabled:opacity-50 dark:border-slate-700 dark:hover:bg-slate-800"
         >
-          Match existing
+          {t("actions.matchExisting")}
         </button>
       )}
       <button
@@ -43,7 +46,9 @@ export function NoWorkoutButtons(props: NoWorkoutButtonsProps) {
         onClick={props.onEditManually}
         className="rounded-md border border-slate-300 px-3 py-1 text-sm hover:bg-slate-100 disabled:opacity-50 dark:border-slate-700 dark:hover:bg-slate-800"
       >
-        {props.creatingManual ? "Creating…" : "Edit manually"}
+        {props.creatingManual
+          ? t("actions.creating")
+          : t("actions.editManually")}
       </button>
       <button
         type="button"
@@ -52,7 +57,7 @@ export function NoWorkoutButtons(props: NoWorkoutButtonsProps) {
         onClick={props.onAiProcess}
         className="rounded-md bg-rose-600 px-3 py-1 text-sm text-white hover:bg-rose-700 disabled:opacity-50"
       >
-        AI process
+        {t("actions.aiProcess")}
       </button>
     </div>
   );

--- a/packages/workout-spa-editor/src/i18n/locales/en/coaching.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/coaching.json
@@ -37,5 +37,54 @@
     "succeeded": "Succeeded {{n}}",
     "failed": "Failed {{n}}",
     "cancelAria": "Cancel batch processing"
+  },
+  "aiError": {
+    "heading": "AI processing failed",
+    "ai-error": "AI returned an error",
+    "ai-cancelled": "AI request was cancelled",
+    "ai-timeout": "AI request timed out",
+    "ai-invalid-krd": "AI returned an invalid workout structure",
+    "transport-error": "Could not reach the AI service",
+    "not-found": "Coaching activity is no longer available",
+    "no-provider": "No AI provider is configured"
+  },
+  "status": {
+    "pending": "Pending",
+    "completed": "Completed",
+    "skipped": "Skipped"
+  },
+  "dialog": {
+    "closeAria": "Close",
+    "loadingDescription": "Loading description…"
+  },
+  "actions": {
+    "close": "Close",
+    "matchExisting": "Match existing",
+    "editManually": "Edit manually",
+    "creating": "Creating…",
+    "retryAi": "Retry AI",
+    "aiProcess": "AI process",
+    "processWithAi": "Process with AI",
+    "openEditor": "Open editor",
+    "pushToGarmin": "Push to Garmin",
+    "split": "Split",
+    "splitting": "Splitting…"
+  },
+  "linked": {
+    "heading": "Linked workout",
+    "fallbackTitle": "Workout",
+    "untitled": "Untitled workout",
+    "cycling": "Cycling",
+    "running": "Running",
+    "swimming": "Swimming",
+    "strength": "Strength"
+  },
+  "picker": {
+    "ariaLabel": "Match to workout",
+    "empty": "No same-day, same-sport workouts available to match."
+  },
+  "sync": {
+    "defaultLabel": "Coach",
+    "connectTo": "Connect to {{label}}"
   }
 }

--- a/packages/workout-spa-editor/src/i18n/locales/es/coaching.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/coaching.json
@@ -37,5 +37,54 @@
     "succeeded": "Completados {{n}}",
     "failed": "Fallidos {{n}}",
     "cancelAria": "Cancelar el procesamiento por lotes"
+  },
+  "aiError": {
+    "heading": "El procesamiento con IA falló",
+    "ai-error": "La IA devolvió un error",
+    "ai-cancelled": "Se canceló la petición a la IA",
+    "ai-timeout": "La petición a la IA agotó el tiempo de espera",
+    "ai-invalid-krd": "La IA devolvió una estructura de entreno no válida",
+    "transport-error": "No se pudo contactar con el servicio de IA",
+    "not-found": "La actividad de coaching ya no está disponible",
+    "no-provider": "No hay ningún proveedor de IA configurado"
+  },
+  "status": {
+    "pending": "Pendiente",
+    "completed": "Completado",
+    "skipped": "Omitido"
+  },
+  "dialog": {
+    "closeAria": "Cerrar",
+    "loadingDescription": "Cargando descripción…"
+  },
+  "actions": {
+    "close": "Cerrar",
+    "matchExisting": "Emparejar existente",
+    "editManually": "Editar manualmente",
+    "creating": "Creando…",
+    "retryAi": "Reintentar IA",
+    "aiProcess": "Procesar con IA",
+    "processWithAi": "Procesar con IA",
+    "openEditor": "Abrir editor",
+    "pushToGarmin": "Enviar a Garmin",
+    "split": "Separar",
+    "splitting": "Separando…"
+  },
+  "linked": {
+    "heading": "Entreno vinculado",
+    "fallbackTitle": "Entreno",
+    "untitled": "Entreno sin título",
+    "cycling": "Ciclismo",
+    "running": "Carrera",
+    "swimming": "Natación",
+    "strength": "Fuerza"
+  },
+  "picker": {
+    "ariaLabel": "Emparejar con entreno",
+    "empty": "No hay entrenos del mismo día y deporte disponibles para emparejar."
+  },
+  "sync": {
+    "defaultLabel": "Coach",
+    "connectTo": "Conectar con {{label}}"
   }
 }


### PR DESCRIPTION
## What

Extends the `coaching` namespace across the **CoachingCard dialog** display layer.

- AI error state (localized by stable error-code key, like the chat ChatErrorNotice pattern), status label, dialog header/loading state, matched-state + no-workout action buttons, linked-workout section, match-to picker, and the connect-to CTA.
- Pure helpers (`sportLabel`/`workoutTitle`) take an optional `t` defaulting to English; `STATUS_LABEL` map replaced by `t("status.<code>")` at the consumer.

**Follow-up (still English):** the sync tooltip helper (`coaching-sync-button-tooltip`), AI processing overlay, and the coaching hooks' toast/fallback strings.

## Verification
- CoachingCard + i18n suites: **122/122**. `tsc` / eslint / prettier clean.

Note: done directly in the main loop (subagent spawns are throttled by API 529s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)