### PR TITLE
chore: untrack accidentally committed node_modules symlinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 # Dependencies
+# Match both directories and symlinks named node_modules: a trailing-slash
+# pattern ignores only directories, so a node_modules SYMLINK (e.g. one that
+# leaks in from a sibling worktree via `git add -A`) would slip past it.
+node_modules
 node_modules/
 
 # Build outputs

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/pablo/development/kaiord.worktrees/main/node_modules

--- a/packages/landing/node_modules
+++ b/packages/landing/node_modules
@@ -1,1 +1,0 @@
-/Users/pablo/development/kaiord.worktrees/main/packages/landing/node_modules


### PR DESCRIPTION
## Summary

**Cleanup of a regression introduced by PR #933.** That hotfix was built in a throwaway worktree whose `node_modules` were symlinked to main's to reuse the install. `git add -A` staged those symlinks — the repo's `.gitignore` uses `node_modules/` (trailing slash), which only matches **directories**, not a **symlink** named node_modules — so two symlink blobs landed in the merged tree:

```
node_modules                  -> /Users/.../kaiord.worktrees/main/node_modules
packages/landing/node_modules -> /Users/.../kaiord.worktrees/main/packages/landing/node_modules
```

The committed target is an **absolute path that resolves to the path itself** once checked out in `main`, so `pnpm install` there fails with `ELOOP: too many symbolic links`. CI never caught it: on the runner that absolute path does not exist, so the symlink is merely dangling and pnpm overwrites it — every check on #933 passed green.

## Fix

- `git rm --cached` both symlinks (they are not real dependencies; the actual `node_modules` is the pnpm-managed, ignored directory).
- Broaden the ignore rule: add a slash-less `node_modules` entry so a symlink named node_modules is ignored too, preventing recurrence.

## Verification

- `git ls-files | grep node_modules` → empty after the change (was 2 entries).
- `git check-ignore node_modules` → matched (was un-ignored for the symlink form).
- `pnpm install` in `main` completes cleanly (4.1s) once the self-referential symlinks are gone.
- Local `pnpm lint` / pre-push green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version-control exclusions to ignore dependency directories.
  * Removed tracked dependency directory references from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->