### PR TITLE
feat(spa-editor): localize the settings panels (settings namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/AiTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/AiTab.tsx
@@ -1,5 +1,6 @@
 import { useAiCustomPromptLive } from "../../../hooks/use-ai-custom-prompt-live";
 import { useAiProvidersLive } from "../../../hooks/use-ai-providers-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { SETTINGS_SECTION_ATTR } from "../../pages/SettingsPage/settings-section";
 import { ModelsSection } from "./ModelsSection";
 import { ProviderForm } from "./ProviderForm";
@@ -7,6 +8,7 @@ import { ProviderList } from "./ProviderList";
 import { useAiTabHandlers } from "./use-ai-tab-handlers";
 
 export const AiTab: React.FC = () => {
+  const t = useTranslate("settings");
   const providers = useAiProvidersLive() ?? [];
   const customPrompt = useAiCustomPromptLive() ?? "";
   const { onAdd, onRemove, onUpdate, onSetDefault, onPromptChange } =
@@ -16,7 +18,7 @@ export const AiTab: React.FC = () => {
     <div className="space-y-6">
       <section tabIndex={-1} {...{ [SETTINGS_SECTION_ATTR]: "providers" }}>
         <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
-          LLM Providers
+          {t("ai.llmProviders")}
         </h3>
         <ProviderList
           providers={providers}
@@ -28,14 +30,14 @@ export const AiTab: React.FC = () => {
 
       <section>
         <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
-          Add Provider
+          {t("ai.addProvider")}
         </h3>
         <ProviderForm onAdd={onAdd} />
       </section>
 
       <section>
         <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
-          Models
+          {t("ai.models")}
         </h3>
         <ModelsSection />
       </section>
@@ -45,20 +47,20 @@ export const AiTab: React.FC = () => {
         {...{ [SETTINGS_SECTION_ATTR]: "custom-instructions" }}
       >
         <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
-          Custom System Prompt
+          {t("ai.customSystemPrompt")}
         </h3>
         <label
           htmlFor="ai-custom-system-prompt"
           className="mb-2 block text-sm text-gray-600 dark:text-gray-300"
         >
-          Additional instructions applied to all generations
+          {t("ai.customInstructionsLabel")}
         </label>
         <textarea
           id="ai-custom-system-prompt"
           className="w-full rounded-lg border border-gray-300 p-3 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           rows={3}
           maxLength={500}
-          placeholder="Additional instructions for all AI generations (e.g., 'I'm recovering from a knee injury')"
+          placeholder={t("ai.customInstructionsPlaceholder")}
           value={customPrompt}
           onChange={(e) => onPromptChange(e.target.value)}
         />

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/BridgeStatusRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/BridgeStatusRow.tsx
@@ -1,3 +1,5 @@
+import { useTranslate } from "../../../i18n/use-translate";
+
 export type BridgeState = "connected" | "no-session" | "not-detected";
 
 type BridgeStatusRowProps = {
@@ -12,34 +14,38 @@ const DOT_CLASSES: Record<BridgeState, string> = {
   "not-detected": "bg-gray-300 dark:bg-gray-600",
 };
 
-const LABEL: Record<BridgeState, string> = {
-  connected: "Connected",
-  "no-session": "Session inactive",
-  "not-detected": "Not detected",
+const LABEL_KEYS: Record<BridgeState, string> = {
+  connected: "extensions.connected",
+  "no-session": "extensions.sessionInactive",
+  "not-detected": "extensions.notDetected",
 };
 
 export const BridgeStatusRow: React.FC<BridgeStatusRowProps> = ({
   name,
   state,
   hint,
-}) => (
-  <tr className="group">
-    <td className="py-2 pr-4 text-sm font-medium text-gray-700 dark:text-gray-300">
-      <div className="flex items-center gap-2">
-        <span
-          className={`inline-block h-2.5 w-2.5 rounded-full ${DOT_CLASSES[state]}`}
-          aria-label={LABEL[state]}
-        />
-        {name}
-      </div>
-    </td>
-    <td className="py-2 text-sm text-gray-500 dark:text-gray-400">
-      {LABEL[state]}
-      {state !== "connected" && (
-        <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">
-          — {hint}
-        </span>
-      )}
-    </td>
-  </tr>
-);
+}) => {
+  const t = useTranslate("settings");
+  const label = t(LABEL_KEYS[state]);
+  return (
+    <tr className="group">
+      <td className="py-2 pr-4 text-sm font-medium text-gray-700 dark:text-gray-300">
+        <div className="flex items-center gap-2">
+          <span
+            className={`inline-block h-2.5 w-2.5 rounded-full ${DOT_CLASSES[state]}`}
+            aria-label={label}
+          />
+          {name}
+        </div>
+      </td>
+      <td className="py-2 text-sm text-gray-500 dark:text-gray-400">
+        {label}
+        {state !== "connected" && (
+          <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">
+            — {hint}
+          </span>
+        )}
+      </td>
+    </tr>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/EncryptionSection.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/EncryptionSection.tsx
@@ -8,13 +8,10 @@
  * uploaded in effectively cleartext form.
  */
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { Input } from "../../atoms/Input";
 import { Toggle } from "../../atoms/Toggle";
 import { useEncryptionSection } from "./use-encryption-section";
-
-const WARNING_TEXT =
-  "Your saved AI API keys will be uploaded without end-to-end encryption. " +
-  "Enable encryption below to protect them.";
 
 export type EncryptionSectionProps = {
   /** Whether the database currently holds any AI provider keys. */
@@ -24,6 +21,7 @@ export type EncryptionSectionProps = {
 export const EncryptionSection: React.FC<EncryptionSectionProps> = ({
   hasAiKeys,
 }) => {
+  const t = useTranslate("settings");
   const { enabled, passphrase, showWarning, toggle, setPassphrase } =
     useEncryptionSection(hasAiKeys);
 
@@ -34,19 +32,19 @@ export const EncryptionSection: React.FC<EncryptionSectionProps> = ({
           data-testid="plaintext-warning"
           className="rounded-md bg-amber-50 p-3 text-sm text-amber-800 dark:bg-amber-950 dark:text-amber-200"
         >
-          {WARNING_TEXT}
+          {t("sync.plaintextWarning")}
         </p>
       )}
       <div className="flex items-center justify-between gap-3">
         <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
-          End-to-end encryption
+          {t("sync.encryption")}
         </span>
         <Toggle checked={enabled} onCheckedChange={toggle} />
       </div>
       {enabled && (
         <Input
           type="password"
-          label="Passphrase"
+          label={t("sync.passphrase")}
           autoComplete="off"
           value={passphrase}
           onChange={(event) => setPassphrase(event.target.value)}

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ExtensionsTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ExtensionsTab.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from "react";
 
 import { useGarminBridge } from "../../../contexts";
+import { useTranslate } from "../../../i18n/use-translate";
 import { useTrain2GoStore } from "../../../store/train2go-store";
 import { Button } from "../../atoms/Button";
 import type { BridgeState } from "./BridgeStatusRow";
@@ -12,6 +13,7 @@ function toBridgeState(installed: boolean, session: boolean): BridgeState {
 }
 
 export const ExtensionsTab: React.FC = () => {
+  const t = useTranslate("settings");
   const garmin = useGarminBridge();
   const train2go = useTrain2GoStore();
   // Destructure stable method refs so the effect/callback dep arrays
@@ -36,10 +38,10 @@ export const ExtensionsTab: React.FC = () => {
         <thead>
           <tr className="border-b border-gray-200 dark:border-gray-700">
             <th className="pb-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Bridge
+              {t("extensions.bridge")}
             </th>
             <th className="pb-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
-              Status
+              {t("extensions.status")}
             </th>
           </tr>
         </thead>
@@ -50,7 +52,7 @@ export const ExtensionsTab: React.FC = () => {
               garmin.extensionInstalled,
               garmin.sessionActive
             )}
-            hint="Open Garmin Connect and navigate around"
+            hint={t("extensions.garminHint")}
           />
           <BridgeStatusRow
             name="Train2Go"
@@ -58,12 +60,12 @@ export const ExtensionsTab: React.FC = () => {
               train2go.extensionInstalled,
               train2go.sessionActive
             )}
-            hint="Open Train2Go and log in"
+            hint={t("extensions.train2goHint")}
           />
         </tbody>
       </table>
       <Button size="sm" variant="secondary" onClick={refreshAll}>
-        Refresh Status
+        {t("extensions.refreshStatus")}
       </Button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ModelPicker.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ModelPicker.tsx
@@ -1,6 +1,7 @@
 import { PROVIDER_MODELS } from "@kaiord/ai/providers";
 import { useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { LlmProviderType } from "../../../store/ai-store-types";
 
 const CUSTOM_SENTINEL = "__custom__";
@@ -16,6 +17,7 @@ export const ModelPicker: React.FC<ModelPickerProps> = ({
   value,
   onChange,
 }) => {
+  const t = useTranslate("settings");
   const models = PROVIDER_MODELS[type];
   const isKnown = models.some((m) => m.id === value);
   const valueIsCustom = value !== "" && !isKnown;
@@ -35,7 +37,7 @@ export const ModelPicker: React.FC<ModelPickerProps> = ({
   return (
     <div className="w-full">
       <label className="mb-1 block text-xs font-medium text-gray-700 dark:text-gray-300">
-        Model
+        {t("models.model")}
       </label>
       <select
         data-testid="model-picker-select"
@@ -48,14 +50,14 @@ export const ModelPicker: React.FC<ModelPickerProps> = ({
             {m.label}
           </option>
         ))}
-        <option value={CUSTOM_SENTINEL}>Custom…</option>
+        <option value={CUSTOM_SENTINEL}>{t("models.custom")}</option>
       </select>
       {showCustom && (
         <input
           data-testid="model-picker-custom"
-          aria-label="Custom model id"
+          aria-label={t("models.customModelIdAriaLabel")}
           className="mt-2 w-full rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-          placeholder="Enter a model id"
+          placeholder={t("models.customModelIdPlaceholder")}
           value={value}
           onChange={(e) => onChange(e.target.value)}
         />

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ModelRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ModelRow.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { LlmProviderConfig } from "../../../store/ai-store-types";
 import { Button } from "../../atoms/Button";
 import { Input } from "../../atoms/Input";
@@ -22,6 +23,7 @@ export const ModelRow: React.FC<ModelRowProps> = ({
   onModelChange,
   onReset,
 }) => {
+  const t = useTranslate("settings");
   const selectedProvider =
     providers.find((p) => p.id === providerId) ?? providers[0];
 
@@ -31,7 +33,7 @@ export const ModelRow: React.FC<ModelRowProps> = ({
         {rowLabel}
       </p>
       <Input
-        label="Provider"
+        label={t("providers.provider")}
         variant="select"
         value={selectedProvider?.id ?? ""}
         onChange={(e) => onProviderChange(e.target.value)}
@@ -46,7 +48,7 @@ export const ModelRow: React.FC<ModelRowProps> = ({
       )}
       {onReset && (
         <Button size="sm" variant="secondary" onClick={onReset}>
-          Reset
+          {t("models.reset")}
         </Button>
       )}
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ModelsSection.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ModelsSection.tsx
@@ -1,41 +1,48 @@
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import { useAiModelBindingsLive } from "../../../hooks/use-ai-model-bindings-live";
 import { useAiProvidersLive } from "../../../hooks/use-ai-providers-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { AiModelPurpose } from "../../../types/ai-model-binding";
 import { ModelRow } from "./ModelRow";
 import { useAiModelsHandlers } from "./use-ai-models-handlers";
 
 const PURPOSE_ROWS: ReadonlyArray<{
   purpose: AiModelPurpose;
-  label: string;
+  labelKey: string;
   resettable: boolean;
 }> = [
-  { purpose: "default", label: "Default model", resettable: false },
-  { purpose: "chat", label: "Chat", resettable: true },
+  { purpose: "default", labelKey: "models.default", resettable: false },
+  { purpose: "chat", labelKey: "models.chat", resettable: true },
   {
     purpose: "workout_generation",
-    label: "Workout generation",
+    labelKey: "models.workoutGeneration",
     resettable: true,
   },
-  { purpose: "lab_extraction", label: "Lab extraction", resettable: true },
+  {
+    purpose: "lab_extraction",
+    labelKey: "models.labExtraction",
+    resettable: true,
+  },
 ];
 
-const HINT =
-  "Add at least one provider and select an active profile to choose models.";
-
 export const ModelsSection: React.FC = () => {
+  const t = useTranslate("settings");
   const profileId = useActiveProfileLive()?.id ?? null;
   const providers = useAiProvidersLive() ?? [];
   const bindings = useAiModelBindingsLive(profileId);
   const { onSetBinding, onClearBinding } = useAiModelsHandlers();
 
   if (!profileId || providers.length === 0) {
-    return <p className="text-sm text-gray-500 dark:text-gray-400">{HINT}</p>;
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {t("models.hint")}
+      </p>
+    );
   }
 
   return (
     <div className="space-y-3">
-      {PURPOSE_ROWS.map(({ purpose, label, resettable }) => {
+      {PURPOSE_ROWS.map(({ purpose, labelKey, resettable }) => {
         const binding = bindings?.find((b) => b.purpose === purpose);
         const providerId = binding?.providerId ?? providers[0]!.id;
         const modelId = binding?.modelId ?? "";
@@ -44,7 +51,7 @@ export const ModelsSection: React.FC = () => {
         return (
           <ModelRow
             key={purpose}
-            rowLabel={label}
+            rowLabel={t(labelKey)}
             providers={providers}
             providerId={providerId}
             modelId={modelId}

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/NotificationsRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/NotificationsRow.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { Toggle } from "../../atoms/Toggle";
 import { useNotificationPermission } from "./use-notification-permission";
 
@@ -10,6 +11,7 @@ export const NotificationsRow = ({
   enabled,
   onChange,
 }: NotificationsRowProps) => {
+  const t = useTranslate("settings");
   const { permission, request } = useNotificationPermission();
   const checked = enabled && permission === "granted";
 
@@ -25,7 +27,7 @@ export const NotificationsRow = ({
   if (permission === "unsupported") {
     return (
       <p className="text-sm text-gray-500 dark:text-gray-400">
-        Notifications aren&apos;t supported in this browser.
+        {t("notifications.unsupported")}
       </p>
     );
   }
@@ -34,17 +36,17 @@ export const NotificationsRow = ({
     <div className="space-y-2">
       <div className="flex items-center justify-between">
         <span className="text-sm text-gray-900 dark:text-white">
-          Enable notifications
+          {t("notifications.enable")}
         </span>
         <Toggle
           checked={checked}
           onCheckedChange={(next) => void handleChange(next)}
-          aria-label="Enable notifications"
+          aria-label={t("notifications.enable")}
         />
       </div>
       {permission === "denied" && (
         <p className="text-sm text-amber-600 dark:text-amber-400">
-          Notifications are blocked in your browser settings.
+          {t("notifications.blocked")}
         </p>
       )}
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PreferencesTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PreferencesTab.tsx
@@ -1,6 +1,7 @@
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import { useSetUserPreferenceFields } from "../../../hooks/use-set-user-preference-fields";
 import { useUserPreferences } from "../../../hooks/use-user-preferences";
+import { useTranslate } from "../../../i18n/use-translate";
 import type { LocalePreference, Units } from "../../../types/user-preferences";
 import { logger } from "../../../utils/logger";
 import { Segmented, type SegmentedOption } from "../../atoms/Segmented";
@@ -8,18 +9,18 @@ import { SectionHead } from "../../molecules/SectionHead";
 import { LanguageRow } from "./LanguageRow";
 import { NotificationsRow } from "./NotificationsRow";
 
-const UNIT_OPTIONS: SegmentedOption<Units>[] = [
-  { value: "metric", label: "Metric" },
-  { value: "imperial", label: "Imperial" },
-];
-
 export const PreferencesTab: React.FC = () => {
+  const t = useTranslate("settings");
   const active = useActiveProfileLive();
   const profileId = active?.id ?? null;
   const prefs = useUserPreferences({ profileId, defaultView: "grid" });
   const setPrefs = useSetUserPreferenceFields(profileId);
   const units: Units = prefs?.units ?? "metric";
   const locale: LocalePreference = prefs?.locale ?? "auto";
+  const unitOptions: SegmentedOption<Units>[] = [
+    { value: "metric", label: t("preferences.metric") },
+    { value: "imperial", label: t("preferences.imperial") },
+  ];
 
   const handleUnits = (next: Units) => {
     void setPrefs({ units: next }).catch((error: unknown) => {
@@ -42,17 +43,17 @@ export const PreferencesTab: React.FC = () => {
   return (
     <div className="space-y-6" data-testid="settings-preferences">
       <section>
-        <SectionHead title="Units" />
+        <SectionHead title={t("preferences.units")} />
         <Segmented
-          options={UNIT_OPTIONS}
+          options={unitOptions}
           value={units}
           onChange={handleUnits}
-          ariaLabel="Units"
+          ariaLabel={t("preferences.units")}
         />
       </section>
       <LanguageRow value={locale} onChange={handleLocale} />
       <section>
-        <SectionHead title="Notifications" />
+        <SectionHead title={t("preferences.notifications")} />
         <NotificationsRow
           enabled={prefs?.notificationsEnabled ?? false}
           onChange={handleNotifications}

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PrivacyInformationSection.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PrivacyInformationSection.tsx
@@ -1,25 +1,18 @@
+import { useTranslate } from "../../../i18n/use-translate";
+
 export function PrivacyInformationSection() {
+  const t = useTranslate("settings");
   return (
     <section>
       <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
-        Privacy Information
+        {t("privacy.information")}
       </h3>
       <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-400">
-        <li>We do not store your credentials on any server.</li>
-        <li>
-          Garmin integration uses a browser extension that piggybacks on your
-          existing Garmin Connect session. No credentials leave your browser.
-        </li>
-        <li>
-          Train2Go import uses a browser extension that reads the coaching plan
-          displayed on Train2Go pages you are already viewing. It does not read
-          your password or authentication tokens.
-        </li>
-        <li>
-          LLM API keys are sent directly to the provider (Anthropic, OpenAI, or
-          Google) — Kaiord does not receive or relay this data.
-        </li>
-        <li>We are not responsible for credential security on your device.</li>
+        <li>{t("privacy.infoNoServer")}</li>
+        <li>{t("privacy.infoGarmin")}</li>
+        <li>{t("privacy.infoTrain2go")}</li>
+        <li>{t("privacy.infoLlmKeys")}</li>
+        <li>{t("privacy.infoNotResponsible")}</li>
       </ul>
       <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
         <a
@@ -28,7 +21,7 @@ export function PrivacyInformationSection() {
           rel="noopener noreferrer"
           className="underline underline-offset-2 hover:text-gray-700 dark:hover:text-gray-300"
         >
-          Read the full privacy policy
+          {t("privacy.privacyPolicyLink")}
         </a>
       </p>
     </section>

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PrivacyTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/PrivacyTab.tsx
@@ -1,6 +1,7 @@
 import { clearAllProviders } from "../../../application/ai/clear-all-providers";
 import { usePersistence } from "../../../contexts/persistence-context";
 import { useToastContext } from "../../../contexts/ToastContext";
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button";
 import { SETTINGS_SECTION_ATTR } from "../../pages/SettingsPage/settings-section";
 import { PrivacyInformationSection } from "./PrivacyInformationSection";
@@ -15,6 +16,7 @@ const clearSecureStorage = (): void => {
 };
 
 export const PrivacyTab: React.FC = () => {
+  const t = useTranslate("settings");
   const persistence = usePersistence();
   const toast = useToastContext();
 
@@ -33,20 +35,19 @@ export const PrivacyTab: React.FC = () => {
 
       <section>
         <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
-          Analytics
+          {t("privacy.analytics")}
         </h3>
         <p className="text-sm text-gray-600 dark:text-gray-400">
-          This editor uses{" "}
+          {t("privacy.analyticsIntro")}{" "}
           <a
             href="https://www.cloudflare.com/web-analytics/"
             target="_blank"
             rel="noopener noreferrer"
             className="underline underline-offset-2 hover:text-gray-800 dark:hover:text-gray-200"
           >
-            Cloudflare Web Analytics
+            {t("privacy.analyticsLink")}
           </a>{" "}
-          to track aggregate usage (page views, workout generation, exports). No
-          cookies are set and no personal data is collected.
+          {t("privacy.analyticsOutro")}
         </p>
       </section>
 
@@ -55,13 +56,13 @@ export const PrivacyTab: React.FC = () => {
         {...{ [SETTINGS_SECTION_ATTR]: "data-management" }}
       >
         <h3 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
-          Data Management
+          {t("privacy.dataManagement")}
         </h3>
         <Button variant="danger" size="sm" onClick={handleClearAll}>
-          Clear All API Keys
+          {t("privacy.clearAllApiKeys")}
         </Button>
         <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
-          This removes all stored API keys from your browser.
+          {t("privacy.clearAllHint")}
         </p>
       </section>
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ProviderEditRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ProviderEditRow.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { LlmProviderConfig } from "../../../store/ai-store-types";
 import { Button } from "../../atoms/Button";
 import { Input } from "../../atoms/Input";
@@ -15,18 +16,19 @@ export const ProviderEditRow: React.FC<ProviderEditRowProps> = ({
   onSave,
   onCancel,
 }) => {
+  const t = useTranslate("settings");
   const [label, setLabel] = useState(provider.label);
   const [apiKey, setApiKey] = useState(provider.apiKey);
 
   return (
     <div className="space-y-2 rounded-lg border border-blue-200 p-3 dark:border-blue-700">
       <Input
-        label="Label"
+        label={t("providers.label")}
         value={label}
         onChange={(e) => setLabel(e.target.value)}
       />
       <Input
-        label="API Key"
+        label={t("providers.apiKey")}
         type="password"
         value={apiKey}
         onChange={(e) => setApiKey(e.target.value)}
@@ -37,10 +39,10 @@ export const ProviderEditRow: React.FC<ProviderEditRowProps> = ({
           onClick={() => onSave(provider.id, { label, apiKey })}
           disabled={!label || !apiKey}
         >
-          Save
+          {t("providers.save")}
         </Button>
         <Button size="sm" variant="secondary" onClick={onCancel}>
-          Cancel
+          {t("providers.cancel")}
         </Button>
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ProviderForm.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ProviderForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { LlmProviderType } from "../../../store/ai-store-types";
 import { Button } from "../../atoms/Button";
 import { Input } from "../../atoms/Input";
@@ -13,6 +14,7 @@ type ProviderFormProps = {
 };
 
 export const ProviderForm: React.FC<ProviderFormProps> = ({ onAdd }) => {
+  const t = useTranslate("settings");
   const [type, setType] = useState<LlmProviderType>("anthropic");
   const [apiKey, setApiKey] = useState("");
   const [label, setLabel] = useState("");
@@ -27,7 +29,7 @@ export const ProviderForm: React.FC<ProviderFormProps> = ({ onAdd }) => {
   return (
     <div className="space-y-3 rounded-lg border border-gray-200 p-4 dark:border-gray-700">
       <Input
-        label="Provider"
+        label={t("providers.provider")}
         variant="select"
         value={type}
         onChange={(e) => setType(e.target.value as LlmProviderType)}
@@ -38,20 +40,20 @@ export const ProviderForm: React.FC<ProviderFormProps> = ({ onAdd }) => {
         ]}
       />
       <Input
-        label="Label"
-        placeholder="e.g., My Claude"
+        label={t("providers.label")}
+        placeholder={t("providers.labelPlaceholder")}
         value={label}
         onChange={(e) => setLabel(e.target.value)}
       />
       <Input
-        label="API Key"
+        label={t("providers.apiKey")}
         type="password"
         placeholder="sk-..."
         value={apiKey}
         onChange={(e) => setApiKey(e.target.value)}
       />
       <Button size="sm" onClick={handleSubmit} disabled={!apiKey || !label}>
-        Add Provider
+        {t("providers.addProvider")}
       </Button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ProviderList.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ProviderList.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { LlmProviderConfig } from "../../../store/ai-store-types";
 import { ProviderEditRow } from "./ProviderEditRow";
 import { ProviderRow } from "./ProviderRow";
@@ -20,18 +21,23 @@ export const ProviderList: React.FC<ProviderListProps> = ({
   onSetDefault,
   onUpdate,
 }) => {
+  const t = useTranslate("settings");
   const [editingId, setEditingId] = useState<string | null>(null);
 
   if (providers.length === 0) {
     return (
       <p className="text-sm text-gray-500 dark:text-gray-400">
-        No providers configured. Add one below.
+        {t("providers.empty")}
       </p>
     );
   }
 
   return (
-    <ul role="list" aria-label="Configured LLM providers" className="space-y-2">
+    <ul
+      role="list"
+      aria-label={t("providers.listAriaLabel")}
+      className="space-y-2"
+    >
       {providers.map((p) => (
         <li key={p.id}>
           {editingId === p.id ? (

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ProviderRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/ProviderRow.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { LlmProviderConfig } from "../../../store/ai-store-types";
 import { Button } from "../../atoms/Button";
 
@@ -19,31 +20,34 @@ export const ProviderRow: React.FC<ProviderRowProps> = ({
   onEdit,
   onRemove,
   onSetDefault,
-}) => (
-  <div className="flex items-center justify-between rounded-lg border border-gray-200 p-3 dark:border-gray-700">
-    <div>
-      <span className="font-medium">{p.label}</span>
-      <span className="ml-2 text-xs text-gray-500">
-        {PROVIDER_LABELS[p.type]}
-      </span>
-      {p.isDefault && (
-        <span className="ml-2 rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-700 dark:bg-blue-900 dark:text-blue-300">
-          Default
+}) => {
+  const t = useTranslate("settings");
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-gray-200 p-3 dark:border-gray-700">
+      <div>
+        <span className="font-medium">{p.label}</span>
+        <span className="ml-2 text-xs text-gray-500">
+          {PROVIDER_LABELS[p.type]}
         </span>
-      )}
-    </div>
-    <div className="flex gap-2">
-      <Button size="sm" variant="secondary" onClick={onEdit}>
-        Edit
-      </Button>
-      {!p.isDefault && (
-        <Button size="sm" variant="secondary" onClick={onSetDefault}>
-          Set Default
+        {p.isDefault && (
+          <span className="ml-2 rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-700 dark:bg-blue-900 dark:text-blue-300">
+            {t("providers.default")}
+          </span>
+        )}
+      </div>
+      <div className="flex gap-2">
+        <Button size="sm" variant="secondary" onClick={onEdit}>
+          {t("providers.edit")}
         </Button>
-      )}
-      <Button size="sm" variant="danger" onClick={onRemove}>
-        Remove
-      </Button>
+        {!p.isDefault && (
+          <Button size="sm" variant="secondary" onClick={onSetDefault}>
+            {t("providers.setDefault")}
+          </Button>
+        )}
+        <Button size="sm" variant="danger" onClick={onRemove}>
+          {t("providers.remove")}
+        </Button>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/SyncStatusLine.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/SyncStatusLine.tsx
@@ -1,4 +1,9 @@
 import type { SyncStatus } from "../../../hooks/sync-engine-types";
+import {
+  getTranslate,
+  type Translate,
+  useTranslate,
+} from "../../../i18n/use-translate";
 
 export type SyncStatusLineProps = {
   connected: boolean;
@@ -6,21 +11,29 @@ export type SyncStatusLineProps = {
   lastSyncedAt: string | null;
 };
 
-function describe(props: SyncStatusLineProps): string {
-  if (!props.connected) return "Not connected";
-  if (props.status === "syncing") return "Syncing…";
-  if (props.status === "error") return "Last sync failed — working offline";
+function describe(
+  props: SyncStatusLineProps,
+  t: Translate = getTranslate("settings")
+): string {
+  if (!props.connected) return t("sync.notConnected");
+  if (props.status === "syncing") return t("sync.syncing");
+  if (props.status === "error") return t("sync.offline");
   if (props.lastSyncedAt) {
-    return `Last synced ${new Date(props.lastSyncedAt).toLocaleString()}`;
+    return t("sync.lastSynced", {
+      date: new Date(props.lastSyncedAt).toLocaleString(),
+    });
   }
-  return "Connected — not synced yet";
+  return t("sync.connectedNotSynced");
 }
 
-export const SyncStatusLine: React.FC<SyncStatusLineProps> = (props) => (
-  <p
-    data-testid="sync-status"
-    className="text-sm font-medium text-gray-700 dark:text-gray-300"
-  >
-    {describe(props)}
-  </p>
-);
+export const SyncStatusLine: React.FC<SyncStatusLineProps> = (props) => {
+  const t = useTranslate("settings");
+  return (
+    <p
+      data-testid="sync-status"
+      className="text-sm font-medium text-gray-700 dark:text-gray-300"
+    >
+      {describe(props, t)}
+    </p>
+  );
+};

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/SyncTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/SyncTab.tsx
@@ -1,6 +1,7 @@
 import { useSync } from "../../../contexts/sync-context";
 import { useToastContext } from "../../../contexts/ToastContext";
 import { useAiProvidersLive } from "../../../hooks/use-ai-providers-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { Button } from "../../atoms/Button";
 import { EncryptionSection } from "./EncryptionSection";
 import { SyncStatusLine } from "./SyncStatusLine";
@@ -10,6 +11,7 @@ const SYNC_FAILED_TOAST = "Sync failed — your data is safe and stays local.";
 const SYNC_OK_TOAST = "Sync complete.";
 
 export const SyncTab: React.FC = () => {
+  const t = useTranslate("settings");
   const sync = useSync();
   const toast = useToastContext();
   const providers = useAiProvidersLive();
@@ -32,8 +34,7 @@ export const SyncTab: React.FC = () => {
   return (
     <div className="space-y-4" data-testid="sync-tab">
       <p className="text-sm text-gray-600 dark:text-gray-400">
-        Sync your workouts and settings across devices through your own Google
-        Drive. Data lives on your Drive; no Kaiord server is involved.
+        {t("sync.description")}
       </p>
       <SyncStatusLine
         connected={sync.connected}
@@ -49,15 +50,15 @@ export const SyncTab: React.FC = () => {
               loading={sync.status === "syncing"}
               onClick={handleSyncNow}
             >
-              Sync now
+              {t("sync.syncNow")}
             </Button>
             <Button size="sm" variant="tertiary" onClick={sync.disconnect}>
-              Disconnect
+              {t("sync.disconnect")}
             </Button>
           </>
         ) : (
           <Button size="sm" variant="primary" onClick={handleConnect}>
-            Connect Google account
+            {t("sync.connect")}
           </Button>
         )}
       </div>

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageEmptyState.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageEmptyState.tsx
@@ -3,20 +3,20 @@
  * the month-window.
  */
 
+import { useTranslate } from "../../../i18n/use-translate";
+
 export type UsageEmptyStateProps = {
   monthsWindow: number;
 };
 
 export function UsageEmptyState({ monthsWindow }: UsageEmptyStateProps) {
+  const t = useTranslate("settings");
   return (
     <div className="space-y-3 text-sm text-gray-600 dark:text-gray-400">
       <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
-        AI Usage
+        {t("usage.title")}
       </h3>
-      <p>
-        No AI usage recorded yet for the last {monthsWindow} months. The panel
-        will populate automatically after your first batch run.
-      </p>
+      <p>{t("usage.empty", { count: monthsWindow })}</p>
     </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageTable.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageTable.tsx
@@ -5,6 +5,7 @@
  * `—` under "Output" to avoid presenting a fabricated zero as fact.
  */
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { UsageRecord } from "../../../types/usage-schemas";
 
 export type UsageTableProps = {
@@ -17,19 +18,20 @@ function formatOutput(row: UsageRecord): string {
 }
 
 export function UsageTable({ rows, monthsWindow }: UsageTableProps) {
+  const t = useTranslate("settings");
   return (
     <div className="space-y-3">
       <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
-        AI Usage — last {monthsWindow} months
+        {t("usage.heading", { count: monthsWindow })}
       </h3>
       <table className="w-full text-sm" data-testid="usage-table">
         <thead>
           <tr className="border-b border-gray-200 text-left text-gray-500 dark:border-gray-700 dark:text-gray-400">
-            <th className="py-2 pr-4 font-medium">Month</th>
-            <th className="py-2 pr-4 font-medium">Input</th>
-            <th className="py-2 pr-4 font-medium">Output</th>
-            <th className="py-2 pr-4 font-medium">Total</th>
-            <th className="py-2 font-medium">Cost (USD)</th>
+            <th className="py-2 pr-4 font-medium">{t("usage.month")}</th>
+            <th className="py-2 pr-4 font-medium">{t("usage.input")}</th>
+            <th className="py-2 pr-4 font-medium">{t("usage.output")}</th>
+            <th className="py-2 pr-4 font-medium">{t("usage.total")}</th>
+            <th className="py-2 font-medium">{t("usage.cost")}</th>
           </tr>
         </thead>
         <tbody>
@@ -65,10 +67,8 @@ export function UsageTable({ rows, monthsWindow }: UsageTableProps) {
         </tbody>
       </table>
       <p className="text-xs text-gray-500 dark:text-gray-400">
-        Values reflect actual usage recorded per batch run — not the pre-run
-        estimate shown in the confirmation dialog. Rows marked{" "}
-        <span aria-hidden="true">—</span> are from a legacy schema where the
-        input / output split was not captured.
+        {t("usage.footnoteBefore")} <span aria-hidden="true">—</span>{" "}
+        {t("usage.footnoteAfter")}
       </p>
     </div>
   );

--- a/packages/workout-spa-editor/src/i18n/locales/en/settings.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/settings.json
@@ -30,5 +30,103 @@
     "usage": "Usage",
     "privacy": "Privacy",
     "preferences": "Preferences"
+  },
+  "ai": {
+    "llmProviders": "LLM Providers",
+    "addProvider": "Add Provider",
+    "models": "Models",
+    "customSystemPrompt": "Custom System Prompt",
+    "customInstructionsLabel": "Additional instructions applied to all generations",
+    "customInstructionsPlaceholder": "Additional instructions for all AI generations (e.g., 'I'm recovering from a knee injury')"
+  },
+  "providers": {
+    "empty": "No providers configured. Add one below.",
+    "listAriaLabel": "Configured LLM providers",
+    "provider": "Provider",
+    "label": "Label",
+    "apiKey": "API Key",
+    "labelPlaceholder": "e.g., My Claude",
+    "addProvider": "Add Provider",
+    "default": "Default",
+    "edit": "Edit",
+    "setDefault": "Set Default",
+    "remove": "Remove",
+    "save": "Save",
+    "cancel": "Cancel"
+  },
+  "models": {
+    "default": "Default model",
+    "chat": "Chat",
+    "workoutGeneration": "Workout generation",
+    "labExtraction": "Lab extraction",
+    "hint": "Add at least one provider and select an active profile to choose models.",
+    "model": "Model",
+    "custom": "Custom…",
+    "customModelIdAriaLabel": "Custom model id",
+    "customModelIdPlaceholder": "Enter a model id",
+    "reset": "Reset"
+  },
+  "sync": {
+    "description": "Sync your workouts and settings across devices through your own Google Drive. Data lives on your Drive; no Kaiord server is involved.",
+    "syncNow": "Sync now",
+    "disconnect": "Disconnect",
+    "connect": "Connect Google account",
+    "notConnected": "Not connected",
+    "syncing": "Syncing…",
+    "offline": "Last sync failed — working offline",
+    "lastSynced": "Last synced {{date}}",
+    "connectedNotSynced": "Connected — not synced yet",
+    "encryption": "End-to-end encryption",
+    "passphrase": "Passphrase",
+    "plaintextWarning": "Your saved AI API keys will be uploaded without end-to-end encryption. Enable encryption below to protect them."
+  },
+  "privacy": {
+    "information": "Privacy Information",
+    "infoNoServer": "We do not store your credentials on any server.",
+    "infoGarmin": "Garmin integration uses a browser extension that piggybacks on your existing Garmin Connect session. No credentials leave your browser.",
+    "infoTrain2go": "Train2Go import uses a browser extension that reads the coaching plan displayed on Train2Go pages you are already viewing. It does not read your password or authentication tokens.",
+    "infoLlmKeys": "LLM API keys are sent directly to the provider (Anthropic, OpenAI, or Google) — Kaiord does not receive or relay this data.",
+    "infoNotResponsible": "We are not responsible for credential security on your device.",
+    "privacyPolicyLink": "Read the full privacy policy",
+    "analytics": "Analytics",
+    "analyticsIntro": "This editor uses",
+    "analyticsLink": "Cloudflare Web Analytics",
+    "analyticsOutro": "to track aggregate usage (page views, workout generation, exports). No cookies are set and no personal data is collected.",
+    "dataManagement": "Data Management",
+    "clearAllApiKeys": "Clear All API Keys",
+    "clearAllHint": "This removes all stored API keys from your browser."
+  },
+  "usage": {
+    "title": "AI Usage",
+    "heading": "AI Usage — last {{count}} months",
+    "empty": "No AI usage recorded yet for the last {{count}} months. The panel will populate automatically after your first batch run.",
+    "month": "Month",
+    "input": "Input",
+    "output": "Output",
+    "total": "Total",
+    "cost": "Cost (USD)",
+    "footnoteBefore": "Values reflect actual usage recorded per batch run — not the pre-run estimate shown in the confirmation dialog. Rows marked",
+    "footnoteAfter": "are from a legacy schema where the input / output split was not captured."
+  },
+  "preferences": {
+    "units": "Units",
+    "metric": "Metric",
+    "imperial": "Imperial",
+    "notifications": "Notifications"
+  },
+  "extensions": {
+    "bridge": "Bridge",
+    "status": "Status",
+    "garminHint": "Open Garmin Connect and navigate around",
+    "train2goHint": "Open Train2Go and log in",
+    "refreshStatus": "Refresh Status",
+    "connected": "Connected",
+    "sessionInactive": "Session inactive",
+    "notDetected": "Not detected"
+  },
+  "notifications": {
+    "unsupported": "Notifications aren't supported in this browser.",
+    "enable": "Enable notifications",
+    "blocked": "Notifications are blocked in your browser settings."
   }
 }

--- a/packages/workout-spa-editor/src/i18n/locales/es/settings.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/settings.json
@@ -30,5 +30,103 @@
     "usage": "Uso",
     "privacy": "Privacidad",
     "preferences": "Preferencias"
+  },
+  "ai": {
+    "llmProviders": "Proveedores LLM",
+    "addProvider": "Añadir proveedor",
+    "models": "Modelos",
+    "customSystemPrompt": "Prompt de sistema personalizado",
+    "customInstructionsLabel": "Instrucciones adicionales aplicadas a todas las generaciones",
+    "customInstructionsPlaceholder": "Instrucciones adicionales para todas las generaciones de IA (p. ej., 'Me estoy recuperando de una lesión de rodilla')"
+  },
+  "providers": {
+    "empty": "No hay proveedores configurados. Añade uno abajo.",
+    "listAriaLabel": "Proveedores LLM configurados",
+    "provider": "Proveedor",
+    "label": "Etiqueta",
+    "apiKey": "Clave de API",
+    "labelPlaceholder": "p. ej., Mi Claude",
+    "addProvider": "Añadir proveedor",
+    "default": "Predeterminado",
+    "edit": "Editar",
+    "setDefault": "Establecer predeterminado",
+    "remove": "Eliminar",
+    "save": "Guardar",
+    "cancel": "Cancelar"
+  },
+  "models": {
+    "default": "Modelo predeterminado",
+    "chat": "Chat",
+    "workoutGeneration": "Generación de entrenamientos",
+    "labExtraction": "Extracción de laboratorio",
+    "hint": "Añade al menos un proveedor y selecciona un perfil activo para elegir modelos.",
+    "model": "Modelo",
+    "custom": "Personalizado…",
+    "customModelIdAriaLabel": "ID de modelo personalizado",
+    "customModelIdPlaceholder": "Introduce un ID de modelo",
+    "reset": "Restablecer"
+  },
+  "sync": {
+    "description": "Sincroniza tus entrenamientos y ajustes entre dispositivos a través de tu propio Google Drive. Los datos residen en tu Drive; no interviene ningún servidor de Kaiord.",
+    "syncNow": "Sincronizar ahora",
+    "disconnect": "Desconectar",
+    "connect": "Conectar cuenta de Google",
+    "notConnected": "No conectado",
+    "syncing": "Sincronizando…",
+    "offline": "La última sincronización falló — trabajando sin conexión",
+    "lastSynced": "Última sincronización {{date}}",
+    "connectedNotSynced": "Conectado — aún sin sincronizar",
+    "encryption": "Cifrado de extremo a extremo",
+    "passphrase": "Frase de contraseña",
+    "plaintextWarning": "Tus claves de API de IA guardadas se subirán sin cifrado de extremo a extremo. Activa el cifrado abajo para protegerlas."
+  },
+  "privacy": {
+    "information": "Información de privacidad",
+    "infoNoServer": "No almacenamos tus credenciales en ningún servidor.",
+    "infoGarmin": "La integración con Garmin usa una extensión del navegador que se apoya en tu sesión existente de Garmin Connect. Ninguna credencial sale de tu navegador.",
+    "infoTrain2go": "La importación de Train2Go usa una extensión del navegador que lee el plan de entrenamiento mostrado en las páginas de Train2Go que ya estás viendo. No lee tu contraseña ni tus tokens de autenticación.",
+    "infoLlmKeys": "Las claves de API de LLM se envían directamente al proveedor (Anthropic, OpenAI o Google) — Kaiord no recibe ni retransmite estos datos.",
+    "infoNotResponsible": "No nos hacemos responsables de la seguridad de las credenciales en tu dispositivo.",
+    "privacyPolicyLink": "Lee la política de privacidad completa",
+    "analytics": "Analíticas",
+    "analyticsIntro": "Este editor usa",
+    "analyticsLink": "Cloudflare Web Analytics",
+    "analyticsOutro": "para hacer un seguimiento del uso agregado (visitas de página, generación de entrenamientos, exportaciones). No se establecen cookies ni se recopilan datos personales.",
+    "dataManagement": "Gestión de datos",
+    "clearAllApiKeys": "Borrar todas las claves de API",
+    "clearAllHint": "Esto elimina todas las claves de API almacenadas de tu navegador."
+  },
+  "usage": {
+    "title": "Uso de IA",
+    "heading": "Uso de IA — últimos {{count}} meses",
+    "empty": "Aún no hay uso de IA registrado en los últimos {{count}} meses. El panel se rellenará automáticamente tras tu primera ejecución por lotes.",
+    "month": "Mes",
+    "input": "Entrada",
+    "output": "Salida",
+    "total": "Total",
+    "cost": "Coste (USD)",
+    "footnoteBefore": "Los valores reflejan el uso real registrado por ejecución por lotes, no la estimación previa mostrada en el diálogo de confirmación. Las filas marcadas con",
+    "footnoteAfter": "provienen de un esquema heredado donde no se capturó la división entre entrada y salida."
+  },
+  "preferences": {
+    "units": "Unidades",
+    "metric": "Métrico",
+    "imperial": "Imperial",
+    "notifications": "Notificaciones"
+  },
+  "extensions": {
+    "bridge": "Puente",
+    "status": "Estado",
+    "garminHint": "Abre Garmin Connect y navega por la aplicación",
+    "train2goHint": "Abre Train2Go e inicia sesión",
+    "refreshStatus": "Actualizar estado",
+    "connected": "Conectado",
+    "sessionInactive": "Sesión inactiva",
+    "notDetected": "No detectado"
+  },
+  "notifications": {
+    "unsupported": "Las notificaciones no son compatibles con este navegador.",
+    "enable": "Activar notificaciones",
+    "blocked": "Las notificaciones están bloqueadas en la configuración de tu navegador."
   }
 }


### PR DESCRIPTION
## What

Extends the existing `settings` namespace across all SettingsPanel tabs: AI providers + models, sync, privacy + encryption, preferences, extensions, the usage table, and the notification/bridge rows.

## Notes

- Adds `ai/providers/models/sync/privacy/usage/preferences/extensions/notifications` sections; existing `settings` keys (title/back/groups/rows/tabs) untouched.
- `LanguageRow` left as-is (already localized via react-i18next).
- Raw `error.message` renders left literal — errors are localized by stable code, never by message text.
- No `resources.ts` change — JSON auto-discovered by the glob loader (#901). English byte-identical.

## Verification

- `pnpm build` (tsc -b + vite) ✅ · eslint + prettier ✅
- SettingsPanel + parity: **41/41** ✅
- Full SPA suite: **5464/5464** ✅ (one flaky LabDashboardSection blip cleared on re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)