### PR TITLE
fix(docs-site): dark theme-color reads real .dark block, not a commented ref

### DIFF
--- a/.changeset/fix-docs-brand-token-dark-block.md
+++ b/.changeset/fix-docs-brand-token-dark-block.md
@@ -1,0 +1,9 @@
+---
+"@kaiord/docs": patch
+---
+
+Fix the docs theme-color helper reading the light `:root` value instead of
+the dark palette: `extractDarkBlock` matched a `.dark { … }` reference inside
+a comment (capturing an ellipsis) rather than the real `.dark` rule, so it
+silently fell back to `:root`. Anchor the selector to the start of a line.
+The brand-tokens tests (which pin the dark-first theme-color) pass again.

--- a/packages/docs/.vitepress/brand-tokens.mjs
+++ b/packages/docs/.vitepress/brand-tokens.mjs
@@ -31,7 +31,10 @@ function matchToken(source, name) {
 }
 
 function extractDarkBlock(source) {
-  const match = source.match(/\.dark\s*\{([^}]*)\}/);
+  // Anchor `.dark` to the start of a line so the real rule block is matched,
+  // not a `.dark { … }` reference inside a comment (which would capture an
+  // ellipsis and silently fall back to the light `:root` values).
+  const match = source.match(/^\.dark\s*\{([^}]*)\}/m);
   return match?.[1] ?? "";
 }
 


### PR DESCRIPTION
**Pre-existing red on main** (not caught by CI — the docs `.mjs` scripts test isn't in the CI `test` matrix, so `pnpm -r test` locally / pre-commit catches it but releases pass). Found while verifying #978.

**Root cause:** since #930 split brand tokens into light `:root` + dark `.dark`, the theme-color helper `readBrandTokenColor` should read the dark palette (docs are dark-first). But `extractDarkBlock`'s regex `/\.dark\s*\{([^}]*)\}/` matched a `.dark { … }` **reference inside a comment** (capturing " … "), missed the token, and fell back to `:root` → returned the light values. So the docs `<meta name="theme-color">` silently regressed to light, and `brand-tokens.test.mjs` went red.

**Fix:** anchor the selector to line-start (`/^\.dark…/m`) so the real rule matches, not the comment. Helper now returns `#0f172a`/`#f8fafc` (dark); the 2 failing brand-tokens tests pass (28 tests, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dark theme color detection in the documentation site.
  * Prevented comments or placeholder text from being mistaken for the active dark palette.
  * Restored the expected dark-first theme color behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->