### PR TITLE
chore: drop Node 20 runtime warnings + make action pins self-maintaining

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,13 +18,16 @@ updates:
       - "dependencies"
       - "automated"
 
-  # GitHub Actions
+  # GitHub Actions (workflows + composite actions, which "/" alone does not scan)
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/setup-pnpm"
+      - "/.github/actions/consume-build-artifacts"
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 10
     reviewers:
       - "pablo-albaladejo"
     labels:

--- a/.github/workflows/cws-publish.yml
+++ b/.github/workflows/cws-publish.yml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Upload decision artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cws-decision-${{ matrix.extension.name }}
           path: ${{ runner.temp }}/decision/


### PR DESCRIPTION
Long-term fix for the 'Node.js 20 is deprecated' warnings:

1. **`upload-artifact` v4 → v7** in `cws-publish.yml` — the last node20-runtime action in the repo, matching the v7 pin already used in `ci.yml`/`eval.yml` (artifact format compatible with the `download-artifact@v8` consumer).
2. **Dependabot now scans composite actions**: `directory: "/"` only covers `.github/workflows`, so pins inside `.github/actions/*` (setup-pnpm, consume-build-artifacts) were invisible to it. Switched to `directories` including both.
3. **`open-pull-requests-limit` 3 → 10** for github-actions so bumps don't queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated artifact handling in automated publishing workflows.
  * Expanded automated dependency update coverage to include additional local actions.
  * Increased the maximum number of simultaneously open dependency update pull requests.
  * Maintained the existing weekly update schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->