### PR TITLE
fix: align LinkedIn sameAs/links with the current profile URL

### DIFF
--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -10,8 +10,7 @@ const OG_IMAGE = `${SITE_URL}${DOCS_BASE}og-image-docs.png`;
 
 const AUTHOR = {
   name: "Pablo Albaladejo",
-  linkedin:
-    "https://www.linkedin.com/in/pablo-albaladejo-aws-software-engineer-ai/",
+  linkedin: "https://www.linkedin.com/in/pabloalbaladejomestre",
   github: "https://github.com/pablo-albaladejo",
 };
 
@@ -204,7 +203,7 @@ const config = {
 
     footer: {
       message:
-        'Built by <a href="https://www.linkedin.com/in/pablo-albaladejo-aws-software-engineer-ai/" target="_blank" rel="noopener">Pablo Albaladejo</a>',
+        'Built by <a href="https://www.linkedin.com/in/pabloalbaladejomestre" target="_blank" rel="noopener">Pablo Albaladejo</a>',
       copyright:
         '<a href="https://github.com/pablo-albaladejo/kaiord/releases" target="_blank" rel="noopener">GitHub Releases</a>',
     },

--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -71,7 +71,7 @@
               "@type": "Person",
               "name": "Pablo Albaladejo",
               "sameAs": [
-                "https://www.linkedin.com/in/pablo-albaladejo-aws-software-engineer-ai/",
+                "https://www.linkedin.com/in/pabloalbaladejomestre",
                 "https://github.com/pablo-albaladejo"
               ]
             }
@@ -92,7 +92,7 @@
               "@type": "Person",
               "name": "Pablo Albaladejo",
               "sameAs": [
-                "https://www.linkedin.com/in/pablo-albaladejo-aws-software-engineer-ai/",
+                "https://www.linkedin.com/in/pabloalbaladejomestre",
                 "https://github.com/pablo-albaladejo"
               ]
             }
@@ -162,7 +162,7 @@
               "@type": "Person",
               "name": "Pablo Albaladejo",
               "sameAs": [
-                "https://www.linkedin.com/in/pablo-albaladejo-aws-software-engineer-ai/",
+                "https://www.linkedin.com/in/pabloalbaladejomestre",
                 "https://github.com/pablo-albaladejo"
               ]
             }
@@ -2493,7 +2493,7 @@
           <div class="text-sm text-[var(--brand-text-muted)]">
             Built by
             <a
-              href="https://www.linkedin.com/in/pablo-albaladejo-aws-software-engineer-ai/"
+              href="https://www.linkedin.com/in/pabloalbaladejomestre"
               target="_blank"
               rel="noopener noreferrer"
               class="font-medium text-[var(--brand-text-secondary)] transition-colors hover:text-[var(--brand-text-primary)] focus-visible:outline-2 focus-visible:outline-[var(--brand-accent-blue)]"

--- a/packages/workout-spa-editor/index.html
+++ b/packages/workout-spa-editor/index.html
@@ -97,7 +97,7 @@
           "@type": "Person",
           "name": "Pablo Albaladejo",
           "sameAs": [
-            "https://www.linkedin.com/in/pablo-albaladejo-aws-software-engineer-ai/",
+            "https://www.linkedin.com/in/pabloalbaladejomestre",
             "https://github.com/pablo-albaladejo"
           ]
         }


### PR DESCRIPTION
Entity-consistency cleanup for GEO. The landing (WebSite/WebApplication/SoftwareSourceCode author `sameAs` + footer link), the editor (`sameAs`), and the docs config still pointed at the old vanity slug `…/pablo-albaladejo-aws-software-engineer-ai`. Aligned all 7 references with the current LinkedIn URL (`…/pabloalbaladejomestre`) used across the other properties, so the `sameAs` graph resolves to one canonical profile.

Build green; no changeset (landing/editor/docs are private, non-published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)