### PR TITLE
feat(spa-editor): localize the athlete profile page (athlete namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/AthletePage/AthleteEmptyState.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/AthleteEmptyState.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button";
 
 type AthleteEmptyStateProps = {
@@ -9,11 +10,12 @@ type AthleteEmptyStateProps = {
    away — creating the first profile auto-activates it, swapping this page
    to the populated body. */
 export function AthleteEmptyState({ onCreate }: AthleteEmptyStateProps) {
+  const t = useTranslate("athlete");
   return (
     <div className="flex flex-col items-center gap-4 py-16 text-center">
-      <p className="text-[15px] text-slate-300">No athlete profile yet</p>
+      <p className="text-[15px] text-slate-300">{t("emptyTitle")}</p>
       <Button variant="primary" onClick={onCreate}>
-        Create profile
+        {t("createProfile")}
       </Button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/AthleteIdentity.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/AthleteIdentity.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { Profile } from "../../../types/profile";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 import { AvatarRing } from "../../molecules/AvatarRing";
@@ -13,6 +14,7 @@ type AthleteIdentityProps = {
 };
 
 export function AthleteIdentity({ profile }: AthleteIdentityProps) {
+  const t = useTranslate("athlete");
   const [editing, setEditing] = useState(false);
 
   return (
@@ -23,12 +25,12 @@ export function AthleteIdentity({ profile }: AthleteIdentityProps) {
           {profile.name}
         </div>
         <div className="text-[13.5px] text-slate-400">
-          {deriveTagline(profile)}
+          {deriveTagline(profile, t)}
         </div>
       </div>
       <button
         type="button"
-        aria-label="Edit profile"
+        aria-label={t("editProfile")}
         onClick={() => setEditing(true)}
         className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-slate-700/60 bg-white/5 text-slate-300"
       >

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/AthletePageBody.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/AthletePageBody.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 
 import { useSetUserPreferenceFields } from "../../../hooks/use-set-user-preference-fields";
 import { useUserPreferences } from "../../../hooks/use-user-preferences";
+import { useTranslate } from "../../../i18n/use-translate";
 import {
   type ActiveSport,
   ATHLETE_SPORTS,
@@ -22,6 +23,7 @@ type AthletePageBodyProps = {
 };
 
 export function AthletePageBody({ profileId, profile }: AthletePageBodyProps) {
+  const t = useTranslate("athlete");
   const prefs = useUserPreferences({ profileId, defaultView: "grid" });
   const setPrefs = useSetUserPreferenceFields(profileId);
   const [sport, setSport] = useState<ActiveSport>(() => defaultSport(profile));
@@ -52,7 +54,7 @@ export function AthletePageBody({ profileId, profile }: AthletePageBodyProps) {
         options={[...ATHLETE_SPORTS]}
         value={sport}
         onChange={handleSportChange}
-        ariaLabel="Sport"
+        ariaLabel={t("sportAria")}
       />
       <ThresholdCard
         profile={profile}

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/CreateProfileDialog.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/CreateProfileDialog.tsx
@@ -1,5 +1,6 @@
 import * as Dialog from "@radix-ui/react-dialog";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { ProfileManagerDialog } from "../../organisms/ProfileManager/components/ProfileManagerDialog";
 import { useProfileManager } from "../../organisms/ProfileManager/useProfileManager";
 
@@ -18,6 +19,7 @@ export function CreateProfileDialog({
   open,
   onClose,
 }: CreateProfileDialogProps) {
+  const t = useTranslate("athlete");
   const manager = useProfileManager();
 
   return (
@@ -26,7 +28,7 @@ export function CreateProfileDialog({
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
         <Dialog.Content className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800">
           <Dialog.Title className="sr-only">
-            Create athlete profile
+            {t("createProfileTitle")}
           </Dialog.Title>
           <ProfileManagerDialog {...manager} />
         </Dialog.Content>

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ProfileEditDialog.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ProfileEditDialog.tsx
@@ -1,6 +1,7 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { useEffect, useRef } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { Profile } from "../../../types/profile";
 import { ProfileManagerDialog } from "../../organisms/ProfileManager/components/ProfileManagerDialog";
 import { useProfileManager } from "../../organisms/ProfileManager/useProfileManager";
@@ -20,6 +21,7 @@ export function ProfileEditDialog({
   profile,
   onClose,
 }: ProfileEditDialogProps) {
+  const t = useTranslate("athlete");
   const manager = useProfileManager();
   const { handleEdit } = manager;
 
@@ -44,7 +46,7 @@ export function ProfileEditDialog({
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
         <Dialog.Content className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800">
-          <Dialog.Title className="sr-only">Edit profile</Dialog.Title>
+          <Dialog.Title className="sr-only">{t("editProfile")}</Dialog.Title>
           <ProfileManagerDialog {...manager} />
         </Dialog.Content>
       </Dialog.Portal>

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ThresholdCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ThresholdCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { useUnits } from "../../../contexts/units-context";
+import { useTranslate } from "../../../i18n/use-translate";
 import { type ActiveSport, deriveThresholdMetrics } from "../../../lib/athlete";
 import type { Profile } from "../../../types/profile";
 import { Button } from "../../atoms/Button";
@@ -23,6 +24,7 @@ export function ThresholdCard({
   sport,
   sportLabel,
 }: ThresholdCardProps) {
+  const t = useTranslate("athlete");
   const [auto, setAuto] = useState(true);
   const [editing, setEditing] = useState(false);
   const units = useUnits();
@@ -45,7 +47,7 @@ export function ThresholdCard({
           color="inherit"
           strokeWidth={1.9}
         />
-        Edit thresholds
+        {t("editThresholds")}
       </Button>
       <ThresholdEditDialog
         open={editing}

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ThresholdCardHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ThresholdCardHeader.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 import { Toggle } from "../../atoms/Toggle";
 
@@ -10,6 +11,7 @@ export function ThresholdCardHeader({
   auto,
   onAutoChange,
 }: ThresholdCardHeaderProps) {
+  const t = useTranslate("athlete");
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-2 text-sky-400">
@@ -20,19 +22,19 @@ export function ThresholdCardHeader({
           strokeWidth={1.9}
         />
         <span className="text-[15px] font-semibold text-slate-50">
-          Thresholds
+          {t("thresholds")}
         </span>
       </div>
       <div className="flex items-center gap-2.5">
         <span
           className={`text-[13px] ${auto ? "text-sky-400" : "text-slate-400"}`}
         >
-          {auto ? "Auto zones" : "Manual zones"}
+          {auto ? t("autoZones") : t("manualZones")}
         </span>
         <Toggle
           checked={auto}
           onCheckedChange={onAutoChange}
-          aria-label="Auto zones"
+          aria-label={t("autoZones")}
         />
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ThresholdEditDialog.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ThresholdEditDialog.tsx
@@ -1,5 +1,6 @@
 import * as Dialog from "@radix-ui/react-dialog";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { SportZoneEditor } from "../../organisms/ZoneEditor";
 
 type ThresholdEditDialogProps = {
@@ -15,12 +16,13 @@ export function ThresholdEditDialog({
   profileId,
   onClose,
 }: ThresholdEditDialogProps) {
+  const t = useTranslate("athlete");
   return (
     <Dialog.Root open={open} onOpenChange={(next) => !next && onClose()}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
         <Dialog.Content className="fixed left-1/2 top-1/2 z-50 max-h-[85vh] w-full max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-lg border bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-800">
-          <Dialog.Title className="sr-only">Edit thresholds</Dialog.Title>
+          <Dialog.Title className="sr-only">{t("editThresholds")}</Dialog.Title>
           <SportZoneEditor profileId={profileId} />
         </Dialog.Content>
       </Dialog.Portal>

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/ZoneMapCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/ZoneMapCard.tsx
@@ -1,13 +1,11 @@
 import { useUnits } from "../../../contexts/units-context";
+import { useTranslate } from "../../../i18n/use-translate";
 import { type ActiveSport, deriveZoneMap } from "../../../lib/athlete";
 import type { Profile } from "../../../types/profile";
 import { Card } from "../../atoms/Card";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 import { SectionHead } from "../../molecules/SectionHead";
 import { ZoneMap } from "../../organisms/ZoneMap";
-
-const ZONE_INFO_COPY =
-  "These zones power AI workout generation and every target you push to Garmin.";
 
 type ZoneMapCardProps = {
   profile: Profile;
@@ -16,18 +14,19 @@ type ZoneMapCardProps = {
 };
 
 export function ZoneMapCard({ profile, sport, sportLabel }: ZoneMapCardProps) {
+  const t = useTranslate("athlete");
   const units = useUnits();
   const zones = deriveZoneMap(profile, sport, units);
 
   return (
     <div>
-      <SectionHead title={`${sportLabel} zones`} />
+      <SectionHead title={t("zonesTitle", { sport: sportLabel })} />
       <Card className="rounded-[20px] border border-slate-700/60 bg-surface p-4">
         {zones ? (
           <ZoneMap zones={zones} />
         ) : (
           <p className="text-[13.5px] text-slate-400">
-            Set a {sportLabel.toLowerCase()} threshold to see your zones
+            {t("noThreshold", { sport: sportLabel.toLowerCase() })}
           </p>
         )}
         <div className="mt-3 flex items-start gap-2 rounded-xl border border-sky-400/15 bg-sky-400/5 p-3">
@@ -39,7 +38,7 @@ export function ZoneMapCard({ profile, sport, sportLabel }: ZoneMapCardProps) {
               strokeWidth={1.9}
             />
           </span>
-          <p className="text-[12.5px] text-slate-300">{ZONE_INFO_COPY}</p>
+          <p className="text-[12.5px] text-slate-300">{t("zonesBlurb")}</p>
         </div>
       </Card>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/AthletePage/athlete-identity-helpers.ts
+++ b/packages/workout-spa-editor/src/components/pages/AthletePage/athlete-identity-helpers.ts
@@ -1,4 +1,5 @@
-import { type ActiveSport, ATHLETE_SPORTS } from "../../../lib/athlete";
+import { getTranslate, type Translate } from "../../../i18n/use-translate";
+import { ATHLETE_SPORTS } from "../../../lib/athlete";
 import type { Profile } from "../../../types/profile";
 
 const MAX_INITIAL_WORDS = 2;
@@ -14,16 +15,13 @@ export function deriveInitials(name: string): string {
   return letters.join("") || "?";
 }
 
-const SPORT_NOUN: Record<ActiveSport, string> = {
-  cycling: "Cyclist",
-  running: "Runner",
-  swimming: "Swimmer",
-};
-
 /** Tagline like "Cyclist · Runner" for sports that have a stored config. */
-export function deriveTagline(profile: Profile): string {
+export function deriveTagline(
+  profile: Profile,
+  t: Translate = getTranslate("athlete")
+): string {
   const nouns = ATHLETE_SPORTS.filter(
     (sport) => profile.sportZones[sport.value] !== undefined
-  ).map((sport) => SPORT_NOUN[sport.value]);
-  return nouns.join(" · ") || "Athlete";
+  ).map((sport) => t(`tagline.${sport.value}`));
+  return nouns.join(" · ") || t("tagline.fallback");
 }

--- a/packages/workout-spa-editor/src/i18n/locales/en/athlete.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/athlete.json
@@ -1,0 +1,20 @@
+{
+  "emptyTitle": "No athlete profile yet",
+  "createProfile": "Create profile",
+  "createProfileTitle": "Create athlete profile",
+  "editProfile": "Edit profile",
+  "editThresholds": "Edit thresholds",
+  "thresholds": "Thresholds",
+  "autoZones": "Auto zones",
+  "manualZones": "Manual zones",
+  "sportAria": "Sport",
+  "zonesTitle": "{{sport}} zones",
+  "noThreshold": "Set a {{sport}} threshold to see your zones",
+  "zonesBlurb": "These zones power AI workout generation and every target you push to Garmin.",
+  "tagline": {
+    "cycling": "Cyclist",
+    "running": "Runner",
+    "swimming": "Swimmer",
+    "fallback": "Athlete"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/athlete.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/athlete.json
@@ -1,0 +1,20 @@
+{
+  "emptyTitle": "Aún no hay perfil de atleta",
+  "createProfile": "Crear perfil",
+  "createProfileTitle": "Crear perfil de atleta",
+  "editProfile": "Editar perfil",
+  "editThresholds": "Editar umbrales",
+  "thresholds": "Umbrales",
+  "autoZones": "Zonas automáticas",
+  "manualZones": "Zonas manuales",
+  "sportAria": "Deporte",
+  "zonesTitle": "Zonas de {{sport}}",
+  "noThreshold": "Establece un umbral de {{sport}} para ver tus zonas",
+  "zonesBlurb": "Estas zonas alimentan la generación de entrenos con IA y cada objetivo que envías a Garmin.",
+  "tagline": {
+    "cycling": "Ciclista",
+    "running": "Corredor",
+    "swimming": "Nadador",
+    "fallback": "Atleta"
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/athlete.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/athlete.json
@@ -10,7 +10,7 @@
   "sportAria": "Deporte",
   "zonesTitle": "Zonas de {{sport}}",
   "noThreshold": "Establece un umbral de {{sport}} para ver tus zonas",
-  "zonesBlurb": "Estas zonas alimentan la generación de entrenos con IA y cada objetivo que envías a Garmin.",
+  "zonesBlurb": "Estas zonas alimentan la generación de entrenamientos con IA y cada objetivo que envías a Garmin.",
   "tagline": {
     "cycling": "Ciclista",
     "running": "Corredor",

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -7,6 +7,7 @@
 
 import type { LocaleResources } from "@kaiord/i18n";
 
+import enAthlete from "./locales/en/athlete.json";
 import enCalendar from "./locales/en/calendar.json";
 import enChat from "./locales/en/chat.json";
 import enCoaching from "./locales/en/coaching.json";
@@ -22,6 +23,7 @@ import enNav from "./locales/en/nav.json";
 import enSettings from "./locales/en/settings.json";
 import enTargets from "./locales/en/targets.json";
 import enWorkoutDetail from "./locales/en/workout-detail.json";
+import esAthlete from "./locales/es/athlete.json";
 import esCalendar from "./locales/es/calendar.json";
 import esChat from "./locales/es/chat.json";
 import esCoaching from "./locales/es/coaching.json";
@@ -42,6 +44,7 @@ export const DEFAULT_NAMESPACE = "common";
 
 export const resources: LocaleResources = {
   en: {
+    athlete: enAthlete,
     calendar: enCalendar,
     chat: enChat,
     coaching: enCoaching,
@@ -59,6 +62,7 @@ export const resources: LocaleResources = {
     "workout-detail": enWorkoutDetail,
   },
   es: {
+    athlete: esAthlete,
     calendar: esCalendar,
     chat: esChat,
     coaching: esCoaching,


### PR DESCRIPTION
## What

New `athlete` namespace across the Athlete profile page.

- Empty state, identity (tagline via a default-en pure helper `deriveTagline`), profile + threshold edit dialogs, threshold card + header (auto/manual zones toggle), sport selector aria, zone-map card (interpolated `{{sport}} zones` title + threshold hint + zones blurb).
- Sport display labels + threshold metric labels come from the shared `lib/athlete` and stay English for now (shared follow-up).

## Verification
- AthletePage + i18n suites: **32/32**. `tsc` / eslint / prettier clean.

Note: done directly in the main loop (subagent spawns still throttled by API 529s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized English and Spanish text for the athlete editor, including empty states, create/edit actions, and threshold/zone UI.
  * Localized sport-based athlete taglines, with a translated fallback.

* **Accessibility**
  * Updated aria-labels and dialog titles in the athlete page to use localized strings (e.g., profile editing, sport selector, and zones controls).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->