### PR TITLE
fix(docs-site): dark theme-color reads real .dark block, not a commented ref

### DIFF
--- a/.changeset/fix-docs-brand-token-dark-block.md
+++ b/.changeset/fix-docs-brand-token-dark-block.md
@@ -1,0 +1,9 @@
+---
+"@kaiord/docs": patch
+---
+
+Fix the docs theme-color helper reading the light `:root` value instead of
+the dark palette: `extractDarkBlock` matched a `.dark { … }` reference inside
+a comment (capturing an ellipsis) rather than the real `.dark` rule, so it
+silently fell back to `:root`. Anchor the selector to the start of a line.
+The brand-tokens tests (which pin the dark-first theme-color) pass again.

--- a/packages/docs/.vitepress/brand-tokens.mjs
+++ b/packages/docs/.vitepress/brand-tokens.mjs
@@ -31,7 +31,10 @@ function matchToken(source, name) {
 }
 
 function extractDarkBlock(source) {
-  const match = source.match(/\.dark\s*\{([^}]*)\}/);
+  // Anchor `.dark` to the start of a line so the real rule block is matched,
+  // not a `.dark { … }` reference inside a comment (which would capture an
+  // ellipsis and silently fall back to the light `:root` values).
+  const match = source.match(/^\.dark\s*\{([^}]*)\}/m);
   return match?.[1] ?? "";
 }
 


### PR DESCRIPTION
Re-opens the brand-token fix (prior PR #979 auto-closed when an over-eager cleanup deleted its branch pre-merge; commit recovered intact via cherry-pick — no content changed).

**Pre-existing red on main** (docs .mjs scripts test isn't in the CI `test` matrix, so releases pass but `pnpm -r test` / pre-commit catches it). Found while verifying #978.

**Root cause:** since #930 split brand tokens into light `:root` + dark `.dark`, the theme-color helper should read the dark palette (docs are dark-first), but `extractDarkBlock`'s regex matched a `.dark { … }` reference inside a COMMENT, missed the token, and fell back to `:root` → light. Docs `<meta name=theme-color>` silently regressed to light; `brand-tokens.test.mjs` went red.

**Fix:** anchor the selector to line-start (`/^\.dark…/m`). Helper returns dark `#0f172a`/`#f8fafc`; 2 failing tests pass (27 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dark-mode theme colors in the documentation site.
  * Prevented commented text from being mistaken for active dark-mode styling.
  * Ensured the correct dark theme color is used instead of falling back to the light theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->