### PR TITLE
refactor(garmin): reduce to minimal code

### DIFF
--- a/packages/garmin/src/adapters/schemas/common/index.ts
+++ b/packages/garmin/src/adapters/schemas/common/index.ts
@@ -27,7 +27,6 @@ export {
   targetTypeKeySchema,
 } from "./target-type.schema";
 export {
-  type GarminUnit,
   garminUnitInputSchema,
   garminUnitSchema,
   unitKeySchema,

--- a/packages/garmin/src/adapters/schemas/common/unit.schema.ts
+++ b/packages/garmin/src/adapters/schemas/common/unit.schema.ts
@@ -15,5 +15,3 @@ export const garminUnitInputSchema = z.object({
   unitKey: unitKeySchema,
   factor: z.number().positive().nullable().optional(),
 });
-
-export type GarminUnit = z.infer<typeof garminUnitSchema>;

--- a/packages/garmin/src/adapters/schemas/input/repeat-input.schema.ts
+++ b/packages/garmin/src/adapters/schemas/input/repeat-input.schema.ts
@@ -2,33 +2,23 @@ import { z } from "zod";
 
 import { garminConditionTypeSchema, garminStepTypeSchema } from "../common";
 import { executableStepDTOInputSchema } from "./step-input.schema";
-import type { GarminWorkoutStepInput } from "./types";
+import type { GarminWorkoutStepInput, RepeatGroupDTOInputType } from "./types";
 
-export const repeatGroupDTOInputSchema: z.ZodType<{
-  type: "RepeatGroupDTO";
-  stepOrder: number;
-  stepType: z.infer<typeof garminStepTypeSchema>;
-  numberOfIterations: number;
-  smartRepeat?: boolean;
-  endCondition: z.infer<typeof garminConditionTypeSchema>;
-  endConditionValue: number;
-  workoutSteps: GarminWorkoutStepInput[];
-  childStepId?: number | null;
-  description?: string;
-}> = z.lazy(() =>
-  z.object({
-    type: z.literal("RepeatGroupDTO"),
-    stepOrder: z.number().int().positive(),
-    stepType: garminStepTypeSchema,
-    numberOfIterations: z.number().int().positive().min(1).max(99),
-    smartRepeat: z.boolean().optional(),
-    endCondition: garminConditionTypeSchema,
-    endConditionValue: z.number(),
-    workoutSteps: z.array(garminWorkoutStepInputSchema).min(1),
-    childStepId: z.number().int().positive().nullable().optional(),
-    description: z.string().max(500).optional(),
-  })
-);
+export const repeatGroupDTOInputSchema: z.ZodType<RepeatGroupDTOInputType> =
+  z.lazy(() =>
+    z.object({
+      type: z.literal("RepeatGroupDTO"),
+      stepOrder: z.number().int().positive(),
+      stepType: garminStepTypeSchema,
+      numberOfIterations: z.number().int().positive().min(1).max(99),
+      smartRepeat: z.boolean().optional(),
+      endCondition: garminConditionTypeSchema,
+      endConditionValue: z.number(),
+      workoutSteps: z.array(garminWorkoutStepInputSchema).min(1),
+      childStepId: z.number().int().positive().nullable().optional(),
+      description: z.string().max(500).optional(),
+    })
+  );
 
 export const garminWorkoutStepInputSchema: z.ZodType<GarminWorkoutStepInput> =
   z.lazy(() =>


### PR DESCRIPTION
Automated nightly code-reduction of @kaiord/garmin (rotation). Local gate passed: build green, garmin coverage >= baseline (base[96.39 91.52 94.11 96.55] now[96.39 91.52 94.11 96.55]), lint clean. The watcher will fix any CI findings and merge on green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal schema type definitions while preserving existing validation behavior.
  * Centralized repeat-group input typing for improved consistency and maintainability.
  * Removed an unused public type export; unit schema validation remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->