### PR TITLE
refactor(mcp): reduce to minimal code

### DIFF
--- a/.changeset/mcp-code-reduction.md
+++ b/.changeset/mcp-code-reduction.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/mcp": patch
+---
+
+Internal code reduction, no behavior change.

--- a/packages/mcp/src/tools/health/derive-recovery-status.ts
+++ b/packages/mcp/src/tools/health/derive-recovery-status.ts
@@ -1,9 +1,7 @@
 import type { HrvSummary, SleepRecord } from "@kaiord/core";
 
-export type RecoveryStatus = "ready" | "moderate" | "fatigued" | "unknown";
-
 export type RecoveryResult = {
-  status: RecoveryStatus;
+  status: "ready" | "moderate" | "fatigued" | "unknown";
   reason: string;
 };
 


### PR DESCRIPTION
Automated nightly code-reduction of @kaiord/mcp (rotation). Local gate passed: build green, mcp coverage >= baseline (base[94.13 86.97 90.15 93.87] now[94.13 86.97 90.15 93.87]), lint clean. The watcher will fix any CI findings and merge on green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal recovery-status type definitions without changing behavior.
  * Recovery results continue to use the same statuses: ready, moderate, fatigued, and unknown.

* **Release**
  * Included as a patch update with no user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->