### PR TITLE
feat(spa-editor): localize the health pages (health namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/health/HealthActivityPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/HealthActivityPage.tsx
@@ -4,25 +4,33 @@
  */
 import { useHealthDailyTodayLive } from "../../../hooks/health/use-health-daily-today-live";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { todayIso } from "./health-date-windows";
 import { HealthPageHeader } from "./HealthPageHeader";
 
-const EMPTY_MSG = "No activity recorded today yet.";
-
 export default function HealthActivityPage() {
+  const t = useTranslate("health");
   const active = useActiveProfileLive();
   const today = todayIso();
   const record = useHealthDailyTodayLive(active?.id ?? "", today);
   const loading = record === undefined;
   return (
     <section data-testid="health-activity">
-      <HealthPageHeader title="Activity" subtitle={today} />
-      {loading && <p className="text-sm text-gray-600">{EMPTY_MSG}</p>}
+      <HealthPageHeader title={t("activity.title")} subtitle={today} />
+      {loading && (
+        <p className="text-sm text-gray-600">{t("activity.empty")}</p>
+      )}
       {!loading && (
         <dl className="grid gap-3 sm:grid-cols-3">
-          <Stat label="Steps" value={record.krd.steps} />
-          <Stat label="Active kcal" value={record.krd.activeCalories} />
-          <Stat label="Resting kcal" value={record.krd.restingCalories} />
+          <Stat label={t("activity.steps")} value={record.krd.steps} />
+          <Stat
+            label={t("activity.activeKcal")}
+            value={record.krd.activeCalories}
+          />
+          <Stat
+            label={t("activity.restingKcal")}
+            value={record.krd.restingCalories}
+          />
         </dl>
       )}
     </section>

--- a/packages/workout-spa-editor/src/components/pages/health/HealthDashboardPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/HealthDashboardPage.tsx
@@ -10,6 +10,7 @@
 import { useMemo } from "react";
 
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { lastNDays } from "./health-date-windows";
 import { HealthPageHeader } from "./HealthPageHeader";
 import { HealthSubRouteLinks } from "./HealthSubRouteLinks";
@@ -20,14 +21,15 @@ import { useTrendSelection } from "./trends/use-trend-selection";
 import { useTrendSeries } from "./trends/use-trend-series";
 
 export default function HealthDashboardPage() {
+  const t = useTranslate("health");
   const active = useActiveProfileLive();
-  const profileLabel = active?.profile?.name ?? "Active profile";
+  const profileLabel = active?.profile?.name ?? t("dashboard.activeProfile");
   const { selected, toggle, rangeDays, setRangeDays } = useTrendSelection();
   const range = useMemo(() => lastNDays(rangeDays), [rangeDays]);
   const series = useTrendSeries(active?.id ?? "", range);
   return (
     <section data-testid="health-dashboard">
-      <HealthPageHeader title="Trends" subtitle={profileLabel} />
+      <HealthPageHeader title={t("dashboard.title")} subtitle={profileLabel} />
       <div className="mb-4 flex flex-col gap-3">
         <TrendMetricSelector selected={selected} onToggle={toggle} />
         <TrendRangeSelector selected={rangeDays} onSelect={setRangeDays} />

--- a/packages/workout-spa-editor/src/components/pages/health/HealthRecoveryPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/HealthRecoveryPage.tsx
@@ -4,12 +4,14 @@
 import { useHealthHrvHistoryLive } from "../../../hooks/health/use-health-hrv-history-live";
 import { useHealthStressDayLive } from "../../../hooks/health/use-health-stress-day-live";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { lastNinetyDays, todayIso } from "./health-date-windows";
 import { HealthPageHeader } from "./HealthPageHeader";
 import { HrvHistoryList } from "./HrvHistoryList";
 import { TodayStressList } from "./TodayStressList";
 
 export default function HealthRecoveryPage() {
+  const t = useTranslate("health");
   // Computed per render so the window stays current across day rollovers.
   const range = lastNinetyDays();
   const today = todayIso();
@@ -20,15 +22,19 @@ export default function HealthRecoveryPage() {
   return (
     <section data-testid="health-recovery">
       <HealthPageHeader
-        title="Recovery"
-        subtitle={`HRV ${range.start} → ${range.end} · Stress ${today}`}
+        title={t("recovery.title")}
+        subtitle={t("recovery.subtitle", {
+          start: range.start,
+          end: range.end,
+          today,
+        })}
       />
       <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400">
-        HRV history
+        {t("recovery.hrvHistory")}
       </h2>
       <HrvHistoryList loading={hrv === undefined} records={hrv} />
       <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-gray-600 dark:text-gray-400">
-        Stress today
+        {t("recovery.stressToday")}
       </h2>
       <TodayStressList loading={stress === undefined} records={stress} />
     </section>

--- a/packages/workout-spa-editor/src/components/pages/health/HealthSleepPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/HealthSleepPage.tsx
@@ -3,13 +3,13 @@
  */
 import { useHealthSleepWeekLive } from "../../../hooks/health/use-health-sleep-week-live";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { lastSevenDays } from "./health-date-windows";
 import { HealthPageHeader } from "./HealthPageHeader";
 import { HealthSourceBadge } from "./HealthSourceBadge";
 
-const EMPTY_MSG = "No sleep records yet for the last 7 days.";
-
 export default function HealthSleepPage() {
+  const t = useTranslate("health");
   // Computed per render so the window stays current across day rollovers.
   const range = lastSevenDays();
   const active = useActiveProfileLive();
@@ -19,12 +19,14 @@ export default function HealthSleepPage() {
   return (
     <section data-testid="health-sleep">
       <HealthPageHeader
-        title="Sleep"
+        title={t("sleep.title")}
         subtitle={`${range.start} → ${range.end}`}
       />
-      {loading && <p className="text-sm text-gray-600">Loading…</p>}
+      {loading && (
+        <p className="text-sm text-gray-600">{t("common.loading")}</p>
+      )}
       {!loading && records.length === 0 && (
-        <p className="text-sm text-gray-600">{EMPTY_MSG}</p>
+        <p className="text-sm text-gray-600">{t("sleep.empty")}</p>
       )}
       {!loading && records.length > 0 && (
         <ul className="space-y-2">

--- a/packages/workout-spa-editor/src/components/pages/health/HealthSourceBadge.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/HealthSourceBadge.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import { healthSourceBadge } from "./health-source-badge";
 
 type Props = {
@@ -9,10 +10,11 @@ type Props = {
    sourceBridgeId). "usedFallback" marks a record the multi-source
    resolver picked because the preferred source had none that day. */
 export function HealthSourceBadge({ sourceBridgeId, usedFallback }: Props) {
+  const t = useTranslate("health");
   return (
     <span className="inline-flex items-center gap-1 rounded bg-gray-100 px-1.5 py-0.5 text-[11px] font-medium text-gray-600 dark:bg-slate-800 dark:text-gray-400">
       {healthSourceBadge(sourceBridgeId)}
-      {usedFallback && <span title="Fallback active">↩</span>}
+      {usedFallback && <span title={t("source.fallbackActive")}>↩</span>}
     </span>
   );
 }

--- a/packages/workout-spa-editor/src/components/pages/health/HealthSubRouteLinks.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/HealthSubRouteLinks.tsx
@@ -1,28 +1,30 @@
 import { Link } from "wouter";
 
+import { useTranslate } from "../../../i18n/use-translate";
 import type { WellnessMetric } from "../../../types/health/day-wellness";
 import { WELLNESS_BADGE_ROUTES } from "../../molecules/WorkoutCard/WellnessBand/wellness-badge-routes";
 
 type SubRouteDef = {
   metric: WellnessMetric;
-  label: string;
+  labelKey: string;
 };
 
 const SUB_ROUTES: ReadonlyArray<SubRouteDef> = [
-  { metric: "sleep", label: "Sleep" },
-  { metric: "hrv", label: "Recovery" },
-  { metric: "weight", label: "Weight" },
-  { metric: "steps", label: "Activity" },
+  { metric: "sleep", labelKey: "nav.sleep" },
+  { metric: "hrv", labelKey: "nav.recovery" },
+  { metric: "weight", labelKey: "nav.weight" },
+  { metric: "steps", labelKey: "nav.activity" },
 ];
 
 const linkClass =
   "flex items-center justify-center rounded-md border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700";
 
 export function HealthSubRouteLinks() {
+  const t = useTranslate("health");
   return (
     <nav
       data-testid="health-sub-route-links"
-      aria-label="Health detail pages"
+      aria-label={t("nav.ariaLabel")}
       className="grid grid-cols-2 gap-2 sm:grid-cols-4"
     >
       {SUB_ROUTES.map((sub) => (
@@ -31,7 +33,7 @@ export function HealthSubRouteLinks() {
           href={WELLNESS_BADGE_ROUTES[sub.metric]}
           className={linkClass}
         >
-          {sub.label}
+          {t(sub.labelKey)}
         </Link>
       ))}
     </nav>

--- a/packages/workout-spa-editor/src/components/pages/health/HealthWeightPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/HealthWeightPage.tsx
@@ -6,14 +6,14 @@ import { useUnits } from "../../../contexts/units-context";
 import { useHealthBodyCompositionLatestLive } from "../../../hooks/health/use-health-body-composition-latest-live";
 import { useHealthWeightHistoryLive } from "../../../hooks/health/use-health-weight-history-live";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../i18n/use-translate";
 import { formatWeightKg } from "../../../lib/units/units";
 import { lastNinetyDays } from "./health-date-windows";
 import { HealthPageHeader } from "./HealthPageHeader";
 import { HealthSourceBadge } from "./HealthSourceBadge";
 
-const EMPTY_MSG = "No weight records yet for the last 90 days.";
-
 export default function HealthWeightPage() {
+  const t = useTranslate("health");
   // Computed per render so the window stays current across day rollovers.
   const range = lastNinetyDays();
   const units = useUnits();
@@ -25,20 +25,22 @@ export default function HealthWeightPage() {
   return (
     <section data-testid="health-weight">
       <HealthPageHeader
-        title="Weight"
+        title={t("weight.title")}
         subtitle={`${range.start} → ${range.end}`}
       />
       {composition && (
         <div className="mb-4 rounded border border-blue-200 bg-blue-50 p-3 text-sm dark:border-blue-800 dark:bg-blue-950">
-          <div className="font-medium">Body composition (latest)</div>
+          <div className="font-medium">{t("weight.bodyComposition")}</div>
           <div className="text-gray-600 dark:text-gray-400">
             {composition.date}
           </div>
         </div>
       )}
-      {loading && <p className="text-sm text-gray-600">Loading…</p>}
+      {loading && (
+        <p className="text-sm text-gray-600">{t("common.loading")}</p>
+      )}
       {!loading && records.length === 0 && (
-        <p className="text-sm text-gray-600">{EMPTY_MSG}</p>
+        <p className="text-sm text-gray-600">{t("weight.empty")}</p>
       )}
       {!loading && records.length > 0 && (
         <ul className="space-y-1">

--- a/packages/workout-spa-editor/src/components/pages/health/HrvHistoryList.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/HrvHistoryList.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { HealthHrvRecord } from "../../../types/health/health-records";
 import { HealthSourceBadge } from "./HealthSourceBadge";
 
@@ -7,9 +8,11 @@ type Props = {
 };
 
 export function HrvHistoryList({ loading, records }: Props) {
-  if (loading) return <p className="text-sm text-gray-600">Loading…</p>;
+  const t = useTranslate("health");
+  if (loading)
+    return <p className="text-sm text-gray-600">{t("common.loading")}</p>;
   if (!records || records.length === 0) {
-    return <p className="mb-4 text-sm text-gray-600">No HRV records yet.</p>;
+    return <p className="mb-4 text-sm text-gray-600">{t("hrv.empty")}</p>;
   }
   return (
     <ul className="mb-4 space-y-1">

--- a/packages/workout-spa-editor/src/components/pages/health/TodayStressList.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/TodayStressList.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../i18n/use-translate";
 import type { HealthStressRecord } from "../../../types/health/health-records";
 import { HealthSourceBadge } from "./HealthSourceBadge";
 
@@ -7,13 +8,11 @@ type Props = {
 };
 
 export function TodayStressList({ loading, records }: Props) {
-  if (loading) return <p className="text-sm text-gray-600">Loading…</p>;
+  const t = useTranslate("health");
+  if (loading)
+    return <p className="text-sm text-gray-600">{t("common.loading")}</p>;
   if (!records || records.length === 0) {
-    return (
-      <p className="text-sm text-gray-600">
-        No stress episodes recorded today.
-      </p>
-    );
+    return <p className="text-sm text-gray-600">{t("stress.empty")}</p>;
   }
   return (
     <ul className="space-y-1">
@@ -23,7 +22,10 @@ export function TodayStressList({ loading, records }: Props) {
           className="flex items-center justify-between gap-2 rounded border border-gray-200 p-2 text-sm dark:border-slate-800"
         >
           <span>
-            Avg {r.krd.averageLevel} · Peak {r.krd.peakLevel}
+            {t("stress.avgPeak", {
+              avg: r.krd.averageLevel,
+              peak: r.krd.peakLevel,
+            })}
           </span>
           <HealthSourceBadge sourceBridgeId={r.sourceBridgeId} />
         </li>

--- a/packages/workout-spa-editor/src/components/pages/health/trends/TrendMetricSelector.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/trends/TrendMetricSelector.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../../i18n/use-translate";
 import type { TrendMetricKey } from "./trend-metrics";
 import { TREND_METRICS } from "./trend-metrics";
 
@@ -14,22 +15,28 @@ const offClass =
 export const TrendMetricSelector = ({
   selected,
   onToggle,
-}: TrendMetricSelectorProps) => (
-  <fieldset className="flex flex-wrap gap-2" data-testid="trend-metric-select">
-    <legend className="sr-only">Metrics</legend>
-    {TREND_METRICS.map((m) => {
-      const isOn = selected.has(m.key);
-      return (
-        <button
-          key={m.key}
-          type="button"
-          aria-pressed={isOn}
-          onClick={() => onToggle(m.key)}
-          className={`${baseClass} ${isOn ? onClass : offClass}`}
-        >
-          {m.label}
-        </button>
-      );
-    })}
-  </fieldset>
-);
+}: TrendMetricSelectorProps) => {
+  const t = useTranslate("health");
+  return (
+    <fieldset
+      className="flex flex-wrap gap-2"
+      data-testid="trend-metric-select"
+    >
+      <legend className="sr-only">{t("trends.metricsLegend")}</legend>
+      {TREND_METRICS.map((m) => {
+        const isOn = selected.has(m.key);
+        return (
+          <button
+            key={m.key}
+            type="button"
+            aria-pressed={isOn}
+            onClick={() => onToggle(m.key)}
+            className={`${baseClass} ${isOn ? onClass : offClass}`}
+          >
+            {t(`trends.metric.${m.key}`)}
+          </button>
+        );
+      })}
+    </fieldset>
+  );
+};

--- a/packages/workout-spa-editor/src/components/pages/health/trends/TrendRangeSelector.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/trends/TrendRangeSelector.tsx
@@ -1,3 +1,4 @@
+import { useTranslate } from "../../../../i18n/use-translate";
 import { TREND_RANGES, type TrendRangeDays } from "./trend-metrics";
 
 export type TrendRangeSelectorProps = {
@@ -13,27 +14,30 @@ const offClass =
 export const TrendRangeSelector = ({
   selected,
   onSelect,
-}: TrendRangeSelectorProps) => (
-  <div
-    role="radiogroup"
-    aria-label="Date range"
-    className="flex gap-2"
-    data-testid="trend-range-select"
-  >
-    {TREND_RANGES.map((r) => {
-      const isOn = r.days === selected;
-      return (
-        <button
-          key={r.days}
-          type="button"
-          role="radio"
-          aria-checked={isOn}
-          onClick={() => onSelect(r.days)}
-          className={`${baseClass} ${isOn ? onClass : offClass}`}
-        >
-          {r.label}
-        </button>
-      );
-    })}
-  </div>
-);
+}: TrendRangeSelectorProps) => {
+  const t = useTranslate("health");
+  return (
+    <div
+      role="radiogroup"
+      aria-label={t("trends.rangeAria")}
+      className="flex gap-2"
+      data-testid="trend-range-select"
+    >
+      {TREND_RANGES.map((r) => {
+        const isOn = r.days === selected;
+        return (
+          <button
+            key={r.days}
+            type="button"
+            role="radio"
+            aria-checked={isOn}
+            onClick={() => onSelect(r.days)}
+            className={`${baseClass} ${isOn ? onClass : offClass}`}
+          >
+            {r.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/workout-spa-editor/src/components/pages/health/trends/TrendSingleChartCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/trends/TrendSingleChartCard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 
 import { useUnits } from "../../../../contexts/units-context";
 import { useActiveLocale } from "../../../../i18n/LocaleProvider";
+import { useTranslate } from "../../../../i18n/use-translate";
 import {
   buildTrendChartData,
   type PerMetricPoints,
@@ -13,8 +14,6 @@ import type { TrendSeriesByMetric } from "./use-trend-series";
 
 const CHART_WIDTH = 880;
 const CHART_HEIGHT = 360;
-const EMPTY_MSG = "Select at least one metric to see its trend.";
-const LOADING_MSG = "Loading…";
 
 const BY_KEY: Record<TrendMetricKey, (typeof TREND_METRICS)[number]> =
   Object.fromEntries(TREND_METRICS.map((m) => [m.key, m])) as Record<
@@ -33,6 +32,7 @@ export const TrendSingleChartCard = ({
   series,
   rangeDays,
 }: TrendSingleChartCardProps) => {
+  const t = useTranslate("health");
   const units = useUnits();
   const locale = useActiveLocale();
   const selectedKeys = TREND_METRICS.map((m) => m.key).filter((k) =>
@@ -60,11 +60,11 @@ export const TrendSingleChartCard = ({
   );
 
   if (selected.size === 0)
-    return <p className="text-sm text-gray-600">{EMPTY_MSG}</p>;
+    return <p className="text-sm text-gray-600">{t("trends.selectMetric")}</p>;
   if (anyLoading && presentKeys.length === 0)
     return (
       <p className="text-sm text-gray-600" data-testid="trend-loading">
-        {LOADING_MSG}
+        {t("common.loading")}
       </p>
     );
 

--- a/packages/workout-spa-editor/src/i18n/locales/en/health.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/health.json
@@ -1,0 +1,59 @@
+{
+  "common": {
+    "loading": "Loading…"
+  },
+  "dashboard": {
+    "title": "Trends",
+    "activeProfile": "Active profile"
+  },
+  "activity": {
+    "title": "Activity",
+    "empty": "No activity recorded today yet.",
+    "steps": "Steps",
+    "activeKcal": "Active kcal",
+    "restingKcal": "Resting kcal"
+  },
+  "recovery": {
+    "title": "Recovery",
+    "subtitle": "HRV {{start}} → {{end}} · Stress {{today}}",
+    "hrvHistory": "HRV history",
+    "stressToday": "Stress today"
+  },
+  "sleep": {
+    "title": "Sleep",
+    "empty": "No sleep records yet for the last 7 days."
+  },
+  "weight": {
+    "title": "Weight",
+    "empty": "No weight records yet for the last 90 days.",
+    "bodyComposition": "Body composition (latest)"
+  },
+  "hrv": {
+    "empty": "No HRV records yet."
+  },
+  "stress": {
+    "empty": "No stress episodes recorded today.",
+    "avgPeak": "Avg {{avg}} · Peak {{peak}}"
+  },
+  "nav": {
+    "ariaLabel": "Health detail pages",
+    "sleep": "Sleep",
+    "recovery": "Recovery",
+    "weight": "Weight",
+    "activity": "Activity"
+  },
+  "source": {
+    "fallbackActive": "Fallback active"
+  },
+  "trends": {
+    "metricsLegend": "Metrics",
+    "rangeAria": "Date range",
+    "selectMetric": "Select at least one metric to see its trend.",
+    "metric": {
+      "sleep": "Sleep",
+      "hrv": "HRV",
+      "weight": "Weight",
+      "steps": "Steps"
+    }
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/health.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/health.json
@@ -1,0 +1,59 @@
+{
+  "common": {
+    "loading": "Cargando…"
+  },
+  "dashboard": {
+    "title": "Tendencias",
+    "activeProfile": "Perfil activo"
+  },
+  "activity": {
+    "title": "Actividad",
+    "empty": "No hay actividad registrada hoy todavía.",
+    "steps": "Pasos",
+    "activeKcal": "kcal activas",
+    "restingKcal": "kcal en reposo"
+  },
+  "recovery": {
+    "title": "Recuperación",
+    "subtitle": "VFC {{start}} → {{end}} · Estrés {{today}}",
+    "hrvHistory": "Historial de VFC",
+    "stressToday": "Estrés de hoy"
+  },
+  "sleep": {
+    "title": "Sueño",
+    "empty": "No hay registros de sueño de los últimos 7 días."
+  },
+  "weight": {
+    "title": "Peso",
+    "empty": "No hay registros de peso de los últimos 90 días.",
+    "bodyComposition": "Composición corporal (última)"
+  },
+  "hrv": {
+    "empty": "No hay registros de VFC todavía."
+  },
+  "stress": {
+    "empty": "No hay episodios de estrés registrados hoy.",
+    "avgPeak": "Media {{avg}} · Pico {{peak}}"
+  },
+  "nav": {
+    "ariaLabel": "Páginas de detalle de salud",
+    "sleep": "Sueño",
+    "recovery": "Recuperación",
+    "weight": "Peso",
+    "activity": "Actividad"
+  },
+  "source": {
+    "fallbackActive": "Reserva activa"
+  },
+  "trends": {
+    "metricsLegend": "Métricas",
+    "rangeAria": "Intervalo de fechas",
+    "selectMetric": "Selecciona al menos una métrica para ver su tendencia.",
+    "metric": {
+      "sleep": "Sueño",
+      "hrv": "VFC",
+      "weight": "Peso",
+      "steps": "Pasos"
+    }
+  }
+}


### PR DESCRIPTION
## What

New `health` namespace across the health dashboard and sub-pages: activity, recovery, sleep, weight, HRV history, today's stress, source badge, sub-route links, and the trend metric/range selectors + single-chart card.

## Notes

- The `labs/` subtree and the imperative `UplotChart` wrapper are out of scope (labs handled separately; UplotChart has no user-facing strings).
- Metric/range labels used as keys keep a stable enum; only displayed text is translated.
- No `resources.ts` change — JSON auto-discovered by the glob loader (#901). English byte-identical.

## Verification

- `pnpm build` (tsc -b + vite) ✅ · eslint + prettier ✅
- health subtree + parity: **161/161** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)