### PR TITLE
feat(docs-site): long-tail converter pages (wave 1)

### DIFF
--- a/.changeset/docs-convert-pages.md
+++ b/.changeset/docs-convert-pages.md
@@ -1,0 +1,10 @@
+---
+"@kaiord/docs": patch
+"@kaiord/landing": patch
+---
+
+Add a "Convert" section to the docs site with a hub and six long-tail
+"how to convert X to Y" pages (FIT↔ZWO, FIT↔TCX, ZWO↔Garmin). Each page
+covers the Editor, CLI, and SDK paths plus a grounded "what survives the
+conversion" table and per-pair gotchas. Link the hub from the sidebar, top
+nav, and the landing `llms.txt`.

--- a/lychee.toml
+++ b/lychee.toml
@@ -52,6 +52,7 @@ exclude_path = [
   "packages/docs/guide",
   "packages/docs/formats",
   "packages/docs/cli",
+  "packages/docs/convert",
   "packages/docs/mcp",
   "packages/docs/legal",
   "packages/docs/index.md",

--- a/packages/docs/.cspell.json
+++ b/packages/docs/.cspell.json
@@ -63,7 +63,9 @@
     "affordances",
     "frontmatter",
     "openspec",
-    "CCPA"
+    "CCPA",
+    "Strava",
+    "untargeted"
   ],
   "ignorePaths": ["api/**", "node_modules/**", ".vitepress/**", "CHANGELOG.md"]
 }

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -120,6 +120,7 @@ const config = {
 
     nav: [
       { text: "Quick Start", link: "/guide/quick-start" },
+      { text: "Convert", link: "/convert/" },
       { text: "Formats", link: "/formats/krd" },
       { text: "API Reference", link: "/api/" },
     ],
@@ -140,6 +141,19 @@ const config = {
           { text: "Architecture", link: "/guide/architecture" },
           { text: "Testing", link: "/guide/testing" },
           { text: "Contributing", link: "/guide/contributing" },
+        ],
+      },
+      {
+        text: "Convert",
+        collapsed: false,
+        items: [
+          { text: "All converters", link: "/convert/" },
+          { text: "FIT to ZWO", link: "/convert/fit-to-zwo" },
+          { text: "ZWO to FIT", link: "/convert/zwo-to-fit" },
+          { text: "FIT to TCX", link: "/convert/fit-to-tcx" },
+          { text: "TCX to FIT", link: "/convert/tcx-to-fit" },
+          { text: "ZWO to Garmin", link: "/convert/zwo-to-garmin" },
+          { text: "Garmin to ZWO", link: "/convert/garmin-to-zwo" },
         ],
       },
       {

--- a/packages/docs/convert/fit-to-tcx.md
+++ b/packages/docs/convert/fit-to-tcx.md
@@ -1,0 +1,77 @@
+---
+title: "Convert FIT to TCX"
+description: "Convert a Garmin FIT workout to a TCX (Training Center XML) file — free and in-browser, or via the Kaiord CLI and TypeScript SDK. See what survives the conversion."
+---
+
+# Convert FIT to TCX
+
+Turn a **Garmin FIT** workout into a **TCX** (Training Center XML) file — the
+format most training platforms accept for import. Use the free, in-browser
+[Kaiord Editor](https://kaiord.com/editor/) (no account, no upload), or the
+[CLI](/cli/commands#convert) and [TypeScript SDK](/guide/quick-start).
+Conversions go through Kaiord's canonical [KRD format](/formats/krd) and stay
+within round-trip tolerances (time ±1 s, heart rate ±1 bpm, cadence ±1 rpm).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your `.fit` file,
+choose **TCX** as the export format, and download `workout.tcx`.
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.fit -o workout.tcx
+```
+
+### 3. SDK
+
+```ts
+import { fromBinary, toText } from "@kaiord/core";
+import { fitReader } from "@kaiord/fit";
+import { tcxWriter } from "@kaiord/tcx";
+import { readFile, writeFile } from "node:fs/promises";
+
+const buffer = await readFile("workout.fit");
+const krd = await fromBinary(new Uint8Array(buffer), fitReader);
+const tcx = await toText(krd, tcxWriter);
+await writeFile("workout.tcx", tcx);
+```
+
+## What survives the conversion
+
+| Data                | FIT           | TCX                         | Result                                          |
+| ------------------- | ------------- | --------------------------- | ----------------------------------------------- |
+| Step order & names  | workout steps | `<Step>` / `<Name>`         | Preserved                                       |
+| Time durations      | seconds       | `Time_t` seconds            | Preserved (±1 s)                                |
+| Distance durations  | meters        | `Distance_t` meters         | Preserved                                       |
+| Heart-rate targets  | bpm / zone    | `HeartRate_t` (zone or bpm) | Preserved (±1 bpm)                              |
+| Speed targets       | m/s           | `Speed_t`                   | Preserved                                       |
+| Cadence targets     | rpm           | `Cadence_t`                 | Preserved (±1 rpm)                              |
+| Power targets       | watts / % FTP | —                           | **Dropped** — TCX workouts have no power target |
+| Repeats / intervals | repeat steps  | `Repeat_t`                  | Preserved                                       |
+| Developer fields    | custom fields | —                           | Preserved under `extensions.fit`                |
+
+## Gotchas
+
+**My power targets disappeared.** The TCX workout schema (Garmin Training
+Center) only defines heart-rate, speed, and cadence targets — there is no power
+target. If your FIT workout is power-based, convert it to
+[ZWO](/convert/fit-to-zwo) or Garmin Connect instead, which keep power.
+
+**Workouts vs. activities.** This page is about structured _workouts_ (the
+target plan). TCX can also hold recorded _activity_ data; Kaiord reads and
+writes both, but the field mapping above is for the workout definition.
+
+**Which apps accept TCX?** TrainingPeaks, Strava, and Garmin Connect all import
+TCX, which makes it a good interchange format when a platform can't read FIT
+directly.
+
+## Related
+
+- [Convert TCX to FIT](/convert/tcx-to-fit) — the reverse direction
+- [Convert FIT to ZWO](/convert/fit-to-zwo) — keep power targets
+- [FIT format](/formats/fit) · [TCX format](/formats/tcx)
+- [All converters](/convert/)

--- a/packages/docs/convert/fit-to-zwo.md
+++ b/packages/docs/convert/fit-to-zwo.md
@@ -1,0 +1,85 @@
+---
+title: "Convert FIT to ZWO"
+description: "Convert a Garmin FIT workout to a Zwift ZWO file — free and in-browser, or via the Kaiord CLI and TypeScript SDK. See exactly what survives the conversion."
+---
+
+# Convert FIT to ZWO
+
+Turn a **Garmin FIT** workout into a **Zwift ZWO** file so a structured session
+from your head unit or coach can run in Zwift. The fastest way is the free,
+in-browser [Kaiord Editor](https://kaiord.com/editor/) — no account and no file
+upload. Developers can use the [CLI](/cli/commands#convert) or the
+[TypeScript SDK](/guide/quick-start). Every conversion goes through Kaiord's
+canonical [KRD format](/formats/krd), so values stay within round-trip
+tolerances (time ±1 s, power ±1 W or ±1 % FTP).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your `.fit` file,
+choose **ZWO** as the export format, and download `workout.zwo`. Everything runs
+locally in your browser.
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.fit -o workout.zwo
+```
+
+The format is detected from the file extensions. Add `--input-format fit` if
+your file has a non-standard extension.
+
+### 3. SDK
+
+```ts
+import { fromBinary, toText } from "@kaiord/core";
+import { fitReader } from "@kaiord/fit";
+import { zwiftWriter } from "@kaiord/zwo";
+import { readFile, writeFile } from "node:fs/promises";
+
+const buffer = await readFile("workout.fit");
+const krd = await fromBinary(new Uint8Array(buffer), fitReader);
+const zwo = await toText(krd, zwiftWriter);
+await writeFile("workout.zwo", zwo);
+```
+
+## What survives the conversion
+
+| Data                | FIT                  | ZWO (Zwift)                           | Result                                                                     |
+| ------------------- | -------------------- | ------------------------------------- | -------------------------------------------------------------------------- |
+| Step order & names  | workout steps        | `SteadyState` / `Warmup` / `Cooldown` | Preserved (names kept as `kaiord:` attributes)                             |
+| Time durations      | seconds              | `Duration` seconds                    | Preserved (±1 s)                                                           |
+| Distance durations  | meters               | time-based `Duration`                 | Converted to time; original meters kept in `kaiord:originalDurationMeters` |
+| Power targets       | watts / % FTP / zone | `Power` (fraction of FTP)             | Normalized to % FTP (see FTP note below)                                   |
+| Heart-rate targets  | bpm / zone           | —                                     | Dropped (Zwift is power-based); kept under `extensions.zwift`              |
+| Cadence targets     | rpm                  | limited                               | Preserved under `extensions.zwift`                                         |
+| Repeats / intervals | repeat steps         | `IntervalsT`                          | Preserved                                                                  |
+
+The Kaiord CLI logs a warning for every lossy step (for example
+`Lossy conversion: heart rate target not supported by Zwift`) so you can see
+exactly what changed.
+
+## Gotchas
+
+**Do I need my FTP?** ZWO expresses power as a fraction of FTP. If your FIT
+targets are absolute watts, the conversion maps them to % FTP using a default
+FTP assumption — rescale in Zwift (or the Editor) if the exact watts matter.
+Zone- and %FTP-based FIT targets map across directly.
+
+**My heart-rate targets are gone.** Zwift workouts are power-based and ZWO has
+no native heart-rate target, so HR targets are dropped from the visible workout.
+Kaiord preserves them under `extensions.zwift` so a later ZWO → FIT round-trip
+can restore them.
+
+**My distance intervals became time intervals.** ZWO durations are
+time-based. Distance durations are converted to time and the original distance
+is preserved in `kaiord:originalDurationMeters`.
+
+## Related
+
+- [Convert ZWO to FIT](/convert/zwo-to-fit) — the reverse direction
+- [Convert FIT to TCX](/convert/fit-to-tcx) — a sibling FIT export
+- [FIT format](/formats/fit) · [ZWO format](/formats/zwo)
+- [All converters](/convert/)

--- a/packages/docs/convert/garmin-to-zwo.md
+++ b/packages/docs/convert/garmin-to-zwo.md
@@ -1,0 +1,75 @@
+---
+title: "Convert Garmin to ZWO (Garmin Connect to Zwift)"
+description: "Convert a Garmin Connect workout to a Zwift ZWO file — free and in-browser, or via the Kaiord CLI and TypeScript SDK. See exactly what survives the conversion."
+---
+
+# Convert Garmin to ZWO
+
+Take a **Garmin Connect** workout (GCN JSON) into a **Zwift ZWO** file so a plan
+from Garmin can run in Zwift. Use the free, in-browser
+[Kaiord Editor](https://kaiord.com/editor/) (no account, no upload), or the
+[CLI](/cli/commands#convert) and [TypeScript SDK](/guide/quick-start).
+Conversions go through Kaiord's canonical [KRD format](/formats/krd) and stay
+within round-trip tolerances (time ±1 s, power ±1 W or ±1 % FTP).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your Garmin Connect
+workout file, choose **ZWO** as the export format, and download `workout.zwo`.
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.gcn -o workout.zwo
+```
+
+### 3. SDK
+
+```ts
+import { fromText, toText } from "@kaiord/core";
+import { garminReader } from "@kaiord/garmin";
+import { zwiftWriter } from "@kaiord/zwo";
+import { readFile, writeFile } from "node:fs/promises";
+
+const gcn = await readFile("workout.gcn", "utf-8");
+const krd = await fromText(gcn, garminReader);
+const zwo = await toText(krd, zwiftWriter);
+await writeFile("workout.zwo", zwo);
+```
+
+## What survives the conversion
+
+| Data                | Garmin Connect (GCN)    | ZWO (Zwift)                     | Result                                                        |
+| ------------------- | ----------------------- | ------------------------------- | ------------------------------------------------------------- |
+| Step order & names  | workout steps           | blocks (names as `kaiord:name`) | Preserved                                                     |
+| Time durations      | time durations          | `Duration` seconds              | Preserved (±1 s)                                              |
+| Distance durations  | distance durations      | time-based `Duration`           | Converted to time; original kept under `extensions.zwift`     |
+| Power targets       | watts                   | % FTP (`Power` fraction)        | Converted using an assumed FTP (see below)                    |
+| Repeats / intervals | repeat blocks           | `IntervalsT`                    | Preserved                                                     |
+| Steps without power | open / non-power target | `FreeRide`                      | Rendered as a free-ride segment                               |
+| Heart-rate targets  | bpm                     | —                               | Dropped (Zwift is power-based); kept under `extensions.zwift` |
+
+## Gotchas
+
+**Watts vs. % FTP.** Garmin Connect stores power as watts; Zwift needs % FTP.
+The conversion divides watts by an assumed FTP (recorded as `kaiord:assumedFtp`,
+e.g. 250 W). If the percentages look off, rescale to your own FTP.
+
+**Non-power steps become free rides.** ZWO is power-centric. Garmin steps that
+target heart rate or have no power target become `FreeRide` segments, since
+Zwift has no equivalent structured target for them.
+
+**Where do I get the `.gcn` file?** GCN is Garmin Connect's workout JSON. Fetch
+it through the Garmin Connect API with
+[`@kaiord/garmin-connect`](/formats/gcn#garmin-connect-api) (e.g.
+`kaiord garmin list`) or the Editor's Garmin integration.
+
+## Related
+
+- [Convert ZWO to Garmin](/convert/zwo-to-garmin) — the reverse direction
+- [Convert FIT to ZWO](/convert/fit-to-zwo) — a device-file source
+- [GCN format](/formats/gcn) · [ZWO format](/formats/zwo)
+- [All converters](/convert/)

--- a/packages/docs/convert/index.md
+++ b/packages/docs/convert/index.md
@@ -1,0 +1,64 @@
+---
+title: "Workout file converter — FIT, TCX, ZWO, Garmin"
+description: "Free, in-browser converter for FIT, TCX, ZWO, and Garmin Connect workout files. No account, no upload. Plus a CLI and TypeScript SDK for developers."
+---
+
+# Workout file converter — FIT, TCX, ZWO & Garmin
+
+Convert workout files between **FIT**, **TCX**, **ZWO** (Zwift), and **Garmin
+Connect** formats — free, in your browser, with no account and no file upload.
+Drop a file into the [Kaiord Editor](https://kaiord.com/editor/) and download
+the result. Developers can script the same conversions with the
+[CLI](/cli/commands) or the [TypeScript SDK](/guide/quick-start).
+
+Every conversion goes through **KRD**, Kaiord's canonical format, so round-trips
+stay within tight tolerances (time ±1 s, power ±1 W or ±1 % FTP, heart rate
+±1 bpm, cadence ±1 rpm). See the [KRD format](/formats/krd) for the details.
+
+## Pick a conversion
+
+| From ↓ / To → | FIT                              | TCX                              | ZWO (Zwift)                            | Garmin                                 |
+| ------------- | -------------------------------- | -------------------------------- | -------------------------------------- | -------------------------------------- |
+| **FIT**       | —                                | [FIT → TCX](/convert/fit-to-tcx) | [FIT → ZWO](/convert/fit-to-zwo)       | via CLI/SDK                            |
+| **TCX**       | [TCX → FIT](/convert/tcx-to-fit) | —                                | via CLI/SDK                            | via CLI/SDK                            |
+| **ZWO**       | [ZWO → FIT](/convert/zwo-to-fit) | via CLI/SDK                      | —                                      | [ZWO → Garmin](/convert/zwo-to-garmin) |
+| **Garmin**    | via CLI/SDK                      | via CLI/SDK                      | [Garmin → ZWO](/convert/garmin-to-zwo) | —                                      |
+
+The six pairs above are the guided walkthroughs. Any other direction
+(`fit-to-garmin`, `tcx-to-zwo`, and so on) works today with the same
+[`kaiord convert`](/cli/commands#convert) command and SDK calls — format is
+detected from the file extension.
+
+## Three ways to convert
+
+1. **Editor** — [kaiord.com/editor](https://kaiord.com/editor/). Drag & drop a
+   file, pick the target format, download. Nothing leaves your browser.
+2. **CLI** — `kaiord convert -i workout.fit -o workout.zwo`. Formats are
+   detected from the extensions. See the [CLI reference](/cli/commands#convert).
+3. **SDK** — `@kaiord/core` plus the reader/writer for each format. See the
+   [Quick Start](/guide/quick-start).
+
+## What is lossless?
+
+KRD is designed to be round-trip safe, but the source and target formats are
+not identical — each pair page has a **"What survives the conversion"** table
+and the gotchas that matter for that direction. In short:
+
+- **FIT** is the richest workout format (power, heart rate, cadence, speed, and
+  distance/time durations).
+- **TCX** workout targets are heart rate, speed, and cadence — **not power**.
+- **ZWO** is power-based (% of FTP); heart-rate and cadence targets have no
+  native equivalent.
+- **Garmin Connect (GCN)** covers power, heart rate, speed, and cadence in
+  watts/bpm/rpm, plus calorie durations.
+
+Format-specific data that has no target-side equivalent is preserved under the
+KRD `extensions` object so it can survive a later round-trip.
+
+## Formats
+
+- [FIT](/formats/fit) — Garmin's binary protocol
+- [TCX](/formats/tcx) — Training Center XML
+- [ZWO](/formats/zwo) — Zwift workout XML
+- [GCN](/formats/gcn) — Garmin Connect JSON
+- [KRD](/formats/krd) — Kaiord's canonical format

--- a/packages/docs/convert/tcx-to-fit.md
+++ b/packages/docs/convert/tcx-to-fit.md
@@ -1,0 +1,74 @@
+---
+title: "Convert TCX to FIT"
+description: "Convert a TCX (Training Center XML) workout to a Garmin FIT file — free and in-browser, or via the Kaiord CLI and TypeScript SDK. Push the result to your Garmin."
+---
+
+# Convert TCX to FIT
+
+Turn a **TCX** (Training Center XML) workout into a **Garmin FIT** file so a
+plan exported from another platform can run on your Garmin device. Use the free,
+in-browser [Kaiord Editor](https://kaiord.com/editor/) (no account, no upload),
+or the [CLI](/cli/commands#convert) and [TypeScript SDK](/guide/quick-start).
+Conversions go through Kaiord's canonical [KRD format](/formats/krd) and stay
+within round-trip tolerances (time ±1 s, heart rate ±1 bpm, cadence ±1 rpm).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your `.tcx` file,
+choose **FIT** as the export format, and download `workout.fit`.
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.tcx -o workout.fit
+```
+
+### 3. SDK
+
+```ts
+import { fromText, toBinary } from "@kaiord/core";
+import { tcxReader } from "@kaiord/tcx";
+import { fitWriter } from "@kaiord/fit";
+import { readFile, writeFile } from "node:fs/promises";
+
+const tcx = await readFile("workout.tcx", "utf-8");
+const krd = await fromText(tcx, tcxReader);
+const fit = await toBinary(krd, fitWriter);
+await writeFile("workout.fit", fit);
+```
+
+## What survives the conversion
+
+| Data                | TCX                         | FIT           | Result             |
+| ------------------- | --------------------------- | ------------- | ------------------ |
+| Step order & names  | `<Step>` / `<Name>`         | workout steps | Preserved          |
+| Time durations      | `Time_t` seconds            | seconds       | Preserved (±1 s)   |
+| Distance durations  | `Distance_t` meters         | meters        | Preserved          |
+| Heart-rate targets  | `HeartRate_t` (zone or bpm) | bpm / zone    | Preserved (±1 bpm) |
+| Speed targets       | `Speed_t`                   | m/s           | Preserved          |
+| Cadence targets     | `Cadence_t`                 | rpm           | Preserved (±1 rpm) |
+| Repeats / intervals | `Repeat_t`                  | repeat steps  | Preserved          |
+
+## Gotchas
+
+**No power targets appear.** TCX workouts have no power target (the schema
+covers heart rate, speed, and cadence only), so a TCX-sourced FIT file won't
+gain power targets. If you need power, start from a
+[ZWO](/convert/zwo-to-fit) or Garmin Connect workout instead.
+
+**Getting it onto your Garmin.** Push the FIT file with the CLI —
+`kaiord garmin push -i workout.fit --input-format fit` — or use the Editor's
+Garmin integration. See the [garmin command](/cli/commands#garmin).
+
+**Sport mapping.** TCX `Sport` values (`Running`, `Biking`, `Other`) map to the
+corresponding FIT sports; anything unrecognized falls back to `Other`.
+
+## Related
+
+- [Convert FIT to TCX](/convert/fit-to-tcx) — the reverse direction
+- [Convert ZWO to FIT](/convert/zwo-to-fit) — a power-based FIT source
+- [TCX format](/formats/tcx) · [FIT format](/formats/fit)
+- [All converters](/convert/)

--- a/packages/docs/convert/zwo-to-fit.md
+++ b/packages/docs/convert/zwo-to-fit.md
@@ -1,0 +1,77 @@
+---
+title: "Convert ZWO to FIT"
+description: "Convert a Zwift ZWO workout to a Garmin FIT file — free and in-browser, or via the Kaiord CLI and TypeScript SDK. Push the result to your Garmin head unit."
+---
+
+# Convert ZWO to FIT
+
+Turn a **Zwift ZWO** workout into a **Garmin FIT** file so a session built in
+Zwift can run on your Garmin head unit or watch. Use the free, in-browser
+[Kaiord Editor](https://kaiord.com/editor/) — no account, no upload — or the
+[CLI](/cli/commands#convert) and [TypeScript SDK](/guide/quick-start) if you
+prefer to script it. Conversions go through Kaiord's canonical
+[KRD format](/formats/krd) and stay within round-trip tolerances (time ±1 s,
+power ±1 W or ±1 % FTP).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your `.zwo` file,
+choose **FIT** as the export format, and download `workout.fit`. It runs
+entirely in your browser.
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.zwo -o workout.fit
+```
+
+### 3. SDK
+
+```ts
+import { fromText, toBinary } from "@kaiord/core";
+import { zwiftReader } from "@kaiord/zwo";
+import { fitWriter } from "@kaiord/fit";
+import { readFile, writeFile } from "node:fs/promises";
+
+const zwo = await readFile("workout.zwo", "utf-8");
+const krd = await fromText(zwo, zwiftReader);
+const fit = await toBinary(krd, fitWriter);
+await writeFile("workout.fit", fit);
+```
+
+## What survives the conversion
+
+| Data               | ZWO (Zwift)                    | FIT                 | Result                                 |
+| ------------------ | ------------------------------ | ------------------- | -------------------------------------- |
+| Step order & names | blocks                         | workout steps       | Preserved                              |
+| Time durations     | `Duration` seconds             | seconds             | Preserved (±1 s)                       |
+| Power targets      | % FTP (`Power` fraction)       | power target        | Preserved (±1 % FTP)                   |
+| Ramps              | `Warmup` / `Cooldown` / `Ramp` | ranged power target | Preserved as a power range             |
+| Free-ride segments | `FreeRide`                     | open step           | Preserved as an untargeted step        |
+| Cadence targets    | limited                        | rpm                 | Preserved when present                 |
+| Text events        | in-ride messages               | —                   | Not part of the FIT workout definition |
+
+## Gotchas
+
+**Will it load on my Garmin?** FIT is Garmin's native workout format, so the
+output is directly loadable. To send it to your device, push it with the CLI —
+`kaiord garmin push -i workout.fit --input-format fit` — or use the Editor's
+Garmin integration. See the [garmin command](/cli/commands#garmin).
+
+**Sport type.** ZWO uses `bike` or `run`; these map to the FIT `cycling` /
+`running` sports. Zwift workouts are overwhelmingly cycling, so most files land
+as indoor cycling on your device.
+
+**In-ride text messages don't transfer.** ZWO text events are Zwift-specific
+overlays and are not part of the FIT workout target model, so they are not
+emitted into the FIT file.
+
+## Related
+
+- [Convert FIT to ZWO](/convert/fit-to-zwo) — the reverse direction
+- [Convert Garmin to ZWO](/convert/garmin-to-zwo) — sibling Zwift export
+- [ZWO format](/formats/zwo) · [FIT format](/formats/fit)
+- [All converters](/convert/)

--- a/packages/docs/convert/zwo-to-garmin.md
+++ b/packages/docs/convert/zwo-to-garmin.md
@@ -1,0 +1,84 @@
+---
+title: "Convert ZWO to Garmin (Zwift to Garmin Connect)"
+description: "Convert a Zwift ZWO workout to Garmin Connect format and push it to your watch — free and in-browser, or via the Kaiord CLI and TypeScript SDK."
+---
+
+# Convert ZWO to Garmin
+
+Take a **Zwift ZWO** workout into **Garmin Connect** so you can run a session you
+built in Zwift on your Garmin watch or head unit. Kaiord converts ZWO to the
+Garmin Connect workout format (GCN JSON) — free and in-browser in the
+[Kaiord Editor](https://kaiord.com/editor/) (no account, no upload), or via the
+[CLI](/cli/commands#convert) and [TypeScript SDK](/guide/quick-start).
+Conversions go through Kaiord's canonical [KRD format](/formats/krd) and stay
+within round-trip tolerances (time ±1 s, power ±1 W or ±1 % FTP).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your `.zwo` file,
+choose **Garmin (GCN)** as the export format, and download the result. To send
+it straight to your watch, use the Editor's Garmin sync (backed by the
+`garmin-bridge` extension).
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.zwo -o workout.gcn
+```
+
+To push directly to Garmin Connect (after `kaiord garmin login`):
+
+```bash
+kaiord garmin push -i workout.zwo --input-format zwo
+```
+
+### 3. SDK
+
+```ts
+import { fromText, toText } from "@kaiord/core";
+import { zwiftReader } from "@kaiord/zwo";
+import { garminWriter } from "@kaiord/garmin";
+import { readFile, writeFile } from "node:fs/promises";
+
+const zwo = await readFile("workout.zwo", "utf-8");
+const krd = await fromText(zwo, zwiftReader);
+const gcn = await toText(krd, garminWriter);
+await writeFile("workout.gcn", gcn);
+```
+
+## What survives the conversion
+
+| Data                | ZWO (Zwift)                    | Garmin Connect (GCN) | Result                                     |
+| ------------------- | ------------------------------ | -------------------- | ------------------------------------------ |
+| Step order & names  | blocks                         | workout steps        | Preserved                                  |
+| Time durations      | `Duration` seconds             | time durations       | Preserved (±1 s)                           |
+| Power targets       | % FTP (`Power` fraction)       | watts                | Converted using an assumed FTP (see below) |
+| Ramps               | `Warmup` / `Cooldown` / `Ramp` | ranged target        | Preserved as a power range                 |
+| Repeats / intervals | `IntervalsT`                   | repeat blocks        | Preserved                                  |
+| Free-ride segments  | `FreeRide`                     | open step            | Preserved as an untargeted step            |
+
+## Gotchas
+
+**Watts vs. % FTP.** Zwift stores power as % FTP; Garmin Connect stores watts.
+The conversion applies an assumed FTP (the output records it as
+`kaiord:assumedFtp`, e.g. 250 W) to turn percentages into watts. If exact watts
+matter, set your real FTP in Garmin Connect or rescale afterwards.
+
+**How does it get on my watch?** A `.gcn` file is Garmin Connect's JSON, not a
+device file. Push it to your account with `kaiord garmin push` (via
+[`@kaiord/garmin-connect`](/formats/gcn#garmin-connect-api)) or use the Editor's
+Garmin sync; Garmin Connect then syncs it to your device.
+
+**Heart-rate and cadence.** Zwift workouts are power-based, so ZWO rarely
+carries heart-rate or cadence targets to bring across. Any that exist are
+mapped where Garmin Connect supports them.
+
+## Related
+
+- [Convert Garmin to ZWO](/convert/garmin-to-zwo) — the reverse direction
+- [Convert ZWO to FIT](/convert/zwo-to-fit) — a device-file alternative
+- [ZWO format](/formats/zwo) · [GCN format](/formats/gcn)
+- [All converters](/convert/)

--- a/packages/landing/public/llms.txt
+++ b/packages/landing/public/llms.txt
@@ -27,6 +27,8 @@ Key facts:
 - [Docs home](https://kaiord.com/docs/): guides, format specs, API reference
 - [Quick start](https://kaiord.com/docs/guide/quick-start.md): convert a FIT
   file to TCX in 4 lines of TypeScript
+- [Converters](https://kaiord.com/docs/convert/): how to convert workout files
+  between FIT, TCX, ZWO, and Garmin Connect (with per-pair fidelity notes)
 - [Why Kaiord?](https://kaiord.com/docs/guide/why-kaiord.md): one SDK for
   every workout file format
 - [KRD format](https://kaiord.com/docs/formats/krd.md): the canonical JSON


### PR DESCRIPTION
## What

Adds a new **Convert** section to the docs site (`kaiord.com/docs/convert/`)
targeting long-tail / answer-engine queries like *"convert fit to zwo"*,
*"export Zwift workout to Garmin"*, *"fit to tcx converter free"*. This is
**wave 1** of the plan in `.omc/plans/long-tail-convert-pages.md`.

New pages (hub + 6 highest-intent pairs):

- `convert/index.md` — hub: converter matrix, three-ways, lossless overview
- `convert/fit-to-zwo.md`, `convert/zwo-to-fit.md` (Zwift ↔ head units)
- `convert/fit-to-tcx.md`, `convert/tcx-to-fit.md` (classic pair)
- `convert/zwo-to-garmin.md`, `convert/garmin-to-zwo.md` (GCN; push-to-watch)

Each page follows the GEO template: query-tuned frontmatter, a direct-answer
paragraph, **Editor → CLI → SDK** three ways, a grounded *"what survives the
conversion"* table, and 2–3 per-pair gotcha FAQs, with cross-links to the
reverse direction, sibling pairs, and format specs.

Wiring:

- New **Convert** sidebar group + top-nav entry in `.vitepress/config.ts`
- One line under **## Documentation** in `packages/landing/public/llms.txt`
- `.cspell.json`: added `Strava`, `untargeted`
- Changeset `docs-convert-pages.md` (`@kaiord/docs` + `@kaiord/landing`, patch)

## Why

Capture long-tail search/LLM-citation traffic and route athletes to the free
in-browser Editor and developers to the CLI/SDK. Lives in the existing
VitePress docs, so sitemap, llms.txt mirrors, cleanUrls, and analytics work
with zero build changes.

## Grounding (no marketing claims)

Every fidelity claim is sourced from `packages/docs/formats/*.md` and the
round-trip tolerances (time ±1 s, power ±1 W / ±1 % FTP, HR ±1 bpm, cadence
±1 rpm). Notable grounded gotchas: TCX workouts have no power target; ZWO is
% FTP so watt↔%FTP needs an assumed FTP (`kaiord:assumedFtp`); Zwift has no
native HR target (dropped, preserved under `extensions.zwift`); distance
durations become time in ZWO.

## Verification

Ran the built CLI (`packages/cli/dist/bin/kaiord.js`) on committed fixtures to
confirm the documented directions actually work:

- `convert -i test-fixtures/fit/WorkoutIndividualSteps.fit -o out.zwo` ✅
  (emits the exact lossy-conversion warnings cited on the FIT→ZWO page)
- `convert -i test-fixtures/fit/WorkoutIndividualSteps.fit -o out.tcx` ✅
- `convert -i test-fixtures/tcx/WorkoutHeartRateTargets.tcx -o out.fit` ✅
- ZWO→FIT, ZWO→GCN, GCN→ZWO ✅ (with a clean minimal ZWO; the round-trip
  fixtures embed a numeric `serialNumber` in `kaiord:` attrs that trips KRD
  validation — a fixture artifact, not a real Zwift export)

Other checks:

- `pnpm --filter @kaiord/docs lint` (prettier + cspell + privacy) ✅
- `pnpm --filter @kaiord/docs build` ✅ — all 7 pages + `.md` mirrors emitted,
  present in `sitemap.xml` and `llms.txt`
- Pre-commit typecheck + `test:scripts` (538 tests) ✅

### Deviation from the plan

The plan/template wrote the CLI flags as `kaiord convert --in … --out …`. The
built CLI does **not** accept `--in`/`--out` (they print help and produce no
output); the real flags are `-i`/`-o` (aliases of `--input`/`--output`), per
`cli/commands.md`. **The docs use `-i`/`-o`** — verified working. Flagging so
the plan wording can be corrected.

### Not covered / pending

- **Wave 2** (traffic-dependent): remaining 6 pairs — `fit-to-garmin`,
  `garmin-to-fit`, `tcx-to-zwo`, `zwo-to-tcx`, `tcx-to-garmin`, `garmin-to-tcx`.
- **FAQPage JSON-LD**: kept FAQs as visible Q&A only (plan marked the JSON-LD
  `transformPageData` extension as a nice-to-have / wave 2). Existing
  TechArticle + BreadcrumbList JSON-LD already applies to these pages.
- **i18n**: docs are EN-only (no i18n layer); Spanish converter pages are a
  known gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)