### PR TITLE
refactor(spa-editor): lazy, glob-discovered i18n locale loading

### DIFF
--- a/packages/workout-spa-editor/src/i18n/LocaleProvider.test.tsx
+++ b/packages/workout-spa-editor/src/i18n/LocaleProvider.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { LocaleProvider, useActiveLocale } from "./LocaleProvider";
@@ -22,7 +22,7 @@ vi.mock("../hooks/use-user-preferences", () => ({
 const Probe = () => <span data-testid="loc">{useActiveLocale()}</span>;
 
 describe("LocaleProvider", () => {
-  it("should resolve an explicit es preference and set the document language", () => {
+  it("should resolve an explicit es preference and set the document language", async () => {
     // Arrange
     prefsMock.locale = "es";
 
@@ -34,7 +34,11 @@ describe("LocaleProvider", () => {
     );
 
     // Assert
-    expect(screen.getByTestId("loc")).toHaveTextContent("es");
+    // The es catalog is code-split and loaded on demand; the context holds at
+    // en until it is live, then flips.
+    await waitFor(() =>
+      expect(screen.getByTestId("loc")).toHaveTextContent("es")
+    );
     expect(document.documentElement.lang).toBe("es");
   });
 

--- a/packages/workout-spa-editor/src/i18n/LocaleProvider.tsx
+++ b/packages/workout-spa-editor/src/i18n/LocaleProvider.tsx
@@ -5,7 +5,13 @@
  * keeps both in sync with the persisted per-profile locale preference.
  */
 import { DEFAULT_LOCALE, type Locale } from "@kaiord/i18n";
-import { createContext, type ReactNode, useContext, useEffect } from "react";
+import {
+  createContext,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import { I18nextProvider } from "react-i18next";
 
 import { resolveLocale } from "../application/resolve-locale";
@@ -28,13 +34,25 @@ const LocaleSync = ({ children }: { children: ReactNode }) => {
     defaultView: "grid",
   });
   const locale = resolveLocale(prefs?.locale, readNavigatorLanguage());
+  // Hold the previous locale until the target's catalog is loaded and live, so
+  // the subtree never renders the active locale before its strings exist (it
+  // falls back to English meanwhile). Lazy locales load a code-split chunk.
+  const [activeLocale, setResolvedLocale] = useState<Locale>(DEFAULT_LOCALE);
 
   useEffect(() => {
-    setActiveLocale(locale);
+    let cancelled = false;
+    void setActiveLocale(locale).then(() => {
+      if (!cancelled) setResolvedLocale(locale);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [locale]);
 
   return (
-    <LocaleContext.Provider value={locale}>{children}</LocaleContext.Provider>
+    <LocaleContext.Provider value={activeLocale}>
+      {children}
+    </LocaleContext.Provider>
   );
 };
 

--- a/packages/workout-spa-editor/src/i18n/i18n.ts
+++ b/packages/workout-spa-editor/src/i18n/i18n.ts
@@ -1,22 +1,28 @@
 /**
  * The SPA's react-i18next instance. English is the source-of-truth and
- * fallback locale; missing keys render the English value. The active locale
- * is driven by the persisted user preference (see `useLocaleSync`), never by
- * i18next language detection.
+ * fallback locale and the only catalog bundled at init; every other locale is
+ * code-split and registered on first switch (see `setActiveLocale`). The
+ * active locale is driven by the persisted user preference (see
+ * `LocaleProvider`), never by i18next language detection.
  */
 
 import { DEFAULT_LOCALE, type Locale } from "@kaiord/i18n";
 import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
 
-import { DEFAULT_NAMESPACE, NAMESPACES, resources } from "./resources";
+import {
+  DEFAULT_CATALOG,
+  DEFAULT_NAMESPACE,
+  loadLocaleNamespaces,
+  NAMESPACES,
+} from "./resources";
 
 export const appI18n = i18next.createInstance();
 
 void appI18n.use(initReactI18next).init({
   lng: DEFAULT_LOCALE,
   fallbackLng: DEFAULT_LOCALE,
-  resources,
+  resources: { [DEFAULT_LOCALE]: DEFAULT_CATALOG },
   ns: [...NAMESPACES],
   defaultNS: DEFAULT_NAMESPACE,
   interpolation: { escapeValue: false },
@@ -24,13 +30,29 @@ void appI18n.use(initReactI18next).init({
   returnNull: false,
 });
 
+const registerBundle = (
+  locale: Locale,
+  namespaces: Record<string, unknown>
+): void => {
+  for (const [ns, dict] of Object.entries(namespaces)) {
+    appI18n.addResourceBundle(locale, ns, dict, true, true);
+  }
+};
+
 /**
- * Switch the active locale and reflect it on `<html lang>`. No-op when the
- * locale is already active. Called from the preference-sync effect.
+ * Load (if needed), register, and activate a locale, reflecting it on
+ * `<html lang>`. Resolves once the locale's catalog is live, so callers can
+ * flip the UI atomically. No-op when the locale is already active.
  */
-export function setActiveLocale(locale: Locale): void {
+export async function setActiveLocale(locale: Locale): Promise<void> {
+  if (
+    locale !== DEFAULT_LOCALE &&
+    !appI18n.hasResourceBundle(locale, DEFAULT_NAMESPACE)
+  ) {
+    registerBundle(locale, await loadLocaleNamespaces(locale));
+  }
   if (appI18n.language !== locale) {
-    void appI18n.changeLanguage(locale);
+    await appI18n.changeLanguage(locale);
   }
   if (typeof document !== "undefined") {
     document.documentElement.lang = locale;

--- a/packages/workout-spa-editor/src/i18n/resource-parity.test.ts
+++ b/packages/workout-spa-editor/src/i18n/resource-parity.test.ts
@@ -1,17 +1,49 @@
-import { findParityViolations } from "@kaiord/i18n";
+import {
+  DEFAULT_LOCALE,
+  findParityViolations,
+  type LocaleNamespaces,
+  type NamespaceDictionary,
+  SUPPORTED_LOCALES,
+} from "@kaiord/i18n";
 import { describe, expect, it } from "vitest";
 
-import { resources } from "./resources";
+// Eagerly load every catalog here (test-only bundle) to assert parity against
+// English without going through the app's lazy locale loader.
+const MODULES = import.meta.glob<NamespaceDictionary>("./locales/*/*.json", {
+  eager: true,
+  import: "default",
+});
+
+const namespaceOf = (path: string): string =>
+  path.slice(path.lastIndexOf("/") + 1, -".json".length);
+
+const localeOf = (path: string): string => {
+  const dir = path.slice(0, path.lastIndexOf("/"));
+  return dir.slice(dir.lastIndexOf("/") + 1);
+};
+
+const catalogFor = (locale: string): LocaleNamespaces =>
+  Object.fromEntries(
+    Object.entries(MODULES)
+      .filter(([path]) => localeOf(path) === locale)
+      .map(([path, dict]) => [namespaceOf(path), dict])
+  );
 
 describe("SPA i18n resource parity", () => {
-  it("should keep en and es catalogs at key parity across every namespace", () => {
-    // Arrange
-    const { en, es } = resources;
+  const en = catalogFor(DEFAULT_LOCALE);
+  const others = SUPPORTED_LOCALES.filter((l) => l !== DEFAULT_LOCALE);
 
-    // Act
-    const violations = findParityViolations(en, es);
+  it.each(others)(
+    "should keep %s at key parity with en across every namespace",
+    (locale) => {
+      // Arrange
+      const catalog = catalogFor(locale);
 
-    // Assert
-    expect(violations).toEqual([]);
-  });
+      // Act
+      const violations = findParityViolations(en, catalog);
+
+      // Assert
+      expect(violations).toEqual([]);
+    }
+  );
 });

--- a/packages/workout-spa-editor/src/i18n/resources.ts
+++ b/packages/workout-spa-editor/src/i18n/resources.ts
@@ -1,85 +1,76 @@
 /**
- * Assembles the SPA i18n resource tree from per-locale, per-namespace JSON.
- * English is the source-of-truth catalog; `es` must maintain key parity
- * (enforced by `resource-parity.test.ts`). Add a namespace by importing its
- * `en`/`es` JSON and listing it in both maps plus `NAMESPACES`.
+ * SPA i18n resource registry, discovered from `locales/<locale>/<ns>.json`.
+ *
+ * English is bundled eagerly — it is the synchronous source-of-truth, the
+ * fallback for every missing key/locale, and the default that keeps the
+ * thousands of unwrapped component tests rendering in `en`. Every other locale
+ * is code-split and pulled in on demand by `loadLocaleNamespaces`, so a catalog
+ * of N languages ships only English plus the active locale's chunk — never all
+ * of them.
+ *
+ * Add a namespace: drop `locales/<locale>/<name>.json`. Add a language: drop a
+ * `locales/<locale>/` folder. Neither requires editing this file.
  */
 
-import type { LocaleResources } from "@kaiord/i18n";
-
-import enAthlete from "./locales/en/athlete.json";
-import enCalendar from "./locales/en/calendar.json";
-import enChat from "./locales/en/chat.json";
-import enCoaching from "./locales/en/coaching.json";
-import enCommon from "./locales/en/common.json";
-import enCreateWorkout from "./locales/en/create-workout.json";
-import enDaily from "./locales/en/daily.json";
-import enEditor from "./locales/en/editor.json";
-import enErrors from "./locales/en/errors.json";
-import enLabImport from "./locales/en/labImport.json";
-import enLabs from "./locales/en/labs.json";
-import enLibrary from "./locales/en/library.json";
-import enNav from "./locales/en/nav.json";
-import enSettings from "./locales/en/settings.json";
-import enTargets from "./locales/en/targets.json";
-import enWorkoutDetail from "./locales/en/workout-detail.json";
-import esAthlete from "./locales/es/athlete.json";
-import esCalendar from "./locales/es/calendar.json";
-import esChat from "./locales/es/chat.json";
-import esCoaching from "./locales/es/coaching.json";
-import esCommon from "./locales/es/common.json";
-import esCreateWorkout from "./locales/es/create-workout.json";
-import esDaily from "./locales/es/daily.json";
-import esEditor from "./locales/es/editor.json";
-import esErrors from "./locales/es/errors.json";
-import esLabImport from "./locales/es/labImport.json";
-import esLabs from "./locales/es/labs.json";
-import esLibrary from "./locales/es/library.json";
-import esNav from "./locales/es/nav.json";
-import esSettings from "./locales/es/settings.json";
-import esTargets from "./locales/es/targets.json";
-import esWorkoutDetail from "./locales/es/workout-detail.json";
+import {
+  DEFAULT_LOCALE,
+  type Locale,
+  type LocaleNamespaces,
+  type NamespaceDictionary,
+} from "@kaiord/i18n";
 
 export const DEFAULT_NAMESPACE = "common";
 
-export const resources: LocaleResources = {
-  en: {
-    athlete: enAthlete,
-    calendar: enCalendar,
-    chat: enChat,
-    coaching: enCoaching,
-    common: enCommon,
-    "create-workout": enCreateWorkout,
-    daily: enDaily,
-    editor: enEditor,
-    errors: enErrors,
-    labs: enLabs,
-    labImport: enLabImport,
-    library: enLibrary,
-    nav: enNav,
-    settings: enSettings,
-    targets: enTargets,
-    "workout-detail": enWorkoutDetail,
-  },
-  es: {
-    athlete: esAthlete,
-    calendar: esCalendar,
-    chat: esChat,
-    coaching: esCoaching,
-    common: esCommon,
-    "create-workout": esCreateWorkout,
-    daily: esDaily,
-    editor: esEditor,
-    errors: esErrors,
-    labs: esLabs,
-    labImport: esLabImport,
-    library: esLibrary,
-    nav: esNav,
-    settings: esSettings,
-    targets: esTargets,
-    "workout-detail": esWorkoutDetail,
-  },
+const EN_MODULES = import.meta.glob<NamespaceDictionary>(
+  "./locales/en/*.json",
+  { eager: true, import: "default" }
+);
+
+const LOCALE_MODULES = import.meta.glob<NamespaceDictionary>(
+  "./locales/*/*.json",
+  { import: "default" }
+);
+
+const namespaceOf = (path: string): string =>
+  path.slice(path.lastIndexOf("/") + 1, -".json".length);
+
+const localeOf = (path: string): string => {
+  const dir = path.slice(0, path.lastIndexOf("/"));
+  return dir.slice(dir.lastIndexOf("/") + 1);
 };
 
-/** Namespace list for i18next, derived from the resource tree (single source). */
-export const NAMESPACES = Object.keys(resources.en);
+/** The eager, always-bundled English catalog: fallback and test default. */
+export const DEFAULT_CATALOG: LocaleNamespaces = Object.fromEntries(
+  Object.entries(EN_MODULES).map(([path, dict]) => [namespaceOf(path), dict])
+);
+
+const cache: Partial<Record<Locale, LocaleNamespaces>> = {
+  [DEFAULT_LOCALE]: DEFAULT_CATALOG,
+};
+
+/** Namespace list for i18next, derived from the eager English catalog. */
+export const NAMESPACES = Object.keys(DEFAULT_CATALOG);
+
+/** Already-loaded namespaces for a locale, or `undefined` if not yet loaded. */
+export const getLocaleNamespaces = (
+  locale: Locale
+): LocaleNamespaces | undefined => cache[locale];
+
+/** Code-split-load and cache a locale's namespaces (no-op once cached). */
+export const loadLocaleNamespaces = async (
+  locale: Locale
+): Promise<LocaleNamespaces> => {
+  const cached = cache[locale];
+  if (cached) return cached;
+  const entries = Object.entries(LOCALE_MODULES).filter(
+    ([path]) => localeOf(path) === locale
+  );
+  const loaded = await Promise.all(
+    entries.map(
+      async ([path, load]) => [namespaceOf(path), await load()] as const
+    )
+  );
+  const namespaces = Object.fromEntries(loaded);
+  cache[locale] = namespaces;
+  return namespaces;
+};

--- a/packages/workout-spa-editor/src/i18n/use-translate.test.tsx
+++ b/packages/workout-spa-editor/src/i18n/use-translate.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { LocaleProvider } from "./LocaleProvider";
@@ -35,7 +35,7 @@ describe("useTranslate", () => {
     expect(screen.getByTestId("out")).toHaveTextContent("Daily");
   });
 
-  it("should return the Spanish value under an es locale provider", () => {
+  it("should return the Spanish value under an es locale provider", async () => {
     // Arrange
     prefsMock.locale = "es";
 
@@ -47,7 +47,11 @@ describe("useTranslate", () => {
     );
 
     // Assert
-    expect(screen.getByTestId("out")).toHaveTextContent("Diario");
+    // The es catalog loads on demand; the seam falls back to en until it is
+    // live, then resolves to the Spanish value.
+    await waitFor(() =>
+      expect(screen.getByTestId("out")).toHaveTextContent("Diario")
+    );
   });
 
   it("should fall back to the key when it is missing", () => {

--- a/packages/workout-spa-editor/src/i18n/use-translate.ts
+++ b/packages/workout-spa-editor/src/i18n/use-translate.ts
@@ -13,7 +13,7 @@
 import { DEFAULT_LOCALE, type Locale } from "@kaiord/i18n";
 
 import { useActiveLocale } from "./LocaleProvider";
-import { resources } from "./resources";
+import { getLocaleNamespaces } from "./resources";
 
 type TranslateParams = Record<string, string | number>;
 
@@ -22,8 +22,9 @@ const lookup = (
   ns: string,
   key: string
 ): string | undefined => {
-  const namespaces = resources[locale] ?? resources[DEFAULT_LOCALE];
-  let current: unknown = namespaces[ns];
+  const namespaces =
+    getLocaleNamespaces(locale) ?? getLocaleNamespaces(DEFAULT_LOCALE);
+  let current: unknown = namespaces?.[ns];
   for (const segment of key.split(".")) {
     if (current && typeof current === "object") {
       current = (current as Record<string, unknown>)[segment];


### PR DESCRIPTION
## What

The SPA i18n catalog was assembled from a hand-maintained list of `import` statements in `resources.ts` — one per namespace **per locale**. That list grows by two lines for every namespace, is the sole source of merge conflicts between namespace PRs, and — critically — **bundles every locale into the main app**. That does not scale: with 50 languages every user would download all 50 catalogs.

This replaces that with Vite glob discovery + on-demand locale loading.

## How

- **English is eager** (`import.meta.glob("./locales/en/*.json", { eager: true })`) — the synchronous source-of-truth, the fallback for any missing key/locale, and the default that keeps the ~5.4k unwrapped component tests rendering in `en`.
- **Every other locale is lazy**: `import.meta.glob("./locales/*/*.json")` yields a code-split importer per file. `loadLocaleNamespaces(locale)` pulls only that locale's chunks on first switch.
- **`setActiveLocale` is now async** — it loads + registers the locale's bundle with i18next (`addResourceBundle`) before `changeLanguage`, so the react-i18next consumers stay correct.
- **`LocaleProvider` flips atomically**: the context holds the previous locale until the target's catalog is live (English shows meanwhile — no missing-key flash).
- **Resource parity** now generalizes over every `SUPPORTED_LOCALE`.

## Why it scales to N languages

Build output confirms per-`(locale, namespace)` chunks: en `nav` → `nav-C1AceB8u.js`, es `nav` → `nav-CBEfqKV8.js`, two separate files. **No `es` strings appear in the main bundle.** Switching to `fr` would load only the `fr` chunks for the namespaces in use.

Adding a namespace is now dropping `locales/<locale>/<name>.json`; adding a language is dropping a `locales/<locale>/` folder. **Neither touches code** — and namespace PRs stop conflicting on `resources.ts`.

## Verification

- `pnpm build` (tsc -b + vite build) ✅ — clean; per-locale chunks confirmed.
- `pnpm lint` (tsc --noEmit + eslint + prettier) ✅
- Full SPA suite: **5464 passed / 789 files, 0 failures** — en-default output byte-identical.
- i18n suite updated: es-under-provider tests now `await` the on-demand chunk load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)