### PR TITLE
feat(fit): carry visceral fat rating and BMR through body composition

### DIFF
--- a/.changeset/body-composition-visceral-bmr.md
+++ b/.changeset/body-composition-visceral-bmr.md
@@ -1,0 +1,12 @@
+---
+"@kaiord/core": minor
+"@kaiord/fit": minor
+---
+
+Carry visceral fat rating and basal metabolic rate through body composition.
+The KRD `bodyComposition` schema gains optional `visceralFatRating` (unitless)
+and `basalMetabolicRateKcal` (kcal/day) fields, and the FIT `body_composition`
+converter now maps both directions (FIT `visceralFatRating`/`basalMet` ↔ KRD),
+so scales reporting them no longer silently drop the values. BMR is carried as
+real kcal because the @garmin/fitsdk Encoder/Decoder auto-applies the FIT
+profile scale (4) for `basal_met`.

--- a/packages/core/src/domain/schemas/health/body-composition.test.ts
+++ b/packages/core/src/domain/schemas/health/body-composition.test.ts
@@ -32,6 +32,27 @@ describe("bodyCompositionSchema", () => {
       boneMassKilograms: 3.1,
       bodyWaterPercent: 56.1,
       bmi: 22.7,
+      visceralFatRating: 12,
+      basalMetabolicRateKcal: 1500,
+    };
+
+    // Act
+    const result = bodyCompositionSchema.safeParse(input);
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept a payload carrying only visceralFatRating and basalMetabolicRateKcal", () => {
+    // Arrange
+    // The superRefine hasAny check must count the new fields, else a scale
+    // reporting only visceral fat + BMR is wrongly rejected as empty.
+    const input = {
+      kind: "bodyComposition" as const,
+      version: "2.0",
+      measuredAt: baseMeasuredAt,
+      visceralFatRating: 12,
+      basalMetabolicRateKcal: 1500,
     };
 
     // Act

--- a/packages/core/src/domain/schemas/health/body-composition.ts
+++ b/packages/core/src/domain/schemas/health/body-composition.ts
@@ -21,6 +21,8 @@ export const bodyCompositionSchema = z
     boneMassKilograms: z.number().positive().optional(),
     bodyWaterPercent: z.number().min(0).max(100).optional(),
     bmi: z.number().positive().optional(),
+    visceralFatRating: z.number().nonnegative().optional(),
+    basalMetabolicRateKcal: z.number().positive().optional(),
     kaiordRecordId: z.string().uuid().optional(),
     sourceBridgeId: z.string().optional(),
     externalId: z.string().optional(),
@@ -31,12 +33,14 @@ export const bodyCompositionSchema = z
       value.leanMassKilograms !== undefined ||
       value.boneMassKilograms !== undefined ||
       value.bodyWaterPercent !== undefined ||
-      value.bmi !== undefined;
+      value.bmi !== undefined ||
+      value.visceralFatRating !== undefined ||
+      value.basalMetabolicRateKcal !== undefined;
     if (!hasAny) {
       ctx.addIssue({
         code: "custom",
         message:
-          "At least one body-composition field (bodyFatPercent, leanMassKilograms, boneMassKilograms, bodyWaterPercent, bmi) must be present.",
+          "At least one body-composition field (bodyFatPercent, leanMassKilograms, boneMassKilograms, bodyWaterPercent, bmi, visceralFatRating, basalMetabolicRateKcal) must be present.",
       });
     }
   });

