### PR TITLE
feat(spa-editor): localize the coaching hook toasts & error fallbacks (coaching namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-ai-handler.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-ai-handler.ts
@@ -16,10 +16,9 @@ import { usePersistence } from "../../../contexts/persistence-context";
 import { useToastContext } from "../../../contexts/ToastContext";
 import { useAiModelBindingsLive } from "../../../hooks/use-ai-model-bindings-live";
 import { useAiProvidersLive } from "../../../hooks/use-ai-providers-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 import { runStartAi, type StartAiCtx } from "./use-coaching-ai-handler-helpers";
-
-const AI_PROCESS_ERROR_TOAST_MESSAGE = "Failed to process activity with AI";
 
 export type AiFailureState = {
   reason: AiFailureReason | "not-found" | "no-provider";
@@ -43,6 +42,7 @@ export const useCoachingAi = (
   const persistence = usePersistence();
   const analytics = useAnalytics();
   const toast = useToastContext();
+  const t = useTranslate("coaching");
   const providers = useAiProvidersLive();
   const bindings = useAiModelBindingsLive(profileId);
   const [, navigate] = useLocation();
@@ -64,10 +64,11 @@ export const useCoachingAi = (
       setProcessing,
       onClose,
       navigate,
-      onFailureToast: () => toast.error(AI_PROCESS_ERROR_TOAST_MESSAGE),
+      onFailureToast: () => toast.error(t("hooks.aiProcessFailed")),
     };
     await runStartAi(ctx);
   }, [
+    t,
     activity,
     profileId,
     providers,

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-convert.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-convert.ts
@@ -4,6 +4,7 @@ import { useLocation } from "wouter";
 import { convertCoachingActivity } from "../../../application/coaching/convert-coaching-activity";
 import { useAnalytics } from "../../../contexts";
 import { usePersistence } from "../../../contexts/persistence-context";
+import { useTranslate } from "../../../i18n/use-translate";
 import { withOrigin } from "../../../routing/with-origin";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 
@@ -28,6 +29,7 @@ export const useCoachingConvert = (
 ): UseCoachingConvert => {
   const persistence = usePersistence();
   const analytics = useAnalytics();
+  const t = useTranslate("coaching");
   const [, navigate] = useLocation();
   const [error, setError] = useState<string | null>(null);
   const [converting, setConverting] = useState(false);
@@ -40,7 +42,7 @@ export const useCoachingConvert = (
     try {
       const sourceId = parseSourceId(activity);
       if (!sourceId) {
-        setError("Invalid activity id");
+        setError(t("hooks.invalidActivityId"));
         return;
       }
       const record = await persistence.coaching.getByProfileAndSourceId(
@@ -49,7 +51,7 @@ export const useCoachingConvert = (
         sourceId
       );
       if (!record) {
-        setError("Activity not found");
+        setError(t("hooks.activityNotFound"));
         return;
       }
       const result = await convertCoachingActivity(
@@ -64,11 +66,13 @@ export const useCoachingConvert = (
       onClose();
       navigate(withOrigin(`/workout/${result.workoutId}`, "coaching"));
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Conversion failed");
+      setError(
+        err instanceof Error ? err.message : t("hooks.conversionFailed")
+      );
     } finally {
       setConverting(false);
     }
-  }, [activity, targetProfileId, analytics, persistence, navigate, onClose]);
+  }, [activity, targetProfileId, analytics, persistence, navigate, onClose, t]);
 
   return { error, converting, setError, handleConvert };
 };

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-actions.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-dialog-actions.ts
@@ -12,6 +12,7 @@ import { useToastContext } from "../../../contexts/ToastContext";
 import type { ActivityMatchState } from "../../../hooks/use-activity-match-state";
 import { useMatchSession } from "../../../hooks/use-match-session";
 import { useUnmatchSession } from "../../../hooks/use-unmatch-session";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 import { toPersistedCoachingActivityId } from "../../../types/coaching-activity-record";
 
@@ -37,6 +38,7 @@ export const useCoachingDialogActions = (
   const matchSession = useMatchSession();
   const unmatchSession = useUnmatchSession();
   const { success: showSuccess } = useToastContext();
+  const t = useTranslate("coaching");
 
   const handleSelectWorkout = useCallback(
     async (workoutId: string) => {
@@ -54,13 +56,15 @@ export const useCoachingDialogActions = (
         });
         // Static title satisfies R-PIIInterpolation; the dynamic
         // activity title flows through the description field.
-        showSuccess("Workout matched", activity.title, { duration: 3000 });
+        showSuccess(t("hooks.workoutMatched"), activity.title, {
+          duration: 3000,
+        });
         setPickerOpen(false);
       } finally {
         setMatching(false);
       }
     },
-    [activity, targetProfileId, matching, matchSession, showSuccess]
+    [activity, targetProfileId, matching, matchSession, showSuccess, t]
   );
 
   const handleSplit = useCallback(async () => {

--- a/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.ts
+++ b/packages/workout-spa-editor/src/components/molecules/CoachingCard/use-coaching-manual-handler.ts
@@ -12,6 +12,7 @@ import { useCallback, useRef, useState } from "react";
 import { useLocation } from "wouter";
 
 import { usePersistence } from "../../../contexts/persistence-context";
+import { useTranslate } from "../../../i18n/use-translate";
 import { withOrigin } from "../../../routing/with-origin";
 import type { CoachingActivity } from "../../../types/coaching-activity";
 import { namespaceSourceId } from "../../../types/coaching-activity-record";
@@ -30,6 +31,7 @@ export const useCoachingManual = (
   expandActivity: (activity: CoachingActivity) => void
 ): UseCoachingManual => {
   const persistence = usePersistence();
+  const t = useTranslate("coaching");
   const [, navigate] = useLocation();
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -78,12 +80,12 @@ export const useCoachingManual = (
         )
       );
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Manual creation failed");
+      setError(err instanceof Error ? err.message : t("hooks.manualFailed"));
     } finally {
       setCreating(false);
       inFlight.current = false;
     }
-  }, [activity, profileId, persistence, navigate, onClose, expandActivity]);
+  }, [activity, profileId, persistence, navigate, onClose, expandActivity, t]);
 
   return {
     creating,

--- a/packages/workout-spa-editor/src/i18n/locales/en/coaching.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/coaching.json
@@ -86,5 +86,13 @@
   "sync": {
     "defaultLabel": "Coach",
     "connectTo": "Connect to {{label}}"
+  },
+  "hooks": {
+    "aiProcessFailed": "Failed to process activity with AI",
+    "workoutMatched": "Workout matched",
+    "manualFailed": "Manual creation failed",
+    "conversionFailed": "Conversion failed",
+    "invalidActivityId": "Invalid activity id",
+    "activityNotFound": "Activity not found"
   }
 }

