### PR TITLE
feat(landing): hreflang, language switcher, and localized copy feedback

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -119,6 +119,7 @@ jobs:
         run: |
           set -e
           test -f merged-dist/index.html          || { echo "❌ Missing landing index.html"; exit 1; }
+          test -f merged-dist/es/index.html       || { echo "❌ Missing landing es/index.html"; exit 1; }
           test -f merged-dist/editor/index.html    || { echo "❌ Missing editor index.html"; exit 1; }
           test -f merged-dist/docs/index.html      || { echo "❌ Missing docs index.html"; exit 1; }
           test -f merged-dist/CNAME                || { echo "❌ Missing CNAME"; exit 1; }

--- a/packages/landing/scripts/build-locales.mjs
+++ b/packages/landing/scripts/build-locales.mjs
@@ -1,8 +1,9 @@
-// Postbuild step: derive localized dist/<locale>/index.html files from Vite's
-// already-built dist/index.html. The English dist/index.html is the source of
-// truth and is NEVER rewritten — its sha256 is snapshotted and re-checked so
-// the build fails loudly if anything touches it. Deterministic and idempotent.
-import { createHash } from "node:crypto";
+// Postbuild step: post-process Vite's built dist/index.html into two localized
+// outputs. The English dist/index.html is rewritten IN PLACE to add SEO
+// hreflang/canonical-alternate links plus a language switcher, but its visible
+// English copy is asserted unchanged (only head <link>s and the switcher <a>s
+// are added). dist/es/index.html additionally text-swaps every translatable
+// string to Spanish. Deterministic and idempotent.
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,7 +16,26 @@ const DIST = resolve(landingRoot, "dist");
 const EN_HTML = resolve(DIST, "index.html");
 const I18N = resolve(landingRoot, "i18n");
 
-const sha256 = (buffer) => createHash("sha256").update(buffer).digest("hex");
+// Language-switcher config per output page. `label` is the *target* language's
+// endonym (shown in the target language by convention); `href` points at the
+// other locale's document; `aria` localizes the control for the current page.
+const SWITCH = {
+  en: { href: "/es/", label: "Español", lang: "es", aria: "Cambiar idioma" },
+  es: { href: "/", label: "English", lang: "en", aria: "Switch language" },
+};
+
+// querySelector anchors that survive the Vite build byte-for-byte. The first
+// "/editor/" link is the desktop-nav CTA; the npm link is unique to the footer.
+const HEADER_ANCHOR = 'a[href="/editor/"]';
+const FOOTER_ANCHOR = 'a[href="https://www.npmjs.com/org/kaiord"]';
+
+// Reuse the exact utility classes already present on neighbouring nav/footer
+// links so Tailwind (which generates CSS at Vite build time, before this script
+// runs) has already emitted them and the switcher inherits real styling.
+const HEADER_CLASS =
+  "text-[var(--brand-text-secondary)] transition-colors hover:text-[var(--brand-text-primary)]";
+const FOOTER_CLASS =
+  "transition-colors hover:text-[var(--brand-text-secondary)] focus-visible:outline-2 focus-visible:outline-[var(--brand-accent-blue)]";
 
 const setAttr = (root, selector, attr, value) => {
   const el = root.querySelector(selector);
@@ -47,22 +67,84 @@ const rewriteHead = (root, meta) => {
   );
 };
 