--- a/packages/fit/src/adapters/health/body-composition/basal-met-sdk-scale.test.ts
+++ b/packages/fit/src/adapters/health/body-composition/basal-met-sdk-scale.test.ts
@@ -1,0 +1,111 @@
+import { Decoder, Encoder, Stream } from "@garmin/fitsdk";
+import type { BodyComposition } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  mapFitBodyCompositionToKrd,
+  mapKrdBodyCompositionToFit,
+} from "./health-body-composition.converter";
+
+/**
+ * Byte-level scale probe for `basalMet` against the REAL @garmin/fitsdk
+ * Encoder/Decoder.
+ *
+ * A pure in-memory KRD↔FIT round-trip is NOT sufficient to pin the scale:
+ * a symmetric scale error (mapper multiplies by N, then divides by N) round-
+ * trips clean while still corrupting the value on the wire. Only the SDK byte
+ * path — which knows the profile scale — catches a wrong scale.
+ *
+ * The @garmin/fitsdk Profile (v21.208.0) has NO `body_composition` message
+ * (mesgNum 41); the `basalMet` (scale 4, kcal/day) and `visceralFatRating`
+ * (scale 1) fields live in `weight_scale` (mesgNum 30) with identical field
+ * definitions. We therefore drive the SAME field definitions through the SDK
+ * via a weight_scale message, feeding the mapper's output so a mapper scale
+ * bug would surface here.
+ */
+const WEIGHT_SCALE_MESG_NUM = 30;
+const MEASURED_AT = "2026-05-22T07:15:00.000Z";
+const BASAL_MET_KCAL = 1500;
+const VISCERAL_FAT_RATING = 12;
+// The FIT profile scale for `basal_met` (kcal/day). Only used to construct a
+// deliberately pre-scaled value that proves double-scaling corrupts BMR.
+const BASAL_MET_PROFILE_SCALE = 4;
+
+const encodeDecodeWeightScale = (fields: {
+  basalMet?: number;
+  visceralFatRating?: number;
+}): { basalMet?: number; visceralFatRating?: number } => {
+  const encoder = new Encoder();
+  // The SDK's writeMesg is typed against a fixed `Mesg` shape (mesgNum +
+  // developerFields only); real FIT fields are passed as a loose record, as
+  // the production writer does. Cast at the boundary to satisfy the types.
+  const inputMesg: Record<string, unknown> = {
+    mesgNum: WEIGHT_SCALE_MESG_NUM,
+    timestamp: new Date(MEASURED_AT),
+    ...fields,
+  };
+  encoder.writeMesg(
+    inputMesg as unknown as Parameters<typeof encoder.writeMesg>[0]
+  );
+  const bytes = encoder.close();
+  const decoder = new Decoder(Stream.fromByteArray(Array.from(bytes)));
+  const { messages, errors } = decoder.read();
+  expect(errors).toEqual([]);
+  const decoded = (
+    messages as { weightScaleMesgs?: Array<Record<string, number>> }
+  ).weightScaleMesgs?.[0];
+  if (!decoded) throw new Error("no weight_scale message decoded");
+  return decoded;
+};
+
+describe("basalMet scale through the real @garmin/fitsdk byte path", () => {
+  it("should preserve REAL kcal through encode-decode, proving the SDK auto-applies scale 4", () => {
+    // Arrange
+    // The mapper output carries the real kcal (no manual scaling).
+    const body: BodyComposition = {
+      kind: "bodyComposition",
+      version: "2.0",
+      measuredAt: MEASURED_AT,
+      basalMetabolicRateKcal: BASAL_MET_KCAL,
+      visceralFatRating: VISCERAL_FAT_RATING,
+    };
+    const fit = mapKrdBodyCompositionToFit(body);
+    expect(fit.basalMet).toBe(BASAL_MET_KCAL); // mapper does not scale
+
+    // Act
+    // Drive the mapper output through the real SDK byte path.
+    const decoded = encodeDecodeWeightScale({
+      basalMet: fit.basalMet,
+      visceralFatRating: fit.visceralFatRating,
+    });
+
+    // Assert
+    // The SDK returns the SAME real kcal (scale 4 applied internally), and the
+    // integer rating survives unchanged. A mapper that pre-scaled by 4 would
+    // decode 6000 here, not 1500. Map back to KRD to close the loop.
+    expect(decoded.basalMet).toBe(BASAL_MET_KCAL);
+    expect(decoded.visceralFatRating).toBe(VISCERAL_FAT_RATING);
+    const replayed = mapFitBodyCompositionToKrd({
+      timestamp: new Date(MEASURED_AT),
+      basalMet: decoded.basalMet,
+      visceralFatRating: decoded.visceralFatRating,
+    });
+    expect(replayed?.basalMetabolicRateKcal).toBe(BASAL_MET_KCAL);
+    expect(replayed?.visceralFatRating).toBe(VISCERAL_FAT_RATING);
+  });
+
+  it("should decode a wrong value when fed a pre-scaled raw basalMet, guarding the mapper no-scale contract", () => {
+    // Arrange
+    // Feeding a value pre-multiplied by the profile scale makes the SDK apply
+    // the scale a SECOND time, so the decoded real value is wrong — the exact
+    // corruption the mapper avoids by passing real kcal through.
+    const preScaled = BASAL_MET_KCAL * BASAL_MET_PROFILE_SCALE;
+
+    // Act
+    const decoded = encodeDecodeWeightScale({ basalMet: preScaled });
+
+    // Assert
+    expect(decoded.basalMet).not.toBe(BASAL_MET_KCAL);
+    expect(decoded.basalMet).toBe(preScaled);
+  });
+});

