### PR TITLE
feat(spa-editor): localize the labs report UI (labs-ui namespace)

### DIFF
--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabEntryForm.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabEntryForm.tsx
@@ -3,6 +3,7 @@
  * saved as one `LabReport` + N `LabValue` via `useLabEntryForm`. Also hosts the
  * AI import affordance and, once a draft is loaded, a review banner.
  */
+import { useTranslate } from "../../../../i18n/use-translate";
 import { LabAiDraftBanner } from "./LabAiDraftBanner";
 import { LabImportSection } from "./LabImportSection";
 import { LabParameterRow } from "./LabParameterRow";
@@ -10,6 +11,7 @@ import { LabReportHeaderFields } from "./LabReportHeaderFields";
 import { useLabEntryForm } from "./use-lab-entry-form";
 
 export function LabEntryForm() {
+  const t = useTranslate("labs-ui");
   const {
     header,
     setHeader,
@@ -47,7 +49,7 @@ export function LabEntryForm() {
           onClick={addRow}
           className="rounded border border-gray-300 px-3 py-1.5 text-sm dark:border-gray-600"
         >
-          Add parameter
+          {t("form.addParameter")}
         </button>
         <button
           type="button"
@@ -55,7 +57,7 @@ export function LabEntryForm() {
           onClick={save}
           className="rounded bg-blue-600 px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50"
         >
-          Save
+          {t("form.save")}
         </button>
       </div>
     </div>

--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabEntryPage.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabEntryPage.tsx
@@ -7,6 +7,7 @@
 import { useState } from "react";
 
 import { useActiveProfileLive } from "../../../../hooks/use-active-profile-live";
+import { useTranslate } from "../../../../i18n/use-translate";
 import { HealthPageHeader } from "../HealthPageHeader";
 import { LabDashboardSection } from "./dashboard/LabDashboardSection";
 import { LabEntryForm } from "./LabEntryForm";
@@ -14,12 +15,13 @@ import { LabHistorySection } from "./LabHistorySection";
 
 type LabTab = "entry" | "dashboard";
 
-const TABS: { id: LabTab; label: string }[] = [
-  { id: "entry", label: "Entry & history" },
-  { id: "dashboard", label: "Dashboard" },
+const TABS: { id: LabTab; labelKey: string }[] = [
+  { id: "entry", labelKey: "entry.tabEntry" },
+  { id: "dashboard", labelKey: "entry.tabDashboard" },
 ];
 
 export default function LabEntryPage() {
+  const t = useTranslate("labs-ui");
   const active = useActiveProfileLive();
   const loading = active === undefined;
   const profileId = active?.id ?? null;
@@ -27,12 +29,13 @@ export default function LabEntryPage() {
 
   return (
     <section data-testid="health-labs">
-      <HealthPageHeader title="Lab analytics" subtitle="Add a new lab report" />
-      {loading && <p className="text-sm text-gray-600">Loading…</p>}
+      <HealthPageHeader
+        title={t("entry.title")}
+        subtitle={t("entry.subtitle")}
+      />
+      {loading && <p className="text-sm text-gray-600">{t("entry.loading")}</p>}
       {!loading && !profileId && (
-        <p className="text-sm text-gray-600">
-          Create an athlete profile first to log lab analytics.
-        </p>
+        <p className="text-sm text-gray-600">{t("entry.noProfile")}</p>
       )}
       {!loading && profileId && (
         <>
@@ -40,7 +43,7 @@ export default function LabEntryPage() {
             role="tablist"
             className="mb-4 flex gap-2 border-b border-gray-200 dark:border-slate-800"
           >
-            {TABS.map(({ id, label }) => (
+            {TABS.map(({ id, labelKey }) => (
               <button
                 key={id}
                 type="button"
@@ -54,7 +57,7 @@ export default function LabEntryPage() {
                     : "text-gray-600 dark:text-gray-400"
                 }`}
               >
-                {label}
+                {t(labelKey)}
               </button>
             ))}
           </div>

--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabFlagBadge.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabFlagBadge.tsx
@@ -4,17 +4,19 @@
  */
 import type { LabFlag } from "@kaiord/core";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { LAB_FLAG_STYLES } from "./lab-flag-display";
 
 export const LabFlagBadge = ({ flag }: { flag: LabFlag }) => {
-  const { label, className } = LAB_FLAG_STYLES[flag];
+  const t = useTranslate("labs-ui");
+  const { className } = LAB_FLAG_STYLES[flag];
   return (
     <span
       data-testid="lab-flag-badge"
       data-flag={flag}
       className={`rounded px-1.5 py-0.5 text-xs font-medium ${className}`}
     >
-      {label}
+      {t(`flag.${flag}`)}
     </span>
   );
 };

--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabHistorySection.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabHistorySection.tsx
@@ -9,16 +9,14 @@ import { useState } from "react";
 import { deleteLabReport } from "../../../../application/lab/delete-lab-report.use-case";
 import { usePersistence } from "../../../../contexts/persistence-context";
 import { useToastContext } from "../../../../contexts/ToastContext";
+import { useTranslate } from "../../../../i18n/use-translate";
 import { LabLatestValuesSection } from "./LabLatestValuesSection";
 import { LabReportReview } from "./LabReportReview";
 import { LabReportsList } from "./LabReportsList";
 import { useLabReportDetailLive, useLabReportsLive } from "./use-lab-history";
 
-const LOADING = "Loading…";
-const DELETED_MSG = "Lab report deleted";
-const DELETE_FAILED_MSG = "Could not delete the lab report";
-
 export const LabHistorySection = ({ profileId }: { profileId: string }) => {
+  const t = useTranslate("labs-ui");
   const persistence = usePersistence();
   const toast = useToastContext();
   const reports = useLabReportsLive(profileId);
@@ -32,9 +30,9 @@ export const LabHistorySection = ({ profileId }: { profileId: string }) => {
     try {
       await deleteLabReport(persistence, reportId);
       setSelectedId((prev) => (prev === reportId ? null : prev));
-      toast.success(DELETED_MSG);
+      toast.success(t("history.deleted"));
     } catch {
-      toast.error(DELETE_FAILED_MSG);
+      toast.error(t("history.deleteFailed"));
     }
   };
 
@@ -42,9 +40,9 @@ export const LabHistorySection = ({ profileId }: { profileId: string }) => {
     <div data-testid="lab-history" className="mt-6 flex flex-col gap-6">
       <LabLatestValuesSection profileId={profileId} />
       <section>
-        <h3 className="mb-2 text-sm font-semibold">Reports</h3>
+        <h3 className="mb-2 text-sm font-semibold">{t("history.reports")}</h3>
         {reports === undefined ? (
-          <p className="text-sm text-gray-600">{LOADING}</p>
+          <p className="text-sm text-gray-600">{t("history.loading")}</p>
         ) : (
           <LabReportsList
             reports={reports}

--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabParameterIdentityField.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabParameterIdentityField.tsx
@@ -8,6 +8,7 @@ import type { BiologicalSex } from "@kaiord/core";
 import { useId } from "react";
 
 import { useActiveLocale } from "../../../../i18n/LocaleProvider";
+import { useTranslate } from "../../../../i18n/use-translate";
 import {
   findParameterByLabel,
   labParameterOptions,
@@ -34,6 +35,7 @@ export function LabParameterIdentityField({
 }: LabParameterIdentityFieldProps) {
   const datalistId = useId();
   const locale = useActiveLocale();
+  const t = useTranslate("labs-ui");
 
   return (
     <div className="flex flex-1 flex-col gap-1">
@@ -46,7 +48,7 @@ export function LabParameterIdentityField({
             onClick={() => onChange(setRowMode(row, mode))}
             className={row.mode === mode ? "font-semibold underline" : ""}
           >
-            {mode === "catalog" ? "Catalog" : "Custom"}
+            {t(mode === "catalog" ? "form.catalog" : "form.custom")}
           </button>
         ))}
       </div>
@@ -54,8 +56,8 @@ export function LabParameterIdentityField({
         <>
           <input
             list={datalistId}
-            aria-label="Parameter"
-            placeholder="Search parameter…"
+            aria-label={t("form.parameterAria")}
+            placeholder={t("form.searchPlaceholder")}
             value={row.catalogLabel}
             className={FIELD_CLASS}
             onChange={(e) => {
@@ -72,8 +74,8 @@ export function LabParameterIdentityField({
         </>
       ) : (
         <input
-          aria-label="Custom parameter name"
-          placeholder="Parameter name"
+          aria-label={t("form.customNameAria")}
+          placeholder={t("form.customNamePlaceholder")}
           value={row.customName}
           className={FIELD_CLASS}
           onChange={(e) => onChange(setCustomName(row, e.target.value))}

--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabParameterMeasurementFields.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabParameterMeasurementFields.tsx
@@ -10,6 +10,7 @@ import {
 } from "@kaiord/core";
 import { useId } from "react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { unitOptionsFor } from "./lab-parameter-options";
 import {
   type LabRowState,
@@ -28,6 +29,7 @@ type FieldsProps = {
 };
 
 function ValueUnitFields({ row, onChange }: FieldsProps) {
+  const t = useTranslate("labs-ui");
   const unitListId = useId();
   const param = isCustomParameterKey(row.parameterKey)
     ? undefined
@@ -42,21 +44,21 @@ function ValueUnitFields({ row, onChange }: FieldsProps) {
   return (
     <>
       <label className="flex flex-col gap-1 text-xs">
-        Value
+        {t("form.value")}
         <input
           type="number"
           step="any"
-          aria-label="Value"
+          aria-label={t("form.value")}
           value={row.valueRaw}
           className={FIELD_CLASS}
           onChange={(e) => onChange(setValueRaw(row, e.target.value))}
         />
       </label>
       <label className="flex flex-col gap-1 text-xs">
-        Unit
+        {t("form.unit")}
         <input
           list={param ? unitListId : undefined}
-          aria-label="Unit"
+          aria-label={t("form.unit")}
           value={row.unitRaw}
           className={FIELD_CLASS}
           onChange={(e) => onChange(setUnitRaw(row, e.target.value))}
@@ -79,26 +81,27 @@ function ValueUnitFields({ row, onChange }: FieldsProps) {
 }
 
 export function LabParameterMeasurementFields({ row, onChange }: FieldsProps) {
+  const t = useTranslate("labs-ui");
   return (
     <div className="flex flex-wrap items-end gap-2">
       <ValueUnitFields row={row} onChange={onChange} />
       <label className="flex flex-col gap-1 text-xs">
-        Ref low
+        {t("form.refLow")}
         <input
           type="number"
           step="any"
-          aria-label="Reference low"
+          aria-label={t("form.referenceLow")}
           value={row.refLowRaw}
           className={FIELD_CLASS}
           onChange={(e) => onChange(setRefLowRaw(row, e.target.value))}
         />
       </label>
       <label className="flex flex-col gap-1 text-xs">
-        Ref high
+        {t("form.refHigh")}
         <input
           type="number"
           step="any"
-          aria-label="Reference high"
+          aria-label={t("form.referenceHigh")}
           value={row.refHighRaw}
           className={FIELD_CLASS}
           onChange={(e) => onChange(setRefHighRaw(row, e.target.value))}

--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabParameterRow.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabParameterRow.tsx
@@ -6,6 +6,7 @@
  */
 import type { BiologicalSex } from "@kaiord/core";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import type { LabRowState } from "./lab-row-model";
 import { LabParameterIdentityField } from "./LabParameterIdentityField";
 import { LabParameterMeasurementFields } from "./LabParameterMeasurementFields";
@@ -23,6 +24,7 @@ export function LabParameterRow({
   onChange,
   onRemove,
 }: LabParameterRowProps) {
+  const t = useTranslate("labs-ui");
   return (
     <div
       className="flex flex-col gap-2 rounded border border-gray-200 p-3 dark:border-slate-800"
@@ -32,11 +34,11 @@ export function LabParameterRow({
         <LabParameterIdentityField row={row} sex={sex} onChange={onChange} />
         <button
           type="button"
-          aria-label="Remove parameter"
+          aria-label={t("form.removeParameter")}
           onClick={onRemove}
           className="text-sm text-gray-500 hover:text-red-600"
         >
-          Remove
+          {t("form.remove")}
         </button>
       </div>
       <LabParameterMeasurementFields row={row} onChange={onChange} />

--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabReportHeaderFields.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabReportHeaderFields.tsx
@@ -5,6 +5,7 @@
 import type { ReactNode } from "react";
 
 import type { LabReportHeaderInput } from "../../../../application/lab/build-lab-report";
+import { useTranslate } from "../../../../i18n/use-translate";
 
 const FIELD_CLASS =
   "rounded border border-gray-300 bg-white px-2 py-1 text-sm dark:border-gray-600 dark:bg-gray-700 dark:text-white";
@@ -32,26 +33,30 @@ const FastingField = ({
 }: {
   value: LabReportHeaderInput["fasting"];
   set: SetHeaderField;
-}) => (
-  <Field label="Fasting">
-    <select
-      value={value}
-      className={FIELD_CLASS}
-      onChange={(e) =>
-        set("fasting", e.target.value as LabReportHeaderInput["fasting"])
-      }
-    >
-      <option value="unspecified">Not specified</option>
-      <option value="yes">Yes</option>
-      <option value="no">No</option>
-    </select>
-  </Field>
-);
+}) => {
+  const t = useTranslate("labs-ui");
+  return (
+    <Field label={t("form.fasting")}>
+      <select
+        value={value}
+        className={FIELD_CLASS}
+        onChange={(e) =>
+          set("fasting", e.target.value as LabReportHeaderInput["fasting"])
+        }
+      >
+        <option value="unspecified">{t("form.fastingUnspecified")}</option>
+        <option value="yes">{t("form.yes")}</option>
+        <option value="no">{t("form.no")}</option>
+      </select>
+    </Field>
+  );
+};
 
 export function LabReportHeaderFields({
   value,
   onChange,
 }: LabReportHeaderFieldsProps) {
+  const t = useTranslate("labs-ui");
   const set: SetHeaderField = (key, next) =>
     onChange({ ...value, [key]: next });
 
@@ -60,8 +65,8 @@ export function LabReportHeaderFields({
       className="grid grid-cols-1 gap-3 sm:grid-cols-2"
       data-testid="lab-report-header"
     >
-      <legend className="sr-only">Report details</legend>
-      <Field label="Date">
+      <legend className="sr-only">{t("form.reportDetails")}</legend>
+      <Field label={t("form.date")}>
         <input
           type="date"
           required
@@ -70,7 +75,7 @@ export function LabReportHeaderFields({
           onChange={(e) => set("date", e.target.value)}
         />
       </Field>
-      <Field label="Lab">
+      <Field label={t("form.lab")}>
         <input
           type="text"
           value={value.labName}
@@ -79,7 +84,7 @@ export function LabReportHeaderFields({
         />
       </Field>
       <FastingField value={value.fasting} set={set} />
-      <Field label="Draw time">
+      <Field label={t("form.drawTime")}>
         <input
           type="time"
           value={value.drawTime}
@@ -88,7 +93,7 @@ export function LabReportHeaderFields({
         />
       </Field>
       <div className="col-span-full">
-        <Field label="Notes">
+        <Field label={t("form.notes")}>
           <textarea
             value={value.notes}
             className={FIELD_CLASS}

--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabReportReview.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabReportReview.tsx
@@ -3,9 +3,11 @@
  * plus every parameter with value, unit, range + origin, and flag.
  */
 import type { LabReportDetail } from "../../../../application/lab/lab-queries";
+import { useTranslate } from "../../../../i18n/use-translate";
 import { LabReportValueRow } from "./LabReportValueRow";
 
 export const LabReportReview = ({ detail }: { detail: LabReportDetail }) => {
+  const t = useTranslate("labs-ui");
   const { report, values } = detail;
   return (
     <div
@@ -16,10 +18,10 @@ export const LabReportReview = ({ detail }: { detail: LabReportDetail }) => {
       <div className="mb-2 text-sm font-medium">
         {report.date}
         {report.labName ? ` · ${report.labName}` : ""}
-        {report.fasting ? " · fasting" : ""}
+        {report.fasting ? ` · ${t("report.fasting")}` : ""}
       </div>
       {values.length === 0 ? (
-        <p className="text-sm text-gray-600">This report has no parameters.</p>
+        <p className="text-sm text-gray-600">{t("report.emptyValues")}</p>
       ) : (
         <ul className="flex flex-col gap-2">
           {values.map((value) => (

--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabReportRow.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabReportRow.tsx
@@ -5,6 +5,8 @@
 import type { LabReport } from "@kaiord/core";
 import { useState } from "react";
 
+import { useTranslate } from "../../../../i18n/use-translate";
+
 const BTN = "rounded border px-2 py-1 text-xs";
 
 export type LabReportRowProps = {
@@ -20,6 +22,7 @@ export const LabReportRow = ({
   onToggle,
   onDelete,
 }: LabReportRowProps) => {
+  const t = useTranslate("labs-ui");
   const [confirming, setConfirming] = useState(false);
   return (
     <li
@@ -31,7 +34,7 @@ export const LabReportRow = ({
         <span className="font-medium">{report.date}</span>
         {report.labName ? ` · ${report.labName}` : ""}
         <span className="ml-2 text-xs text-blue-600 dark:text-blue-400">
-          {isSelected ? "Hide" : "View"}
+          {isSelected ? t("report.hide") : t("report.view")}
         </span>
       </button>
       {confirming ? (
@@ -41,24 +44,24 @@ export const LabReportRow = ({
             onClick={onDelete}
             className={`${BTN} border-red-300 text-red-700 dark:border-red-800 dark:text-red-300`}
           >
-            Confirm
+            {t("report.confirm")}
           </button>
           <button
             type="button"
             onClick={() => setConfirming(false)}
             className={`${BTN} border-gray-300 dark:border-gray-600`}
           >
-            Cancel
+            {t("report.cancel")}
           </button>
         </span>
       ) : (
         <button
           type="button"
-          aria-label={`Delete report ${report.date}`}
+          aria-label={t("report.deleteAria", { date: report.date })}
           onClick={() => setConfirming(true)}
           className={`${BTN} border-gray-300 dark:border-gray-600`}
         >
-          Delete
+          {t("report.delete")}
         </button>
       )}
     </li>

--- a/packages/workout-spa-editor/src/components/pages/health/labs/LabReportsList.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/LabReportsList.tsx
@@ -4,9 +4,8 @@
  */
 import type { LabReport } from "@kaiord/core";
 
+import { useTranslate } from "../../../../i18n/use-translate";
 import { LabReportRow } from "./LabReportRow";
-
-const EMPTY_MSG = "No reports saved yet.";
 
 export type LabReportsListProps = {
   reports: LabReport[];
@@ -21,8 +20,9 @@ export const LabReportsList = ({
   onToggle,
   onDelete,
 }: LabReportsListProps) => {
+  const t = useTranslate("labs-ui");
   if (reports.length === 0)
-    return <p className="text-sm text-gray-600">{EMPTY_MSG}</p>;
+    return <p className="text-sm text-gray-600">{t("report.emptyList")}</p>;
   return (
     <ul data-testid="lab-reports-list" className="flex flex-col gap-2">
       {reports.map((report) => (

--- a/packages/workout-spa-editor/src/components/pages/health/labs/charts/LabParameterChart.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/charts/LabParameterChart.tsx
@@ -9,6 +9,7 @@ import type { LabValue } from "@kaiord/core";
 import { useMemo } from "react";
 
 import { useActiveLocale } from "../../../../../i18n/LocaleProvider";
+import { useTranslate } from "../../../../../i18n/use-translate";
 import type { ChartMetricDef } from "../../../../charts/uplot-base/uplot-base";
 import { UplotChart } from "../../../../charts/uplot-base/uplot-chart";
 import { labParameterLabel } from "../lab-parameter-label";
@@ -18,7 +19,6 @@ import { resolveReferenceBand } from "./reference-band";
 
 const CHART_WIDTH = 720;
 const CHART_HEIGHT = 300;
-const EMPTY_MSG = "No history for this parameter yet.";
 
 export const LabParameterChart = ({
   parameterKey,
@@ -28,6 +28,7 @@ export const LabParameterChart = ({
   values: LabValue[];
 }) => {
   const locale = useActiveLocale();
+  const t = useTranslate("labs-ui");
   const def: ChartMetricDef = useMemo(
     () => ({
       key: parameterKey,
@@ -41,7 +42,7 @@ export const LabParameterChart = ({
   const options = useMemo(() => buildLabChartOptions(def, band), [def, band]);
 
   if (values.length === 0)
-    return <p className="text-sm text-gray-600">{EMPTY_MSG}</p>;
+    return <p className="text-sm text-gray-600">{t("chart.empty")}</p>;
 
   return (
     <div

--- a/packages/workout-spa-editor/src/components/pages/health/labs/charts/LabParameterChartCard.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/charts/LabParameterChartCard.tsx
@@ -4,11 +4,10 @@
  * reference band and out-of-range markers.
  */
 import { useActiveLocale } from "../../../../../i18n/LocaleProvider";
+import { useTranslate } from "../../../../../i18n/use-translate";
 import { labParameterLabel } from "../lab-parameter-label";
 import { LabParameterChart } from "./LabParameterChart";
 import { useLabValueSeriesLive } from "./use-lab-value-series";
-
-const LOADING = "Loading…";
 
 export const LabParameterChartCard = ({
   profileId,
@@ -19,13 +18,16 @@ export const LabParameterChartCard = ({
 }) => {
   const values = useLabValueSeriesLive(profileId, parameterKey);
   const locale = useActiveLocale();
+  const t = useTranslate("labs-ui");
   return (
     <div data-testid="lab-parameter-chart-card" className="mt-3">
       <h4 className="mb-2 text-sm font-semibold">
-        {labParameterLabel(parameterKey, locale)} evolution
+        {t("chart.evolutionTitle", {
+          label: labParameterLabel(parameterKey, locale),
+        })}
       </h4>
       {values === undefined ? (
-        <p className="text-sm text-gray-600">{LOADING}</p>
+        <p className="text-sm text-gray-600">{t("chart.loading")}</p>
       ) : (
         <LabParameterChart parameterKey={parameterKey} values={values} />
       )}

--- a/packages/workout-spa-editor/src/components/pages/health/labs/dashboard/LabDashboardSection.tsx
+++ b/packages/workout-spa-editor/src/components/pages/health/labs/dashboard/LabDashboardSection.tsx
@@ -5,24 +5,25 @@
  * `LabParameterChartCard` per pinned parameter in a grid. The selection is
  * persisted in `userPreferences.labDashboardParams` and survives reload.
  */
+import { useTranslate } from "../../../../../i18n/use-translate";
 import { LabParameterChartCard } from "../charts/LabParameterChartCard";
 import { LabLatestValuesList } from "../LabLatestValuesList";
 import { useLabParameterSummariesLive } from "../use-lab-history";
 import { useLabDashboardParams } from "./use-lab-dashboard-params";
 
-const LOADING = "Loading…";
-const EMPTY_GRID_MSG = "Pin a parameter above to see its evolution chart.";
-
 export const LabDashboardSection = ({ profileId }: { profileId: string }) => {
+  const t = useTranslate("labs-ui");
   const summaries = useLabParameterSummariesLive(profileId);
   const { pinned, toggle } = useLabDashboardParams(profileId);
   const pinnedKeys = new Set(pinned);
 
   return (
     <section data-testid="lab-dashboard">
-      <h3 className="mb-2 text-sm font-semibold">Pin parameters</h3>
+      <h3 className="mb-2 text-sm font-semibold">
+        {t("dashboard.pinParameters")}
+      </h3>
       {summaries === undefined ? (
-        <p className="text-sm text-gray-600">{LOADING}</p>
+        <p className="text-sm text-gray-600">{t("dashboard.loading")}</p>
       ) : (
         <LabLatestValuesList
           summaries={summaries}
@@ -30,9 +31,11 @@ export const LabDashboardSection = ({ profileId }: { profileId: string }) => {
           selectedKeys={pinnedKeys}
         />
       )}
-      <h3 className="mt-6 mb-2 text-sm font-semibold">Evolution charts</h3>
+      <h3 className="mt-6 mb-2 text-sm font-semibold">
+        {t("dashboard.evolutionCharts")}
+      </h3>
       {pinned.length === 0 ? (
-        <p className="text-sm text-gray-600">{EMPTY_GRID_MSG}</p>
+        <p className="text-sm text-gray-600">{t("dashboard.emptyGrid")}</p>
       ) : (
         <div
           data-testid="lab-dashboard-grid"

--- a/packages/workout-spa-editor/src/i18n/locales/en/labs-ui.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/labs-ui.json
@@ -1,0 +1,71 @@
+{
+  "entry": {
+    "tabEntry": "Entry & history",
+    "tabDashboard": "Dashboard",
+    "title": "Lab analytics",
+    "subtitle": "Add a new lab report",
+    "loading": "Loading…",
+    "noProfile": "Create an athlete profile first to log lab analytics."
+  },
+  "form": {
+    "addParameter": "Add parameter",
+    "save": "Save",
+    "catalog": "Catalog",
+    "custom": "Custom",
+    "parameterAria": "Parameter",
+    "searchPlaceholder": "Search parameter…",
+    "customNameAria": "Custom parameter name",
+    "customNamePlaceholder": "Parameter name",
+    "value": "Value",
+    "unit": "Unit",
+    "refLow": "Ref low",
+    "refHigh": "Ref high",
+    "referenceLow": "Reference low",
+    "referenceHigh": "Reference high",
+    "removeParameter": "Remove parameter",
+    "remove": "Remove",
+    "fasting": "Fasting",
+    "fastingUnspecified": "Not specified",
+    "yes": "Yes",
+    "no": "No",
+    "date": "Date",
+    "lab": "Lab",
+    "drawTime": "Draw time",
+    "notes": "Notes",
+    "reportDetails": "Report details"
+  },
+  "flag": {
+    "in": "In range",
+    "low": "Low",
+    "high": "High",
+    "unknown": "No range"
+  },
+  "history": {
+    "loading": "Loading…",
+    "reports": "Reports",
+    "deleted": "Lab report deleted",
+    "deleteFailed": "Could not delete the lab report"
+  },
+  "report": {
+    "fasting": "fasting",
+    "emptyValues": "This report has no parameters.",
+    "hide": "Hide",
+    "view": "View",
+    "confirm": "Confirm",
+    "cancel": "Cancel",
+    "deleteAria": "Delete report {{date}}",
+    "delete": "Delete",
+    "emptyList": "No reports saved yet."
+  },
+  "chart": {
+    "empty": "No history for this parameter yet.",
+    "loading": "Loading…",
+    "evolutionTitle": "{{label}} evolution"
+  },
+  "dashboard": {
+    "loading": "Loading…",
+    "pinParameters": "Pin parameters",
+    "evolutionCharts": "Evolution charts",
+    "emptyGrid": "Pin a parameter above to see its evolution chart."
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/labs-ui.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/labs-ui.json
@@ -1,0 +1,71 @@
+{
+  "entry": {
+    "tabEntry": "Entrada e historial",
+    "tabDashboard": "Panel",
+    "title": "Analíticas",
+    "subtitle": "Añadir un nuevo informe de laboratorio",
+    "loading": "Cargando…",
+    "noProfile": "Crea primero un perfil de atleta para registrar analíticas."
+  },
+  "form": {
+    "addParameter": "Añadir parámetro",
+    "save": "Guardar",
+    "catalog": "Catálogo",
+    "custom": "Personalizado",
+    "parameterAria": "Parámetro",
+    "searchPlaceholder": "Buscar parámetro…",
+    "customNameAria": "Nombre de parámetro personalizado",
+    "customNamePlaceholder": "Nombre del parámetro",
+    "value": "Valor",
+    "unit": "Unidad",
+    "refLow": "Ref. baja",
+    "refHigh": "Ref. alta",
+    "referenceLow": "Referencia baja",
+    "referenceHigh": "Referencia alta",
+    "removeParameter": "Eliminar parámetro",
+    "remove": "Eliminar",
+    "fasting": "En ayunas",
+    "fastingUnspecified": "Sin especificar",
+    "yes": "Sí",
+    "no": "No",
+    "date": "Fecha",
+    "lab": "Laboratorio",
+    "drawTime": "Hora de extracción",
+    "notes": "Notas",
+    "reportDetails": "Detalles del informe"
+  },
+  "flag": {
+    "in": "En rango",
+    "low": "Bajo",
+    "high": "Alto",
+    "unknown": "Sin rango"
+  },
+  "history": {
+    "loading": "Cargando…",
+    "reports": "Informes",
+    "deleted": "Informe de laboratorio eliminado",
+    "deleteFailed": "No se pudo eliminar el informe de laboratorio"
+  },
+  "report": {
+    "fasting": "en ayunas",
+    "emptyValues": "Este informe no tiene parámetros.",
+    "hide": "Ocultar",
+    "view": "Ver",
+    "confirm": "Confirmar",
+    "cancel": "Cancelar",
+    "deleteAria": "Eliminar informe {{date}}",
+    "delete": "Eliminar",
+    "emptyList": "Aún no hay informes guardados."
+  },
+  "chart": {
+    "empty": "Aún no hay historial para este parámetro.",
+    "loading": "Cargando…",
+    "evolutionTitle": "Evolución de {{label}}"
+  },
+  "dashboard": {
+    "loading": "Cargando…",
+    "pinParameters": "Fijar parámetros",
+    "evolutionCharts": "Gráficos de evolución",
+    "emptyGrid": "Fija un parámetro arriba para ver su gráfico de evolución."
+  }
+}


### PR DESCRIPTION
## What

New `labs-ui` namespace across the lab entry/report UI chrome: entry form + page, parameter identity/measurement fields, parameter rows, report header fields, report review + rows + list, flag badge, history section, and the parameter charts + dashboard section.

## Notes

- Kept separate from the existing `labs` namespace (clinical parameter display names) and from `labImport`. Parameter names still come from the shared display helper — not re-localized.
- `LabImportSection` / `LabAiDraftBanner` (already localized) untouched.
- No `resources.ts` change — JSON auto-discovered by the glob loader (#901). English byte-identical.

## Verification

- `pnpm build` (tsc -b + vite) ✅ · eslint + prettier ✅
- labs subtree + parity: **105/105** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full English and Spanish localization for the labs experience, including forms, tabs, report history, charts, dashboard text, and empty/loading states.
  * Updated lab screens to display translated labels, button text, and messages throughout the workflow.
* **Bug Fixes**
  * Improved accessibility labels and placeholders for several lab input fields.
  * Localized delete confirmations and status messages to better match the selected language.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->