### PR TITLE
fix(spa-editor): coaching auto-sync skips the week when bridge detection races state

### DIFF
--- a/.changeset/coaching-autosync-source-race.md
+++ b/.changeset/coaching-autosync-source-race.md
@@ -1,0 +1,9 @@
+---
+"@kaiord/workout-spa-editor": patch
+---
+
+Fix a race in the coaching auto-sync hook: when bridge detection resolved
+after profile/week state settled, the first effect run saw zero sync sources
+and stamped the fired-week key anyway, permanently skipping that week's
+auto-sync. The key is now only stamped once real targets exist, so the re-run
+triggered by the source list populating fires the sync as intended.

--- a/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync.test.tsx
@@ -150,6 +150,31 @@ describe("useCoachingAutoSync", () => {
     expect(src.sync).not.toHaveBeenCalled();
   });
 
+  it("should fire sync when sources populate after an initial empty-sources run", async () => {
+    // Arrange
+    // Bridge detection lands AFTER profile/week settle: the first effect
+    // run sees zero sources and must not burn the week key.
+    const src = makeSource();
+    const { rerender } = renderHook(
+      ({ sources }: { sources: CoachingSyncState[] }) =>
+        useCoachingAutoSync(sources, "2026-04-13"),
+      {
+        initialProps: { sources: [] as CoachingSyncState[] },
+        wrapper: ({ children }) => wrap(children),
+      }
+    );
+    await new Promise((r) => setTimeout(r, NO_FIRE_SETTLE_MS));
+
+    // Act
+    // The bridge announces itself and the source list re-emits.
+    rerender({ sources: [src] });
+
+    // Assert
+    await waitFor(() => {
+      expect(src.sync).toHaveBeenCalledWith("2026-04-13");
+    });
+  });
+
   it("should invalidate staleness on profile switch — A's fresh row does NOT suppress sync for B", async () => {
     // Arrange
     const persistence = createInMemoryPersistence();

--- a/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync.ts
+++ b/packages/workout-spa-editor/src/hooks/use-coaching-auto-sync.ts
@@ -40,15 +40,20 @@ export const useCoachingAutoSync = (
     const now = Date.now();
     const key = `${activeProfileId}:${weekStart}`;
     if (lastFiredKey.current === key) return;
-    const trigger =
-      lastFiredKey.current === null ? "auto-mount" : "auto-week-change";
-    lastFiredKey.current = key;
 
     const linkedSourceIds = new Set(
       profile.linkedAccounts.map((a) => a.source)
     );
     const targets = syncSources.filter((s) => linkedSourceIds.has(s.id));
+    // Bridge detection can resolve AFTER profile/week state settles, so an
+    // empty-sources run must not stamp the fired key — otherwise the re-run
+    // that arrives with real sources hits the key guard and this week's
+    // auto-sync is permanently skipped.
     if (targets.length === 0) return;
+
+    const trigger =
+      lastFiredKey.current === null ? "auto-mount" : "auto-week-change";
+    lastFiredKey.current = key;
 
     void (async () => {
       const outcomes: { source: string; outcome: SourceSyncOutcome }[] = [];


### PR DESCRIPTION
## Summary

Root cause of the `e2e-frontend (4)` failures on PR #919's final round and on main's post-merge run (`zones-sync.spec.ts:192`, read-week never issued):

`useCoachingAutoSync` stamped `lastFiredKey` **before** checking whether any sync targets exist. When bridge detection resolves after profile/week state settles — which slower CI runners now hit consistently — the first effect run sees zero sources, stamps the week key anyway, and the re-run that arrives with real sources bails on the key guard. `syncWeek` never fires for that week. The light-theme merge only perturbed mount timing enough to flip this latent race; the bug predates it.

Fix: stamp the key only once targets exist, so the source-list re-emit fires the sync. Regression unit test covers the late-populating source list.

## Verification

- `use-coaching-auto-sync` unit tests: 15/15 (new regression test fails on the old code)
- `zones-sync.spec.ts` e2e (chromium): 7/7 locally on this branch
- Repo lint + typecheck via pre-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed coaching auto-sync so synchronization still runs when sources become available after initial loading.
  * Prevented weeks from being incorrectly marked as completed when no sync targets were available.

* **Tests**
  * Added coverage for delayed source availability during coaching auto-sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->