### PR TITLE
fix(zwo,tcx): coerce ZWO serialNumber to string and fix TCX repeat-block writer

### DIFF
--- a/.changeset/fix-tcx-repeat-writer.md
+++ b/.changeset/fix-tcx-repeat-writer.md
@@ -1,0 +1,10 @@
+---
+"@kaiord/tcx": patch
+---
+
+Fix `fit → tcx` (and any `* → tcx`) conversions throwing `TcxParsingError` on
+workouts with repeat/interval blocks (#976). The KRD→TCX writer treated every
+step as a leaf, so a repetition block had no `duration`/`target` and the
+encoder threw. The writer now serializes repetition blocks to a TCX `Repeat_t`
+step carrying `Repetitions` and `Child` steps, assigning contiguous `StepId`s
+across the flattened tree.

--- a/.changeset/fix-zwo-serialnumber-coercion.md
+++ b/.changeset/fix-zwo-serialnumber-coercion.md
@@ -1,0 +1,9 @@
+---
+"@kaiord/zwo": patch
+---
+
+Fix `zwo → *` conversions failing on a numeric serial number (#976). The ZWO
+reader emitted `serialNumber` as a number when the source attribute was numeric
+(e.g. `serialNumber="1234"`), which the KRD domain schema rejects because it
+types `serialNumber` as a string. The reader now coerces the value to a string
+at the KRD boundary, keeping the domain schema strict.

--- a/packages/cli/src/tests/cross-format-round-trip.test.ts
+++ b/packages/cli/src/tests/cross-format-round-trip.test.ts
@@ -145,6 +145,28 @@ describe("Cross-format round-trip: FIT → KRD → TCX → KRD", () => {
     }
   });
 
+  it("should serialize FIT repeat blocks to a TCX Repeat_t without throwing", async () => {
+    // Arrange
+    const logger = createMockLogger();
+    const fitReader = createFitReader(logger);
+    const tcxWriter = createTcxWriter(logger);
+    const fitBuffer = loadFitFixture("WorkoutRepeatSteps.fit");
+
+    // Act
+    const krdFromFit = await fitReader(fitBuffer);
+    const tcxXml = await tcxWriter(krdFromFit);
+
+    // Assert
+    const repeatBlock = extractWorkout(krdFromFit).steps.find(
+      (step): step is RepetitionBlock => "repeatCount" in step
+    );
+    expect(repeatBlock).toBeDefined();
+    expect(tcxXml).toContain('xsi:type="Repeat_t"');
+    expect(tcxXml).toContain(
+      `<Repetitions>${repeatBlock?.repeatCount}</Repetitions>`
+    );
+  });
+
   it("should keep representable target values within round-trip tolerances", async () => {
     // Arrange
     const logger = createMockLogger();

--- a/packages/tcx/src/adapters/workout/repeat-block-to-tcx.converter.test.ts
+++ b/packages/tcx/src/adapters/workout/repeat-block-to-tcx.converter.test.ts
@@ -1,0 +1,89 @@
+import type { Logger, RepetitionBlock, WorkoutStep } from "@kaiord/core";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  REPEAT_COUNT_THREE,
+  STEP_ID_FIVE,
+  STEP_ID_FOUR,
+  STEP_ID_THREE,
+} from "../../test-utils/constants";
+import { buildTcxSteps } from "./repeat-block-to-tcx.converter";
+
+const createMockLogger = (): Logger => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+const createWorkoutStep = (
+  overrides: Partial<WorkoutStep> = {}
+): WorkoutStep => ({
+  stepIndex: 0,
+  durationType: "time",
+  duration: { type: "time", seconds: 300 },
+  targetType: "open",
+  target: { type: "open" },
+  ...overrides,
+});
+
+const createRepetitionBlock = (): RepetitionBlock => ({
+  repeatCount: REPEAT_COUNT_THREE,
+  steps: [
+    createWorkoutStep({ name: "Work" }),
+    createWorkoutStep({ name: "Rest" }),
+  ],
+});
+
+describe("buildTcxSteps", () => {
+  it("should emit a Repeat_t step for a repetition block", () => {
+    // Arrange
+    const logger = createMockLogger();
+    const steps = [createRepetitionBlock()];
+
+    // Act
+    const result = buildTcxSteps(steps, "generic", logger);
+
+    // Assert
+    expect(result[0]["@_xsi:type"]).toBe("Repeat_t");
+    expect(result[0].Repetitions).toBe(REPEAT_COUNT_THREE);
+    expect(result[0].Child).toHaveLength(2);
+  });
+
+  it("should assign contiguous StepIds across leaf steps and repeat children", () => {
+    // Arrange
+    const logger = createMockLogger();
+    const steps = [
+      createWorkoutStep({ name: "Warmup" }),
+      createRepetitionBlock(),
+      createWorkoutStep({ name: "Cooldown" }),
+    ];
+
+    // Act
+    const result = buildTcxSteps(steps, "generic", logger);
+
+    // Assert
+    expect(result[0].StepId).toBe(1);
+    expect(result[1].StepId).toBe(2);
+    const children = result[1].Child as Array<Record<string, unknown>>;
+    expect(children.map((child) => child.StepId)).toStrictEqual([
+      STEP_ID_THREE,
+      STEP_ID_FOUR,
+    ]);
+    expect(result[2].StepId).toBe(STEP_ID_FIVE);
+  });
+
+  it("should mark repeat children as Step_t leaf steps", () => {
+    // Arrange
+    const logger = createMockLogger();
+    const steps = [createRepetitionBlock()];
+
+    // Act
+    const result = buildTcxSteps(steps, "generic", logger);
+
+    // Assert
+    const children = result[0].Child as Array<Record<string, unknown>>;
+    expect(children[0]["@_xsi:type"]).toBe("Step_t");
+    expect(children[1]["@_xsi:type"]).toBe("Step_t");
+  });
+});

--- a/packages/tcx/src/adapters/workout/repeat-block-to-tcx.converter.ts
+++ b/packages/tcx/src/adapters/workout/repeat-block-to-tcx.converter.ts
@@ -1,0 +1,68 @@
+import type { Logger, RepetitionBlock, Sport, WorkoutStep } from "@kaiord/core";
+import { isRepetitionBlock } from "@kaiord/core";
+
+import { convertStepToTcx } from "./step-to-tcx.converter";
+
+type RepeatBlockResult = {
+  tcxStep: Record<string, unknown>;
+  // Number of sequential TCX StepIds the block occupies (the Repeat_t itself
+  // plus one per child), so the caller can keep numbering later siblings.
+  consumed: number;
+};
+
+// KRD repetition blocks map to a TCX `Repeat_t` step whose `Repetitions`
+// carries the repeat count and whose `Child` steps are the (leaf) inner steps.
+// StepIds are a single running sequence across the flattened tree, matching
+// how native TCX writers number the Repeat_t and its children.
+export const convertRepeatBlockToTcx = (
+  block: RepetitionBlock,
+  startIndex: number,
+  sport: Sport,
+  logger: Logger
+): RepeatBlockResult => {
+  logger.debug("Converting repetition block to TCX", {
+    repeatCount: block.repeatCount,
+  });
+
+  const children = block.steps.map((child, childOffset) =>
+    convertStepToTcx(child, startIndex + 1 + childOffset, sport, logger)
+  );
+
+  const tcxStep: Record<string, unknown> = {
+    "@_xsi:type": "Repeat_t",
+    StepId: startIndex + 1,
+    Repetitions: block.repeatCount,
+    Child: children,
+  };
+
+  return { tcxStep, consumed: 1 + children.length };
+};
+
+// Walks the KRD step union, emitting flat leaf steps and `Repeat_t` blocks
+// while assigning a single, contiguous StepId sequence across both.
+export const buildTcxSteps = (
+  steps: Array<WorkoutStep | RepetitionBlock>,
+  sport: Sport,
+  logger: Logger
+): Array<Record<string, unknown>> => {
+  const tcxSteps: Array<Record<string, unknown>> = [];
+  let nextIndex = 0;
+
+  for (const step of steps) {
+    if (isRepetitionBlock(step)) {
+      const { tcxStep, consumed } = convertRepeatBlockToTcx(
+        step,
+        nextIndex,
+        sport,
+        logger
+      );
+      tcxSteps.push(tcxStep);
+      nextIndex += consumed;
+    } else {
+      tcxSteps.push(convertStepToTcx(step, nextIndex, sport, logger));
+      nextIndex += 1;
+    }
+  }
+
+  return tcxSteps;
+};

--- a/packages/tcx/src/adapters/workout/tcx.converter.ts
+++ b/packages/tcx/src/adapters/workout/tcx.converter.ts
@@ -1,9 +1,9 @@
-import type { KRD, Logger, Workout, WorkoutStep } from "@kaiord/core";
+import type { KRD, Logger, Workout } from "@kaiord/core";
 import { createTcxParsingError } from "@kaiord/core";
 
 import { krdToTcxSport } from "../schemas/tcx-sport";
 import { addKaiordMetadata } from "./metadata-builder";
-import { convertStepToTcx } from "./step-to-tcx.converter";
+import { buildTcxSteps } from "./repeat-block-to-tcx.converter";
 
 const buildTcxWorkout = (
   workout: Workout,
@@ -11,9 +11,7 @@ const buildTcxWorkout = (
 ): Record<string, unknown> => {
   const tcxSport = krdToTcxSport(workout.sport);
 
-  const tcxSteps = workout.steps.map((step, index) =>
-    convertStepToTcx(step as WorkoutStep, index, workout.sport, logger)
-  );
+  const tcxSteps = buildTcxSteps(workout.steps, workout.sport, logger);
 
   const tcxWorkout: Record<string, unknown> = {
     "@_Sport": tcxSport,

--- a/packages/tcx/src/test-utils/constants.ts
+++ b/packages/tcx/src/test-utils/constants.ts
@@ -18,9 +18,14 @@ export const POWER_WATTS_250 = 250 as const;
 export const STEP_COUNT_THREE = 3 as const;
 
 // === Step indices / IDs ===
+export const STEP_ID_THREE = 3 as const;
+export const STEP_ID_FOUR = 4 as const;
 export const STEP_INDEX_FOUR = 4 as const;
 export const STEP_ID_FIVE = 5 as const;
 export const STEP_INDEX_FIVE = 5 as const;
+
+// === Repetition blocks ===
+export const REPEAT_COUNT_THREE = 3 as const;
 
 // === Misc invalid value sentinels ===
 export const INVALID_NUMERIC_DURATION_TYPE = 123 as const;

--- a/packages/zwo/src/adapters/zwift-to-krd.converter.test.ts
+++ b/packages/zwo/src/adapters/zwift-to-krd.converter.test.ts
@@ -101,8 +101,22 @@ describe("convertZwiftToKRD (characterization)", () => {
 
     // Assert
     expect(krd.metadata.manufacturer).toBe("dynastream");
-    expect(krd.metadata.serialNumber).toBe(PARSER_NUMERICS.ID_1234);
+    expect(krd.metadata.serialNumber).toBe(String(PARSER_NUMERICS.ID_1234));
     expect(krd.metadata.created).toBe("2009-09-09T20:38:00.000Z");
+  });
+
+  it("should coerce a numeric ZWO serialNumber to a string in KRD", () => {
+    // Arrange
+    const zwoXml = loadZwoFixture("WorkoutIndividualSteps.zwo");
+    const zwoData = parseZwiftXml(zwoXml);
+    const logger = createMockLogger();
+
+    // Act
+    const krd = convertZwiftToKRD(zwoData, logger);
+
+    // Assert
+    expect(typeof krd.metadata.serialNumber).toBe("string");
+    expect(krd.metadata.serialNumber).toBe(String(PARSER_NUMERICS.ID_1234));
   });
 
   it("should emit a non-empty steps array for the repeat fixture", () => {

--- a/packages/zwo/src/adapters/zwift-to-krd/metadata-extractor.ts
+++ b/packages/zwo/src/adapters/zwift-to-krd/metadata-extractor.ts
@@ -5,10 +5,16 @@ type ZwiftWorkoutFile = {
   "@_kaiord:timeCreated"?: string;
   "@_kaiord:manufacturer"?: string;
   "@_kaiord:product"?: string;
-  "@_kaiord:serialNumber"?: string;
+  // `parseAttributeValue: true` in the XML parser coerces a numeric serial
+  // (e.g. `serialNumber="1234"`) to a number, but KRD types it as a string.
+  "@_kaiord:serialNumber"?: string | number;
   "@_kaiord:fitType"?: string;
   "@_kaiord:hrmFitProductId"?: number;
 };
+
+const toOptionalString = (
+  value: string | number | undefined
+): string | undefined => (value === undefined ? undefined : String(value));
 
 export const extractMetadata = (
   workoutFile: ZwiftWorkoutFile,
@@ -18,7 +24,7 @@ export const extractMetadata = (
   sport,
   manufacturer: workoutFile["@_kaiord:manufacturer"],
   product: workoutFile["@_kaiord:product"],
-  serialNumber: workoutFile["@_kaiord:serialNumber"],
+  serialNumber: toOptionalString(workoutFile["@_kaiord:serialNumber"]),
 });
 
 export const extractFitExtensions = (


### PR DESCRIPTION
Fixes two pre-existing adapter bugs that broke docs-advertised conversions (both surfaced while verifying the long-tail converter docs). Each bug has a focused fix and regression test.

## Bug A — `zwo → *` failed: numeric `serialNumber` rejected by the KRD schema

**Root cause:** the ZWO reader parses attributes with `parseAttributeValue: true`, so a numeric `kaiord:serialNumber="1234"` comes back as the **number** `1234`. The KRD domain schema types `metadata.serialNumber` as a **string**, so KRD validation threw `expected string, received number` before any writer ran — breaking every `zwo → *` direction for fixtures carrying the attribute.

**Fix:** coerce `serialNumber` to a string at the ZWO reader boundary (`zwift-to-krd/metadata-extractor.ts`), keeping the domain schema strict (real Zwift/kaiord round-trip files may carry it numeric). `@kaiord/zwo` patch.

**Tests:** added a focused unit test proving a numeric ZWO serial becomes a `string` in KRD, and updated the existing metadata-capture test to assert the coerced string (`packages/zwo/src/adapters/zwift-to-krd.converter.test.ts`).

## Bug B — `fit → tcx` threw `TcxParsingError` on repeat/interval structures

**Root cause:** the KRD→TCX writer mapped **every** step through the leaf-step converter. A KRD repetition block (`{ repeatCount, steps }`) has no `duration`/`target`, so the duration/target encoder threw; the error was wrapped as `TcxParsingError` and the conversion produced no file. Individual-step workouts were unaffected — hence the control passing.

**Fix:** walk the KRD step union with a running `StepId` counter and serialize each repetition block to a TCX `Repeat_t` step carrying `Repetitions` and `Child` (leaf) steps, matching how native TCX writers number the block and its children (`workout/repeat-block-to-tcx.converter.ts`, wired into `workout/tcx.converter.ts`). The generated TCX still passes XSD validation. `@kaiord/tcx` patch.

**Tests:**
- Focused unit tests for the new converter (`Repeat_t` shape, contiguous `StepId` sequencing across leaves + repeat children, `Step_t` children).
- Cross-format regression test `should serialize FIT repeat blocks to a TCX Repeat_t without throwing` in `packages/cli/src/tests/cross-format-round-trip.test.ts`, exercising the real `WorkoutRepeatSteps.fit` through fit→KRD→TCX (with XSD validation).

## Repros — both now succeed

```bash
# Bug A (was: validation error on serialNumber)
node packages/cli/dist/bin/kaiord.js convert -i test-fixtures/zwo/WorkoutRepeatSteps.zwo -o /tmp/z.tcx
# → Conversion complete ✓

# Bug B (was: TcxParsingError, exit 1, no file)
node packages/cli/dist/bin/kaiord.js convert -i test-fixtures/fit/WorkoutRepeatSteps.fit -o /tmp/repeat.tcx
# → Conversion complete ✓  (emits a <Step xsi:type="Repeat_t"> with <Repetitions>3</Repetitions>)

# Control (unchanged, still works)
node packages/cli/dist/bin/kaiord.js convert -i test-fixtures/fit/WorkoutIndividualSteps.fit -o /tmp/ok.tcx
# → Conversion complete ✓
```

## Verification

- `pnpm -r build` ✓, `pnpm lint` ✓ (type check + eslint + prettier + specs).
- All packages `pnpm test` green **except** a pre-existing, unrelated `@kaiord/docs` `brand-tokens.test.mjs` failure (a `--brand-bg-primary`/`--brand-text-primary` light/dark mismatch in `styles/brand-tokens.css`) that also fails on the untouched tip of `main` (`9dd36253`). Not touched here — out of scope for these converter fixes.

Closes #976

🤖 Generated with [Claude Code](https://claude.com/claude-code)