--- a/packages/fit/src/adapters/health/body-composition/body-composition-round-trip.test.ts
+++ b/packages/fit/src/adapters/health/body-composition/body-composition-round-trip.test.ts
@@ -24,6 +24,8 @@ const buildOriginalBody = (): BodyComposition =>
     leanMassKilograms: 33.5,
     boneMassKilograms: 3.1,
     bmi: 23.5,
+    visceralFatRating: 12,
+    basalMetabolicRateKcal: 1500,
   });
 
 const buildOriginalKrd = (body: BodyComposition): KRD => ({
@@ -72,5 +74,7 @@ describe("body composition KRD → FIT → KRD round-trip", () => {
     expect(boneDelta).toBeLessThanOrEqual(WEIGHT_TOLERANCE_KG);
     expect(replayed.bodyWaterPercent).toBe(body.bodyWaterPercent);
     expect(replayed.bmi).toBe(body.bmi);
+    expect(replayed.visceralFatRating).toBe(body.visceralFatRating);
+    expect(replayed.basalMetabolicRateKcal).toBe(body.basalMetabolicRateKcal);
   });
 });

--- a/packages/fit/src/adapters/health/body-composition/health-body-composition.converter.test.ts
+++ b/packages/fit/src/adapters/health/body-composition/health-body-composition.converter.test.ts
@@ -10,6 +10,14 @@ const BODY_FAT_PERCENT = 18.4;
 const MUSCLE_MASS_KG = 58.2;
 const MUSCLE_MASS_RAW = 5820;
 const BONE_MASS_KG = 3.1;
