### PR TITLE
feat(docs-site): long-tail converter pages (wave 2)

### DIFF
--- a/.changeset/docs-convert-wave2.md
+++ b/.changeset/docs-convert-wave2.md
@@ -1,0 +1,9 @@
+---
+"@kaiord/docs": patch
+---
+
+Add the wave-2 long-tail converter pages to the docs site: the remaining six
+directed pairs (FIT↔Garmin, TCX↔ZWO, TCX↔Garmin). Each page covers the Editor,
+CLI, and SDK paths plus a grounded "what survives the conversion" table and
+per-pair gotchas. Every cell in the hub's conversion matrix is now a guided
+walkthrough, and the six new pages are linked from the sidebar.

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -154,6 +154,12 @@ const config = {
           { text: "TCX to FIT", link: "/convert/tcx-to-fit" },
           { text: "ZWO to Garmin", link: "/convert/zwo-to-garmin" },
           { text: "Garmin to ZWO", link: "/convert/garmin-to-zwo" },
+          { text: "FIT to Garmin", link: "/convert/fit-to-garmin" },
+          { text: "Garmin to FIT", link: "/convert/garmin-to-fit" },
+          { text: "TCX to ZWO", link: "/convert/tcx-to-zwo" },
+          { text: "ZWO to TCX", link: "/convert/zwo-to-tcx" },
+          { text: "TCX to Garmin", link: "/convert/tcx-to-garmin" },
+          { text: "Garmin to TCX", link: "/convert/garmin-to-tcx" },
         ],
       },
       {

--- a/packages/docs/convert/fit-to-garmin.md
+++ b/packages/docs/convert/fit-to-garmin.md
@@ -1,0 +1,91 @@
+---
+title: "Convert FIT to Garmin (FIT to Garmin Connect)"
+description: "Convert a Garmin FIT workout to Garmin Connect format (GCN JSON) and push it to your account — free and in-browser, or via the Kaiord CLI and TypeScript SDK."
+---
+
+# Convert FIT to Garmin
+
+Turn a **Garmin FIT** workout into the **Garmin Connect** workout format (GCN
+JSON) so a session from a FIT file can live in your Garmin Connect account and
+sync to your watch or head unit. Use the free, in-browser
+[Kaiord Editor](https://kaiord.com/editor/) (no account, no upload), or the
+[CLI](/cli/commands#convert) and [TypeScript SDK](/guide/quick-start).
+Conversions go through Kaiord's canonical [KRD format](/formats/krd) and stay
+within round-trip tolerances (time ±1 s, power ±1 W, heart rate ±1 bpm, cadence
+±1 rpm).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your `.fit` file,
+choose **Garmin (GCN)** as the export format, and download the result. To send
+it straight to your account, use the Editor's Garmin sync (backed by the
+`garmin-bridge` extension).
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.fit -o workout.gcn
+```
+
+To push directly to Garmin Connect (after `kaiord garmin login`):
+
+```bash
+kaiord garmin push -i workout.fit --input-format fit
+```
+
+### 3. SDK
+
+```ts
+import { fromBinary, toText } from "@kaiord/core";
+import { fitReader } from "@kaiord/fit";
+import { garminWriter } from "@kaiord/garmin";
+import { readFile, writeFile } from "node:fs/promises";
+
+const buffer = await readFile("workout.fit");
+const krd = await fromBinary(new Uint8Array(buffer), fitReader);
+const gcn = await toText(krd, garminWriter);
+await writeFile("workout.gcn", gcn);
+```
+
+## What survives the conversion
+
+| Data                 | FIT           | Garmin Connect (GCN)  | Result                             |
+| -------------------- | ------------- | --------------------- | ---------------------------------- |
+| Step order & names   | workout steps | workout steps         | Preserved                          |
+| Time durations       | seconds       | time durations        | Preserved (±1 s)                   |
+| Distance durations   | meters        | distance durations    | Preserved                          |
+| Power targets        | watts / zone  | watts / power zone    | Preserved (±1 W; zones map across) |
+| Heart-rate targets   | bpm / zone    | bpm / heart-rate zone | Preserved (±1 bpm)                 |
+| Cadence targets      | rpm           | rpm                   | Preserved (±1 rpm)                 |
+| Speed / pace targets | m/s           | m/s                   | Preserved                          |
+| Repeats / intervals  | repeat steps  | repeat blocks         | Preserved                          |
+| Developer fields     | custom fields | —                     | Preserved under `extensions.fit`   |
+
+FIT and Garmin Connect are both Garmin-native, watt-based formats, so this is
+one of the highest-fidelity conversions Kaiord does — no assumed FTP is needed.
+
+## Gotchas
+
+**FIT file vs. Garmin Connect JSON.** A `.fit` file is Garmin's on-device binary
+format; a `.gcn` file is Garmin Connect's workout JSON. They are not the same
+thing, which is why the conversion matters — the GCN output is what the Garmin
+Connect API accepts.
+
+**How does it get on my watch?** Push the `.gcn` to your account with
+`kaiord garmin push` (via [`@kaiord/garmin-connect`](/formats/gcn#garmin-connect-api))
+or use the Editor's Garmin sync; Garmin Connect then syncs it to your device.
+
+**Developer and unknown fields.** FIT developer fields and unknown messages have
+no Garmin Connect equivalent, so they are kept under `extensions.fit` and
+survive a later `garmin-to-fit` round-trip rather than being emitted into the
+GCN workout.
+
+## Related
+
+- [Convert Garmin to FIT](/convert/garmin-to-fit) — the reverse direction
+- [Convert FIT to TCX](/convert/fit-to-tcx) — a cross-platform FIT export
+- [FIT format](/formats/fit) · [GCN format](/formats/gcn)
+- [All converters](/convert/)

--- a/packages/docs/convert/garmin-to-fit.md
+++ b/packages/docs/convert/garmin-to-fit.md
@@ -1,0 +1,84 @@
+---
+title: "Convert Garmin to FIT (Garmin Connect to FIT)"
+description: "Convert a Garmin Connect workout (GCN JSON) to a Garmin FIT file — free and in-browser, or via the Kaiord CLI and TypeScript SDK. Push the result to your device."
+---
+
+# Convert Garmin to FIT
+
+Take a **Garmin Connect** workout (GCN JSON) into a **Garmin FIT** file — the
+on-device binary format — so a plan from your Garmin Connect account can be
+loaded as a native FIT workout. Use the free, in-browser
+[Kaiord Editor](https://kaiord.com/editor/) (no account, no upload), or the
+[CLI](/cli/commands#convert) and [TypeScript SDK](/guide/quick-start).
+Conversions go through Kaiord's canonical [KRD format](/formats/krd) and stay
+within round-trip tolerances (time ±1 s, power ±1 W, heart rate ±1 bpm, cadence
+±1 rpm).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your Garmin Connect
+workout file, choose **FIT** as the export format, and download `workout.fit`.
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.gcn -o workout.fit
+```
+
+### 3. SDK
+
+```ts
+import { fromText, toBinary } from "@kaiord/core";
+import { garminReader } from "@kaiord/garmin";
+import { fitWriter } from "@kaiord/fit";
+import { readFile, writeFile } from "node:fs/promises";
+
+const gcn = await readFile("workout.gcn", "utf-8");
+const krd = await fromText(gcn, garminReader);
+const fit = await toBinary(krd, fitWriter);
+await writeFile("workout.fit", fit);
+```
+
+## What survives the conversion
+
+| Data                 | Garmin Connect (GCN) | FIT                | Result                             |
+| -------------------- | -------------------- | ------------------ | ---------------------------------- |
+| Step order & names   | workout steps        | workout steps      | Preserved                          |
+| Time durations       | time durations       | seconds            | Preserved (±1 s)                   |
+| Distance durations   | distance durations   | meters             | Preserved                          |
+| Power targets        | watts / power zone   | watts / zone       | Preserved (±1 W; zones map across) |
+| Heart-rate targets   | bpm                  | bpm / zone         | Preserved (±1 bpm)                 |
+| Cadence targets      | rpm                  | rpm                | Preserved (±1 rpm)                 |
+| Speed / pace targets | m/s                  | m/s                | Preserved                          |
+| Repeats / intervals  | repeat blocks        | repeat steps       | Preserved                          |
+| Step notes           | `description`        | workout step notes | Preserved (truncated to 256 chars) |
+
+Both formats are Garmin-native and watt-based, so this is a high-fidelity
+conversion — no assumed FTP is needed.
+
+## Gotchas
+
+**Where do I get the `.gcn` file?** GCN is Garmin Connect's workout JSON. Fetch
+it through the Garmin Connect API with
+[`@kaiord/garmin-connect`](/formats/gcn#garmin-connect-api) (e.g.
+`kaiord garmin list`) or the Editor's Garmin integration.
+
+**Will it load on my Garmin?** FIT is Garmin's native workout format, so the
+output is directly loadable. To send it to your device, push it with the CLI —
+`kaiord garmin push -i workout.fit --input-format fit` — or use the Editor's
+Garmin integration.
+
+**Calorie-based durations.** Garmin Connect can express a step duration in
+calories. KRD models calorie durations natively, so they carry through to FIT
+(which also supports calorie durations); a target format without them, such as
+[TCX](/convert/garmin-to-tcx), would not.
+
+## Related
+
+- [Convert FIT to Garmin](/convert/fit-to-garmin) — the reverse direction
+- [Convert Garmin to ZWO](/convert/garmin-to-zwo) — a Zwift export
+- [GCN format](/formats/gcn) · [FIT format](/formats/fit)
+- [All converters](/convert/)

--- a/packages/docs/convert/garmin-to-tcx.md
+++ b/packages/docs/convert/garmin-to-tcx.md
@@ -1,0 +1,79 @@
+---
+title: "Convert Garmin to TCX (Garmin Connect to TCX)"
+description: "Convert a Garmin Connect workout (GCN JSON) to a TCX (Training Center XML) file — free and in-browser, or via the Kaiord CLI and TypeScript SDK."
+---
+
+# Convert Garmin to TCX
+
+Take a **Garmin Connect** workout (GCN JSON) into a **TCX** (Training Center XML)
+file so a plan from Garmin can import into another training platform. Use the
+free, in-browser [Kaiord Editor](https://kaiord.com/editor/) (no account, no
+upload), or the [CLI](/cli/commands#convert) and
+[TypeScript SDK](/guide/quick-start). Conversions go through Kaiord's canonical
+[KRD format](/formats/krd) and stay within round-trip tolerances (time ±1 s,
+heart rate ±1 bpm, cadence ±1 rpm).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your Garmin Connect
+workout file, choose **TCX** as the export format, and download `workout.tcx`.
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.gcn -o workout.tcx
+```
+
+### 3. SDK
+
+```ts
+import { fromText, toText } from "@kaiord/core";
+import { garminReader } from "@kaiord/garmin";
+import { tcxWriter } from "@kaiord/tcx";
+import { readFile, writeFile } from "node:fs/promises";
+
+const gcn = await readFile("workout.gcn", "utf-8");
+const krd = await fromText(gcn, garminReader);
+const tcx = await toText(krd, tcxWriter);
+await writeFile("workout.tcx", tcx);
+```
+
+## What survives the conversion
+
+| Data                 | Garmin Connect (GCN) | TCX                 | Result                                          |
+| -------------------- | -------------------- | ------------------- | ----------------------------------------------- |
+| Step order & names   | workout steps        | `<Step>` / `<Name>` | Preserved                                       |
+| Time durations       | time durations       | `Time_t` seconds    | Preserved (±1 s)                                |
+| Distance durations   | distance durations   | `Distance_t` meters | Preserved                                       |
+| Heart-rate targets   | bpm                  | `HeartRate_t`       | Preserved (±1 bpm)                              |
+| Speed / pace targets | m/s                  | `Speed_t`           | Preserved                                       |
+| Cadence targets      | rpm                  | `Cadence_t`         | Preserved (±1 rpm)                              |
+| Power targets        | watts                | —                   | **Dropped** — TCX workouts have no power target |
+| Repeats / intervals  | repeat blocks        | `Repeat_t`          | Preserved                                       |
+
+## Gotchas
+
+**My power targets disappeared.** The TCX workout schema covers heart rate,
+speed, and cadence — there is no power target. Garmin Connect stores power in
+watts, so any power targets are dropped in the TCX output. To keep power, convert
+to [FIT](/convert/garmin-to-fit) instead, which keeps watt targets.
+
+**Where do I get the `.gcn` file?** GCN is Garmin Connect's workout JSON. Fetch
+it through the Garmin Connect API with
+[`@kaiord/garmin-connect`](/formats/gcn#garmin-connect-api) (e.g.
+`kaiord garmin list`) or the Editor's Garmin integration.
+
+**Calorie-based durations.** Garmin Connect can express a step duration in
+calories, but TCX supports only time- and distance-based durations. A
+calorie-duration step therefore has no direct TCX equivalent — prefer
+[FIT](/convert/garmin-to-fit) if your workout relies on calorie goals.
+
+## Related
+
+- [Convert TCX to Garmin](/convert/tcx-to-garmin) — the reverse direction
+- [Convert Garmin to ZWO](/convert/garmin-to-zwo) — a Zwift export
+- [GCN format](/formats/gcn) · [TCX format](/formats/tcx)
+- [All converters](/convert/)

--- a/packages/docs/convert/index.md
+++ b/packages/docs/convert/index.md
@@ -17,17 +17,16 @@ stay within tight tolerances (time ±1 s, power ±1 W or ±1 % FTP, heart rate
 
 ## Pick a conversion
 
-| From ↓ / To → | FIT                              | TCX                              | ZWO (Zwift)                            | Garmin                                 |
-| ------------- | -------------------------------- | -------------------------------- | -------------------------------------- | -------------------------------------- |
-| **FIT**       | —                                | [FIT → TCX](/convert/fit-to-tcx) | [FIT → ZWO](/convert/fit-to-zwo)       | via CLI/SDK                            |
-| **TCX**       | [TCX → FIT](/convert/tcx-to-fit) | —                                | via CLI/SDK                            | via CLI/SDK                            |
-| **ZWO**       | [ZWO → FIT](/convert/zwo-to-fit) | via CLI/SDK                      | —                                      | [ZWO → Garmin](/convert/zwo-to-garmin) |
-| **Garmin**    | via CLI/SDK                      | via CLI/SDK                      | [Garmin → ZWO](/convert/garmin-to-zwo) | —                                      |
+| From ↓ / To → | FIT                                    | TCX                                    | ZWO (Zwift)                            | Garmin                                 |
+| ------------- | -------------------------------------- | -------------------------------------- | -------------------------------------- | -------------------------------------- |
+| **FIT**       | —                                      | [FIT → TCX](/convert/fit-to-tcx)       | [FIT → ZWO](/convert/fit-to-zwo)       | [FIT → Garmin](/convert/fit-to-garmin) |
+| **TCX**       | [TCX → FIT](/convert/tcx-to-fit)       | —                                      | [TCX → ZWO](/convert/tcx-to-zwo)       | [TCX → Garmin](/convert/tcx-to-garmin) |
+| **ZWO**       | [ZWO → FIT](/convert/zwo-to-fit)       | [ZWO → TCX](/convert/zwo-to-tcx)       | —                                      | [ZWO → Garmin](/convert/zwo-to-garmin) |
+| **Garmin**    | [Garmin → FIT](/convert/garmin-to-fit) | [Garmin → TCX](/convert/garmin-to-tcx) | [Garmin → ZWO](/convert/garmin-to-zwo) | —                                      |
 
-The six pairs above are the guided walkthroughs. Any other direction
-(`fit-to-garmin`, `tcx-to-zwo`, and so on) works today with the same
-[`kaiord convert`](/cli/commands#convert) command and SDK calls — format is
-detected from the file extension.
+All twelve directed pairs have a guided walkthrough. Every conversion uses the
+same [`kaiord convert`](/cli/commands#convert) command and SDK calls — the
+format is detected from the file extension.
 
 ## Three ways to convert
 

--- a/packages/docs/convert/tcx-to-garmin.md
+++ b/packages/docs/convert/tcx-to-garmin.md
@@ -1,0 +1,88 @@
+---
+title: "Convert TCX to Garmin (TCX to Garmin Connect)"
+description: "Convert a TCX (Training Center XML) workout to Garmin Connect format and push it to your watch — free and in-browser, or via the Kaiord CLI and TypeScript SDK."
+---
+
+# Convert TCX to Garmin
+
+Take a **TCX** (Training Center XML) workout into the **Garmin Connect** workout
+format (GCN JSON) so a plan exported from another platform can run on your Garmin
+watch or head unit. Use the free, in-browser
+[Kaiord Editor](https://kaiord.com/editor/) (no account, no upload), or the
+[CLI](/cli/commands#convert) and [TypeScript SDK](/guide/quick-start).
+Conversions go through Kaiord's canonical [KRD format](/formats/krd) and stay
+within round-trip tolerances (time ±1 s, heart rate ±1 bpm, cadence ±1 rpm).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your `.tcx` file,
+choose **Garmin (GCN)** as the export format, and download the result. To send
+it straight to your watch, use the Editor's Garmin sync (backed by the
+`garmin-bridge` extension).
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.tcx -o workout.gcn
+```
+
+To push directly to Garmin Connect (after `kaiord garmin login`):
+
+```bash
+kaiord garmin push -i workout.tcx --input-format tcx
+```
+
+### 3. SDK
+
+```ts
+import { fromText, toText } from "@kaiord/core";
+import { tcxReader } from "@kaiord/tcx";
+import { garminWriter } from "@kaiord/garmin";
+import { readFile, writeFile } from "node:fs/promises";
+
+const tcx = await readFile("workout.tcx", "utf-8");
+const krd = await fromText(tcx, tcxReader);
+const gcn = await toText(krd, garminWriter);
+await writeFile("workout.gcn", gcn);
+```
+
+## What survives the conversion
+
+| Data                 | TCX                         | Garmin Connect (GCN) | Result                    |
+| -------------------- | --------------------------- | -------------------- | ------------------------- |
+| Step order & names   | `<Step>` / `<Name>`         | workout steps        | Preserved                 |
+| Time durations       | `Time_t` seconds            | time durations       | Preserved (±1 s)          |
+| Distance durations   | `Distance_t` meters         | distance durations   | Preserved                 |
+| Heart-rate targets   | `HeartRate_t` (zone or bpm) | bpm                  | Preserved (±1 bpm)        |
+| Speed / pace targets | `Speed_t`                   | m/s                  | Preserved                 |
+| Cadence targets      | `Cadence_t`                 | rpm                  | Preserved (±1 rpm)        |
+| Power targets        | — (TCX has none)            | watts                | Not present in the source |
+| Repeats / intervals  | `Repeat_t`                  | repeat blocks        | Preserved                 |
+
+Heart-rate-based workouts convert cleanly: TCX carries heart-rate, speed, and
+cadence targets, all of which Garmin Connect supports.
+
+## Gotchas
+
+**No power targets.** TCX workouts have no power target (the schema covers heart
+rate, speed, and cadence only), so a TCX-sourced Garmin Connect workout won't
+gain power targets. If you need power, start from a
+[FIT](/convert/fit-to-garmin) or [ZWO](/convert/zwo-to-garmin) workout instead.
+
+**How does it get on my watch?** A `.gcn` file is Garmin Connect's JSON, not a
+device file. Push it to your account with `kaiord garmin push` (via
+[`@kaiord/garmin-connect`](/formats/gcn#garmin-connect-api)) or use the Editor's
+Garmin sync; Garmin Connect then syncs it to your device.
+
+**Sport mapping.** TCX `Sport` values (`Running`, `Biking`, `Other`) map to the
+corresponding Garmin sports; anything unrecognized falls back to `Other`.
+
+## Related
+
+- [Convert Garmin to TCX](/convert/garmin-to-tcx) — the reverse direction
+- [Convert TCX to FIT](/convert/tcx-to-fit) — a device-file export
+- [TCX format](/formats/tcx) · [GCN format](/formats/gcn)
+- [All converters](/convert/)

--- a/packages/docs/convert/tcx-to-zwo.md
+++ b/packages/docs/convert/tcx-to-zwo.md
@@ -1,0 +1,78 @@
+---
+title: "Convert TCX to ZWO (TCX to Zwift)"
+description: "Convert a TCX (Training Center XML) workout to a Zwift ZWO file — free and in-browser, or via the Kaiord CLI and TypeScript SDK. See what survives the conversion."
+---
+
+# Convert TCX to ZWO
+
+Turn a **TCX** (Training Center XML) workout into a **Zwift ZWO** file so a plan
+exported from a training platform can run in Zwift. Use the free, in-browser
+[Kaiord Editor](https://kaiord.com/editor/) (no account, no upload), or the
+[CLI](/cli/commands#convert) and [TypeScript SDK](/guide/quick-start).
+Conversions go through Kaiord's canonical [KRD format](/formats/krd) and stay
+within round-trip tolerances (time ±1 s).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your `.tcx` file,
+choose **ZWO** as the export format, and download `workout.zwo`.
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.tcx -o workout.zwo
+```
+
+### 3. SDK
+
+```ts
+import { fromText, toText } from "@kaiord/core";
+import { tcxReader } from "@kaiord/tcx";
+import { zwiftWriter } from "@kaiord/zwo";
+import { readFile, writeFile } from "node:fs/promises";
+
+const tcx = await readFile("workout.tcx", "utf-8");
+const krd = await fromText(tcx, tcxReader);
+const zwo = await toText(krd, zwiftWriter);
+await writeFile("workout.zwo", zwo);
+```
+
+## What survives the conversion
+
+| Data                | TCX                         | ZWO (Zwift)           | Result                                                        |
+| ------------------- | --------------------------- | --------------------- | ------------------------------------------------------------- |
+| Step order & names  | `<Step>` / `<Name>`         | blocks                | Preserved (names kept as `kaiord:` attributes)                |
+| Time durations      | `Time_t` seconds            | `Duration` seconds    | Preserved (±1 s)                                              |
+| Distance durations  | `Distance_t` meters         | time-based `Duration` | Converted to time; original kept under `extensions.zwift`     |
+| Power targets       | — (TCX has none)            | `Power` (% FTP)       | No power to carry — steps become `FreeRide` (see below)       |
+| Heart-rate targets  | `HeartRate_t` (zone or bpm) | —                     | Dropped (Zwift is power-based); kept under `extensions.zwift` |
+| Speed targets       | `Speed_t`                   | —                     | Dropped (no Zwift equivalent); kept under `extensions.zwift`  |
+| Cadence targets     | `Cadence_t`                 | limited               | Preserved under `extensions.zwift`                            |
+| Repeats / intervals | `Repeat_t`                  | `IntervalsT`          | Preserved                                                     |
+
+## Gotchas
+
+**My steps became free rides.** TCX workouts have no power target (the schema
+covers heart rate, speed, and cadence only), and Zwift workouts are power-based.
+With no power to map, the structured steps become `FreeRide` segments that keep
+their duration but have no power target. For a power-based Zwift workout, start
+from a source that carries power, such as [FIT](/convert/fit-to-zwo) or
+[Garmin Connect](/convert/garmin-to-zwo).
+
+**My heart-rate targets are gone.** ZWO has no native heart-rate target, so HR
+targets are dropped from the visible workout. Kaiord preserves them under
+`extensions.zwift` so a later ZWO → TCX round-trip can restore them.
+
+**Distance intervals became time intervals.** ZWO durations are time-based.
+Distance durations are converted to time, and the original distance is preserved
+under `extensions.zwift`.
+
+## Related
+
+- [Convert ZWO to TCX](/convert/zwo-to-tcx) — the reverse direction
+- [Convert TCX to FIT](/convert/tcx-to-fit) — a device-file export
+- [TCX format](/formats/tcx) · [ZWO format](/formats/zwo)
+- [All converters](/convert/)

--- a/packages/docs/convert/zwo-to-tcx.md
+++ b/packages/docs/convert/zwo-to-tcx.md
@@ -1,0 +1,78 @@
+---
+title: "Convert ZWO to TCX (Zwift to TCX)"
+description: "Convert a Zwift ZWO workout to a TCX (Training Center XML) file — free and in-browser, or via the Kaiord CLI and TypeScript SDK. See what survives the conversion."
+---
+
+# Convert ZWO to TCX
+
+Turn a **Zwift ZWO** workout into a **TCX** (Training Center XML) file — the
+format most training platforms accept for import. Use the free, in-browser
+[Kaiord Editor](https://kaiord.com/editor/) (no account, no upload), or the
+[CLI](/cli/commands#convert) and [TypeScript SDK](/guide/quick-start).
+Conversions go through Kaiord's canonical [KRD format](/formats/krd) and stay
+within round-trip tolerances (time ±1 s, cadence ±1 rpm).
+
+## Three ways to convert
+
+### 1. Editor (drag & drop)
+
+Open [kaiord.com/editor](https://kaiord.com/editor/), drop your `.zwo` file,
+choose **TCX** as the export format, and download `workout.tcx`.
+
+### 2. CLI
+
+```bash
+pnpm add -g @kaiord/cli
+kaiord convert -i workout.zwo -o workout.tcx
+```
+
+### 3. SDK
+
+```ts
+import { fromText, toText } from "@kaiord/core";
+import { zwiftReader } from "@kaiord/zwo";
+import { tcxWriter } from "@kaiord/tcx";
+import { readFile, writeFile } from "node:fs/promises";
+
+const zwo = await readFile("workout.zwo", "utf-8");
+const krd = await fromText(zwo, zwiftReader);
+const tcx = await toText(krd, tcxWriter);
+await writeFile("workout.tcx", tcx);
+```
+
+## What survives the conversion
+
+| Data                | ZWO (Zwift)                    | TCX                 | Result                                          |
+| ------------------- | ------------------------------ | ------------------- | ----------------------------------------------- |
+| Step order & names  | blocks                         | `<Step>` / `<Name>` | Preserved                                       |
+| Time durations      | `Duration` seconds             | `Time_t` seconds    | Preserved (±1 s)                                |
+| Power targets       | % FTP (`Power` fraction)       | —                   | **Dropped** — TCX workouts have no power target |
+| Ramps               | `Warmup` / `Cooldown` / `Ramp` | untargeted steps    | Duration preserved; the power ramp is dropped   |
+| Cadence targets     | limited                        | `Cadence_t`         | Preserved when present (±1 rpm)                 |
+| Free-ride segments  | `FreeRide`                     | untargeted step     | Preserved as a step without a target            |
+| Repeats / intervals | `IntervalsT`                   | `Repeat_t`          | Preserved                                       |
+
+## Gotchas
+
+**My power targets disappeared.** The TCX workout schema (Garmin Training
+Center) defines heart-rate, speed, and cadence targets only — there is no power
+target. Zwift workouts are power-based (% FTP), so the power targets have
+nowhere to land and are dropped; the step structure and durations remain. To
+keep power, convert to [FIT](/convert/zwo-to-fit) or
+[Garmin Connect](/convert/zwo-to-garmin) instead.
+
+**So why convert to TCX at all?** TCX is a widely accepted interchange format —
+TrainingPeaks, Strava, and Garmin Connect all import it — so it is useful when
+you want the workout's structure (steps, durations, intervals) on a platform
+that reads TCX but cannot read ZWO. Just expect the power targets not to come
+along.
+
+**Cadence.** If your ZWO carries cadence targets, they map to TCX `Cadence_t`
+targets. Most Zwift workouts are pure power, so this is often empty.
+
+## Related
+
+- [Convert TCX to ZWO](/convert/tcx-to-zwo) — the reverse direction
+- [Convert ZWO to FIT](/convert/zwo-to-fit) — keep power targets
+- [ZWO format](/formats/zwo) · [TCX format](/formats/tcx)
+- [All converters](/convert/)


### PR DESCRIPTION
## What

Adds the remaining **six directed converter pages** to the VitePress docs site,
completing the "how to convert X to Y" matrix started in wave 1 (#965):

- `fit-to-garmin` · `garmin-to-fit` (Garmin-native, watt-based — highest fidelity)
- `tcx-to-zwo` · `zwo-to-tcx` (TCX ↔ Zwift — the power/no-power boundary)
- `tcx-to-garmin` · `garmin-to-tcx` (TCX ↔ Garmin Connect)

Each page follows the wave-1 template exactly: query-tuned frontmatter, a
2–3 sentence direct-answer paragraph, the **Editor → CLI → SDK** three ways
(CLI flags `-i`/`-o`), a grounded **"what survives the conversion"** table
sourced from `packages/docs/formats/*.md` + the round-trip tolerances, 2–3
per-pair gotchas, and cross-links to the reverse pair, wave-1 siblings, format
specs, and the hub.

Also:
- **Hub matrix** (`convert/index.md`) — every previously "via CLI/SDK" cell is
  now a link; all twelve directed pairs have a guided walkthrough.
- **Sidebar** (`.vitepress/config.ts`) — the six new pages added under *Convert*.
- **Changeset** — `@kaiord/docs` patch.

No `llms.txt` change needed: its `/docs/convert/` entry already describes all
pairs generically (same as wave 1). `packages/docs/convert` is already in
`lychee.toml`'s `exclude_path` (VitePress validates these links at build).

## Verification

- `pnpm --filter @kaiord/docs build` — **green** (VitePress validates all
  internal cross-links at build time; sitemap generated).
- `pnpm exec prettier --check` on all touched files — **clean**.
- Husky pre-commit — scripts tests (538 pass / 0 fail) + incremental TS type
  check both pass.
- **All six wave-2 `kaiord convert` directions run end-to-end** with the built
  CLI on representative valid inputs (e.g. `fit→garmin`, `garmin→fit`,
  `tcx→zwo`, `zwo→tcx`, `tcx→garmin`, `garmin→tcx`). The `zwo→tcx` run confirms
  the documented behaviour — power targets emit `<Target xsi:type="None_t">`
  (dropped, since TCX has no power target) while names/durations/intensity are
  preserved.

## Notes / deviations

- **EN only** — the docs site has no i18n (Spanish gap, same as wave 1).
- **Pre-existing converter edge cases (out of scope, not introduced here):**
  while verifying, some unit-test fixtures fail end-to-end conversion —
  (a) a numeric `kaiord:serialNumber` attribute in the `test-fixtures/zwo/*`
  files trips KRD validation (`expected string, received number`) on any
  `zwo→*` conversion, and (b) certain repeat/interval structures make the
  KRD→TCX writer throw `TcxParsingError`. Both also affect the **already-live
  wave-1 `fit→tcx` pair** (e.g. `WorkoutRepeatSteps.fit` fails today), so they
  are orthogonal to this docs PR — flagged here as a follow-up bug to fix in the
  adapters, not a blocker for the pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)