### PR TITLE
test(spa-editor): reach Library via BottomNav in mobile e2e nav helper

### DIFF
--- a/packages/workout-spa-editor/e2e/helpers/mobile-menu.ts
+++ b/packages/workout-spa-editor/e2e/helpers/mobile-menu.ts
@@ -16,14 +16,21 @@ export async function openMobileMenuIfNeeded(page: Page): Promise<void> {
 }
 
 /**
- * Opens a header nav action, handling the hamburger menu on mobile.
+ * Opens a header nav action, resilient to the responsive nav surfaces.
  *
- * On desktop: the button is directly visible, just click it.
- * On mobile: open the hamburger menu first, then click the item.
+ * - Desktop: the header button is directly visible — click it.
+ * - Legacy hamburger surfaces: open the "Menu" panel, then click the item.
+ * - Mobile (post-redesign): the header entry is hidden below `md` and the
+ *   destination lives in the floating BottomNav, whose tabs use their short
+ *   visible label as the accessible name and ignore the header's aria
+ *   override (see `nav-destinations.ts`). Pass `bottomNavName` (e.g.
+ *   /library/i) so the helper can reach the tab when the header entry is
+ *   hidden.
  */
 export async function openHeaderAction(
   page: Page,
-  actionName: string | RegExp
+  actionName: string | RegExp,
+  bottomNavName?: string | RegExp
 ): Promise<void> {
   // Both DesktopNav and MobileMenuPanel render buttons with the same
   // aria-label. Filter to visible ones to avoid strict mode violations.
@@ -36,7 +43,7 @@ export async function openHeaderAction(
     return;
   }
 
-  // On mobile, open the hamburger menu first
+  // Legacy hamburger surface, if one is still mounted.
   const menuButton = page.getByLabel("Menu");
   if (await menuButton.isVisible().catch(() => false)) {
     await menuButton.click();
@@ -47,5 +54,14 @@ export async function openHeaderAction(
       .first();
     await menuItem.waitFor({ state: "visible" });
     await menuItem.click();
+    return;
+  }
+
+  // Mobile: the header entry is hidden; reach the destination via BottomNav.
+  if (bottomNavName) {
+    await page
+      .getByTestId("bottom-nav")
+      .getByRole("button", { name: bottomNavName })
+      .click();
   }
 }

--- a/packages/workout-spa-editor/e2e/library-calendar.spec.ts
+++ b/packages/workout-spa-editor/e2e/library-calendar.spec.ts
@@ -103,7 +103,7 @@ test.describe("Library-Calendar Integration", () => {
 
     // Per surface-classification rule, Library is a routed page —
     // the header click navigates, it does not open a modal.
-    await openHeaderAction(page, /open workout library/i);
+    await openHeaderAction(page, /open workout library/i, /library/i);
     await page.waitForURL(/\/library$/);
 
     await expect(page.getByTestId("library-page")).toBeVisible();

--- a/packages/workout-spa-editor/e2e/library-flows.spec.ts
+++ b/packages/workout-spa-editor/e2e/library-flows.spec.ts
@@ -43,7 +43,7 @@ test.describe("Library flows", () => {
 
     // Use the mobile-aware helper so the test works on mobile
     // emulators where the Library button lives behind the hamburger menu.
-    await openHeaderAction(page, /open workout library/i);
+    await openHeaderAction(page, /open workout library/i, /library/i);
     await page.waitForURL(/\/library$/);
 
     await expect(page.getByTestId("library-page")).toBeVisible();
@@ -151,7 +151,7 @@ test.describe("Library flows", () => {
     // state survives the route transition. `page.goto('/library')`
     // would force a full reload and drop Zustand. The mobile-aware
     // helper opens the hamburger menu first on small viewports.
-    await openHeaderAction(page, /open workout library/i);
+    await openHeaderAction(page, /open workout library/i, /library/i);
     await page.waitForURL(/\/library$/);
     await expect(page.getByTestId("library-page")).toBeVisible();
 

--- a/packages/workout-spa-editor/e2e/workout-library.spec.ts
+++ b/packages/workout-spa-editor/e2e/workout-library.spec.ts
@@ -100,7 +100,7 @@ test.describe("Workout Library", () => {
       // the Zustand current-workout state, hiding the CTA). The
       // mobile-aware helper opens the hamburger menu first on small
       // viewports (Pixel 5 / iPhone 12 in Playwright).
-      await openHeaderAction(page, /open workout library/i);
+      await openHeaderAction(page, /open workout library/i, /library/i);
       await page.waitForURL(/\/library$/);
       await expect(page.getByTestId("library-page")).toBeVisible();
 


### PR DESCRIPTION
## Problem

The **"Workout SPA Editor E2E Tests"** mobile matrix has been red on `main` since the nav redesign (6+ consecutive failures). Four Library-navigation tests time out on `page.waitForURL` under **Mobile Chrome**:

- `e2e/library-calendar.spec.ts:99`
- `e2e/library-flows.spec.ts:38` (Test A)
- `e2e/library-flows.spec.ts:137` (Test C)
- `e2e/workout-library.spec.ts:83`

It runs only on push to `main` (not on PRs), so PR CI stays green while the post-merge run is red.

## Root cause — the e2e helper, not the product

`openHeaderAction` (`e2e/helpers/mobile-menu.ts`) tried a visible header button, then fell back to a `"Menu"` **hamburger that the redesign removed**. Below `md`, the header Library entry is hidden and the destination lives in the floating **BottomNav**, whose tabs use their short visible label (`"Library"`) as the accessible name and **intentionally ignore** the header's aria override (`"Open workout library"`) — documented in `nav-destinations.ts`. So on mobile the helper matched neither the header button (hidden) nor a hamburger (gone) and **silently no-oped** → no navigation → 60s timeout.

The product is correct by design: mobile users reach Library via the BottomNav, as `Test D` already asserts.

## Fix (test-only)

Add an optional `bottomNavName` to `openHeaderAction` and pass `/library/i` from the four Library call sites, so the helper reaches the BottomNav tab when the header entry is hidden. No product change.

## Verification (local)

| Project | Result |
|---|---|
| **Mobile Chrome** (was failing) | ✅ 23/23 (the 4 target tests now pass) |
| Desktop chromium | ✅ 23/23 (no regression) |
| Mobile Safari | ✅ 4 target tests pass; one unrelated `page.goto` vite-dev module-load flake is retry-covered |

Husky pre-commit (scripts tests + monorepo incremental type check) passed. No changeset needed — the change touches only `packages/workout-spa-editor/e2e/**` (private, non-publishable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved responsive navigation test coverage for accessing the Workout Library through mobile bottom navigation.
  * Added destination checks confirming navigation reaches `/library`.
  * Continued validating that Library opens without an unexpected modal and that workout templates can be loaded successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->