### PR TITLE
feat(spa-editor): localize the help page (help namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/HelpSection/components/HelpHeader.tsx
+++ b/packages/workout-spa-editor/src/components/pages/HelpSection/components/HelpHeader.tsx
@@ -6,6 +6,7 @@
 
 import { Play } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { Button } from "../../../atoms/Button/Button";
 
 type HelpHeaderProps = {
@@ -13,16 +14,16 @@ type HelpHeaderProps = {
 };
 
 export function HelpHeader({ onReplayTutorial }: HelpHeaderProps) {
+  const t = useTranslate("help");
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <div className="flex items-start justify-between">
         <div>
           <h1 className="mb-2 text-3xl font-bold text-gray-900 dark:text-white">
-            Help & Documentation
+            {t("header.title")}
           </h1>
           <p className="text-gray-600 dark:text-gray-400">
-            Learn how to use the Kaiord Editor to create and manage structured
-            workout files
+            {t("header.subtitle")}
           </p>
         </div>
         {onReplayTutorial && (
@@ -32,7 +33,7 @@ export function HelpHeader({ onReplayTutorial }: HelpHeaderProps) {
             className="flex items-center gap-2"
           >
             <Play className="h-4 w-4" />
-            Replay Tutorial
+            {t("header.replayTutorial")}
           </Button>
         )}
       </div>

--- a/packages/workout-spa-editor/src/components/pages/HelpSection/sections/ExamplesSection.tsx
+++ b/packages/workout-spa-editor/src/components/pages/HelpSection/sections/ExamplesSection.tsx
@@ -6,51 +6,33 @@
 
 import { FileText } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { ExampleWorkout } from "../components/ExampleWorkout";
 
+const EXAMPLE_KEYS = ["sweetSpot", "tempo", "swim"];
+const STEP_KEYS = ["step1", "step2", "step3"];
+
 export function ExamplesSection() {
+  const t = useTranslate("help");
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <div className="mb-4 flex items-center gap-2">
         <FileText className="h-6 w-6 text-primary-600 dark:text-primary-400" />
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-          Example Workouts
+          {t("examples.heading")}
         </h2>
       </div>
 
       <div className="space-y-4">
-        <ExampleWorkout
-          title="Sweet Spot Intervals"
-          sport="Cycling"
-          description="Classic sweet spot training with 3x10 minute intervals at 88-93% FTP"
-          steps={[
-            "10 min warmup at 50-60% FTP",
-            "3x (10 min at 88-93% FTP, 5 min recovery at 50% FTP)",
-            "10 min cooldown at 50% FTP",
-          ]}
-        />
-
-        <ExampleWorkout
-          title="Tempo Run"
-          sport="Running"
-          description="Sustained tempo effort to build aerobic endurance"
-          steps={[
-            "15 min easy warmup",
-            "20 min at tempo pace (Zone 3-4)",
-            "10 min easy cooldown",
-          ]}
-        />
-
-        <ExampleWorkout
-          title="Swim Intervals"
-          sport="Swimming"
-          description="High-intensity intervals with active recovery"
-          steps={[
-            "400m easy warmup",
-            "8x (100m hard, 50m easy)",
-            "200m cooldown",
-          ]}
-        />
+        {EXAMPLE_KEYS.map((key) => (
+          <ExampleWorkout
+            key={key}
+            title={t(`examples.${key}.title`)}
+            sport={t(`examples.${key}.sport`)}
+            description={t(`examples.${key}.description`)}
+            steps={STEP_KEYS.map((step) => t(`examples.${key}.${step}`))}
+          />
+        ))}
       </div>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/HelpSection/sections/FAQSection.tsx
+++ b/packages/workout-spa-editor/src/components/pages/HelpSection/sections/FAQSection.tsx
@@ -6,58 +6,39 @@
 
 import { HelpCircle } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { FAQItem } from "../components/FAQItem";
 
+const FAQ_KEYS = [
+  "formats",
+  "block",
+  "offline",
+  "zones",
+  "export",
+  "undo",
+  "durations",
+  "library",
+];
+
 export function FAQSection() {
+  const t = useTranslate("help");
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <div className="mb-4 flex items-center gap-2">
         <HelpCircle className="h-6 w-6 text-primary-600 dark:text-primary-400" />
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-          Frequently Asked Questions
+          {t("faq.heading")}
         </h2>
       </div>
 
       <div className="space-y-4">
-        <FAQItem
-          question="What file formats are supported?"
-          answer="The editor supports KRD (native format), FIT (Garmin), TCX (Training Center XML), and ZWO (Zwift) formats for both import and export."
-        />
-
-        <FAQItem
-          question="How do I create a repetition block?"
-          answer="Select multiple steps by clicking while holding Shift or Ctrl, then press Ctrl+G (Cmd+G on Mac) or click the 'Create Block' button. You can also drag steps into an existing block."
-        />
-
-        <FAQItem
-          question="Can I use this offline?"
-          answer="Yes! The editor works offline once loaded. Your workouts are saved in your browser's local storage and will be available even without an internet connection."
-        />
-
-        <FAQItem
-          question="What are training zones?"
-          answer="Training zones are intensity ranges based on your FTP (power) or maximum heart rate. Configure your zones in the Profile Manager to see zone-based targets in your workouts."
-        />
-
-        <FAQItem
-          question="How do I export my workout?"
-          answer="Click the 'Save' button and select your desired export format (KRD, FIT, TCX, or ZWO). The file will be downloaded to your device."
-        />
-
-        <FAQItem
-          question="Can I undo changes?"
-          answer="Yes! Use Ctrl+Z (Cmd+Z on Mac) to undo and Ctrl+Y (Cmd+Y on Mac) to redo. The editor maintains a full history of your changes."
-        />
-
-        <FAQItem
-          question="What's the difference between duration types?"
-          answer="Time-based durations use minutes/seconds, distance-based use meters/kilometers, and open durations continue until you manually advance (lap button press)."
-        />
-
-        <FAQItem
-          question="How do I save workouts to my library?"
-          answer="Click the 'Save to Library' button to store your workout locally. You can add tags and notes for easy organization and retrieval."
-        />
+        {FAQ_KEYS.map((key) => (
+          <FAQItem
+            key={key}
+            question={t(`faq.${key}.q`)}
+            answer={t(`faq.${key}.a`)}
+          />
+        ))}
       </div>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/pages/HelpSection/sections/GettingStartedSection.tsx
+++ b/packages/workout-spa-editor/src/components/pages/HelpSection/sections/GettingStartedSection.tsx
@@ -6,58 +6,54 @@
 
 import { BookOpen } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
+
+const CREATING_STEPS = ["step1", "step2", "step3", "step4", "step5", "step6"];
+const LOADING_STEPS = ["step1", "step2", "step3", "step4"];
+const ORGANIZING_STEPS = ["step1", "step2", "step3", "step4", "step5"];
+
 export function GettingStartedSection() {
+  const t = useTranslate("help");
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <div className="mb-4 flex items-center gap-2">
         <BookOpen className="h-6 w-6 text-primary-600 dark:text-primary-400" />
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-          Getting Started
+          {t("gettingStarted.heading")}
         </h2>
       </div>
 
       <div className="space-y-4">
         <div>
           <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
-            Creating a Workout
+            {t("gettingStarted.creating.heading")}
           </h3>
           <ol className="list-decimal space-y-2 pl-5 text-gray-600 dark:text-gray-400">
-            <li>Click "Create New Workout" on the welcome screen</li>
-            <li>
-              Enter a workout name and select a sport (cycling, running,
-              swimming)
-            </li>
-            <li>Add workout steps by clicking "Add Step"</li>
-            <li>Configure duration (time, distance, or open) for each step</li>
-            <li>Set target intensity (power, heart rate, pace, or cadence)</li>
-            <li>Save your workout using Ctrl+S (Cmd+S on Mac)</li>
+            {CREATING_STEPS.map((step) => (
+              <li key={step}>{t(`gettingStarted.creating.${step}`)}</li>
+            ))}
           </ol>
         </div>
 
         <div>
           <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
-            Loading a Workout
+            {t("gettingStarted.loading.heading")}
           </h3>
           <ol className="list-decimal space-y-2 pl-5 text-gray-600 dark:text-gray-400">
-            <li>Click "Load Workout" or drag and drop a file</li>
-            <li>Supported formats: KRD, FIT, TCX, ZWO</li>
-            <li>The workout will load and display all steps</li>
-            <li>Edit any step by clicking on it</li>
+            {LOADING_STEPS.map((step) => (
+              <li key={step}>{t(`gettingStarted.loading.${step}`)}</li>
+            ))}
           </ol>
         </div>
 
         <div>
           <h3 className="mb-2 text-lg font-semibold text-gray-900 dark:text-white">
-            Organizing Steps
+            {t("gettingStarted.organizing.heading")}
           </h3>
           <ul className="list-disc space-y-2 pl-5 text-gray-600 dark:text-gray-400">
-            <li>Drag and drop steps to reorder them</li>
-            <li>Use Alt+Up/Down to move selected steps</li>
-            <li>
-              Group steps into repetition blocks with Ctrl+G (Cmd+G on Mac)
-            </li>
-            <li>Ungroup blocks with Ctrl+Shift+G (Cmd+Shift+G on Mac)</li>
-            <li>Copy steps with Ctrl+C and paste with Ctrl+V</li>
+            {ORGANIZING_STEPS.map((step) => (
+              <li key={step}>{t(`gettingStarted.organizing.${step}`)}</li>
+            ))}
           </ul>
         </div>
       </div>

--- a/packages/workout-spa-editor/src/components/pages/HelpSection/sections/KeyboardShortcutsSection.tsx
+++ b/packages/workout-spa-editor/src/components/pages/HelpSection/sections/KeyboardShortcutsSection.tsx
@@ -6,18 +6,20 @@
 
 import { Keyboard } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { EditOperationsShortcuts } from "./shortcuts/EditOperationsShortcuts";
 import { FileOperationsShortcuts } from "./shortcuts/FileOperationsShortcuts";
 import { SelectionShortcuts } from "./shortcuts/SelectionShortcuts";
 import { StepManagementShortcuts } from "./shortcuts/StepManagementShortcuts";
 
 export function KeyboardShortcutsSection() {
+  const t = useTranslate("help");
   return (
     <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
       <div className="mb-4 flex items-center gap-2">
         <Keyboard className="h-6 w-6 text-primary-600 dark:text-primary-400" />
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
-          Keyboard Shortcuts
+          {t("shortcuts.heading")}
         </h2>
       </div>
 

--- a/packages/workout-spa-editor/src/components/pages/HelpSection/sections/shortcuts/EditOperationsShortcuts.tsx
+++ b/packages/workout-spa-editor/src/components/pages/HelpSection/sections/shortcuts/EditOperationsShortcuts.tsx
@@ -6,38 +6,40 @@
 
 import { Copy, RotateCcw, Scissors } from "lucide-react";
 
+import { useTranslate } from "../../../../../i18n/use-translate";
 import { ShortcutRow } from "../../components/ShortcutRow";
 
 export function EditOperationsShortcuts() {
+  const t = useTranslate("help");
   return (
     <div>
       <h3 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
-        Edit Operations
+        {t("shortcuts.edit.heading")}
       </h3>
       <div className="space-y-2">
         <ShortcutRow
           icon={<RotateCcw className="h-4 w-4" />}
           keys={["Ctrl", "Z"]}
           macKeys={["Cmd", "Z"]}
-          description="Undo"
+          description={t("shortcuts.edit.undo")}
         />
         <ShortcutRow
           icon={<RotateCcw className="h-4 w-4 rotate-180" />}
           keys={["Ctrl", "Y"]}
           macKeys={["Cmd", "Y"]}
-          description="Redo"
+          description={t("shortcuts.edit.redo")}
         />
         <ShortcutRow
           icon={<Copy className="h-4 w-4" />}
           keys={["Ctrl", "C"]}
           macKeys={["Cmd", "C"]}
-          description="Copy selected steps"
+          description={t("shortcuts.edit.copy")}
         />
         <ShortcutRow
           icon={<Scissors className="h-4 w-4" />}
           keys={["Ctrl", "V"]}
           macKeys={["Cmd", "V"]}
-          description="Paste steps"
+          description={t("shortcuts.edit.paste")}
         />
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/HelpSection/sections/shortcuts/FileOperationsShortcuts.tsx
+++ b/packages/workout-spa-editor/src/components/pages/HelpSection/sections/shortcuts/FileOperationsShortcuts.tsx
@@ -6,20 +6,22 @@
 
 import { Save } from "lucide-react";
 
+import { useTranslate } from "../../../../../i18n/use-translate";
 import { ShortcutRow } from "../../components/ShortcutRow";
 
 export function FileOperationsShortcuts() {
+  const t = useTranslate("help");
   return (
     <div>
       <h3 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
-        File Operations
+        {t("shortcuts.file.heading")}
       </h3>
       <div className="space-y-2">
         <ShortcutRow
           icon={<Save className="h-4 w-4" />}
           keys={["Ctrl", "S"]}
           macKeys={["Cmd", "S"]}
-          description="Save workout"
+          description={t("shortcuts.file.save")}
         />
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/HelpSection/sections/shortcuts/SelectionShortcuts.tsx
+++ b/packages/workout-spa-editor/src/components/pages/HelpSection/sections/shortcuts/SelectionShortcuts.tsx
@@ -6,25 +6,27 @@
 
 import { Zap } from "lucide-react";
 
+import { useTranslate } from "../../../../../i18n/use-translate";
 import { ShortcutRow } from "../../components/ShortcutRow";
 
 export function SelectionShortcuts() {
+  const t = useTranslate("help");
   return (
     <div>
       <h3 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
-        Selection
+        {t("shortcuts.selection.heading")}
       </h3>
       <div className="space-y-2">
         <ShortcutRow
           icon={<Zap className="h-4 w-4" />}
           keys={["Ctrl", "A"]}
           macKeys={["Cmd", "A"]}
-          description="Select all steps"
+          description={t("shortcuts.selection.selectAll")}
         />
         <ShortcutRow
           icon={<Zap className="h-4 w-4" />}
           keys={["Esc"]}
-          description="Clear selection"
+          description={t("shortcuts.selection.clear")}
         />
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/HelpSection/sections/shortcuts/StepManagementShortcuts.tsx
+++ b/packages/workout-spa-editor/src/components/pages/HelpSection/sections/shortcuts/StepManagementShortcuts.tsx
@@ -6,36 +6,38 @@
 
 import { ArrowDown, ArrowUp, Layers } from "lucide-react";
 
+import { useTranslate } from "../../../../../i18n/use-translate";
 import { ShortcutRow } from "../../components/ShortcutRow";
 
 export function StepManagementShortcuts() {
+  const t = useTranslate("help");
   return (
     <div>
       <h3 className="mb-3 text-lg font-semibold text-gray-900 dark:text-white">
-        Step Management
+        {t("shortcuts.step.heading")}
       </h3>
       <div className="space-y-2">
         <ShortcutRow
           icon={<ArrowUp className="h-4 w-4" />}
           keys={["Alt", "↑"]}
-          description="Move step up"
+          description={t("shortcuts.step.moveUp")}
         />
         <ShortcutRow
           icon={<ArrowDown className="h-4 w-4" />}
           keys={["Alt", "↓"]}
-          description="Move step down"
+          description={t("shortcuts.step.moveDown")}
         />
         <ShortcutRow
           icon={<Layers className="h-4 w-4" />}
           keys={["Ctrl", "G"]}
           macKeys={["Cmd", "G"]}
-          description="Create repetition block"
+          description={t("shortcuts.step.createBlock")}
         />
         <ShortcutRow
           icon={<Layers className="h-4 w-4" />}
           keys={["Ctrl", "Shift", "G"]}
           macKeys={["Cmd", "Shift", "G"]}
-          description="Ungroup block"
+          description={t("shortcuts.step.ungroup")}
         />
       </div>
     </div>

--- a/packages/workout-spa-editor/src/i18n/locales/en/help.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/help.json
@@ -1,0 +1,122 @@
+{
+  "header": {
+    "title": "Help & Documentation",
+    "subtitle": "Learn how to use the Kaiord Editor to create and manage structured workout files",
+    "replayTutorial": "Replay Tutorial"
+  },
+  "gettingStarted": {
+    "heading": "Getting Started",
+    "creating": {
+      "heading": "Creating a Workout",
+      "step1": "Click \"Create New Workout\" on the welcome screen",
+      "step2": "Enter a workout name and select a sport (cycling, running, swimming)",
+      "step3": "Add workout steps by clicking \"Add Step\"",
+      "step4": "Configure duration (time, distance, or open) for each step",
+      "step5": "Set target intensity (power, heart rate, pace, or cadence)",
+      "step6": "Save your workout using Ctrl+S (Cmd+S on Mac)"
+    },
+    "loading": {
+      "heading": "Loading a Workout",
+      "step1": "Click \"Load Workout\" or drag and drop a file",
+      "step2": "Supported formats: KRD, FIT, TCX, ZWO",
+      "step3": "The workout will load and display all steps",
+      "step4": "Edit any step by clicking on it"
+    },
+    "organizing": {
+      "heading": "Organizing Steps",
+      "step1": "Drag and drop steps to reorder them",
+      "step2": "Use Alt+Up/Down to move selected steps",
+      "step3": "Group steps into repetition blocks with Ctrl+G (Cmd+G on Mac)",
+      "step4": "Ungroup blocks with Ctrl+Shift+G (Cmd+Shift+G on Mac)",
+      "step5": "Copy steps with Ctrl+C and paste with Ctrl+V"
+    }
+  },
+  "shortcuts": {
+    "heading": "Keyboard Shortcuts",
+    "file": {
+      "heading": "File Operations",
+      "save": "Save workout"
+    },
+    "edit": {
+      "heading": "Edit Operations",
+      "undo": "Undo",
+      "redo": "Redo",
+      "copy": "Copy selected steps",
+      "paste": "Paste steps"
+    },
+    "step": {
+      "heading": "Step Management",
+      "moveUp": "Move step up",
+      "moveDown": "Move step down",
+      "createBlock": "Create repetition block",
+      "ungroup": "Ungroup block"
+    },
+    "selection": {
+      "heading": "Selection",
+      "selectAll": "Select all steps",
+      "clear": "Clear selection"
+    }
+  },
+  "examples": {
+    "heading": "Example Workouts",
+    "sweetSpot": {
+      "title": "Sweet Spot Intervals",
+      "sport": "Cycling",
+      "description": "Classic sweet spot training with 3x10 minute intervals at 88-93% FTP",
+      "step1": "10 min warmup at 50-60% FTP",
+      "step2": "3x (10 min at 88-93% FTP, 5 min recovery at 50% FTP)",
+      "step3": "10 min cooldown at 50% FTP"
+    },
+    "tempo": {
+      "title": "Tempo Run",
+      "sport": "Running",
+      "description": "Sustained tempo effort to build aerobic endurance",
+      "step1": "15 min easy warmup",
+      "step2": "20 min at tempo pace (Zone 3-4)",
+      "step3": "10 min easy cooldown"
+    },
+    "swim": {
+      "title": "Swim Intervals",
+      "sport": "Swimming",
+      "description": "High-intensity intervals with active recovery",
+      "step1": "400m easy warmup",
+      "step2": "8x (100m hard, 50m easy)",
+      "step3": "200m cooldown"
+    }
+  },
+  "faq": {
+    "heading": "Frequently Asked Questions",
+    "formats": {
+      "q": "What file formats are supported?",
+      "a": "The editor supports KRD (native format), FIT (Garmin), TCX (Training Center XML), and ZWO (Zwift) formats for both import and export."
+    },
+    "block": {
+      "q": "How do I create a repetition block?",
+      "a": "Select multiple steps by clicking while holding Shift or Ctrl, then press Ctrl+G (Cmd+G on Mac) or click the 'Create Block' button. You can also drag steps into an existing block."
+    },
+    "offline": {
+      "q": "Can I use this offline?",
+      "a": "Yes! The editor works offline once loaded. Your workouts are saved in your browser's local storage and will be available even without an internet connection."
+    },
+    "zones": {
+      "q": "What are training zones?",
+      "a": "Training zones are intensity ranges based on your FTP (power) or maximum heart rate. Configure your zones in the Profile Manager to see zone-based targets in your workouts."
+    },
+    "export": {
+      "q": "How do I export my workout?",
+      "a": "Click the 'Save' button and select your desired export format (KRD, FIT, TCX, or ZWO). The file will be downloaded to your device."
+    },
+    "undo": {
+      "q": "Can I undo changes?",
+      "a": "Yes! Use Ctrl+Z (Cmd+Z on Mac) to undo and Ctrl+Y (Cmd+Y on Mac) to redo. The editor maintains a full history of your changes."
+    },
+    "durations": {
+      "q": "What's the difference between duration types?",
+      "a": "Time-based durations use minutes/seconds, distance-based use meters/kilometers, and open durations continue until you manually advance (lap button press)."
+    },
+    "library": {
+      "q": "How do I save workouts to my library?",
+      "a": "Click the 'Save to Library' button to store your workout locally. You can add tags and notes for easy organization and retrieval."
+    }
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/help.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/help.json
@@ -1,0 +1,122 @@
+{
+  "header": {
+    "title": "Ayuda y documentación",
+    "subtitle": "Aprende a usar el Editor de Kaiord para crear y gestionar archivos de entrenamiento estructurados",
+    "replayTutorial": "Repetir tutorial"
+  },
+  "gettingStarted": {
+    "heading": "Primeros pasos",
+    "creating": {
+      "heading": "Crear un entrenamiento",
+      "step1": "Haz clic en «Crear entrenamiento nuevo» en la pantalla de bienvenida",
+      "step2": "Introduce un nombre de entrenamiento y selecciona un deporte (ciclismo, carrera, natación)",
+      "step3": "Añade pasos de entrenamiento haciendo clic en «Añadir paso»",
+      "step4": "Configura la duración (tiempo, distancia o abierta) de cada paso",
+      "step5": "Define la intensidad objetivo (potencia, frecuencia cardíaca, ritmo o cadencia)",
+      "step6": "Guarda tu entrenamiento con Ctrl+S (Cmd+S en Mac)"
+    },
+    "loading": {
+      "heading": "Cargar un entrenamiento",
+      "step1": "Haz clic en «Cargar entrenamiento» o arrastra y suelta un archivo",
+      "step2": "Formatos admitidos: KRD, FIT, TCX, ZWO",
+      "step3": "El entrenamiento se cargará y mostrará todos los pasos",
+      "step4": "Edita cualquier paso haciendo clic en él"
+    },
+    "organizing": {
+      "heading": "Organizar los pasos",
+      "step1": "Arrastra y suelta los pasos para reordenarlos",
+      "step2": "Usa Alt+Arriba/Abajo para mover los pasos seleccionados",
+      "step3": "Agrupa pasos en bloques de repetición con Ctrl+G (Cmd+G en Mac)",
+      "step4": "Desagrupa bloques con Ctrl+Shift+G (Cmd+Shift+G en Mac)",
+      "step5": "Copia pasos con Ctrl+C y pégalos con Ctrl+V"
+    }
+  },
+  "shortcuts": {
+    "heading": "Atajos de teclado",
+    "file": {
+      "heading": "Operaciones de archivo",
+      "save": "Guardar entrenamiento"
+    },
+    "edit": {
+      "heading": "Operaciones de edición",
+      "undo": "Deshacer",
+      "redo": "Rehacer",
+      "copy": "Copiar pasos seleccionados",
+      "paste": "Pegar pasos"
+    },
+    "step": {
+      "heading": "Gestión de pasos",
+      "moveUp": "Subir paso",
+      "moveDown": "Bajar paso",
+      "createBlock": "Crear bloque de repetición",
+      "ungroup": "Desagrupar bloque"
+    },
+    "selection": {
+      "heading": "Selección",
+      "selectAll": "Seleccionar todos los pasos",
+      "clear": "Borrar selección"
+    }
+  },
+  "examples": {
+    "heading": "Entrenamientos de ejemplo",
+    "sweetSpot": {
+      "title": "Series de sweet spot",
+      "sport": "Ciclismo",
+      "description": "Entrenamiento clásico de sweet spot con 3x10 minutos de series al 88-93 % del FTP",
+      "step1": "10 min de calentamiento al 50-60 % del FTP",
+      "step2": "3x (10 min al 88-93 % del FTP, 5 min de recuperación al 50 % del FTP)",
+      "step3": "10 min de vuelta a la calma al 50 % del FTP"
+    },
+    "tempo": {
+      "title": "Carrera a ritmo tempo",
+      "sport": "Carrera",
+      "description": "Esfuerzo sostenido a ritmo tempo para desarrollar la resistencia aeróbica",
+      "step1": "15 min de calentamiento suave",
+      "step2": "20 min a ritmo tempo (Zona 3-4)",
+      "step3": "10 min de vuelta a la calma suave"
+    },
+    "swim": {
+      "title": "Series de natación",
+      "sport": "Natación",
+      "description": "Series de alta intensidad con recuperación activa",
+      "step1": "400 m de calentamiento suave",
+      "step2": "8x (100 m fuerte, 50 m suave)",
+      "step3": "200 m de vuelta a la calma"
+    }
+  },
+  "faq": {
+    "heading": "Preguntas frecuentes",
+    "formats": {
+      "q": "¿Qué formatos de archivo son compatibles?",
+      "a": "El editor admite los formatos KRD (formato nativo), FIT (Garmin), TCX (Training Center XML) y ZWO (Zwift), tanto para importar como para exportar."
+    },
+    "block": {
+      "q": "¿Cómo creo un bloque de repetición?",
+      "a": "Selecciona varios pasos haciendo clic mientras mantienes pulsado Shift o Ctrl y, a continuación, pulsa Ctrl+G (Cmd+G en Mac) o haz clic en el botón «Crear bloque». También puedes arrastrar pasos a un bloque existente."
+    },
+    "offline": {
+      "q": "¿Puedo usarlo sin conexión?",
+      "a": "¡Sí! El editor funciona sin conexión una vez cargado. Tus entrenamientos se guardan en el almacenamiento local del navegador y estarán disponibles incluso sin conexión a internet."
+    },
+    "zones": {
+      "q": "¿Qué son las zonas de entrenamiento?",
+      "a": "Las zonas de entrenamiento son rangos de intensidad basados en tu FTP (potencia) o tu frecuencia cardíaca máxima. Configura tus zonas en el Gestor de perfiles para ver objetivos por zonas en tus entrenamientos."
+    },
+    "export": {
+      "q": "¿Cómo exporto mi entrenamiento?",
+      "a": "Haz clic en el botón «Guardar» y selecciona el formato de exportación que quieras (KRD, FIT, TCX o ZWO). El archivo se descargará en tu dispositivo."
+    },
+    "undo": {
+      "q": "¿Puedo deshacer cambios?",
+      "a": "¡Sí! Usa Ctrl+Z (Cmd+Z en Mac) para deshacer y Ctrl+Y (Cmd+Y en Mac) para rehacer. El editor mantiene un historial completo de tus cambios."
+    },
+    "durations": {
+      "q": "¿Cuál es la diferencia entre los tipos de duración?",
+      "a": "Las duraciones por tiempo usan minutos/segundos, las de distancia usan metros/kilómetros y las abiertas continúan hasta que avanzas manualmente (pulsando el botón de vuelta)."
+    },
+    "library": {
+      "q": "¿Cómo guardo entrenamientos en mi biblioteca?",
+      "a": "Haz clic en el botón «Guardar en la biblioteca» para almacenar tu entrenamiento localmente. Puedes añadir etiquetas y notas para organizarlos y recuperarlos fácilmente."
+    }
+  }
+}


### PR DESCRIPTION
## What

New `help` namespace across the Help & Documentation page: header, getting-started guide, keyboard shortcuts (4 groups), example workouts, and the FAQ.

## Notes

- **First namespace PR under the glob loader** (#901): no `resources.ts` change — the new `locales/{en,es}/help.json` is auto-discovered.
- FAQ / examples / getting-started steps render by mapping over stable key lists (the translate seam returns strings, not arrays).
- Keyboard keys (Ctrl/Cmd/Alt/↑…) stay literal; only headings and row descriptions are translated.
- English values are byte-identical to the previous literals → the 26 HelpSection tests pass unchanged.

## Verification

- `pnpm build` (tsc -b + vite) ✅
- eslint + prettier ✅
- HelpSection suite: **26/26** ✅
- en/es parity: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)