### PR TITLE
feat(spa-editor): localize the data hub (data-hub namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubActionableCell.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubActionableCell.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+
+import type { IntegrationPolicyMode } from "../../../types/integration-policy";
+import { DataHubCellMenu } from "./DataHubCellMenu";
+
+type Props = {
+  className: string;
+  label: string;
+  testId: string;
+  state: string;
+  onClick: () => void;
+  routeId: string | undefined;
+  mode: IntegrationPolicyMode;
+  onSetMode: (mode: IntegrationPolicyMode) => void;
+  onRemove: (routeId: string) => void;
+  children: ReactNode;
+};
+
+export const DataHubActionableCell = ({
+  className,
+  label,
+  testId,
+  state,
+  onClick,
+  routeId,
+  mode,
+  onSetMode,
+  onRemove,
+  children,
+}: Props) => (
+  <div className="flex items-center gap-0.5">
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      data-testid={testId}
+      data-state={state}
+      onClick={onClick}
+      className={className}
+    >
+      {children}
+    </button>
+    {routeId && (
+      <DataHubCellMenu
+        testId={testId}
+        mode={mode}
+        onSetMode={onSetMode}
+        onRemove={() => onRemove(routeId)}
+      />
+    )}
+  </div>
+);

--- a/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubCell.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubCell.tsx
@@ -6,9 +6,10 @@ import type {
   DataHubSetModeHandler,
   DataHubToggleHandler,
 } from "../../../application/data-hub/build-data-hub-matrix";
+import { useTranslate } from "../../../i18n/use-translate";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 import { CELL_VISUALS } from "./data-hub-cell-visuals";
-import { DataHubCellMenu } from "./DataHubCellMenu";
+import { DataHubActionableCell } from "./DataHubActionableCell";
 
 type Props = {
   dataType: ManagedDataType;
@@ -30,48 +31,37 @@ export const DataHubCell: React.FC<Props> = ({
   onSetMode,
   onRemove,
 }) => {
+  const t = useTranslate("data-hub");
   const visual = CELL_VISUALS[cell.state];
   if (cell.state === "na") return null;
 
   const arrow =
     cell.direction === "import" ? ICON_MAP.arrowDown : ICON_MAP.arrowUp;
-  const verb = cell.direction === "import" ? "Import" : "Export";
-  const label = `${verb} — ${visual.label}`;
+  const cellLabel = t(`cell.${cell.state}`);
+  const label = `${t(`direction.${cell.direction}`)} — ${cellLabel}`;
   const testId = `data-hub-cell-${dataType}-${cell.integrationId}-${cell.direction}`;
   const body = (
     <>
       <Icon icon={arrow} size="xs" color="inherit" />
-      <span>{visual.label}</span>
+      <span>{cellLabel}</span>
     </>
   );
 
-  const routeId = cell.routeId;
-
   if (visual.actionable && bridgeId)
     return (
-      <div className="flex items-center gap-0.5">
-        <button
-          type="button"
-          aria-label={label}
-          title={label}
-          data-testid={testId}
-          data-state={cell.state}
-          onClick={() => {
-            void onToggle(dataType, bridgeId, cell);
-          }}
-          className={`${BASE} ${visual.className}`}
-        >
-          {body}
-        </button>
-        {routeId && (
-          <DataHubCellMenu
-            testId={testId}
-            mode={cell.routeMode ?? "auto"}
-            onSetMode={(mode) => onSetMode(dataType, bridgeId, cell, mode)}
-            onRemove={() => onRemove(routeId)}
-          />
-        )}
-      </div>
+      <DataHubActionableCell
+        className={`${BASE} ${visual.className}`}
+        label={label}
+        testId={testId}
+        state={cell.state}
+        onClick={() => void onToggle(dataType, bridgeId, cell)}
+        routeId={cell.routeId}
+        mode={cell.routeMode ?? "auto"}
+        onSetMode={(mode) => onSetMode(dataType, bridgeId, cell, mode)}
+        onRemove={onRemove}
+      >
+        {body}
+      </DataHubActionableCell>
     );
 
   return (

--- a/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubCellMenu.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubCellMenu.tsx
@@ -5,6 +5,7 @@
  */
 import { useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { IntegrationPolicyMode } from "../../../types/integration-policy";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 import { DataHubCellModeButtons } from "./DataHubCellModeButtons";
@@ -22,13 +23,14 @@ export const DataHubCellMenu: React.FC<Props> = ({
   onSetMode,
   onRemove,
 }) => {
+  const t = useTranslate("data-hub");
   const [open, setOpen] = useState(false);
 
   return (
     <div className="relative">
       <button
         type="button"
-        aria-label="Route options"
+        aria-label={t("routeOptions")}
         aria-haspopup="menu"
         aria-expanded={open}
         data-testid={`${testId}-menu-button`}
@@ -44,7 +46,7 @@ export const DataHubCellMenu: React.FC<Props> = ({
           className="absolute right-0 z-10 mt-1 w-36 rounded border border-gray-200 bg-white p-2 text-xs shadow-lg dark:border-gray-700 dark:bg-gray-800"
         >
           <p className="mb-1 font-medium text-gray-500 dark:text-gray-400">
-            Mode
+            {t("modeHeading")}
           </p>
           <DataHubCellModeButtons
             testId={testId}
@@ -63,7 +65,7 @@ export const DataHubCellMenu: React.FC<Props> = ({
             }}
             className="w-full rounded px-1.5 py-1 text-left text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
           >
-            Remove route
+            {t("removeRoute")}
           </button>
         </div>
       )}

--- a/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubCellModeButtons.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubCellModeButtons.tsx
@@ -2,6 +2,7 @@
  * DataHubCellModeButtons — the Auto/Manual segmented control inside
  * DataHubCellMenu.
  */
+import { useTranslate } from "../../../i18n/use-translate";
 import type { IntegrationPolicyMode } from "../../../types/integration-policy";
 
 type Props = {
@@ -11,32 +12,30 @@ type Props = {
 };
 
 const MODES: readonly IntegrationPolicyMode[] = ["auto", "manual"];
-const MODE_LABEL: Record<IntegrationPolicyMode, string> = {
-  auto: "Auto",
-  manual: "Manual",
-};
-
 export const DataHubCellModeButtons: React.FC<Props> = ({
   testId,
   mode,
   onSelect,
-}) => (
-  <div className="mb-2 flex gap-1">
-    {MODES.map((m) => (
-      <button
-        key={m}
-        type="button"
-        data-testid={`${testId}-mode-${m}`}
-        aria-pressed={mode === m}
-        onClick={() => onSelect(m)}
-        className={`flex-1 rounded px-1.5 py-1 ${
-          mode === m
-            ? "bg-primary-600 text-white"
-            : "bg-gray-100 dark:bg-gray-700"
-        }`}
-      >
-        {MODE_LABEL[m]}
-      </button>
-    ))}
-  </div>
-);
+}) => {
+  const t = useTranslate("data-hub");
+  return (
+    <div className="mb-2 flex gap-1">
+      {MODES.map((m) => (
+        <button
+          key={m}
+          type="button"
+          data-testid={`${testId}-mode-${m}`}
+          aria-pressed={mode === m}
+          onClick={() => onSelect(m)}
+          className={`flex-1 rounded px-1.5 py-1 ${
+            mode === m
+              ? "bg-primary-600 text-white"
+              : "bg-gray-100 dark:bg-gray-700"
+          }`}
+        >
+          {t(`mode.${m}`)}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubColumnHeader.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubColumnHeader.tsx
@@ -1,3 +1,4 @@
+import { type Translate, useTranslate } from "../../../i18n/use-translate";
 import type { IntegrationRegistryEntry } from "../../../integrations/integration-registry";
 
 type Props = {
@@ -7,42 +8,46 @@ type Props = {
 
 const connectionLabel = (
   integration: IntegrationRegistryEntry,
-  connected: boolean
+  connected: boolean,
+  t: Translate
 ): string => {
-  if (connected) return "Connected";
-  if (integration.mechanism === "not-supported") return "—";
-  if (integration.mechanism === "manual") return "Always on";
-  return "Not connected";
+  if (connected) return t("conn.connected");
+  if (integration.mechanism === "not-supported") return t("conn.notSupported");
+  if (integration.mechanism === "manual") return t("conn.alwaysOn");
+  return t("conn.notConnected");
 };
 
 export const DataHubColumnHeader: React.FC<Props> = ({
   integration,
   connected,
-}) => (
-  <th
-    scope="col"
-    className="p-2 text-center text-xs font-medium text-gray-500 dark:text-gray-400"
-    data-testid={`data-hub-col-${integration.id}`}
-  >
-    <div className="flex flex-col items-center gap-1">
-      <span
-        aria-hidden
-        className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-[10px] font-semibold text-gray-700 dark:bg-gray-800 dark:text-gray-200"
-      >
-        {integration.mark}
-      </span>
-      <span className="whitespace-nowrap">{integration.name}</span>
-      <span
-        data-testid={`data-hub-conn-${integration.id}`}
-        data-connected={connected}
-        className={
-          connected
-            ? "text-emerald-600 dark:text-emerald-400"
-            : "text-gray-400 dark:text-gray-600"
-        }
-      >
-        {connectionLabel(integration, connected)}
-      </span>
-    </div>
-  </th>
-);
+}) => {
+  const t = useTranslate("data-hub");
+  return (
+    <th
+      scope="col"
+      className="p-2 text-center text-xs font-medium text-gray-500 dark:text-gray-400"
+      data-testid={`data-hub-col-${integration.id}`}
+    >
+      <div className="flex flex-col items-center gap-1">
+        <span
+          aria-hidden
+          className="flex h-6 w-6 items-center justify-center rounded-full bg-gray-100 text-[10px] font-semibold text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+        >
+          {integration.mark}
+        </span>
+        <span className="whitespace-nowrap">{integration.name}</span>
+        <span
+          data-testid={`data-hub-conn-${integration.id}`}
+          data-connected={connected}
+          className={
+            connected
+              ? "text-emerald-600 dark:text-emerald-400"
+              : "text-gray-400 dark:text-gray-600"
+          }
+        >
+          {connectionLabel(integration, connected, t)}
+        </span>
+      </div>
+    </th>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubLegend.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubLegend.tsx
@@ -1,25 +1,29 @@
 import type { DataHubCellState } from "../../../application/data-hub/build-data-hub-matrix";
+import { useTranslate } from "../../../i18n/use-translate";
 import { CELL_VISUALS } from "./data-hub-cell-visuals";
 
-const LEGEND: ReadonlyArray<{ state: DataHubCellState; hint: string }> = [
-  { state: "active", hint: "Syncing — click to turn off" },
-  { state: "available", hint: "Ready — click to turn on" },
-  { state: "not-connected", hint: "Connect this integration first" },
-  { state: "manual", hint: "Entered by hand in the app" },
-  { state: "aspirational", hint: "Not supported yet" },
+const LEGEND: ReadonlyArray<DataHubCellState> = [
+  "active",
+  "available",
+  "not-connected",
+  "manual",
+  "aspirational",
 ];
 
-export const DataHubLegend: React.FC = () => (
-  <dl className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
-    {LEGEND.map(({ state, hint }) => (
-      <div key={state} className="flex items-center gap-1.5">
-        <dt
-          className={`rounded px-1.5 py-0.5 font-medium ${CELL_VISUALS[state].className}`}
-        >
-          {CELL_VISUALS[state].label}
-        </dt>
-        <dd>{hint}</dd>
-      </div>
-    ))}
-  </dl>
-);
+export const DataHubLegend: React.FC = () => {
+  const t = useTranslate("data-hub");
+  return (
+    <dl className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+      {LEGEND.map((state) => (
+        <div key={state} className="flex items-center gap-1.5">
+          <dt
+            className={`rounded px-1.5 py-0.5 font-medium ${CELL_VISUALS[state].className}`}
+          >
+            {t(`cell.${state}`)}
+          </dt>
+          <dd>{t(`legend.${state}`)}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubSourcePriority.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubSourcePriority.tsx
@@ -1,10 +1,12 @@
 import { useSourcePolicies } from "../../../hooks/data-hub/use-source-policies";
 import { useSourcePolicyEditor } from "../../../hooks/data-hub/use-source-policy-editor";
+import { useTranslate } from "../../../i18n/use-translate";
 import { SourcePriorityRow } from "./SourcePriorityRow";
 
 type Props = { profileId: string };
 
 export const DataHubSourcePriority: React.FC<Props> = ({ profileId }) => {
+  const t = useTranslate("data-hub");
   const rows = useSourcePolicies(profileId);
   const { setMode, move } = useSourcePolicyEditor(profileId);
   if (rows.length === 0) return null;
@@ -13,11 +15,10 @@ export const DataHubSourcePriority: React.FC<Props> = ({ profileId }) => {
     <section className="space-y-3" data-testid="data-hub-source-priority">
       <div>
         <h2 className="text-sm font-semibold text-gray-900 dark:text-white">
-          Multiple sources
+          {t("sourcePriority.title")}
         </h2>
         <p className="text-xs text-gray-500 dark:text-gray-400">
-          When more than one integration imports the same data, keep them all
-          (union) or rank a winner (priority).
+          {t("sourcePriority.description")}
         </p>
       </div>
       {rows.map((row) => (

--- a/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/DataHubTab.tsx
@@ -6,6 +6,7 @@ import { useDataHubRouteEditor } from "../../../hooks/data-hub/use-data-hub-rout
 import { useDataHubToggle } from "../../../hooks/data-hub/use-data-hub-toggle";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import { useConnectionStatus } from "../../../hooks/use-connection-status";
+import { useTranslate } from "../../../i18n/use-translate";
 import { INTEGRATION_REGISTRY } from "../../../integrations/integration-registry";
 import type { IntegrationPolicyMode } from "../../../types/integration-policy";
 import { DataHubLegend } from "./DataHubLegend";
@@ -13,6 +14,7 @@ import { DataHubMatrix } from "./DataHubMatrix";
 import { DataHubSourcePriority } from "./DataHubSourcePriority";
 
 export const DataHubTab: React.FC = () => {
+  const t = useTranslate("data-hub");
   const active = useActiveProfileLive();
   const profileId = active?.id ?? null;
   const connections = useConnectionStatus(profileId);
@@ -38,15 +40,14 @@ export const DataHubTab: React.FC = () => {
         className="text-sm text-gray-500 dark:text-gray-400"
         data-testid="data-hub-no-profile"
       >
-        Select or create a profile to route your health &amp; fitness data.
+        {t("tab.emptyProfile")}
       </p>
     );
 
   return (
     <div className="space-y-4" data-testid="data-hub-tab">
       <p className="text-sm text-gray-600 dark:text-gray-300">
-        Choose where each type of data flows to and from. Every state reflects
-        your live connections — never a guess.
+        {t("tab.description")}
       </p>
       <DataHubMatrix
         rows={rows}

--- a/packages/workout-spa-editor/src/components/organisms/DataHub/SourceOrderList.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/SourceOrderList.tsx
@@ -1,4 +1,5 @@
 import type { SourcePolicyRow } from "../../../application/data-hub/source-policy-rows";
+import { useTranslate } from "../../../i18n/use-translate";
 import { INTEGRATION_REGISTRY } from "../../../integrations/integration-registry";
 import { Icon, ICON_MAP } from "../../atoms/Icon";
 
@@ -11,44 +12,47 @@ type Props = {
   onMove: (row: SourcePolicyRow, bridgeId: string, delta: number) => void;
 };
 
-export const SourceOrderList: React.FC<Props> = ({ row, onMove }) => (
-  <ol className="mt-2 space-y-1" data-testid={`source-order-${row.dataType}`}>
-    {row.sourceOrder.map((bridgeId, index) => (
-      <li
-        key={bridgeId}
-        className="flex items-center justify-between rounded bg-gray-50 px-2 py-1 text-sm dark:bg-gray-800/60"
-      >
-        <span>
-          <span className="mr-2 text-gray-400">{index + 1}</span>
-          {bridgeName(bridgeId)}
-        </span>
-        <span className="flex gap-1">
-          <button
-            type="button"
-            aria-label={`Move ${bridgeName(bridgeId)} up`}
-            disabled={index === 0}
-            data-testid={`source-up-${row.dataType}-${bridgeId}`}
-            onClick={() => {
-              void onMove(row, bridgeId, -1);
-            }}
-            className="rounded p-1 text-gray-500 hover:bg-gray-200 disabled:opacity-30 dark:hover:bg-gray-700"
-          >
-            <Icon icon={ICON_MAP.arrowUp} size="xs" color="inherit" />
-          </button>
-          <button
-            type="button"
-            aria-label={`Move ${bridgeName(bridgeId)} down`}
-            disabled={index === row.sourceOrder.length - 1}
-            data-testid={`source-down-${row.dataType}-${bridgeId}`}
-            onClick={() => {
-              void onMove(row, bridgeId, 1);
-            }}
-            className="rounded p-1 text-gray-500 hover:bg-gray-200 disabled:opacity-30 dark:hover:bg-gray-700"
-          >
-            <Icon icon={ICON_MAP.arrowDown} size="xs" color="inherit" />
-          </button>
-        </span>
-      </li>
-    ))}
-  </ol>
-);
+export const SourceOrderList: React.FC<Props> = ({ row, onMove }) => {
+  const t = useTranslate("data-hub");
+  return (
+    <ol className="mt-2 space-y-1" data-testid={`source-order-${row.dataType}`}>
+      {row.sourceOrder.map((bridgeId, index) => (
+        <li
+          key={bridgeId}
+          className="flex items-center justify-between rounded bg-gray-50 px-2 py-1 text-sm dark:bg-gray-800/60"
+        >
+          <span>
+            <span className="mr-2 text-gray-400">{index + 1}</span>
+            {bridgeName(bridgeId)}
+          </span>
+          <span className="flex gap-1">
+            <button
+              type="button"
+              aria-label={t("moveUp", { name: bridgeName(bridgeId) })}
+              disabled={index === 0}
+              data-testid={`source-up-${row.dataType}-${bridgeId}`}
+              onClick={() => {
+                void onMove(row, bridgeId, -1);
+              }}
+              className="rounded p-1 text-gray-500 hover:bg-gray-200 disabled:opacity-30 dark:hover:bg-gray-700"
+            >
+              <Icon icon={ICON_MAP.arrowUp} size="xs" color="inherit" />
+            </button>
+            <button
+              type="button"
+              aria-label={t("moveDown", { name: bridgeName(bridgeId) })}
+              disabled={index === row.sourceOrder.length - 1}
+              data-testid={`source-down-${row.dataType}-${bridgeId}`}
+              onClick={() => {
+                void onMove(row, bridgeId, 1);
+              }}
+              className="rounded p-1 text-gray-500 hover:bg-gray-200 disabled:opacity-30 dark:hover:bg-gray-700"
+            >
+              <Icon icon={ICON_MAP.arrowDown} size="xs" color="inherit" />
+            </button>
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/DataHub/SourcePriorityRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/SourcePriorityRow.tsx
@@ -1,4 +1,5 @@
 import type { SourcePolicyRow } from "../../../application/data-hub/source-policy-rows";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { DataTypeSourceMode } from "../../../types/data-type-source-policy";
 import { SourceOrderList } from "./SourceOrderList";
 
@@ -10,40 +11,43 @@ type Props = {
   onMove: (row: SourcePolicyRow, bridgeId: string, delta: number) => void;
 };
 
-export const SourcePriorityRow: React.FC<Props> = ({ row, onMode, onMove }) => (
-  <div
-    className="rounded border border-gray-200 p-3 dark:border-gray-700"
-    data-testid={`source-policy-${row.dataType}`}
-  >
-    <div className="flex items-center justify-between gap-2">
-      <span className="font-medium text-gray-900 dark:text-white">
-        {row.label}
-      </span>
-      <div
-        className="flex gap-1"
-        role="group"
-        aria-label={`${row.label} source mode`}
-      >
-        {MODES.map((mode) => (
-          <button
-            key={mode}
-            type="button"
-            aria-pressed={row.mode === mode}
-            data-testid={`source-mode-${row.dataType}-${mode}`}
-            onClick={() => {
-              void onMode(row, mode);
-            }}
-            className={`rounded px-2 py-0.5 text-xs font-medium capitalize ${
-              row.mode === mode
-                ? "bg-primary-600 text-white"
-                : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
-            }`}
-          >
-            {mode}
-          </button>
-        ))}
+export const SourcePriorityRow: React.FC<Props> = ({ row, onMode, onMove }) => {
+  const t = useTranslate("data-hub");
+  return (
+    <div
+      className="rounded border border-gray-200 p-3 dark:border-gray-700"
+      data-testid={`source-policy-${row.dataType}`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-medium text-gray-900 dark:text-white">
+          {row.label}
+        </span>
+        <div
+          className="flex gap-1"
+          role="group"
+          aria-label={t("sourceModeAria", { label: row.label })}
+        >
+          {MODES.map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              aria-pressed={row.mode === mode}
+              data-testid={`source-mode-${row.dataType}-${mode}`}
+              onClick={() => {
+                void onMode(row, mode);
+              }}
+              className={`rounded px-2 py-0.5 text-xs font-medium capitalize ${
+                row.mode === mode
+                  ? "bg-primary-600 text-white"
+                  : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+              }`}
+            >
+              {t(`sourceMode.${mode}`)}
+            </button>
+          ))}
+        </div>
       </div>
+      {row.mode === "priority" && <SourceOrderList row={row} onMove={onMove} />}
     </div>
-    {row.mode === "priority" && <SourceOrderList row={row} onMove={onMove} />}
-  </div>
-);
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/DataHub/data-hub-cell-visuals.ts
+++ b/packages/workout-spa-editor/src/components/organisms/DataHub/data-hub-cell-visuals.ts
@@ -7,36 +7,30 @@
 import type { DataHubCellState } from "../../../application/data-hub/build-data-hub-matrix";
 
 export type CellVisual = {
-  label: string;
   className: string;
   actionable: boolean;
 };
 
 export const CELL_VISUALS: Record<DataHubCellState, CellVisual> = {
   active: {
-    label: "On",
     className:
       "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
     actionable: true,
   },
   available: {
-    label: "Off",
     className: "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300",
     actionable: true,
   },
   "not-connected": {
-    label: "Connect",
     className:
       "bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400",
     actionable: false,
   },
   aspirational: {
-    label: "Soon",
     className: "bg-transparent text-gray-400 dark:text-gray-600",
     actionable: false,
   },
   manual: {
-    label: "Manual",
     className:
       "bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300",
     actionable: false,

--- a/packages/workout-spa-editor/src/i18n/locales/en/data-hub.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/data-hub.json
@@ -1,0 +1,40 @@
+{
+  "cell": {
+    "active": "On",
+    "available": "Off",
+    "not-connected": "Connect",
+    "aspirational": "Soon",
+    "manual": "Manual",
+    "na": ""
+  },
+  "direction": { "import": "Import", "export": "Export" },
+  "mode": { "auto": "Auto", "manual": "Manual" },
+  "modeHeading": "Mode",
+  "removeRoute": "Remove route",
+  "routeOptions": "Route options",
+  "legend": {
+    "active": "Syncing — click to turn off",
+    "available": "Ready — click to turn on",
+    "not-connected": "Connect this integration first",
+    "manual": "Entered by hand in the app",
+    "aspirational": "Not supported yet"
+  },
+  "conn": {
+    "connected": "Connected",
+    "notSupported": "—",
+    "alwaysOn": "Always on",
+    "notConnected": "Not connected"
+  },
+  "sourceMode": { "union": "union", "priority": "priority" },
+  "sourceModeAria": "{{label}} source mode",
+  "moveUp": "Move {{name}} up",
+  "moveDown": "Move {{name}} down",
+  "tab": {
+    "emptyProfile": "Select or create a profile to route your health & fitness data.",
+    "description": "Choose where each type of data flows to and from. Every state reflects your live connections — never a guess."
+  },
+  "sourcePriority": {
+    "title": "Multiple sources",
+    "description": "When more than one integration imports the same data, keep them all (union) or rank a winner (priority)."
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/data-hub.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/data-hub.json
@@ -1,0 +1,40 @@
+{
+  "cell": {
+    "active": "Activado",
+    "available": "Desactivado",
+    "not-connected": "Conectar",
+    "aspirational": "Pronto",
+    "manual": "Manual",
+    "na": ""
+  },
+  "direction": { "import": "Importar", "export": "Exportar" },
+  "mode": { "auto": "Auto", "manual": "Manual" },
+  "modeHeading": "Modo",
+  "removeRoute": "Quitar ruta",
+  "routeOptions": "Opciones de ruta",
+  "legend": {
+    "active": "Sincronizando — clic para desactivar",
+    "available": "Listo — clic para activar",
+    "not-connected": "Conecta esta integración primero",
+    "manual": "Introducido a mano en la app",
+    "aspirational": "Aún no compatible"
+  },
+  "conn": {
+    "connected": "Conectado",
+    "notSupported": "—",
+    "alwaysOn": "Siempre activo",
+    "notConnected": "No conectado"
+  },
+  "sourceMode": { "union": "unión", "priority": "prioridad" },
+  "sourceModeAria": "modo de fuente de {{label}}",
+  "moveUp": "Subir {{name}}",
+  "moveDown": "Bajar {{name}}",
+  "tab": {
+    "emptyProfile": "Selecciona o crea un perfil para enrutar tus datos de salud y fitness.",
+    "description": "Elige a dónde fluye cada tipo de dato y desde dónde. Cada estado refleja tus conexiones reales — nunca una suposición."
+  },
+  "sourcePriority": {
+    "title": "Múltiples fuentes",
+    "description": "Cuando más de una integración importa el mismo dato, mantenlas todas (unión) o elige un ganador (prioridad)."
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -14,6 +14,7 @@ import enCoaching from "./locales/en/coaching.json";
 import enCommon from "./locales/en/common.json";
 import enCreateWorkout from "./locales/en/create-workout.json";
 import enDaily from "./locales/en/daily.json";
+import enDataHub from "./locales/en/data-hub.json";
 import enEditor from "./locales/en/editor.json";
 import enErrors from "./locales/en/errors.json";
 import enLabImport from "./locales/en/labImport.json";
@@ -30,6 +31,7 @@ import esCoaching from "./locales/es/coaching.json";
 import esCommon from "./locales/es/common.json";
 import esCreateWorkout from "./locales/es/create-workout.json";
 import esDaily from "./locales/es/daily.json";
+import esDataHub from "./locales/es/data-hub.json";
 import esEditor from "./locales/es/editor.json";
 import esErrors from "./locales/es/errors.json";
 import esLabImport from "./locales/es/labImport.json";
@@ -51,6 +53,7 @@ export const resources: LocaleResources = {
     common: enCommon,
     "create-workout": enCreateWorkout,
     daily: enDaily,
+    "data-hub": enDataHub,
     editor: enEditor,
     errors: enErrors,
     labs: enLabs,
@@ -69,6 +72,7 @@ export const resources: LocaleResources = {
     common: esCommon,
     "create-workout": esCreateWorkout,
     daily: esDaily,
+    "data-hub": esDataHub,
     editor: esEditor,
     errors: esErrors,
     labs: esLabs,


### PR DESCRIPTION
## What

New `data-hub` namespace across the Data Hub routing surface.

- Routing matrix cells, cell states, legend hints, column connection labels, cell mode buttons + menu, source-priority rows, source-order controls, tab descriptions.
- Config maps (`CELL_VISUALS`/`MODE_LABEL`/`LEGEND`/`connectionLabel`) are translated at the consumer keyed off their stable enum; aria labels interpolate the integration/bridge name.
- Extracted `DataHubActionableCell` from `DataHubCell` to hold the 80-line / 60-function caps.

## Verification
- DataHub + i18n suites: **27/27**. `tsc` / eslint / prettier clean.

Note: done directly in the main loop (subagent spawns still throttled by API 529s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized text for the Data Hub area in English and Spanish.
  * Introduced a more flexible actionable cell experience with menu options when a route is available.

* **Bug Fixes**
  * Replaced hardcoded labels with translations across Data Hub screens, improving consistency and multilingual support.
  * Updated button and menu descriptions for better accessibility and clearer screen reader text.

* **Style**
  * Simplified several Data Hub components while keeping their behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->