### PR TITLE
test(spa-editor): route e2e Dexie-ready waits through a shared helper (fix timeout arg-slot ×27)

### DIFF
--- a/packages/workout-spa-editor/e2e/calendar-performance.spec.ts
+++ b/packages/workout-spa-editor/e2e/calendar-performance.spec.ts
@@ -28,6 +28,7 @@
  */
 
 import { expect, test } from "./fixtures/base";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 // FCP budget is the CI-calibrated envelope (ubuntu-latest runner with
 // CDP throttle 4×). The archived design D11 named 200ms as the
@@ -116,11 +117,7 @@ test.describe("CalendarPage performance budget", () => {
   }, testInfo) => {
     // 1. Boot the SPA (no throttling — only the calendar nav is measured).
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
 
     // 2/3. Bootstrap a perf profile + seed the 30-card week.
     await page.evaluate(

--- a/packages/workout-spa-editor/e2e/coaching-dialog-redesign.spec.ts
+++ b/packages/workout-spa-editor/e2e/coaching-dialog-redesign.spec.ts
@@ -45,6 +45,7 @@ import {
 } from "./helpers/garmin-bridge-stub";
 import { seedAiProvider } from "./helpers/seed-ai-provider";
 import { clearDexie, getWeekDates, getWeekId } from "./helpers/seed-dexie";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 import { disableOnboardingTutorial } from "./test-setup";
 
 const PROFILE_ID = "coaching-redesign-profile";
@@ -275,11 +276,7 @@ test.describe("Coaching activity dialog redesign", () => {
   }) => {
     // Arrange — boot SPA, clear Dexie, seed profile + activity
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     const day = getWeekDates(0)[2];
     const ts = new Date(day + "T08:00:00Z").toISOString();
@@ -337,11 +334,7 @@ test.describe("Coaching activity dialog redesign", () => {
   }) => {
     // Arrange — seed an activity AND a workout (sourceId matched) but NO session_match
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     const day = getWeekDates(0)[2];
     const ts = new Date(day + "T08:00:00Z").toISOString();
@@ -384,11 +377,7 @@ test.describe("Coaching activity dialog redesign", () => {
   }) => {
     // Arrange — boot SPA, clear Dexie, seed profile + activity + AI provider
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     await mockLlmSuccess(page, LLM_CYCLING_RESPONSE);
     await seedAiProvider(page);
@@ -437,11 +426,7 @@ test.describe("Coaching activity dialog redesign", () => {
   }) => {
     // Arrange — capture the LLM request body via a custom route handler
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     const capturedBodies: string[] = [];
     const captureAndRespond = async (route: Route) => {
@@ -499,11 +484,7 @@ test.describe("Coaching activity dialog redesign", () => {
     // Arrange — first call fails, second succeeds (handler swaps via
     // an atomic counter so each interception is deterministic).
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     let calls = 0;
     const handler = async (route: Route) => {
@@ -590,11 +571,7 @@ test.describe("Coaching activity dialog redesign", () => {
     // Arrange — every LLM call returns 401 (non-retryable, so the AI SDK
     // surfaces the error instead of backing off through `maxRetries`).
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     await mockLlmFailure(page, { status: 401 });
     await seedAiProvider(page);
@@ -654,11 +631,7 @@ test.describe("Coaching activity dialog redesign", () => {
   }) => {
     // Arrange — seed a matched workout in `state="raw"` AND its session_match
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     await mockLlmSuccess(page, LLM_CYCLING_RESPONSE);
     await seedAiProvider(page);
@@ -766,11 +739,7 @@ test.describe("Coaching activity dialog redesign", () => {
     // bridge-discovery sees the announce on boot.
     await installGarminBridgeStub(page);
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     const day = getWeekDates(0)[2];
     const ts = new Date(day + "T08:00:00Z").toISOString();
@@ -831,11 +800,7 @@ test.describe("Coaching activity dialog redesign", () => {
     // workout reaches `state="pushed"` the Push button is hidden.
     await installGarminBridgeStub(page);
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     const day = getWeekDates(0)[2];
     const ts = new Date(day + "T08:00:00Z").toISOString();
@@ -895,11 +860,7 @@ test.describe("Coaching activity dialog redesign", () => {
   }) => {
     // Arrange — seed activity with empty description
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     const day = getWeekDates(0)[2];
     const ts = new Date(day + "T08:00:00Z").toISOString();

--- a/packages/workout-spa-editor/e2e/coaching-dialog-train2go.spec.ts
+++ b/packages/workout-spa-editor/e2e/coaching-dialog-train2go.spec.ts
@@ -20,6 +20,7 @@
 import { expect, test } from "@playwright/test";
 
 import { clearDexie, getWeekDates, getWeekId } from "./helpers/seed-dexie";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 import { disableOnboardingTutorial } from "./test-setup";
 
 const PROFILE_ID = "t2g-click-profile";
@@ -37,11 +38,7 @@ test.describe("Coaching activity dialog — Train2Go click path", () => {
   }) => {
     // 1. Boot the SPA so Dexie is initialised.
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
 
     // 2. Pick a deterministic day inside the visible week.

--- a/packages/workout-spa-editor/e2e/coaching-sidebar.visual.spec.ts
+++ b/packages/workout-spa-editor/e2e/coaching-sidebar.visual.spec.ts
@@ -12,6 +12,7 @@ import { expect, test } from "@playwright/test";
 
 import { clearDexie, getWeekDates } from "./helpers/seed-dexie";
 import { seedMatchedCoachingWorkout } from "./helpers/seed-matched-coaching-workout";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 import { disableOnboardingTutorial } from "./test-setup";
 
 const PROFILE_ID = "visual-sidebar-profile";
@@ -38,11 +39,7 @@ test.describe("CoachingSidebar visual regression", () => {
     // Arrange
     await page.setViewportSize({ width: 1024, height: 768 });
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     const day = getWeekDates(0)[2];
     const ts = new Date(day + "T08:00:00Z").toISOString();
@@ -71,11 +68,7 @@ test.describe("CoachingSidebar visual regression", () => {
     // Arrange
     await page.setViewportSize({ width: 768, height: 1024 });
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await clearDexie(page);
     const day = getWeekDates(0)[2];
     const ts = new Date(day + "T08:00:00Z").toISOString();

--- a/packages/workout-spa-editor/e2e/data-flows-density.spec.ts
+++ b/packages/workout-spa-editor/e2e/data-flows-density.spec.ts
@@ -19,6 +19,7 @@ import type { Page } from "@playwright/test";
 
 import { expect, test } from "./fixtures/base";
 import { installGarminBridgeStub } from "./helpers/garmin-bridge-stub";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 const PROFILE_ID = "connections-profile";
 
@@ -60,11 +61,7 @@ test.describe("Athlete Connections", () => {
   }) => {
     // Arrange
     await page.goto("/athlete");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await seedProfile(page);
 
     // Act
@@ -85,11 +82,7 @@ test.describe("Athlete Connections", () => {
     // marks Garmin as connected.
     await installGarminBridgeStub(page);
     await page.goto("/athlete");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await seedProfile(page);
     await page.goto("/athlete");
 

--- a/packages/workout-spa-editor/e2e/data-hub.spec.ts
+++ b/packages/workout-spa-editor/e2e/data-hub.spec.ts
@@ -19,6 +19,7 @@ import {
   installTrain2GoBridgeStub,
   TRAIN2GO_BRIDGE_ID,
 } from "./helpers/train2go-bridge-stub";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 const PROFILE_ID = "00000000-0000-4000-8000-0000000000d4";
 const DATA_HUB_PATH = "/settings/data-hub";
@@ -28,11 +29,7 @@ type DexieDb = {
   table: (n: string) => { put: (r: unknown) => Promise<void> };
 };
 
-const waitForDb = (page: Page): Promise<unknown> =>
-  page.waitForFunction(
-    () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-    { timeout: 10_000 }
-  );
+const waitForDb = (page: Page): Promise<unknown> => waitForDexieReady(page);
 
 const seedProfile = async (page: Page): Promise<void> => {
   await page.evaluate(async (pid) => {

--- a/packages/workout-spa-editor/e2e/garmin-activities-via-policy.spec.ts
+++ b/packages/workout-spa-editor/e2e/garmin-activities-via-policy.spec.ts
@@ -18,6 +18,7 @@ import {
   getGarminBridgeCallActions,
   installGarminBridgeStub,
 } from "./helpers/garmin-bridge-stub";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 const PROFILE_ID = "garmin-activities-policy-e2e";
 
@@ -36,11 +37,7 @@ const stubActivity = () => ({
   distance: 30000,
 });
 
-const waitForDb = (page: Page): Promise<unknown> =>
-  page.waitForFunction(
-    () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-    { timeout: 10_000 }
-  );
+const waitForDb = (page: Page): Promise<unknown> => waitForDexieReady(page);
 
 const seedProfile = async (page: Page): Promise<void> => {
   await page.evaluate(async (pid) => {

--- a/packages/workout-spa-editor/e2e/garmin-push-via-policy.spec.ts
+++ b/packages/workout-spa-editor/e2e/garmin-push-via-policy.spec.ts
@@ -21,6 +21,7 @@ import {
   installGarminBridgeStub,
 } from "./helpers/garmin-bridge-stub";
 import { getWeekDates, makeWorkout, seedWorkouts } from "./helpers/seed-dexie";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 const PROFILE_ID = "garmin-push-policy-e2e";
 
@@ -108,11 +109,7 @@ test.describe("GarminPushButton resolver gating (AC-5)", () => {
     const WORKOUT_ID = "garmin-push-editor-workout";
     await installGarminBridgeStub(page);
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await seedProfileBase(page, PROFILE_ID);
     await addExportPolicy(page, PROFILE_ID, GARMIN_BRIDGE_ID);
     await seedWorkouts(page, [
@@ -143,11 +140,7 @@ test.describe("GarminPushButton resolver gating (AC-5)", () => {
     const WORKOUT_ID = "garmin-push-detail-workout";
     await installGarminBridgeStub(page);
     await page.goto("/calendar");
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
     await seedProfileBase(page, PROFILE_ID);
     await addExportPolicy(page, PROFILE_ID, GARMIN_BRIDGE_ID);
     await seedWorkouts(page, [

--- a/packages/workout-spa-editor/e2e/helpers/wait-for-dexie-ready.ts
+++ b/packages/workout-spa-editor/e2e/helpers/wait-for-dexie-ready.ts
@@ -1,0 +1,14 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Wait until the SPA has exposed its Dexie handle on `window.__KAIORD_DB__`
+ * (the seed helpers require it). The timeout rides the correct 3rd positional
+ * slot — `waitForFunction(fn, arg, options)` — so it is actually applied,
+ * unlike the 2-arg copy-paste this replaces.
+ */
+export const waitForDexieReady = (page: Page): Promise<unknown> =>
+  page.waitForFunction(
+    () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
+    undefined,
+    { timeout: 10_000 }
+  );

--- a/packages/workout-spa-editor/e2e/lab-dashboard.spec.ts
+++ b/packages/workout-spa-editor/e2e/lab-dashboard.spec.ts
@@ -8,6 +8,7 @@
 import type { Page } from "@playwright/test";
 
 import { expect, test } from "./fixtures/base";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 const PROFILE_ID = "labs-dashboard-profile";
 const DATE = "2026-01-01";
@@ -68,10 +69,7 @@ async function seed(page: Page) {
 
 async function gotoDashboard(page: Page) {
   await page.goto("/health/labs");
-  await page.waitForFunction(
-    () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-    { timeout: 10_000 }
-  );
+  await waitForDexieReady(page);
   await seed(page);
   await page.goto("/health/labs");
   await expect(page.getByTestId("health-labs")).toBeVisible({

--- a/packages/workout-spa-editor/e2e/lab-dod-journey.spec.ts
+++ b/packages/workout-spa-editor/e2e/lab-dod-journey.spec.ts
@@ -11,6 +11,7 @@
 import type { Page } from "@playwright/test";
 
 import { expect, test } from "./fixtures/base";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 const PROFILE_ID = "labs-dod-journey-profile";
 const OLD_DATE = "2026-01-01";
@@ -122,10 +123,7 @@ async function seedHistory(page: Page) {
 
 async function gotoLabs(page: Page) {
   await page.goto("/health/labs");
-  await page.waitForFunction(
-    () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-    { timeout: 10_000 }
-  );
+  await waitForDexieReady(page);
   await seedHistory(page);
   await page.goto("/health/labs");
   await expect(page.getByTestId("health-labs")).toBeVisible({

--- a/packages/workout-spa-editor/e2e/lab-entry.spec.ts
+++ b/packages/workout-spa-editor/e2e/lab-entry.spec.ts
@@ -10,6 +10,7 @@
 import type { Page } from "@playwright/test";
 
 import { expect, test } from "./fixtures/base";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 const PROFILE_ID = "labs-e2e-profile";
 const PROFILE_NAME = "Labs E2E Athlete";
@@ -54,10 +55,7 @@ async function seedProfile(page: Page) {
 
 async function gotoLabEntry(page: Page) {
   await page.goto("/health/labs");
-  await page.waitForFunction(
-    () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-    { timeout: 10_000 }
-  );
+  await waitForDexieReady(page);
   await seedProfile(page);
   await page.goto("/health/labs");
   await expect(page.getByTestId("health-labs")).toBeVisible({
@@ -132,11 +130,7 @@ test.describe("Lab analytics entry (DoD-1)", () => {
       timeout: 20_000,
     });
     await page.reload();
-    await page.waitForFunction(
-      () =>
-        Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-      { timeout: 10_000 }
-    );
+    await waitForDexieReady(page);
 
     // Assert — read the persisted rows straight from Dexie (no list UI yet).
     const { reports, values } = await page.evaluate(async (profileId) => {

--- a/packages/workout-spa-editor/e2e/lab-evolution.spec.ts
+++ b/packages/workout-spa-editor/e2e/lab-evolution.spec.ts
@@ -8,6 +8,7 @@
 import type { Page } from "@playwright/test";
 
 import { expect, test } from "./fixtures/base";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 const PROFILE_ID = "labs-evolution-profile";
 const REF_LOW = 70;
@@ -120,10 +121,7 @@ async function seed(page: Page, opts: SeedOpts) {
 
 async function gotoLabs(page: Page, opts: SeedOpts) {
   await page.goto("/health/labs");
-  await page.waitForFunction(
-    () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-    { timeout: 10_000 }
-  );
+  await waitForDexieReady(page);
   await seed(page, opts);
   await page.goto("/health/labs");
   await expect(page.getByTestId("lab-history")).toBeVisible({

--- a/packages/workout-spa-editor/e2e/lab-history.spec.ts
+++ b/packages/workout-spa-editor/e2e/lab-history.spec.ts
@@ -9,6 +9,7 @@
 import type { Page } from "@playwright/test";
 
 import { expect, test } from "./fixtures/base";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 const PROFILE_ID = "labs-history-profile";
 const OLD_DATE = "2026-01-01";
@@ -129,10 +130,7 @@ async function seed(page: Page) {
 
 async function gotoLabHistory(page: Page) {
   await page.goto("/health/labs");
-  await page.waitForFunction(
-    () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-    { timeout: 10_000 }
-  );
+  await waitForDexieReady(page);
   await seed(page);
   await page.goto("/health/labs");
   await expect(page.getByTestId("lab-history")).toBeVisible({

--- a/packages/workout-spa-editor/e2e/profiles.spec.ts
+++ b/packages/workout-spa-editor/e2e/profiles.spec.ts
@@ -18,6 +18,7 @@
 import type { Page } from "@playwright/test";
 
 import { expect, test } from "./fixtures/base";
+import { waitForDexieReady } from "./helpers/wait-for-dexie-ready";
 
 const PROFILE_ID = "athlete-e2e-profile";
 const PROFILE_NAME = "E2E Athlete";
@@ -67,10 +68,7 @@ async function gotoAthlete(page: Page) {
   // Boot once to expose the Dexie singleton, seed the active profile,
   // then load the populated Athlete page.
   await page.goto("/athlete");
-  await page.waitForFunction(
-    () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
-    { timeout: 10_000 }
-  );
+  await waitForDexieReady(page);
   await seedAthleteProfile(page);
   await page.goto("/athlete");
   await expect(page.getByRole("radiogroup", { name: "Sport" })).toBeVisible({


### PR DESCRIPTION
## Context

Follow-up to #982. That PR fixed a flaky `zones-sync` timeout whose root cause was a Playwright footgun: `page.waitForFunction(fn, { timeout })` puts the options object in the **2nd (arg) slot** — the signature is `waitForFunction(pageFunction, arg, options)` — so the timeout is silently swallowed and the wait falls back to the `actionTimeout` default. An audit found the **same mistake copy-pasted 27 times** across 14 e2e specs, all in the "wait for Dexie ready" idiom:

```ts
await page.waitForFunction(
  () => Boolean((window as unknown as Record<string, unknown>).__KAIORD_DB__),
  { timeout: 10_000 },   // ⚠️ swallowed as the page-function arg
);
```

## Fix

Extract one `waitForDexieReady(page)` helper (`e2e/helpers/wait-for-dexie-ready.ts`) that puts the timeout in the correct 3rd slot, and replace all 27 call sites with it.

- **No behaviour change** — the default `actionTimeout` (10 s) equalled the intended 10 s, so these waits already ran at 10 s. This makes the timeout *honest* (a future bump now actually applies) and removes the copy-paste so the footgun cannot recur.
- Net **−74 LOC**.
- Excludes `zones-sync.spec.ts` (its DB-ready wait was already fixed in #982) and the already-correct 3-arg sites.

## Verification

- `tsc --noEmit`, eslint, prettier clean.
- `lab-dashboard.spec.ts` + `coaching-dialog-redesign.spec.ts` pass on chromium (DB-ready wait still works end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
