### PR TITLE
chore(mcp): sync server.json version to released 10.0.0

### DIFF
--- a/.changeset/mcp-server-json-registry-sync.md
+++ b/.changeset/mcp-server-json-registry-sync.md
@@ -1,0 +1,6 @@
+---
+"@kaiord/mcp": patch
+---
+
+Sync `server.json` with the released 10.0.0 version and shorten its
+description to the MCP registry 100-character limit.

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -7,12 +7,12 @@
     "source": "github"
   },
   "websiteUrl": "https://kaiord.com/docs/mcp/tools",
-  "version": "9.2.1",
+  "version": "10.0.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@kaiord/mcp",
-      "version": "9.2.1",
+      "version": "10.0.0",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.pablo-albaladejo/kaiord",
-  "description": "Convert, validate, and inspect workout files (FIT, TCX, ZWO, Garmin Connect, KRD) for AI agents. Round-trip-safe conversions through the KRD canonical format.",
+  "description": "Convert, validate, and inspect workout files (FIT, TCX, ZWO, Garmin Connect) for AI agents.",
   "repository": {
     "url": "https://github.com/pablo-albaladejo/kaiord",
     "source": "github"


### PR DESCRIPTION
The linked changesets release shipped as **10.0.0** (major from the WHOOP internal-API rewrite), not the 9.2.1 patch `server.json` anticipated when it was added in #956. The MCP registry validates that `server.json`'s package version matches the published npm version, so both version fields move to 10.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the MCP package and server version to 10.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->