+const VISCERAL_FAT_RATING = 12;
+// basalMet has FIT profile scale 4 (kcal/day), but the @garmin/fitsdk
+// Decoder/Encoder auto-applies that scale, so the mapper carries the REAL
+// kcal value with NO scaling on either side (FIT raw == KRD kcal at the
+// mapper boundary). The byte-level scale-4 behaviour is pinned separately
+// in basal-met-sdk-scale.test.ts.
+const BASAL_MET_KCAL = 1500;
+const BASAL_MET_FIT_RAW = 1500;
 
 describe("mapFitBodyCompositionToKrd", () => {
   it("should produce a KRD body composition with at least one optional field present", () => {
@@ -45,6 +53,22 @@ describe("mapFitBodyCompositionToKrd", () => {
     expect(krd?.leanMassKilograms).toBe(MUSCLE_MASS_KG);
   });
 
+  it("should pass through visceralFatRating and map basalMet to basalMetabolicRateKcal without scaling", () => {
+    // Arrange
+    const fit = {
+      timestamp: new Date(MEASURED_AT),
+      visceralFatRating: VISCERAL_FAT_RATING,
+      basalMet: BASAL_MET_FIT_RAW,
+    };
+
+    // Act
+    const krd = mapFitBodyCompositionToKrd(fit);
+
+    // Assert
+    expect(krd?.visceralFatRating).toBe(VISCERAL_FAT_RATING);
+    expect(krd?.basalMetabolicRateKcal).toBe(BASAL_MET_KCAL);
+  });
+
   it("should return undefined when no measurement field is present", () => {
     // Arrange
     const fit = { timestamp: new Date(MEASURED_AT) };
@@ -76,5 +100,25 @@ describe("mapKrdBodyCompositionToFit", () => {
     expect(fit.percentFat).toBe(BODY_FAT_PERCENT);
     expect(fit.muscleMass).toBe(MUSCLE_MASS_RAW);
     expect((fit.timestamp as Date).toISOString()).toBe(MEASURED_AT);
+  });
+
+  it("should map basalMetabolicRateKcal to FIT basalMet unscaled and pass through visceralFatRating", () => {
+    // Arrange
+    const body = {
+      kind: "bodyComposition" as const,
+      version: "2.0",
+      measuredAt: MEASURED_AT,
+      visceralFatRating: VISCERAL_FAT_RATING,
+      basalMetabolicRateKcal: BASAL_MET_KCAL,
+    };
+
+    // Act
+    const fit = mapKrdBodyCompositionToFit(body);
+
+    // Assert
+    // The mapper does NOT scale basalMet (the SDK applies profile scale 4);
+    // the intermediate FIT value equals the real kcal.
+    expect(fit.basalMet).toBe(BASAL_MET_FIT_RAW);
+    expect(fit.visceralFatRating).toBe(VISCERAL_FAT_RATING);
   });
 });

--- a/packages/fit/src/adapters/health/body-composition/health-body-composition.converter.ts
+++ b/packages/fit/src/adapters/health/body-composition/health-body-composition.converter.ts
@@ -27,6 +27,15 @@ const collectMeasurements = (
   if (boneMassKilograms !== undefined)
     out.boneMassKilograms = boneMassKilograms;
   if (fit.bmi !== undefined) out.bmi = fit.bmi;
+  // visceralFatRating (profile scale 1) and basalMet (profile scale 4,
+  // kcal/day) are pass-throughs: the @garmin/fitsdk Decoder/Encoder
+  // auto-applies their profile scale, so the mapper carries REAL values
+  // (like percentFat/bmi) and must NOT scale them itself. Verified by an
+  // encode→decode probe against the SDK (weight_scale carries the same
+  // basalMet field definition). See basal-met-sdk-scale.test.ts.
+  if (fit.visceralFatRating !== undefined)
+    out.visceralFatRating = fit.visceralFatRating;
+  if (fit.basalMet !== undefined) out.basalMetabolicRateKcal = fit.basalMet;
   return out;
 };
 
@@ -70,4 +79,10 @@ export const mapKrdBodyCompositionToFit = (
     boneMass: toScaledKg(body.boneMassKilograms),
   }),
   ...(body.bmi !== undefined && { bmi: body.bmi }),
+  ...(body.visceralFatRating !== undefined && {
+    visceralFatRating: body.visceralFatRating,
+  }),
+  ...(body.basalMetabolicRateKcal !== undefined && {
+    basalMet: body.basalMetabolicRateKcal,
+  }),
 });


### PR DESCRIPTION
## What

Adds **visceral fat rating** and **basal metabolic rate (BMR)** end-to-end through body composition, so smart-scale data that reports them is no longer silently dropped.

- `@kaiord/core`: `bodyComposition` schema gains optional `visceralFatRating` (unitless) and `basalMetabolicRateKcal` (kcal/day), and **both are counted in the `superRefine` at-least-one check** (else a payload carrying only visceral fat + BMR would be wrongly rejected as empty).
- `@kaiord/fit`: the `body_composition` converter now maps both fields in **both directions** (FIT `visceralFatRating`/`basalMet` ↔ KRD).

## Why

This is **PR0** of the connectors implementation plan — the domain/FIT enabler that unblocks the Tanita→Garmin flagship (Tanita exports visceral fat + BMR; Garmin's body-composition upload accepts them). Kept intentionally minimal: metabolic age / physique rating / muscle quality / segmentals are **not** included (no FIT field; deferred).

## Scaling — resolved empirically (not guessed)

`basal_met` has FIT profile scale 4. A real `@garmin/fitsdk` encode→decode probe (new `basal-met-sdk-scale.test.ts`) proves the **SDK auto-applies the scale**, so the mapper carries **real kcal with no manual scaling** (like `percent_fat`). Feeding a pre-scaled value would double-scale and silently corrupt BMR on upload — the probe guards against exactly that. `visceral_fat_rating` (scale 1) is an integer pass-through.

## Tests

- `@kaiord/core`: 5/5 (incl. visceral+BMR-only payload accepted).
- `@kaiord/fit`: body-composition suite green, incl. the real-SDK byte-level scale probe and an extended KRD→FIT→KRD round-trip asserting the new fields survive with correct values.
- A changeset (`@kaiord/core` + `@kaiord/fit`, minor) is included.

## ⚠️ Two findings for the follow-up Garmin PR (surfaced by the SDK probe)

1. **`body_composition` (mesgNum 41) is absent from the installed `@garmin/fitsdk` v21.208.0 Profile** — the composition fields live on **`weight_scale` (mesgNum 30)**. A real upload must emit a `weight_scale` message; a `mesgNum:41` message throws at the encoder.
2. **Pre-existing double-scale bug (out of scope here):** the existing bone/muscle `×100/÷100` manual scaling is a *double* scale vs. the SDK (probe: `muscleMass raw 5820 → decoded 577.12`). It's latent because the in-memory round-trip never hits the SDK encoder, but a real upload would corrupt those masses. The Garmin upload PR must fix this with its own byte-level test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)