-const buildLocale = (locale, meta, translations) => {
-  const root = parseHtml(readFileSync(EN_HTML, "utf8"));
-  walkTranslatable(root, ({ value, apply }) => {
-    const next = translations[value];
-    if (typeof next === "string" && next.length > 0) apply(next);
-  });
-  rewriteHead(root, meta);
-  const outDir = resolve(DIST, locale);
-  mkdirSync(outDir, { recursive: true });
-  const outFile = resolve(outDir, "index.html");
-  writeFileSync(outFile, root.toString(), "utf8");
-  return outFile;
+// The hreflang/canonical-alternate block is identical on both pages. Absolute
+// URLs derive from the canonical already present in the built head so the origin
+// stays a single source of truth. Inserted right before </head>.
+const injectHreflang = (root) => {
+  const canonical = root.querySelector('link[rel="canonical"]');
+  if (!canonical)
+    throw new Error("build-locales: missing <link rel=canonical>");
+  const origin = new URL(canonical.getAttribute("href")).origin;
+  const links = [
+    `<link rel="alternate" hreflang="en" href="${origin}/" />`,
+    `<link rel="alternate" hreflang="es" href="${origin}/es/" />`,
+    `<link rel="alternate" hreflang="x-default" href="${origin}/" />`,
+  ].join("\n    ");
+  const head = root.querySelector("head");
+  head.insertAdjacentHTML("beforeend", `\n    ${links}\n  `);
 };
 
-const assertNoResidualEnglish = (outFile, inventory, translations) => {
-  const root = parseHtml(readFileSync(outFile, "utf8"));
+// A single unobtrusive <a> is inserted additively at two stable anchors (desktop
+// header nav + footer links); the existing markup is never restructured.
+const switchAnchor = (sw, className) =>
+  `<a href="${sw.href}" lang="${sw.lang}" data-testid="lang-switch" ` +
+  `aria-label="${sw.aria}" class="${className}">${sw.label}</a>`;
+
+const injectSwitchers = (root, sw) => {
+  const header = root.querySelector(HEADER_ANCHOR);
+  if (!header)
+    throw new Error(`build-locales: no header anchor ${HEADER_ANCHOR}`);
+  header.insertAdjacentHTML("beforebegin", switchAnchor(sw, HEADER_CLASS));
+  const footer = root.querySelector(FOOTER_ANCHOR);
+  if (!footer)
+    throw new Error(`build-locales: no footer anchor ${FOOTER_ANCHOR}`);
+  footer.insertAdjacentHTML("afterend", switchAnchor(sw, FOOTER_CLASS));
+};
+
+// Every translatable text node / attribute value on a parsed page, in document
+// order (a multiset — repeats are significant for the unchanged-copy check).
+const collectText = (root) => {
+  const values = [];
+  walkTranslatable(root, ({ value }) => values.push(value));
+  return values;
+};
+
+// Multiset difference: items of `a` not accounted for by `b`.
+const multisetDiff = (a, b) => {
+  const counts = new Map();
+  for (const v of b) counts.set(v, (counts.get(v) ?? 0) + 1);
+  const extra = [];
+  for (const v of a) {
+    const c = counts.get(v) ?? 0;
+    if (c > 0) counts.set(v, c - 1);
+    else extra.push(v);
+  }
+  return extra;
+};
+
+// Replaces the old byte-identical sha256 assertion: the English page now changes
+// on purpose, so instead we prove no visible English copy was altered — every
+// pre-injection text node still present, and the only additions are the
+// switcher's own label + aria-label.
+const assertEnglishCopyUnchanged = (before, after, sw) => {
+  const removed = multisetDiff(before, after);
+  const added = multisetDiff(after, before);
+  const allowed = new Set([sw.label, sw.aria]);
+  const unexpected = added.filter((v) => !allowed.has(v));
+  if (removed.length > 0 || unexpected.length > 0) {
+    console.error("build-locales: en visible copy changed", {
+      removed,
+      unexpected,
+    });
+    process.exit(1);
+  }
+  console.log(
+    `build-locales: en visible copy unchanged (${before.length} translatable nodes); ` +
+      `added only switcher strings [${[...allowed].join(", ")}]`
+  );
+};
+
+const assertNoResidualEnglish = (root, outFile, inventory, translations) => {
   const known = new Set(inventory);
   const residual = new Set();
   walkTranslatable(root, ({ value }) => {
@@ -77,30 +159,48 @@ const assertNoResidualEnglish = (outFile, inventory, translations) => {
   }
 };
 
-const main = () => {
-  const shaBefore = sha256(readFileSync(EN_HTML));
-  console.log(`build-locales: en dist/index.html sha256=${shaBefore}`);
+const buildEnglish = (rawHtml) => {
+  const root = parseHtml(rawHtml);
+  const before = collectText(root);
+  injectHreflang(root);
+  injectSwitchers(root, SWITCH.en);
+  assertEnglishCopyUnchanged(before, collectText(root), SWITCH.en);
+  writeFileSync(EN_HTML, root.toString(), "utf8");
+  return EN_HTML;
+};
 
+const buildSpanish = (rawHtml, meta, translations, inventory) => {
+  const root = parseHtml(rawHtml);
+  walkTranslatable(root, ({ value, apply }) => {
+    const next = translations[value];
+    if (typeof next === "string" && next.length > 0) apply(next);
+  });
+  rewriteHead(root, meta);
+  const outDir = resolve(DIST, "es");
+  mkdirSync(outDir, { recursive: true });
+  const outFile = resolve(outDir, "index.html");
+  // Residual-English check runs on the translated body *before* the switcher
+  // (whose label is intentionally the English endonym) is added.
+  assertNoResidualEnglish(root, outFile, inventory, translations);
+  injectHreflang(root);
+  injectSwitchers(root, SWITCH.es);
+  writeFileSync(outFile, root.toString(), "utf8");
+  return outFile;
+};
+
+const main = () => {
+  const rawHtml = readFileSync(EN_HTML, "utf8");
   const inventory = JSON.parse(
     readFileSync(resolve(I18N, "en-strings.json"), "utf8")
   );
   const meta = JSON.parse(readFileSync(resolve(I18N, "meta.json"), "utf8"));
   const es = JSON.parse(readFileSync(resolve(I18N, "es.json"), "utf8"));
 
-  const outFile = buildLocale("es", meta.es, es);
-  console.log(`build-locales: wrote ${outFile}`);
-  assertNoResidualEnglish(outFile, inventory, es);
+  const enFile = buildEnglish(rawHtml);
+  console.log(`build-locales: wrote ${enFile} (en + hreflang + switcher)`);
 
-  const shaAfter = sha256(readFileSync(EN_HTML));
-  if (shaAfter !== shaBefore) {
-    console.error(
-      `build-locales: en dist/index.html changed ${shaBefore} -> ${shaAfter}`
-    );
-    process.exit(1);
-  }
-  console.log(
-    `build-locales: en dist/index.html sha256 unchanged (${shaAfter}).`
-  );
+  const esFile = buildSpanish(rawHtml, meta.es, es, inventory);
+  console.log(`build-locales: wrote ${esFile} (es + hreflang + switcher)`);
 };
 
 main();

--- a/packages/landing/src/install-widget.ts
+++ b/packages/landing/src/install-widget.ts
@@ -59,7 +59,9 @@ function wireCopy(root: Root, cmdEl: HTMLElement | null): void {
   btn?.addEventListener("click", async () => {
     try {
       await navigator.clipboard.writeText(cmdEl?.textContent ?? "");
-      if (feedback) feedback.textContent = "Copied!";
+      if (feedback)
+        feedback.textContent =
+          document.documentElement.lang === "es" ? "¡Copiado!" : "Copied!";
       copyIcon?.classList.add("hidden");
       checkIcon?.classList.remove("hidden");
       setTimeout(() => {


### PR DESCRIPTION
## What

Completes the bilingual landing: cross-links the English and Spanish pages for SEO and lets visitors switch languages. Builds on #911 (which shipped `/es/`).

## Notes

- `build-locales.mjs` now post-processes **both** outputs from Vite's built HTML: injects the same hreflang set (`en` / `es` / `x-default`) before `</head>`, and a language switcher (`data-testid="lang-switch"`) into the header + footer of each page — the English page links to `/es/` ("Español"), the Spanish page to `/` ("English"). English canonical stays `/`, Spanish `/es/`.
- This **intentionally re-baselines** the English output (#911 left it untouched). The strict byte-identical assertion is replaced by a **visible-copy-unchanged** guarantee: the build verifies the English page's translatable text nodes still equal the inventory and that only head `<link>`s + the switcher `<a>` were added (logged: `en visible copy unchanged (209 translatable nodes)`).
- `install-widget` "Copied!" is now locale-aware ("¡Copiado!" under `lang="es"`).
- Deploy verifies `dist/es/index.html` exists (one line).

## Verification

- `pnpm build` ✅ — both outputs have **3 hreflang links + a lang-switch in header & footer**; `<html lang="en">` / `<html lang="es">`.
- landing tests **12/12** ✅ · `tsc --noEmit` ✅ · prettier ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)