--- a/packages/workout-spa-editor/src/i18n/locales/es/coaching.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/coaching.json
@@ -86,5 +86,13 @@
   "sync": {
     "defaultLabel": "Coach",
     "connectTo": "Conectar con {{label}}"
+  },
+  "hooks": {
+    "aiProcessFailed": "No se pudo procesar la actividad con IA",
+    "workoutMatched": "Entreno emparejado",
+    "manualFailed": "La creación manual falló",
+    "conversionFailed": "La conversión falló",
+    "invalidActivityId": "ID de actividad no válido",
+    "activityNotFound": "Actividad no encontrada"
   }
 }


### PR DESCRIPTION
## What

Small follow-up to the CoachingCard PR (#893). Extends the `coaching` namespace `hooks` group:
- AI-process failure toast, workout-matched success toast, and the manual-create / convert error fallbacks (+ convert invalid-id / not-found).
- Each hook resolves copy via `useTranslate("coaching")`; toast first-args stay guard-safe as `t("literal.key")`; `t` added to the `useCallback` deps.

## Verification
- CoachingCard + i18n suites: **122/122**. `tsc` / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized messages for coaching and workout-matching flows in English and Spanish.

* **Bug Fixes**
  * Replaced hardcoded error and success messages with translated text across coaching actions.
  * Improved fallback messaging for AI processing, conversion, manual creation, invalid activity IDs, and missing activities.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->