### PR TITLE
feat(spa-editor): localize the file-import chrome (import namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/FileUpload/FileUploadButton.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/FileUpload/FileUploadButton.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button/Button";
 
 type FileUploadButtonProps = {
@@ -11,6 +12,7 @@ export function FileUploadButton({
   disabled,
   isLoading,
 }: FileUploadButtonProps) {
+  const t = useTranslate("import");
   return (
     <Button
       onClick={onClick}
@@ -19,7 +21,7 @@ export function FileUploadButton({
       variant="primary"
       size="md"
     >
-      {isLoading ? "Loading..." : "Upload Workout File"}
+      {isLoading ? t("button.loading") : t("button.upload")}
     </Button>
   );
 }

--- a/packages/workout-spa-editor/src/components/molecules/FileUpload/FileUploadInput.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/FileUpload/FileUploadInput.tsx
@@ -1,5 +1,7 @@
 import type { RefObject } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
+
 type FileUploadInputProps = {
   fileInputRef: RefObject<HTMLInputElement | null>;
   accept: string;
@@ -15,6 +17,7 @@ export function FileUploadInput({
   isLoading,
   onFileChange,
 }: FileUploadInputProps) {
+  const t = useTranslate("import");
   return (
     <input
       ref={fileInputRef}
@@ -23,7 +26,7 @@ export function FileUploadInput({
       onChange={(e) => onFileChange(e.target.files?.[0])}
       className="hidden"
       disabled={disabled || isLoading}
-      aria-label="Upload workout file"
+      aria-label={t("input.ariaLabel")}
       data-testid="file-upload-input"
     />
   );

--- a/packages/workout-spa-editor/src/components/molecules/FileUpload/FormatBadge.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/FileUpload/FormatBadge.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WorkoutFileFormat } from "../../../utils/file-format-detector";
 import { getFormatName } from "../../../utils/file-format-metadata";
 
@@ -15,6 +16,7 @@ const formatColors: Record<WorkoutFileFormat, string> = {
 };
 
 export function FormatBadge({ format, className = "" }: FormatBadgeProps) {
+  const t = useTranslate("import");
   const colorClass = formatColors[format];
   const formatName = getFormatName(format);
 
@@ -22,7 +24,7 @@ export function FormatBadge({ format, className = "" }: FormatBadgeProps) {
     <span
       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colorClass} ${className}`}
       role="status"
-      aria-label={`File format: ${formatName}`}
+      aria-label={t("badge.ariaLabel", { format: formatName })}
     >
       {formatName}
     </span>

--- a/packages/workout-spa-editor/src/components/molecules/FileUpload/LoadingStatus.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/FileUpload/LoadingStatus.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { detectFormat } from "../../../utils/file-format-detector";
 import { FormatBadge } from "./FormatBadge";
 import { useConversionTimeEstimate } from "./use-conversion-time-estimate";
@@ -11,6 +12,7 @@ export function LoadingStatus({
   fileName,
   conversionProgress,
 }: LoadingStatusProps) {
+  const t = useTranslate("import");
   const timeEstimate = useConversionTimeEstimate(true, conversionProgress);
   const formatResult = detectFormat(fileName);
   const showProgress = conversionProgress > 0;
@@ -20,7 +22,7 @@ export function LoadingStatus({
       <div className="flex items-center gap-2">
         <div className="animate-spin h-4 w-4 border-2 border-primary-600 border-t-transparent rounded-full" />
         <p className="text-sm text-gray-600 dark:text-gray-400">
-          Converting {fileName}...
+          {t("status.converting", { fileName })}
         </p>
         {formatResult.success && <FormatBadge format={formatResult.format} />}
       </div>
@@ -34,7 +36,9 @@ export function LoadingStatus({
               aria-valuenow={conversionProgress}
               aria-valuemin={0}
               aria-valuemax={100}
-              aria-label={`Conversion progress: ${conversionProgress}%`}
+              aria-label={t("status.progressLabel", {
+                progress: conversionProgress,
+              })}
             />
           </div>
           {timeEstimate && (
@@ -42,7 +46,7 @@ export function LoadingStatus({
               className="text-xs text-gray-500 dark:text-gray-500"
               aria-live="polite"
             >
-              {timeEstimate} remaining
+              {t("status.remaining", { time: timeEstimate })}
             </p>
           )}
         </div>

--- a/packages/workout-spa-editor/src/components/molecules/FileUpload/SuccessStatus.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/FileUpload/SuccessStatus.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { detectFormat } from "../../../utils/file-format-detector";
 import { FormatBadge } from "./FormatBadge";
 
@@ -6,12 +7,13 @@ type SuccessStatusProps = {
 };
 
 export function SuccessStatus({ fileName }: SuccessStatusProps) {
+  const t = useTranslate("import");
   const formatResult = detectFormat(fileName);
 
   return (
     <div className="flex items-center gap-2">
       <p className="text-sm text-gray-600 dark:text-gray-400">
-        Loaded: {fileName}
+        {t("status.loaded", { fileName })}
       </p>
       {formatResult.success && <FormatBadge format={formatResult.format} />}
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ImportDropzoneOverlay/ImportDropzoneOverlay.tsx
@@ -4,6 +4,7 @@ import { useSearch } from "wouter";
 
 import { useAnalytics } from "../../../contexts/analytics-context";
 import { useAppHandlers } from "../../../hooks/use-app-handlers";
+import { useTranslate } from "../../../i18n/use-translate";
 import { useWorkoutStore } from "../../../store/workout-store";
 import { FileUpload } from "../../molecules/FileUpload/FileUpload";
 import { useImportOnLoad } from "./use-import-on-load";
@@ -22,6 +23,7 @@ import { useImportOnLoad } from "./use-import-on-load";
  * non-persisting behaviour (load into store, let the user decide).
  */
 export function ImportDropzoneOverlay() {
+  const t = useTranslate("import");
   const { handleFileError } = useAppHandlers();
   const analytics = useAnalytics();
   const search = useSearch();
@@ -61,10 +63,10 @@ export function ImportDropzoneOverlay() {
       <div className="mx-auto flex max-w-md flex-col items-center gap-3">
         <Upload className="h-8 w-8 text-gray-400" />
         <p className="text-sm font-medium text-gray-700 dark:text-gray-200">
-          Drop a FIT, TCX, ZWO, GCN, or KRD file
+          {t("dropzone.title")}
         </p>
         <p className="text-xs text-gray-500 dark:text-gray-400">
-          Or click below to choose one from your device.
+          {t("dropzone.hint")}
         </p>
         <FileUpload
           onFileLoad={onFileLoad}

--- a/packages/workout-spa-editor/src/i18n/locales/en/import.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/import.json
@@ -1,0 +1,22 @@
+{
+  "button": {
+    "loading": "Loading...",
+    "upload": "Upload Workout File"
+  },
+  "input": {
+    "ariaLabel": "Upload workout file"
+  },
+  "badge": {
+    "ariaLabel": "File format: {{format}}"
+  },
+  "status": {
+    "converting": "Converting {{fileName}}...",
+    "progressLabel": "Conversion progress: {{progress}}%",
+    "remaining": "{{time}} remaining",
+    "loaded": "Loaded: {{fileName}}"
+  },
+  "dropzone": {
+    "title": "Drop a FIT, TCX, ZWO, GCN, or KRD file",
+    "hint": "Or click below to choose one from your device."
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/import.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/import.json
@@ -1,0 +1,22 @@
+{
+  "button": {
+    "loading": "Cargando...",
+    "upload": "Subir archivo de entrenamiento"
+  },
+  "input": {
+    "ariaLabel": "Subir archivo de entrenamiento"
+  },
+  "badge": {
+    "ariaLabel": "Formato de archivo: {{format}}"
+  },
+  "status": {
+    "converting": "Convirtiendo {{fileName}}...",
+    "progressLabel": "Progreso de conversión: {{progress}} %",
+    "remaining": "{{time}} restante",
+    "loaded": "Cargado: {{fileName}}"
+  },
+  "dropzone": {
+    "title": "Suelta un archivo FIT, TCX, ZWO, GCN o KRD",
+    "hint": "O haz clic abajo para elegir uno de tu dispositivo."
+  }
+}


### PR DESCRIPTION
## What

New `import` namespace across the file-upload / import-dropzone chrome: upload button, input aria-label, format badge, loading + success status, and the dropzone overlay copy.

## Notes

- Status/badge strings interpolate the file name, progress, remaining time, and format via `{{...}}` placeholders.
- Converter/parser error copy (`file-parser-error-*`, `useFileUpload`) is intentionally left untouched — localizing it by stable code is the separate converter-error effort, never message-text matching.
- No `resources.ts` change — locale JSON auto-discovered by the glob loader (#901). English byte-identical.

## Verification

- `pnpm build` (tsc -b + vite) ✅ · eslint + prettier ✅
- FileUpload + dropzone + parity suites: **61/61** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)