### PR TITLE
refactor(landing): reduce to minimal code

### DIFF
--- a/packages/landing/src/setup-analytics.ts
+++ b/packages/landing/src/setup-analytics.ts
@@ -1,25 +1,17 @@
 import { analytics } from "./analytics";
 
+function trackClicks(selector: string, event: string): void {
+  document
+    .querySelectorAll<HTMLAnchorElement>(selector)
+    .forEach((a) => a.addEventListener("click", () => analytics.event(event)));
+}
+
 export function setupAnalytics() {
   analytics.pageView(window.location.pathname);
-
-  document
-    .querySelectorAll<HTMLAnchorElement>('a[href="/editor/"]')
-    .forEach((a) => {
-      a.addEventListener("click", () => analytics.event("editor-opened"));
-    });
-
-  document
-    .querySelectorAll<HTMLAnchorElement>(
-      'a[href^="https://github.com/pablo-albaladejo/kaiord"]'
-    )
-    .forEach((a) => {
-      a.addEventListener("click", () => analytics.event("github-opened"));
-    });
-
-  document
-    .querySelectorAll<HTMLAnchorElement>('a[href="/docs/"]')
-    .forEach((a) => {
-      a.addEventListener("click", () => analytics.event("docs-opened"));
-    });
+  trackClicks('a[href="/editor/"]', "editor-opened");
+  trackClicks(
+    'a[href^="https://github.com/pablo-albaladejo/kaiord"]',
+    "github-opened"
+  );
+  trackClicks('a[href="/docs/"]', "docs-opened");
 }


### PR DESCRIPTION
Automated nightly code-reduction of @kaiord/landing (rotation). Local gate passed: build green, landing coverage >= baseline (base[87.67 52.63 85 88.75] now[87.67 52.63 85 88.75]), lint clean. The watcher will fix any CI findings and merge on green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved analytics tracking for editor, GitHub, and documentation link clicks.
  * Continued recording page views for each page visited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->