### PR TITLE
feat(spa-editor): localize the zone editor (zones namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/SportZoneEditor.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/SportZoneEditor.tsx
@@ -4,6 +4,7 @@
  * Sport-specific zone editor with tabs, thresholds, and zone sections.
  */
 
+import { useTranslate } from "../../../i18n/use-translate";
 import { ConfirmationModal } from "../../molecules/ConfirmationModal/ConfirmationModal";
 import { SportZoneSections } from "./components/SportZoneSections";
 import { SportZoneTabs } from "./components/SportZoneTabs";
@@ -15,6 +16,7 @@ type SportZoneEditorProps = {
 };
 
 export function SportZoneEditor({ profileId }: SportZoneEditorProps) {
+  const t = useTranslate("zones");
   const {
     activeSport,
     setActiveSport,
@@ -30,11 +32,7 @@ export function SportZoneEditor({ profileId }: SportZoneEditorProps) {
   } = useSportZoneEditor(profileId);
 
   if (!sportConfig) {
-    return (
-      <p className="text-sm text-gray-500">
-        No zone configuration for this sport.
-      </p>
-    );
+    return <p className="text-sm text-gray-500">{t("empty.noSportConfig")}</p>;
   }
 
   return (
@@ -55,10 +53,10 @@ export function SportZoneEditor({ profileId }: SportZoneEditorProps) {
       />
       <ConfirmationModal
         isOpen={!!confirmMethod}
-        title="Change Zone Method"
-        message="This will replace your current zones with calculated values. Continue?"
-        confirmLabel="Change Method"
-        cancelLabel="Keep Current"
+        title={t("method.confirmTitle")}
+        message={t("method.confirmMessage")}
+        confirmLabel={t("method.confirmLabel")}
+        cancelLabel={t("method.keepLabel")}
         onConfirm={confirmMethodSwitch}
         onCancel={cancelMethodSwitch}
         variant="default"

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/EditableZoneName.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/EditableZoneName.tsx
@@ -4,7 +4,7 @@
  * Inline editable text cell for a zone name.
  */
 
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 type EditableZoneNameProps = {
   name: string;
@@ -26,8 +26,15 @@ export function EditableZoneName({
     cancelledRef.current = false;
     setDraft(name);
     setEditing(true);
-    requestAnimationFrame(() => inputRef.current?.select());
   }, [name]);
+
+  // Select the field's contents once editing begins so the name can be
+  // overtyped. Using an effect (not requestAnimationFrame) keeps this
+  // deterministic: a deferred rAF could fire mid-keystroke and reselect,
+  // dropping the first typed character.
+  useEffect(() => {
+    if (editing) inputRef.current?.select();
+  }, [editing]);
 
   const handleBlur = useCallback(() => {
     setEditing(false);

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/PaceInput.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/PaceInput.tsx
@@ -4,6 +4,7 @@
  * Input for pace values in mm:ss format, converting to/from total seconds.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { secondsToMmSs } from "../utils/pace-format";
 
 type PaceInputProps = {
@@ -21,6 +22,7 @@ export function PaceInput({
   onChange,
   disabled = false,
 }: PaceInputProps) {
+  const t = useTranslate("zones");
   const displayValue = value !== undefined ? secondsToMmSs(value) : "";
 
   const handleChange = (raw: string) => {
@@ -43,7 +45,7 @@ export function PaceInput({
       </label>
       <input
         type="text"
-        aria-label={`${label} threshold`}
+        aria-label={t("threshold.ariaLabel", { label })}
         value={displayValue}
         onChange={(e) => handleChange(e.target.value)}
         placeholder="mm:ss"

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/SportZoneSections.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/SportZoneSections.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { ZoneType } from "../../../../application/profile/zones/zone-types";
+import { useTranslate } from "../../../../i18n/use-translate";
 import type { SportZoneConfig } from "../../../../types/sport-zones";
 import type { ZoneRowData } from "../types/zone-table";
 import { ZoneTypeSection } from "./ZoneTypeSection";
@@ -26,11 +27,12 @@ export function SportZoneSections({
   onAddZone,
   ftp,
 }: SportZoneSectionsProps) {
+  const t = useTranslate("zones");
   return (
     <div className="space-y-4">
       {capabilities.hr && (
         <ZoneTypeSection
-          title="Heart Rate Zones"
+          title={t("section.heartRate")}
           method={config.heartRateZones.method}
           zones={config.heartRateZones.zones}
           zoneDisplayType="heartRate"
@@ -42,7 +44,7 @@ export function SportZoneSections({
       )}
       {capabilities.power && config.powerZones && (
         <ZoneTypeSection
-          title="Power Zones"
+          title={t("section.power")}
           method={config.powerZones.method}
           zones={config.powerZones.zones}
           zoneDisplayType="power"
@@ -54,7 +56,7 @@ export function SportZoneSections({
       )}
       {capabilities.pace && config.paceZones && (
         <ZoneTypeSection
-          title="Pace Zones"
+          title={t("section.pace")}
           method={config.paceZones.method}
           zones={config.paceZones.zones}
           zoneDisplayType="pace"

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/SportZoneTabs.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/SportZoneTabs.tsx
@@ -4,13 +4,14 @@
  * Tab selector for sport-specific zone editing.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import type { SportKey } from "../../../../types/sport-zones";
 
-const SPORT_TABS: Array<{ id: SportKey; label: string }> = [
-  { id: "cycling", label: "Cycling" },
-  { id: "running", label: "Running" },
-  { id: "swimming", label: "Swimming" },
-  { id: "generic", label: "Generic" },
+const SPORT_IDS: Array<SportKey> = [
+  "cycling",
+  "running",
+  "swimming",
+  "generic",
 ];
 
 type SportZoneTabsProps = {
@@ -22,25 +23,26 @@ export function SportZoneTabs({
   activeSport,
   onSportChange,
 }: SportZoneTabsProps) {
+  const t = useTranslate("zones");
   return (
     <div
       role="tablist"
       className="flex gap-1 border-b border-gray-200 dark:border-gray-700"
     >
-      {SPORT_TABS.map((tab) => (
+      {SPORT_IDS.map((id) => (
         <button
-          key={tab.id}
+          key={id}
           type="button"
           role="tab"
-          aria-selected={activeSport === tab.id}
-          onClick={() => onSportChange(tab.id)}
+          aria-selected={activeSport === id}
+          onClick={() => onSportChange(id)}
           className={`rounded-t-lg px-4 py-2 text-sm font-medium transition-colors ${
-            activeSport === tab.id
+            activeSport === id
               ? "border-b-2 border-blue-600 bg-white text-blue-600 dark:bg-gray-800 dark:text-blue-400"
               : "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
           }`}
         >
-          {tab.label}
+          {t(`tabs.${id}`)}
         </button>
       ))}
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/SportZoneThresholds.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/SportZoneThresholds.tsx
@@ -4,6 +4,7 @@
  * Threshold inputs for a sport based on its capabilities.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import type { SportThresholds } from "../../../../types/sport-zones";
 import { PaceInput } from "./PaceInput";
 import { ThresholdInput } from "./ThresholdInput";
@@ -19,6 +20,7 @@ export function SportZoneThresholds({
   capabilities,
   onChange,
 }: SportZoneThresholdsProps) {
+  const t = useTranslate("zones");
   return (
     <div className="mb-4 flex flex-wrap gap-4">
       {capabilities.hr && (
@@ -39,7 +41,7 @@ export function SportZoneThresholds({
       )}
       {capabilities.pace && (
         <PaceInput
-          label="Threshold Pace"
+          label={t("threshold.pace")}
           unit={thresholds.paceUnit === "min_per_100m" ? "/100m" : "/km"}
           value={thresholds.thresholdPace}
           onChange={(v) =>

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ThresholdInput.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ThresholdInput.tsx
@@ -4,6 +4,8 @@
  * Number input with unit label for threshold values.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
+
 type ThresholdInputProps = {
   label: string;
   unit: string;
@@ -19,6 +21,7 @@ export function ThresholdInput({
   onChange,
   disabled = false,
 }: ThresholdInputProps) {
+  const t = useTranslate("zones");
   return (
     <div className="flex items-center gap-2">
       <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -26,7 +29,7 @@ export function ThresholdInput({
       </label>
       <input
         type="number"
-        aria-label={`${label} threshold`}
+        aria-label={t("threshold.ariaLabel", { label })}
         value={value ?? ""}
         onChange={(e) =>
           onChange(e.target.value ? Number(e.target.value) : undefined)

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ValidationErrors.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ValidationErrors.tsx
@@ -6,16 +6,15 @@
 
 import { AlertCircle } from "lucide-react";
 
-type ZoneValidationError = {
-  zone: number;
-  message: string;
-};
+import { useTranslate } from "../../../../i18n/use-translate";
+import type { ZoneValidationError } from "../hooks/useZoneValidation";
 
 type ValidationErrorsProps = {
   errors: Array<ZoneValidationError>;
 };
 
 export function ValidationErrors({ errors }: ValidationErrorsProps) {
+  const t = useTranslate("zones");
   if (errors.length === 0) return null;
 
   return (
@@ -24,12 +23,15 @@ export function ValidationErrors({ errors }: ValidationErrorsProps) {
         <AlertCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
         <div className="flex-1">
           <h3 className="text-sm font-medium text-red-800 dark:text-red-400">
-            Validation Errors
+            {t("validation.heading")}
           </h3>
           <ul className="mt-1 space-y-1 text-sm text-red-700 dark:text-red-300">
             {errors.map((error) => (
-              <li key={`${error.zone}-${error.message}`}>
-                Zone {error.zone}: {error.message}
+              <li key={`${error.zone}-${error.code}`}>
+                {t("validation.zoneLabel", {
+                  zone: error.zone,
+                  message: t(`validation.${error.code}`),
+                })}
               </li>
             ))}
           </ul>

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneCard.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneCard.tsx
@@ -4,6 +4,7 @@
  * Single zone editor card.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import type {
   HeartRateZone,
   PowerZone,
@@ -35,6 +36,7 @@ export function ZoneCard({
   profile,
   onZoneChange,
 }: ZoneCardProps) {
+  const t = useTranslate("zones");
   return (
     <div
       className={`rounded-lg border p-4 ${
@@ -52,7 +54,7 @@ export function ZoneCard({
         <Input
           value={zone.name}
           onChange={(e) => onZoneChange(index, "name", e.target.value)}
-          placeholder="Zone name"
+          placeholder={t("inputs.namePlaceholder")}
           className="flex-1"
         />
       </div>

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneEditorActions.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneEditorActions.tsx
@@ -6,6 +6,7 @@
 
 import { Check, X } from "lucide-react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { Button } from "../../../atoms/Button/Button";
 
 type ZoneEditorActionsProps = {
@@ -19,15 +20,16 @@ export function ZoneEditorActions({
   onCancel,
   hasErrors,
 }: ZoneEditorActionsProps) {
+  const t = useTranslate("zones");
   return (
     <div className="flex justify-end gap-2">
       <Button variant="secondary" onClick={onCancel}>
         <X className="mr-2 h-4 w-4" />
-        Cancel
+        {t("actions.cancel")}
       </Button>
       <Button onClick={onSave} disabled={hasErrors}>
         <Check className="mr-2 h-4 w-4" />
-        Save Zones
+        {t("actions.saveZones")}
       </Button>
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneEditorHeader.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneEditorHeader.tsx
@@ -4,6 +4,7 @@
  * Header for zone editor.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import type { Profile } from "../../../../types/profile";
 
 type ZoneEditorHeaderProps = {
@@ -17,20 +18,30 @@ export function ZoneEditorHeader({
   zonesCount,
   profile,
 }: ZoneEditorHeaderProps) {
+  const t = useTranslate("zones");
   const cycling = profile.sportZones.cycling;
   const ftp = cycling?.thresholds.ftp;
   const lthr = cycling?.thresholds.lthr;
 
+  const title = isPowerZones
+    ? t("header.powerTitle")
+    : t("header.heartRateTitle");
+  const description = isPowerZones
+    ? t("header.powerDescription", {
+        count: zonesCount,
+        suffix: ftp ? t("header.ftpSuffix", { ftp }) : "",
+      })
+    : t("header.heartRateDescription", {
+        count: zonesCount,
+        suffix: lthr ? t("header.lthrSuffix", { lthr }) : "",
+      });
+
   return (
     <div>
       <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-        {isPowerZones ? "Power Zones" : "Heart Rate Zones"}
+        {title}
       </h2>
-      <p className="text-sm text-gray-600 dark:text-gray-400">
-        {isPowerZones
-          ? `Configure ${zonesCount} power zones based on FTP${ftp ? ` (${ftp}W)` : ""}`
-          : `Configure ${zonesCount} heart rate zones based on LTHR${lthr ? ` (${lthr} bpm)` : ""}`}
-      </p>
+      <p className="text-sm text-gray-600 dark:text-gray-400">{description}</p>
     </div>
   );
 }

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneInputs.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneInputs.tsx
@@ -4,6 +4,7 @@
  * Input fields for zone ranges.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import type { HeartRateZone, PowerZone } from "../../../../types/profile";
 import { Input } from "../../../atoms/Input/Input";
 
@@ -24,11 +25,12 @@ export function ZoneInputs({
   isPowerZones,
   onZoneChange,
 }: ZoneInputsProps) {
+  const t = useTranslate("zones");
   if (isPowerZones) {
     return (
       <>
         <Input
-          label="Min %"
+          label={t("inputs.minPercent")}
           type="number"
           value={(zone as PowerZone).minPercent}
           onChange={(e) => onZoneChange(index, "minPercent", e.target.value)}
@@ -36,7 +38,7 @@ export function ZoneInputs({
           max={200}
         />
         <Input
-          label="Max %"
+          label={t("inputs.maxPercent")}
           type="number"
           value={(zone as PowerZone).maxPercent}
           onChange={(e) => onZoneChange(index, "maxPercent", e.target.value)}
@@ -50,7 +52,7 @@ export function ZoneInputs({
   return (
     <>
       <Input
-        label="Min BPM"
+        label={t("inputs.minBpm")}
         type="number"
         value={(zone as HeartRateZone).minBpm}
         onChange={(e) => onZoneChange(index, "minBpm", e.target.value)}
@@ -58,7 +60,7 @@ export function ZoneInputs({
         max={250}
       />
       <Input
-        label="Max BPM"
+        label={t("inputs.maxBpm")}
         type="number"
         value={(zone as HeartRateZone).maxBpm}
         onChange={(e) => onZoneChange(index, "maxBpm", e.target.value)}

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneMethodSelect.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneMethodSelect.tsx
@@ -4,6 +4,7 @@
  * Dropdown to select a zone calculation method.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { getMethodsForType } from "../../../../lib/zone-methods";
 
 type ZoneMethodSelectProps = {
@@ -17,13 +18,14 @@ export function ZoneMethodSelect({
   value,
   onChange,
 }: ZoneMethodSelectProps) {
+  const t = useTranslate("zones");
   const methods = getMethodsForType(type);
 
   return (
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      aria-label={`${type} zone method`}
+      aria-label={t("method.ariaLabel", { type })}
       className="rounded border border-gray-300 bg-white px-2 py-1 text-xs text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300"
     >
       {methods.map((m) => (

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneRow.tsx
@@ -4,16 +4,17 @@
  * Single zone row with editable name, min/max values, and optional delete.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import type { ZoneRowData, ZoneTableCallbacks } from "../types/zone-table";
 import { getZoneColor } from "../utils/zone-colors";
 import { extractValues, formatSecondary } from "../utils/zone-values";
 import { EditableZoneName } from "./EditableZoneName";
 import { EditableZoneValue } from "./EditableZoneValue";
 
-const TYPE_LABELS = {
-  heartRate: "HR",
-  power: "Power",
-  pace: "Pace",
+const TYPE_KEYS = {
+  heartRate: "hr",
+  power: "power",
+  pace: "pace",
 } as const;
 
 type ZoneRowProps = {
@@ -33,9 +34,10 @@ export function ZoneRow({
   isCustom,
   callbacks,
 }: ZoneRowProps) {
+  const t = useTranslate("zones");
   const { minStr, maxStr } = extractValues(zone, type, threshold);
   const secondary = formatSecondary(zone, type, threshold);
-  const prefix = TYPE_LABELS[type];
+  const prefix = t(`zoneType.${TYPE_KEYS[type]}`);
 
   return (
     <div
@@ -47,25 +49,25 @@ export function ZoneRow({
       <EditableZoneName
         name={zone.name}
         onSave={(n) => callbacks.onNameChange(index, n)}
-        ariaLabel={`${prefix} Zone ${zone.zone} name`}
+        ariaLabel={t("table.zoneNameAria", { prefix, zone: zone.zone })}
       />
       <EditableZoneValue
         value={minStr}
         onSave={(v) => callbacks.onMinChange(index, v)}
-        ariaLabel={`${prefix} Zone ${zone.zone} min`}
+        ariaLabel={t("table.zoneMinAria", { prefix, zone: zone.zone })}
       />
       <span className="text-xs text-gray-500">-</span>
       <EditableZoneValue
         value={maxStr}
         onSave={(v) => callbacks.onMaxChange(index, v)}
-        ariaLabel={`${prefix} Zone ${zone.zone} max`}
+        ariaLabel={t("table.zoneMaxAria", { prefix, zone: zone.zone })}
       />
       {secondary && <span className="text-xs text-gray-400">{secondary}</span>}
       {isCustom && (
         <button
           type="button"
           onClick={() => callbacks.onRemove(index)}
-          aria-label={`Remove ${prefix} zone ${zone.zone}`}
+          aria-label={t("table.removeZoneAria", { prefix, zone: zone.zone })}
           className="ml-1 text-xs text-red-500 hover:text-red-700"
         >
           x

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneTable.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/components/ZoneTable.tsx
@@ -4,6 +4,7 @@
  * Renders editable zone rows with inline editing for names and values.
  */
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import type { ZoneRowData, ZoneTableCallbacks } from "../types/zone-table";
 import { ZoneRow } from "./ZoneRow";
 
@@ -24,10 +25,11 @@ export function ZoneTable({
   callbacks,
   onAddZone,
 }: ZoneTableProps) {
+  const t = useTranslate("zones");
   if (zones.length === 0) {
     return (
       <p className="text-sm text-gray-500 dark:text-gray-400">
-        No zones configured
+        {t("table.noZones")}
       </p>
     );
   }
@@ -53,7 +55,7 @@ export function ZoneTable({
             py-1 text-xs text-gray-500 hover:border-blue-400 hover:text-blue-500
             dark:border-gray-600 dark:text-gray-400"
         >
-          + Add Zone
+          {t("table.addZone")}
         </button>
       )}
     </div>

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/hooks/useZoneEditor.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/hooks/useZoneEditor.test.tsx
@@ -165,9 +165,7 @@ describe("useZoneEditor - handleZoneChange", () => {
     // Assert
     expect(result.current.validationErrors.length).toBeGreaterThan(0);
     expect(
-      result.current.validationErrors.some(
-        (e) => e.message === "Overlaps with next zone"
-      )
+      result.current.validationErrors.some((e) => e.code === "overlap")
     ).toBe(true);
   });
 

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/hooks/useZoneEditor.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/hooks/useZoneEditor.ts
@@ -12,12 +12,8 @@ import type {
   PowerZone,
   Profile,
 } from "../../../../types/profile";
+import type { ZoneValidationError } from "./useZoneValidation";
 import { useZoneValidation } from "./useZoneValidation";
-
-type ZoneValidationError = {
-  zone: number;
-  message: string;
-};
 
 export function useZoneEditor(
   profile: Profile,

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/hooks/useZoneValidation.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/hooks/useZoneValidation.test.tsx
@@ -44,7 +44,7 @@ describe("useZoneValidation - power zones", () => {
     // Assert
     expect(errors).toContainEqual({
       zone: 1,
-      message: "Min must be less than max",
+      code: "min-max",
     });
   });
 
@@ -60,11 +60,7 @@ describe("useZoneValidation - power zones", () => {
     const errors = result.current.validateZones(zones);
 
     // Assert
-    expect(
-      errors.some(
-        (e) => e.zone === 1 && e.message === "Min must be less than max"
-      )
-    ).toBe(true);
+    expect(errors.some((e) => e.zone === 1 && e.code === "min-max")).toBe(true);
   });
 
   it("should flag overlap between consecutive power zones", () => {
@@ -81,7 +77,7 @@ describe("useZoneValidation - power zones", () => {
     // Assert
     expect(errors).toContainEqual({
       zone: 1,
-      message: "Overlaps with next zone",
+      code: "overlap",
     });
   });
 
@@ -97,9 +93,7 @@ describe("useZoneValidation - power zones", () => {
     const errors = result.current.validateZones(zones);
 
     // Assert
-    expect(
-      errors.filter((e) => e.message === "Overlaps with next zone")
-    ).toHaveLength(0);
+    expect(errors.filter((e) => e.code === "overlap")).toHaveLength(0);
   });
 });
 
@@ -133,7 +127,7 @@ describe("useZoneValidation - heart-rate zones", () => {
     // Assert
     expect(errors).toContainEqual({
       zone: 1,
-      message: "Min must be less than max",
+      code: "min-max",
     });
   });
 
@@ -151,7 +145,7 @@ describe("useZoneValidation - heart-rate zones", () => {
     // Assert
     expect(errors).toContainEqual({
       zone: 1,
-      message: "Overlaps with next zone",
+      code: "overlap",
     });
   });
 

--- a/packages/workout-spa-editor/src/components/organisms/ZoneEditor/hooks/useZoneValidation.ts
+++ b/packages/workout-spa-editor/src/components/organisms/ZoneEditor/hooks/useZoneValidation.ts
@@ -6,9 +6,9 @@
 
 import type { HeartRateZone, PowerZone } from "../../../../types/profile";
 
-type ZoneValidationError = {
+export type ZoneValidationError = {
   zone: number;
-  message: string;
+  code: "min-max" | "overlap";
 };
 
 export function useZoneValidation(isPowerZones: boolean) {
@@ -22,17 +22,11 @@ export function useZoneValidation(isPowerZones: boolean) {
 
       if (isPowerZones && "minPercent" in zone && "maxPercent" in zone) {
         if (zone.minPercent >= zone.maxPercent) {
-          errors.push({
-            zone: zone.zone,
-            message: "Min must be less than max",
-          });
+          errors.push({ zone: zone.zone, code: "min-max" });
         }
       } else if (!isPowerZones && "minBpm" in zone && "maxBpm" in zone) {
         if (zone.minBpm >= zone.maxBpm) {
-          errors.push({
-            zone: zone.zone,
-            message: "Min must be less than max",
-          });
+          errors.push({ zone: zone.zone, code: "min-max" });
         }
       }
 
@@ -40,17 +34,11 @@ export function useZoneValidation(isPowerZones: boolean) {
         const nextZone = zonesToValidate[i + 1]!;
         if (isPowerZones && "maxPercent" in zone && "minPercent" in nextZone) {
           if (zone.maxPercent >= nextZone.minPercent) {
-            errors.push({
-              zone: zone.zone,
-              message: "Overlaps with next zone",
-            });
+            errors.push({ zone: zone.zone, code: "overlap" });
           }
         } else if (!isPowerZones && "maxBpm" in zone && "minBpm" in nextZone) {
           if (zone.maxBpm >= nextZone.minBpm) {
-            errors.push({
-              zone: zone.zone,
-              message: "Overlaps with next zone",
-            });
+            errors.push({ zone: zone.zone, code: "overlap" });
           }
         }
       }

--- a/packages/workout-spa-editor/src/i18n/locales/en/zones.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/zones.json
@@ -1,0 +1,65 @@
+{
+  "header": {
+    "powerTitle": "Power Zones",
+    "heartRateTitle": "Heart Rate Zones",
+    "powerDescription": "Configure {{count}} power zones based on FTP{{suffix}}",
+    "heartRateDescription": "Configure {{count}} heart rate zones based on LTHR{{suffix}}",
+    "ftpSuffix": " ({{ftp}}W)",
+    "lthrSuffix": " ({{lthr}} bpm)"
+  },
+  "actions": {
+    "cancel": "Cancel",
+    "saveZones": "Save Zones"
+  },
+  "inputs": {
+    "namePlaceholder": "Zone name",
+    "minPercent": "Min %",
+    "maxPercent": "Max %",
+    "minBpm": "Min BPM",
+    "maxBpm": "Max BPM"
+  },
+  "method": {
+    "ariaLabel": "{{type}} zone method",
+    "confirmTitle": "Change Zone Method",
+    "confirmMessage": "This will replace your current zones with calculated values. Continue?",
+    "confirmLabel": "Change Method",
+    "keepLabel": "Keep Current"
+  },
+  "table": {
+    "noZones": "No zones configured",
+    "addZone": "+ Add Zone",
+    "zoneNameAria": "{{prefix}} Zone {{zone}} name",
+    "zoneMinAria": "{{prefix}} Zone {{zone}} min",
+    "zoneMaxAria": "{{prefix}} Zone {{zone}} max",
+    "removeZoneAria": "Remove {{prefix}} zone {{zone}}"
+  },
+  "tabs": {
+    "cycling": "Cycling",
+    "running": "Running",
+    "swimming": "Swimming",
+    "generic": "Generic"
+  },
+  "threshold": {
+    "pace": "Threshold Pace",
+    "ariaLabel": "{{label}} threshold"
+  },
+  "section": {
+    "heartRate": "Heart Rate Zones",
+    "power": "Power Zones",
+    "pace": "Pace Zones"
+  },
+  "validation": {
+    "heading": "Validation Errors",
+    "zoneLabel": "Zone {{zone}}: {{message}}",
+    "min-max": "Min must be less than max",
+    "overlap": "Overlaps with next zone"
+  },
+  "zoneType": {
+    "hr": "HR",
+    "power": "Power",
+    "pace": "Pace"
+  },
+  "empty": {
+    "noSportConfig": "No zone configuration for this sport."
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/zones.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/zones.json
@@ -1,0 +1,65 @@
+{
+  "header": {
+    "powerTitle": "Zonas de potencia",
+    "heartRateTitle": "Zonas de frecuencia cardíaca",
+    "powerDescription": "Configura {{count}} zonas de potencia según el FTP{{suffix}}",
+    "heartRateDescription": "Configura {{count}} zonas de frecuencia cardíaca según el LTHR{{suffix}}",
+    "ftpSuffix": " ({{ftp}} W)",
+    "lthrSuffix": " ({{lthr}} bpm)"
+  },
+  "actions": {
+    "cancel": "Cancelar",
+    "saveZones": "Guardar zonas"
+  },
+  "inputs": {
+    "namePlaceholder": "Nombre de la zona",
+    "minPercent": "Mín %",
+    "maxPercent": "Máx %",
+    "minBpm": "Mín BPM",
+    "maxBpm": "Máx BPM"
+  },
+  "method": {
+    "ariaLabel": "método de zona {{type}}",
+    "confirmTitle": "Cambiar método de zona",
+    "confirmMessage": "Esto reemplazará tus zonas actuales con valores calculados. ¿Continuar?",
+    "confirmLabel": "Cambiar método",
+    "keepLabel": "Mantener actual"
+  },
+  "table": {
+    "noZones": "No hay zonas configuradas",
+    "addZone": "+ Añadir zona",
+    "zoneNameAria": "{{prefix}} Zona {{zone}} nombre",
+    "zoneMinAria": "{{prefix}} Zona {{zone}} mín",
+    "zoneMaxAria": "{{prefix}} Zona {{zone}} máx",
+    "removeZoneAria": "Eliminar zona {{prefix}} {{zone}}"
+  },
+  "tabs": {
+    "cycling": "Ciclismo",
+    "running": "Carrera",
+    "swimming": "Natación",
+    "generic": "Genérico"
+  },
+  "threshold": {
+    "pace": "Ritmo umbral",
+    "ariaLabel": "umbral {{label}}"
+  },
+  "section": {
+    "heartRate": "Zonas de frecuencia cardíaca",
+    "power": "Zonas de potencia",
+    "pace": "Zonas de ritmo"
+  },
+  "validation": {
+    "heading": "Errores de validación",
+    "zoneLabel": "Zona {{zone}}: {{message}}",
+    "min-max": "El mínimo debe ser menor que el máximo",
+    "overlap": "Se solapa con la zona siguiente"
+  },
+  "zoneType": {
+    "hr": "FC",
+    "power": "Potencia",
+    "pace": "Ritmo"
+  },
+  "empty": {
+    "noSportConfig": "No hay configuración de zonas para este deporte."
+  }
+}


### PR DESCRIPTION
## What

New `zones` namespace across the ZoneEditor: header, method select, tabs, threshold + zone inputs, table headers, actions, and validation.

## Notes

- **Validation by stable code**: zone validation now carries `code: "min-max" | "overlap"` instead of an English message; `ValidationErrors` localizes by code and the hook + its test assert the code (same failure-semantics pattern as chat error categorization). English output byte-identical.
- Zone display names (`lib/athlete`, shared) untouched — only ZoneEditor's own chrome is localized.
- **Bonus flaky fix**: `EditableZoneName` ran its edit-start `select()` on `requestAnimationFrame`, which could fire mid-keystroke, reselect, and drop the first typed char (`"Easy"` → `"asy"`). This flaked `SportZoneEditor.test.tsx > should edit zone name inline` (~60% on main). Moved `select()` to an effect keyed on `editing` (runs once, deterministic). Stress-tested 8×: 0 failures.
- No `resources.ts` change — JSON auto-discovered by the glob loader (#901).

## Verification

- `pnpm build` (tsc -b + vite) ✅ · eslint + prettier ✅
- ZoneEditor + parity: **114/114** ✅
- Full SPA suite: 5463/5464 (the one failure is the pre-existing `LabDashboardSection` flaky, unrelated — passes on re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)