### PR TITLE
refactor(garmin-connect): reduce to minimal code

### DIFF
--- a/packages/garmin-connect/src/adapters/http/retry.ts
+++ b/packages/garmin-connect/src/adapters/http/retry.ts
@@ -16,11 +16,7 @@ export type RetryOptions = {
   logger?: Logger;
 };
 
-type ResolvedOptions = {
-  maxRetries: number;
-  baseDelay: number;
-  maxDelay: number;
-  randomFn: () => number;
+type ResolvedOptions = Required<Omit<RetryOptions, "logger">> & {
   logger?: Logger;
 };
 


### PR DESCRIPTION
Automated nightly code-reduction of @kaiord/garmin-connect (rotation). Local gate passed: build green, garmin-connect coverage >= baseline (base[99.18 89.7 97.46 98.72] now[99.18 89.7 97.46 98.72]), lint clean. The watcher will fix any CI findings and merge on green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal type definitions for retry handling without changing observable behavior or the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->