### PR TITLE
feat(whoop): workouts→activity sync + strain field fix (wave 3b)

### DIFF
--- a/.changeset/whoop-workouts-activity.md
+++ b/.changeset/whoop-workouts-activity.md
@@ -1,0 +1,18 @@
+---
+"@kaiord/whoop": minor
+---
+
+Add workout→activity conversion and a sports catalog, and fix the WHOOP
+STRAIN converter's energy/heart-rate field names.
+
+**New**: `whoopWorkoutSchema` (`record.workouts[]`) and `workoutToActivity`
+map a WHOOP workout to a KRD `Activity`, converting kilojoules to kcal and
+resolving the numeric `sport_id` via a new `whoopSportsResponseSchema` /
+`buildSportCatalog` built from the `activities-service/v1/sports/history`
+catalog.
+
+**Fix**: `cycleToStrain` read a non-existent `cycle.kilojoule` field, so
+`energyKilojoules` was never populated, and never mapped WHOOP's
+`day_avg_heart_rate`/`day_max_heart_rate` at all. It now reads the real
+`day_kilojoules`, `day_avg_heart_rate`, and `day_max_heart_rate` fields
+(additive to previously emitted strain summaries).

--- a/packages/whoop-bridge/background.js
+++ b/packages/whoop-bridge/background.js
@@ -21,7 +21,7 @@ const BRIDGE_MANIFEST = {
   name: "WHOOP",
   version: "10.0.0",
   protocolVersion: PROTOCOL_VERSION,
-  capabilities: ["read:body", "read:sleep"],
+  capabilities: ["read:body", "read:sleep", "read:activities"],
 };
 
 // ── Shared envelope/dispatch (vendored bridge-core) ──

--- a/packages/whoop-bridge/bridge-identity.js
+++ b/packages/whoop-bridge/bridge-identity.js
@@ -10,5 +10,5 @@
 globalThis.KAIORD_BRIDGE_IDENTITY = {
   id: "whoop-bridge",
   name: "WHOOP",
-  capabilities: ["read:body", "read:sleep"],
+  capabilities: ["read:body", "read:sleep", "read:activities"],
 };

--- a/packages/whoop-bridge/test/background.test.js
+++ b/packages/whoop-bridge/test/background.test.js
@@ -52,7 +52,7 @@ describe("PROTOCOL_VERSION and BRIDGE_MANIFEST", () => {
       name: "WHOOP",
       version: pkg.version,
       protocolVersion: 1,
-      capabilities: ["read:body", "read:sleep"],
+      capabilities: ["read:body", "read:sleep", "read:activities"],
     });
   });
 });
@@ -287,7 +287,7 @@ describe("handleAction", () => {
       name: "WHOOP",
       version: pkg.version,
       protocolVersion: 1,
-      capabilities: ["read:body", "read:sleep"],
+      capabilities: ["read:body", "read:sleep", "read:activities"],
       connected: false,
     });
   });

--- a/packages/whoop-bridge/test/kaiord-announce.test.js
+++ b/packages/whoop-bridge/test/kaiord-announce.test.js
@@ -30,7 +30,7 @@ describe("kaiord-announce.js (whoop-bridge)", () => {
         name: "WHOOP",
         version: "0.0.0",
         protocolVersion: 1,
-        capabilities: ["read:body", "read:sleep"],
+        capabilities: ["read:body", "read:sleep", "read:activities"],
       });
     });
 

--- a/packages/whoop/src/adapters/converters/cycle-to-strain.converter.test.ts
+++ b/packages/whoop/src/adapters/converters/cycle-to-strain.converter.test.ts
@@ -11,7 +11,9 @@ import { cycleToStrain } from "./cycle-to-strain.converter";
 const [RECORD] = whoopCyclesResponseSchema.parse(CYCLES_DETAILS_WRAPPED);
 
 const EXPECTED_STRAIN_SCORE = 5.36;
-const EXPECTED_ENERGY_KILOJOULES = 8123.4;
+const EXPECTED_ENERGY_KILOJOULES = 8597.02;
+const EXPECTED_DAY_AVERAGE_HEART_RATE = 60;
+const EXPECTED_DAY_MAX_HEART_RATE = 122;
 const EXPECTED_DATE = "2026-07-10";
 
 describe("cycleToStrain", () => {
@@ -44,11 +46,33 @@ describe("cycleToStrain", () => {
     expect(result.success).toBe(true);
   });
 
-  it("should not set day-level heart-rate fields", () => {
+  it("should set day-level heart-rate fields from day_avg_heart_rate and day_max_heart_rate", () => {
     // Arrange
 
     // Act
     const strain = cycleToStrain(RECORD);
+
+    // Assert
+    expect(strain?.dayAverageHeartRate).toBe(EXPECTED_DAY_AVERAGE_HEART_RATE);
+    expect(strain?.dayMaxHeartRate).toBe(EXPECTED_DAY_MAX_HEART_RATE);
+  });
+
+  it("should omit both day heart-rate fields when day_max_heart_rate is below day_avg_heart_rate", () => {
+    // Arrange
+    // WHOOP computes the two day-HR aggregates independently and they can
+    // occasionally invert; the KRD refine requires dayMax >= dayAverage, so
+    // an inverted pair must be dropped entirely rather than emitted invalid.
+    const record = {
+      ...RECORD,
+      cycle: {
+        ...RECORD.cycle,
+        day_avg_heart_rate: EXPECTED_DAY_MAX_HEART_RATE,
+        day_max_heart_rate: EXPECTED_DAY_AVERAGE_HEART_RATE,
+      },
+    };
+
+    // Act
+    const strain = cycleToStrain(record);
 
     // Assert
     expect(strain?.dayAverageHeartRate).toBeUndefined();
@@ -97,15 +121,15 @@ describe("cycleToStrain", () => {
     expect(strain).toBeNull();
   });
 
-  it("should parse the window and omit energyKilojoules when kilojoule is null", () => {
+  it("should parse the window and omit energyKilojoules when day_kilojoules is null", () => {
     // Arrange
-    // An explicit `null` kilojoule must not fail the whole-window parse nor
-    // emit a KRD-invalid `null` energy value.
+    // An explicit `null` day_kilojoules must not fail the whole-window parse
+    // nor emit a KRD-invalid `null` energy value.
     const rawCycle = CYCLES_DETAILS_RECORDS[0].cycle as Record<string, unknown>;
     const raw = {
       records: [
         {
-          cycle: { ...rawCycle, kilojoule: null },
+          cycle: { ...rawCycle, day_kilojoules: null },
           recovery: CYCLES_DETAILS_RECORDS[0].recovery,
           sleeps: CYCLES_DETAILS_RECORDS[0].sleeps,
         },

--- a/packages/whoop/src/adapters/converters/cycle-to-strain.converter.ts
+++ b/packages/whoop/src/adapters/converters/cycle-to-strain.converter.ts
@@ -9,12 +9,15 @@ const DATE_PATTERN = /\d{4}-\d{2}-\d{2}/;
 /**
  * Maps a WHOOP cycle to `extensions.health.strain`. Strain is a read-only,
  * source-agnostic cardiovascular-load summary — WHOOP's 0–21 `scaled_strain`
- * maps directly to `strainScore`. Day-level heart-rate aggregates are never
- * set: WHOOP's internal API only reliably reports HR aggregates per workout,
- * not per cycle, so `dayAverageHeartRate`/`dayMaxHeartRate` are left unset
- * here rather than guessed. In-progress cycles (no `scaled_strain` yet) or
- * cycles whose `days` range has no parseable date yield `null` so the caller
- * can skip them.
+ * maps directly to `strainScore`, `day_kilojoules` to `energyKilojoules`, and
+ * `day_avg_heart_rate`/`day_max_heart_rate` to `dayAverageHeartRate`/
+ * `dayMaxHeartRate`. The KRD strain schema requires
+ * `dayMaxHeartRate >= dayAverageHeartRate` when both are present; WHOOP's two
+ * day-HR aggregates are computed independently and can occasionally invert,
+ * so an inverted pair is dropped entirely rather than emitting a payload the
+ * schema would reject. In-progress cycles (no `scaled_strain` yet) or cycles
+ * whose `days` range has no parseable date yield `null` so the caller can
+ * skip them.
  */
 export const cycleToStrain = (
   record: WhoopCycleRecord
@@ -29,12 +32,29 @@ export const cycleToStrain = (
     return null;
   }
 
+  const {
+    day_avg_heart_rate: dayAverageHeartRate,
+    day_max_heart_rate: dayMaxHeartRate,
+  } = cycle;
+  const dayHeartRatesInverted =
+    dayAverageHeartRate != null &&
+    dayMaxHeartRate != null &&
+    dayMaxHeartRate < dayAverageHeartRate;
+
   return {
     kind: "strain",
     version: KRD_VERSION,
     date: dateMatch[0],
     strainScore: cycle.scaled_strain,
-    ...(cycle.kilojoule != null ? { energyKilojoules: cycle.kilojoule } : {}),
+    ...(cycle.day_kilojoules != null
+      ? { energyKilojoules: cycle.day_kilojoules }
+      : {}),
+    ...(dayAverageHeartRate != null && !dayHeartRatesInverted
+      ? { dayAverageHeartRate }
+      : {}),
+    ...(dayMaxHeartRate != null && !dayHeartRatesInverted
+      ? { dayMaxHeartRate }
+      : {}),
     sourceBridgeId: SOURCE_BRIDGE_ID,
     externalId: `cycle:${cycle.id}:strain`,
   };

--- a/packages/whoop/src/adapters/converters/workout-to-activity.converter.test.ts
+++ b/packages/whoop/src/adapters/converters/workout-to-activity.converter.test.ts
@@ -88,6 +88,52 @@ describe("workoutToActivity", () => {
     expect(activity).toBeNull();
   });
 
+  it("should date the activity in the workout's local timezone, not UTC", () => {
+    // Arrange
+    // A 9pm-local workout in a western timezone starts after UTC midnight
+    // (05:00Z next day); applying the -08:00 offset keeps it on the local day.
+    const workout: WhoopWorkout = {
+      ...WORKOUT_FIXTURE,
+      during: "['2026-07-11T05:00:00.000Z','2026-07-11T06:00:00.000Z')",
+      timezone_offset: "-08:00",
+    };
+
+    // Act
+    const activity = workoutToActivity(workout, WORKOUT_SPORT_NAME);
+
+    // Assert
+    expect(activity?.summary.date).toBe("2026-07-10");
+    expect(activity?.summary.start_time).toBe("2026-07-11T05:00:00.000Z");
+  });
+
+  it("should return null when during matches the shape but endpoints are not valid dates", () => {
+    // Arrange
+    const workout: WhoopWorkout = {
+      ...WORKOUT_FIXTURE,
+      during: "['not-a-date','also-not-a-date')",
+    };
+
+    // Act
+    const activity = workoutToActivity(workout, WORKOUT_SPORT_NAME);
+
+    // Assert
+    expect(activity).toBeNull();
+  });
+
+  it("should return null when the during window is inverted (end before start)", () => {
+    // Arrange
+    const workout: WhoopWorkout = {
+      ...WORKOUT_FIXTURE,
+      during: "['2026-07-10T09:00:00.000Z','2026-07-10T08:00:00.000Z')",
+    };
+
+    // Act
+    const activity = workoutToActivity(workout, WORKOUT_SPORT_NAME);
+
+    // Assert
+    expect(activity).toBeNull();
+  });
+
   it("should omit total_calories and avg_heart_rate when kilojoules and average_heart_rate are absent", () => {
     // Arrange
     const workout: WhoopWorkout = {

--- a/packages/whoop/src/adapters/converters/workout-to-activity.converter.test.ts
+++ b/packages/whoop/src/adapters/converters/workout-to-activity.converter.test.ts
@@ -1,0 +1,106 @@
+import { activitySchema } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  WORKOUT_ACTIVITY_ID,
+  WORKOUT_FIXTURE,
+  WORKOUT_SPORT_NAME,
+  WORKOUT_START_TIME,
+} from "../../test-utils/workout-fixture";
+import type { WhoopWorkout } from "../schemas/whoop-workout.schema";
+import { workoutToActivity } from "./workout-to-activity.converter";
+
+const EXPECTED_DATE = "2026-07-10";
+const EXPECTED_DURATION_SECONDS = 3030;
+const EXPECTED_TOTAL_CALORIES = 299;
+const EXPECTED_AVG_HEART_RATE = 142;
+const FALLBACK_SPORT_NAME = "Activity";
+
+describe("workoutToActivity", () => {
+  it("should map a workout to an activity with sport, duration, kcal, and source_id", () => {
+    // Arrange
+
+    // Act
+    const activity = workoutToActivity(WORKOUT_FIXTURE, WORKOUT_SPORT_NAME);
+
+    // Assert
+    expect(activity?.summary.sport).toBe(WORKOUT_SPORT_NAME);
+    expect(activity?.summary.date).toBe(EXPECTED_DATE);
+    expect(activity?.summary.start_time).toBe(WORKOUT_START_TIME);
+    expect(activity?.summary.duration_seconds).toBe(EXPECTED_DURATION_SECONDS);
+    expect(activity?.summary.total_calories).toBe(EXPECTED_TOTAL_CALORIES);
+    expect(activity?.summary.avg_heart_rate).toBe(EXPECTED_AVG_HEART_RATE);
+    expect(activity?.summary.source).toBe("whoop");
+    expect(activity?.summary.source_id).toBe(WORKOUT_ACTIVITY_ID);
+  });
+
+  it("should produce an activity that validates against the KRD schema", () => {
+    // Arrange
+    const activity = workoutToActivity(WORKOUT_FIXTURE, WORKOUT_SPORT_NAME);
+
+    // Act
+    const result = activitySchema.safeParse(activity);
+
+    // Assert
+    expect(result.success).toBe(true);
+  });
+
+  it("should use the passed fallback sport name for an unknown sport", () => {
+    // Arrange
+
+    // Act
+    const activity = workoutToActivity(WORKOUT_FIXTURE, FALLBACK_SPORT_NAME);
+
+    // Assert
+    expect(activity?.summary.sport).toBe(FALLBACK_SPORT_NAME);
+  });
+
+  it("should return null when activity_id is missing", () => {
+    // Arrange
+    const workout: WhoopWorkout = { ...WORKOUT_FIXTURE, activity_id: null };
+
+    // Act
+    const activity = workoutToActivity(workout, WORKOUT_SPORT_NAME);
+
+    // Assert
+    expect(activity).toBeNull();
+  });
+
+  it("should return null when during is missing", () => {
+    // Arrange
+    const workout: WhoopWorkout = { ...WORKOUT_FIXTURE, during: null };
+
+    // Act
+    const activity = workoutToActivity(workout, WORKOUT_SPORT_NAME);
+
+    // Assert
+    expect(activity).toBeNull();
+  });
+
+  it("should return null when during does not match the expected range shape", () => {
+    // Arrange
+    const workout: WhoopWorkout = { ...WORKOUT_FIXTURE, during: "not-a-range" };
+
+    // Act
+    const activity = workoutToActivity(workout, WORKOUT_SPORT_NAME);
+
+    // Assert
+    expect(activity).toBeNull();
+  });
+
+  it("should omit total_calories and avg_heart_rate when kilojoules and average_heart_rate are absent", () => {
+    // Arrange
+    const workout: WhoopWorkout = {
+      ...WORKOUT_FIXTURE,
+      kilojoules: null,
+      average_heart_rate: null,
+    };
+
+    // Act
+    const activity = workoutToActivity(workout, WORKOUT_SPORT_NAME);
+
+    // Assert
+    expect(activity && "total_calories" in activity.summary).toBe(false);
+    expect(activity && "avg_heart_rate" in activity.summary).toBe(false);
+  });
+});

--- a/packages/whoop/src/adapters/converters/workout-to-activity.converter.ts
+++ b/packages/whoop/src/adapters/converters/workout-to-activity.converter.ts
@@ -6,31 +6,73 @@ const SOURCE = "whoop";
 const KILOJOULES_PER_KCAL = 4.184;
 const MS_PER_S = 1000;
 const ISO_DATE_LENGTH = 10;
+const MAX_BPM = 300;
+const MIN_BPM = 0;
 const DURING_RANGE = /'([^']+)'\s*,\s*'([^']+)'/;
+const OFFSET = /^([+-])(\d{2}):(\d{2})$/;
+const MINUTES_PER_HOUR = 60;
+const MS_PER_MINUTE = 60_000;
 
 /**
  * Parses a Postgres-range `during` string such as
  * `"['2026-07-10T08:15:00.000Z','2026-07-10T09:05:30.000Z')"` into its two
- * ISO endpoints, or `null` when the string doesn't match the expected shape.
+ * epoch-millisecond endpoints, or `null` when the string doesn't match the
+ * expected shape, either endpoint isn't a valid date, or the window is
+ * inverted (end before start). Real WHOOP data is always well-formed ISO;
+ * the guards keep a malformed `during` from producing an activity the KRD
+ * `activitySchema` would reject (e.g. an unparseable `date`).
  */
-const parseDuringRange = (
+const parseDuringMs = (
   during: string
-): { start: string; end: string } | null => {
+): { startMs: number; end: string } | null => {
   const match = DURING_RANGE.exec(during);
   const start = match?.[1];
   const end = match?.[2];
-  return start === undefined || end === undefined ? null : { start, end };
+  if (start === undefined || end === undefined) return null;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  if (Number.isNaN(startMs) || Number.isNaN(endMs) || endMs < startMs) {
+    return null;
+  }
+  return { startMs, end };
 };
 
 /**
- * Maps a WHOOP cycle `workouts[]` entry to a KRD `Activity`. WHOOP
- * identifies the sport by a numeric `sport_id`; this converter stays pure
- * and does not fetch the sports catalog itself — the caller resolves
- * `sport_id` via `buildSportCatalog` and passes the resolved name in
- * (falling back to `"Activity"` for `-1`/an unknown id). Energy is converted
- * from WHOOP's kilojoules to KRD's kcal (`kilojoules / 4.184`, rounded).
- * Workouts without a stable `activity_id` or a parseable `during` window
- * can't be deduplicated or dated, so those yield `null`.
+ * The WHOOP-local calendar date for a UTC start instant, applying the
+ * workout's own `timezone_offset` (e.g. `"+02:00"`). WHOOP's `during`
+ * endpoints are UTC (`…Z`), so slicing the date off the raw UTC start would
+ * bucket an evening workout that crosses UTC midnight onto the wrong calendar
+ * day for non-UTC users — and disagree with the strain converter, which dates
+ * from WHOOP's local `cycle.days`. When the offset is absent/unparseable the
+ * UTC date is used.
+ */
+const localCalendarDate = (
+  startMs: number,
+  offset: string | null | undefined
+): string => {
+  const m = offset != null ? OFFSET.exec(offset) : null;
+  const offsetMs = m
+    ? (m[1] === "-" ? -1 : 1) *
+      (Number(m[2]) * MINUTES_PER_HOUR + Number(m[3])) *
+      MS_PER_MINUTE
+    : 0;
+  return new Date(startMs + offsetMs).toISOString().slice(0, ISO_DATE_LENGTH);
+};
+
+const clampBpm = (bpm: number): number =>
+  Math.min(MAX_BPM, Math.max(MIN_BPM, Math.round(bpm)));
+
+/**
+ * Maps a WHOOP cycle `workouts[]` entry to a KRD `Activity`. WHOOP identifies
+ * the sport by a numeric `sport_id`; this converter stays pure and does not
+ * fetch the sports catalog itself — the caller resolves `sport_id` via
+ * `buildSportCatalog` and passes the resolved name in (falling back to
+ * `"Activity"` for `-1`/an unknown id). Energy is converted from WHOOP's
+ * kilojoules to KRD's kcal (`kilojoules / 4.184`, rounded); heart rate is
+ * rounded and clamped to 0–300; both are dropped when absent or (for energy)
+ * negative, so the output always satisfies `activitySchema`. Workouts without
+ * a stable `activity_id` or a valid `during` window can't be deduplicated or
+ * dated, so those yield `null`.
  */
 export const workoutToActivity = (
   workout: WhoopWorkout,
@@ -40,35 +82,26 @@ export const workoutToActivity = (
     return null;
   }
 
-  const range = parseDuringRange(workout.during);
+  const range = parseDuringMs(workout.during);
   if (range === null) {
     return null;
   }
 
-  const { start, end } = range;
-  const startMs = Date.parse(start);
-  const endMs = Date.parse(end);
-  const durationSeconds =
-    Number.isNaN(startMs) || Number.isNaN(endMs)
-      ? undefined
-      : Math.round((endMs - startMs) / MS_PER_S);
+  const { startMs, end } = range;
+  const start = new Date(startMs).toISOString();
+  const durationSeconds = Math.round((Date.parse(end) - startMs) / MS_PER_S);
+  const { average_heart_rate: avgHr, kilojoules } = workout;
 
   return {
     kind: "activity",
     summary: {
-      date: start.slice(0, ISO_DATE_LENGTH),
+      date: localCalendarDate(startMs, workout.timezone_offset),
       start_time: start,
       sport: sportName,
-      ...(durationSeconds != null ? { duration_seconds: durationSeconds } : {}),
-      ...(workout.average_heart_rate != null
-        ? { avg_heart_rate: workout.average_heart_rate }
-        : {}),
-      ...(workout.kilojoules != null
-        ? {
-            total_calories: Math.round(
-              workout.kilojoules / KILOJOULES_PER_KCAL
-            ),
-          }
+      duration_seconds: durationSeconds,
+      ...(avgHr != null ? { avg_heart_rate: clampBpm(avgHr) } : {}),
+      ...(kilojoules != null && kilojoules >= 0
+        ? { total_calories: Math.round(kilojoules / KILOJOULES_PER_KCAL) }
         : {}),
       source: SOURCE,
       source_id: workout.activity_id,

--- a/packages/whoop/src/adapters/converters/workout-to-activity.converter.ts
+++ b/packages/whoop/src/adapters/converters/workout-to-activity.converter.ts
@@ -1,0 +1,77 @@
+import type { Activity } from "@kaiord/core";
+
+import type { WhoopWorkout } from "../schemas/whoop-workout.schema";
+
+const SOURCE = "whoop";
+const KILOJOULES_PER_KCAL = 4.184;
+const MS_PER_S = 1000;
+const ISO_DATE_LENGTH = 10;
+const DURING_RANGE = /'([^']+)'\s*,\s*'([^']+)'/;
+
+/**
+ * Parses a Postgres-range `during` string such as
+ * `"['2026-07-10T08:15:00.000Z','2026-07-10T09:05:30.000Z')"` into its two
+ * ISO endpoints, or `null` when the string doesn't match the expected shape.
+ */
+const parseDuringRange = (
+  during: string
+): { start: string; end: string } | null => {
+  const match = DURING_RANGE.exec(during);
+  const start = match?.[1];
+  const end = match?.[2];
+  return start === undefined || end === undefined ? null : { start, end };
+};
+
+/**
+ * Maps a WHOOP cycle `workouts[]` entry to a KRD `Activity`. WHOOP
+ * identifies the sport by a numeric `sport_id`; this converter stays pure
+ * and does not fetch the sports catalog itself — the caller resolves
+ * `sport_id` via `buildSportCatalog` and passes the resolved name in
+ * (falling back to `"Activity"` for `-1`/an unknown id). Energy is converted
+ * from WHOOP's kilojoules to KRD's kcal (`kilojoules / 4.184`, rounded).
+ * Workouts without a stable `activity_id` or a parseable `during` window
+ * can't be deduplicated or dated, so those yield `null`.
+ */
+export const workoutToActivity = (
+  workout: WhoopWorkout,
+  sportName: string
+): Activity | null => {
+  if (workout.activity_id == null || workout.during == null) {
+    return null;
+  }
+
+  const range = parseDuringRange(workout.during);
+  if (range === null) {
+    return null;
+  }
+
+  const { start, end } = range;
+  const startMs = Date.parse(start);
+  const endMs = Date.parse(end);
+  const durationSeconds =
+    Number.isNaN(startMs) || Number.isNaN(endMs)
+      ? undefined
+      : Math.round((endMs - startMs) / MS_PER_S);
+
+  return {
+    kind: "activity",
+    summary: {
+      date: start.slice(0, ISO_DATE_LENGTH),
+      start_time: start,
+      sport: sportName,
+      ...(durationSeconds != null ? { duration_seconds: durationSeconds } : {}),
+      ...(workout.average_heart_rate != null
+        ? { avg_heart_rate: workout.average_heart_rate }
+        : {}),
+      ...(workout.kilojoules != null
+        ? {
+            total_calories: Math.round(
+              workout.kilojoules / KILOJOULES_PER_KCAL
+            ),
+          }
+        : {}),
+      source: SOURCE,
+      source_id: workout.activity_id,
+    },
+  };
+};

--- a/packages/whoop/src/adapters/schemas/whoop-cycles.schema.ts
+++ b/packages/whoop/src/adapters/schemas/whoop-cycles.schema.ts
@@ -1,22 +1,27 @@
 import { z } from "zod";
 
+import { whoopWorkoutSchema } from "./whoop-workout.schema";
+
 /**
  * Schemas for the WHOOP internal `core-details-bff/v0/cycles/details`
- * response. Only the fields the Wave-1 (hrv/sleep) and Wave-2 (strain/vitals)
- * converters read are modelled; unknown fields are tolerated (the objects are
- * not strict). All Wave-2 fields are `.nullish()` (accept both omission AND
- * an explicit `null`) since in-progress cycles may omit strain/vitals data or
- * send `null` for an unrecorded metric — either way they must not fail the
- * whole-window parse and regress Wave-1 hrv/sleep import. Converters treat
- * `null` as absent (`!= null`). The response is either a bare array of records
- * or a `{ records: [...] }` wrapper — both normalize to an array of records.
+ * response. Only the fields the Wave-1 (hrv/sleep), Wave-2 (strain/vitals)
+ * and Wave-3b (workouts) converters read are modelled; unknown fields are
+ * tolerated (the objects are not strict). All Wave-2 fields are `.nullish()`
+ * (accept both omission AND an explicit `null`) since in-progress cycles may
+ * omit strain/vitals data or send `null` for an unrecorded metric — either
+ * way they must not fail the whole-window parse and regress Wave-1 hrv/sleep
+ * import. Converters treat `null` as absent (`!= null`). The response is
+ * either a bare array of records or a `{ records: [...] }` wrapper — both
+ * normalize to an array of records.
  */
 
 export const whoopCycleSchema = z.object({
   id: z.number(),
   days: z.string().nullish(),
   scaled_strain: z.number().nullish(),
-  kilojoule: z.number().nonnegative().nullish(),
+  day_kilojoules: z.number().nonnegative().nullish(),
+  day_avg_heart_rate: z.number().int().min(0).max(300).nullish(),
+  day_max_heart_rate: z.number().int().min(0).max(300).nullish(),
 });
 
 export const whoopCycleRecoverySchema = z.object({
@@ -44,6 +49,7 @@ export const whoopCycleRecordSchema = z.object({
   cycle: whoopCycleSchema,
   recovery: whoopCycleRecoverySchema,
   sleeps: z.array(whoopCycleSleepSchema),
+  workouts: z.array(whoopWorkoutSchema).optional(),
 });
 
 export const whoopCyclesResponseSchema = z

--- a/packages/whoop/src/adapters/schemas/whoop-sports.schema.test.ts
+++ b/packages/whoop/src/adapters/schemas/whoop-sports.schema.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSportCatalog,
+  whoopSportsResponseSchema,
+} from "./whoop-sports.schema";
+
+const SWIMMING_ID = 33;
+const CYCLING_ID = 1;
+
+describe("whoopSportsResponseSchema", () => {
+  it("should normalize a bare-array sports/history response", () => {
+    // Arrange
+    const payload = [{ id: SWIMMING_ID, name: "Swimming" }];
+
+    // Act
+    const result = whoopSportsResponseSchema.safeParse(payload);
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(result.data?.[0].name).toBe("Swimming");
+  });
+
+  it("should normalize a sports-wrapped sports/history response", () => {
+    // Arrange
+    const payload = { sports: [{ id: SWIMMING_ID, name: "Swimming" }] };
+
+    // Act
+    const result = whoopSportsResponseSchema.safeParse(payload);
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(result.data?.[0].name).toBe("Swimming");
+  });
+});
+
+describe("buildSportCatalog", () => {
+  it("should build an id-to-name lookup from the sports catalog", () => {
+    // Arrange
+    const sports = [
+      { id: SWIMMING_ID, name: "Swimming" },
+      { id: CYCLING_ID, name: "Cycling" },
+    ];
+
+    // Act
+    const catalog = buildSportCatalog(sports);
+
+    // Assert
+    expect(catalog.get(SWIMMING_ID)).toBe("Swimming");
+    expect(catalog.get(CYCLING_ID)).toBe("Cycling");
+  });
+});

--- a/packages/whoop/src/adapters/schemas/whoop-sports.schema.ts
+++ b/packages/whoop/src/adapters/schemas/whoop-sports.schema.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+
+/**
+ * Schema for the WHOOP `activities-service/v1/sports/history` catalog: a
+ * list of `{ id, name, ... }` sport definitions (203 entries live; `id: -1`
+ * is the generic "Activity" fallback). Modelled non-strict: unknown fields
+ * (`category`, `activity_type_internal_name`, `has_gps`, `icon_url`, ...)
+ * are tolerated. The response is either a bare array or a
+ * `{ sports: [...] }` wrapper — both normalize to an array of sports.
+ */
+export const whoopSportSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
+export const whoopSportsResponseSchema = z
+  .union([
+    z.array(whoopSportSchema),
+    z.object({ sports: z.array(whoopSportSchema) }),
+  ])
+  .transform((value) => (Array.isArray(value) ? value : value.sports));
+
+export type WhoopSport = z.infer<typeof whoopSportSchema>;
+export type WhoopSportsResponse = z.infer<typeof whoopSportsResponseSchema>;
+
+/**
+ * Builds an `id -> name` lookup from the sports catalog so
+ * `workoutToActivity` can resolve a workout's numeric `sport_id` to a
+ * human-readable sport name without depending on the catalog fetch itself.
+ */
+export const buildSportCatalog = (sports: WhoopSport[]): Map<number, string> =>
+  new Map(sports.map((sport) => [sport.id, sport.name]));

--- a/packages/whoop/src/adapters/schemas/whoop-workout.schema.ts
+++ b/packages/whoop/src/adapters/schemas/whoop-workout.schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+/**
+ * Schema for a WHOOP cycle `workouts[]` entry (from
+ * `core-details-bff/v0/cycles/details`). WHOOP identifies the workout's
+ * sport by a numeric `sport_id`, resolved via the `sports/history` catalog
+ * (see `whoop-sports.schema.ts`) rather than carried as a name. Modelled
+ * non-strict: unknown fields (`percent_recorded`, `zone_durations`,
+ * `gps_data`, `score`, ...) are tolerated. All fields are `.nullish()`
+ * since an in-progress or un-scored workout may omit or explicitly null any
+ * of them.
+ */
+export const whoopWorkoutSchema = z.object({
+  during: z.string().nullish(),
+  sport_id: z.number().nullish(),
+  activity_id: z.string().uuid().nullish(),
+  kilojoules: z.number().nonnegative().nullish(),
+  average_heart_rate: z.number().int().min(0).max(300).nullish(),
+  max_heart_rate: z.number().int().min(0).max(300).nullish(),
+});
+
+export type WhoopWorkout = z.infer<typeof whoopWorkoutSchema>;

--- a/packages/whoop/src/adapters/schemas/whoop-workout.schema.ts
+++ b/packages/whoop/src/adapters/schemas/whoop-workout.schema.ts
@@ -6,17 +6,24 @@ import { z } from "zod";
  * sport by a numeric `sport_id`, resolved via the `sports/history` catalog
  * (see `whoop-sports.schema.ts`) rather than carried as a name. Modelled
  * non-strict: unknown fields (`percent_recorded`, `zone_durations`,
- * `gps_data`, `score`, ...) are tolerated. All fields are `.nullish()`
- * since an in-progress or un-scored workout may omit or explicitly null any
- * of them.
+ * `gps_data`, `score`, ...) are tolerated.
+ *
+ * Every field is deliberately LENIENT (`z.number()`/`z.string()` + `.nullish()`,
+ * no `.int()/.min()/.max()/.uuid()/.nonnegative()` refinements). This array is
+ * part of the shared `whoopCycleRecordSchema` that ALSO drives the Wave-1/2
+ * hrv/sleep/strain/vitals sync: a single out-of-range value on one workout must
+ * not fail the whole-window `safeParse` and silently drop every health record
+ * for that window. Correctness is enforced downstream — `workoutToActivity`
+ * rounds/clamps/guards each value so its KRD `activity` output is always valid.
  */
 export const whoopWorkoutSchema = z.object({
   during: z.string().nullish(),
+  timezone_offset: z.string().nullish(),
   sport_id: z.number().nullish(),
-  activity_id: z.string().uuid().nullish(),
-  kilojoules: z.number().nonnegative().nullish(),
-  average_heart_rate: z.number().int().min(0).max(300).nullish(),
-  max_heart_rate: z.number().int().min(0).max(300).nullish(),
+  activity_id: z.string().nullish(),
+  kilojoules: z.number().nullish(),
+  average_heart_rate: z.number().nullish(),
+  max_heart_rate: z.number().nullish(),
 });
 
 export type WhoopWorkout = z.infer<typeof whoopWorkoutSchema>;

--- a/packages/whoop/src/index.ts
+++ b/packages/whoop/src/index.ts
@@ -1,12 +1,14 @@
 /**
  * @kaiord/whoop — WHOOP internal-API health adapter for Kaiord.
  *
- * A PURE adapter over the WHOOP internal `core-details-bff` cycles/details
- * and `metrics-service` responses. It never performs OAuth and never targets
- * the developer API; the SPA injects the read transport. Wave 1 exposes the
- * cycles schema and the recovery→hrv and sleep→sleep converters; Wave 2 adds
- * the read-only cycle→strain and cycle→vitals converters; Wave 3a adds the
- * metrics-service schema and the metrics→heart-rate-series converter.
+ * A PURE adapter over the WHOOP internal `core-details-bff` cycles/details,
+ * `metrics-service`, and `activities-service` sports catalog responses. It
+ * never performs OAuth and never targets the developer API; the SPA injects
+ * the read transport. Wave 1 exposes the cycles schema and the
+ * recovery→hrv and sleep→sleep converters; Wave 2 adds the read-only
+ * cycle→strain and cycle→vitals converters; Wave 3a adds the metrics-service
+ * schema and the metrics→heart-rate-series converter; Wave 3b adds the
+ * workout schema, the sports catalog, and the workout→activity converter.
  */
 
 // Internal-API response schema & inferred types
@@ -28,6 +30,17 @@ export {
   type WhoopMetricSample,
   type WhoopMetricsResponse,
 } from "./adapters/schemas/whoop-metrics.schema";
+export {
+  whoopWorkoutSchema,
+  type WhoopWorkout,
+} from "./adapters/schemas/whoop-workout.schema";
+export {
+  whoopSportSchema,
+  whoopSportsResponseSchema,
+  buildSportCatalog,
+  type WhoopSport,
+  type WhoopSportsResponse,
+} from "./adapters/schemas/whoop-sports.schema";
 
 // Pure converters (WHOOP cycle/metrics → KRD health extensions)
 export { recoveryToHrv } from "./adapters/converters/recovery-to-hrv.converter";
@@ -35,3 +48,4 @@ export { sleepsToSleep } from "./adapters/converters/sleeps-to-sleep.converter";
 export { cycleToStrain } from "./adapters/converters/cycle-to-strain.converter";
 export { cycleToVitals } from "./adapters/converters/cycle-to-vitals.converter";
 export { metricsToHeartRateSeries } from "./adapters/converters/metrics-to-heart-rate-series.converter";
+export { workoutToActivity } from "./adapters/converters/workout-to-activity.converter";

--- a/packages/whoop/src/test-utils/cycles-fixture.ts
+++ b/packages/whoop/src/test-utils/cycles-fixture.ts
@@ -11,7 +11,9 @@ export const CYCLES_DETAILS_RECORDS = [
       id: 1629599351,
       days: "['2026-07-10','2026-07-11')",
       scaled_strain: 5.36,
-      kilojoule: 8123.4,
+      day_kilojoules: 8597.02,
+      day_avg_heart_rate: 60,
+      day_max_heart_rate: 122,
     },
     recovery: {
       hrv_rmssd: 0.0571,

--- a/packages/whoop/src/test-utils/workout-fixture.ts
+++ b/packages/whoop/src/test-utils/workout-fixture.ts
@@ -13,6 +13,7 @@ export const WORKOUT_SPORT_NAME = "Swimming";
 
 export const WORKOUT_FIXTURE: WhoopWorkout = {
   during: `['${WORKOUT_START_TIME}','${WORKOUT_END_TIME}')`,
+  timezone_offset: "+02:00",
   sport_id: WORKOUT_SPORT_ID,
   activity_id: WORKOUT_ACTIVITY_ID,
   kilojoules: 1250.5,

--- a/packages/whoop/src/test-utils/workout-fixture.ts
+++ b/packages/whoop/src/test-utils/workout-fixture.ts
@@ -1,0 +1,21 @@
+import type { WhoopWorkout } from "../adapters/schemas/whoop-workout.schema";
+
+/**
+ * Scrubbed WHOOP cycle `workouts[]` entry (`sport_id: 33` = "Swimming" per
+ * the live `sports/history` catalog). Values mirror the live shapes.
+ */
+
+export const WORKOUT_ACTIVITY_ID = "3f2a9c1e-6b4d-4a1a-9e2f-7c8d1a5b9e60";
+export const WORKOUT_START_TIME = "2026-07-10T08:15:00.000Z";
+export const WORKOUT_END_TIME = "2026-07-10T09:05:30.000Z";
+export const WORKOUT_SPORT_ID = 33;
+export const WORKOUT_SPORT_NAME = "Swimming";
+
+export const WORKOUT_FIXTURE: WhoopWorkout = {
+  during: `['${WORKOUT_START_TIME}','${WORKOUT_END_TIME}')`,
+  sport_id: WORKOUT_SPORT_ID,
+  activity_id: WORKOUT_ACTIVITY_ID,
+  kilojoules: 1250.5,
+  average_heart_rate: 142,
+  max_heart_rate: 168,
+};

--- a/packages/workout-spa-editor/src/application/import/map-whoop-activity.test.ts
+++ b/packages/workout-spa-editor/src/application/import/map-whoop-activity.test.ts
@@ -1,0 +1,67 @@
+import type { Activity } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import { mapWhoopActivity } from "./map-whoop-activity";
+
+const makeActivity = (
+  overrides: Partial<Activity["summary"]> = {}
+): Activity => ({
+  kind: "activity",
+  summary: {
+    date: "2026-07-10",
+    start_time: "2026-07-10T08:15:00.000Z",
+    sport: "Swimming",
+    duration_seconds: 3030,
+    avg_heart_rate: 142,
+    total_calories: 299,
+    source: "whoop",
+    source_id: "3f2a9c1e-6b4d-4a1a-9e2f-7c8d1a5b9e60",
+    ...overrides,
+  },
+});
+
+describe("mapWhoopActivity", () => {
+  it("should map a WHOOP KRD activity to a summary-only ActivityRecord", () => {
+    // Arrange
+    const activity = makeActivity();
+
+    // Act
+    const record = mapWhoopActivity(activity, "profile-1");
+
+    // Assert
+    expect(record).toMatchObject({
+      profileId: "profile-1",
+      date: "2026-07-10",
+      sport: "Swimming",
+      sourceBridgeId: "whoop-bridge",
+      externalId: "3f2a9c1e-6b4d-4a1a-9e2f-7c8d1a5b9e60",
+      durationSeconds: 3030,
+      avgHeartRate: 142,
+      totalCalories: 299,
+      linkedWorkoutId: null,
+      krd: null,
+    });
+  });
+
+  it("should return null when the summary has no usable date", () => {
+    // Arrange
+    const activity = makeActivity({ date: "" });
+
+    // Act
+    const record = mapWhoopActivity(activity, "profile-1");
+
+    // Assert
+    expect(record).toBeNull();
+  });
+
+  it("should return null when the summary has no source id", () => {
+    // Arrange
+    const activity = makeActivity({ source_id: "" });
+
+    // Act
+    const record = mapWhoopActivity(activity, "profile-1");
+
+    // Assert
+    expect(record).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/application/import/map-whoop-activity.ts
+++ b/packages/workout-spa-editor/src/application/import/map-whoop-activity.ts
@@ -1,0 +1,40 @@
+/**
+ * Maps a WHOOP KRD `Activity` (produced by `@kaiord/whoop`'s
+ * `workoutToActivity`) into a persisted ActivityRecord.
+ *
+ * Summary only — WHOOP's `cycles/details` carries no recorded detail, so
+ * `krd` stays null (never forced). Provenance is stamped through the shared
+ * `stampProvenance` helper: source `whoop-bridge`, externalId = the WHOOP
+ * workout `activity_id` (stable dedup key, surfaced as `summary.source_id`
+ * by `workoutToActivity`). Returns null when the summary has no usable
+ * calendar date or source id, so the caller can skip it rather than persist
+ * garbage.
+ */
+import type { Activity } from "@kaiord/core";
+
+import type { ActivityRecord } from "../../types/activity-record";
+import { buildSourceActivityRecord } from "../../types/activity-record";
+import { stampProvenance } from "./stamp-provenance";
+
+export const WHOOP_BRIDGE_SOURCE = "whoop-bridge";
+
+export const mapWhoopActivity = (
+  activity: Activity,
+  profileId: string
+): ActivityRecord | null => {
+  const { summary } = activity;
+  if (!summary.date || !summary.source_id) return null;
+
+  const provenance = stampProvenance(WHOOP_BRIDGE_SOURCE, summary.source_id);
+  return buildSourceActivityRecord({
+    profileId,
+    date: summary.date,
+    sport: summary.sport,
+    sourceBridgeId: provenance.sourceBridgeId,
+    externalId: provenance.externalId,
+    durationSeconds: summary.duration_seconds,
+    distanceMeters: summary.distance_meters,
+    avgHeartRate: summary.avg_heart_rate,
+    totalCalories: summary.total_calories,
+  });
+};

--- a/packages/workout-spa-editor/src/application/whoop/import-whoop-cycle-workouts.ts
+++ b/packages/workout-spa-editor/src/application/whoop/import-whoop-cycle-workouts.ts
@@ -1,0 +1,74 @@
+/**
+ * Fetches one WHOOP `cycles/details` window and imports every workout it
+ * carries into the `activities` store, resolving each `sport_id` through the
+ * pre-fetched sports catalog. Split out of sync-whoop-activities.use-case.ts
+ * to keep that file under the per-file line cap.
+ */
+import {
+  type WhoopCycleRecord,
+  whoopCyclesResponseSchema,
+  workoutToActivity,
+} from "@kaiord/whoop";
+
+import type { ActivityRepository } from "../../ports/activity-repository";
+import { mapWhoopActivity } from "../import/map-whoop-activity";
+import type { WhoopFetchResult } from "./whoop-fetch-result";
+
+const UNKNOWN_SPORT_NAME = "Activity";
+
+export type WhoopImportCounts = { imported: number; skipped: number };
+export type WhoopCyclesWindowOutcome =
+  { ok: true; counts: WhoopImportCounts } | { ok: false; error?: string };
+
+const importWorkouts = async (
+  activities: ActivityRepository,
+  profileId: string,
+  catalog: Map<number, string>,
+  record: WhoopCycleRecord
+): Promise<WhoopImportCounts> => {
+  const counts: WhoopImportCounts = { imported: 0, skipped: 0 };
+  for (const workout of record.workouts ?? []) {
+    const sportName = catalog.get(workout.sport_id ?? -1) ?? UNKNOWN_SPORT_NAME;
+    const activity = workoutToActivity(workout, sportName);
+    const mapped = activity ? mapWhoopActivity(activity, profileId) : null;
+    if (!mapped) {
+      counts.skipped += 1;
+      continue;
+    }
+    const { created } = await activities.upsertByExternalId(mapped);
+    if (created) counts.imported += 1;
+    else counts.skipped += 1;
+  }
+  return counts;
+};
+
+export const importWhoopCycleWorkouts = async (
+  activities: ActivityRepository,
+  profileId: string,
+  fetchCycles: (path: string) => Promise<WhoopFetchResult>,
+  path: string,
+  catalog: Map<number, string>
+): Promise<WhoopCyclesWindowOutcome> => {
+  let result: WhoopFetchResult;
+  try {
+    result = await fetchCycles(path);
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (!result.ok) return { ok: false, error: result.error };
+  const parsed = whoopCyclesResponseSchema.safeParse(result.data);
+  if (!parsed.success) {
+    return { ok: false, error: "Malformed WHOOP cycles response" };
+  }
+
+  const counts: WhoopImportCounts = { imported: 0, skipped: 0 };
+  for (const record of parsed.data) {
+    const page = await importWorkouts(activities, profileId, catalog, record);
+    counts.imported += page.imported;
+    counts.skipped += page.skipped;
+  }
+  return { ok: true, counts };
+};

--- a/packages/workout-spa-editor/src/application/whoop/sync-whoop-activities.use-case.test.ts
+++ b/packages/workout-spa-editor/src/application/whoop/sync-whoop-activities.use-case.test.ts
@@ -1,0 +1,299 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ActivityRecord } from "../../types/activity-record";
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import type { IntegrationPolicyRepository } from "../integration-policy/integration-policy-repository.port";
+import {
+  syncWhoopActivities,
+  type SyncWhoopActivitiesDeps,
+} from "./sync-whoop-activities.use-case";
+import type { WhoopFetchResult } from "./whoop-fetch-result";
+
+const PROFILE_ID = "11111111-1111-4111-8111-111111111111";
+const WORKOUT_ID = "3f2a9c1e-6b4d-4a1a-9e2f-7c8d1a5b9e60";
+const SWIMMING_SPORT_ID = 33;
+
+const makePolicy = (
+  overrides: Partial<IntegrationPolicy> = {}
+): IntegrationPolicy => ({
+  id: crypto.randomUUID(),
+  profileId: PROFILE_ID,
+  dataType: "activity",
+  bridgeId: "whoop-bridge",
+  direction: "import",
+  mode: "manual",
+  enabled: true,
+  updatedAt: "2026-07-06T00:00:00.000Z",
+  ...overrides,
+});
+
+const makePolicyRepo = (
+  rows: IntegrationPolicy[]
+): IntegrationPolicyRepository => ({
+  findByProfileDirection: async ({ profileId, dataType, direction }) =>
+    rows.filter(
+      (r) =>
+        r.profileId === profileId &&
+        r.dataType === dataType &&
+        r.direction === direction
+    ),
+  findByNaturalKey: async () => undefined,
+  put: async () => undefined,
+  deleteById: async () => undefined,
+});
+
+const SPORTS_RESULT: WhoopFetchResult = {
+  ok: true,
+  status: 200,
+  data: [{ id: SWIMMING_SPORT_ID, name: "Swimming" }],
+};
+
+const WORKOUT_FIXTURE = {
+  during: "['2026-07-10T08:15:00.000Z','2026-07-10T09:05:30.000Z')",
+  sport_id: SWIMMING_SPORT_ID,
+  activity_id: WORKOUT_ID,
+  kilojoules: 1250.5,
+  average_heart_rate: 142,
+  max_heart_rate: 168,
+};
+
+const CYCLE_RECORD = {
+  cycle: { id: 1629599351 },
+  recovery: {
+    hrv_rmssd: 0.0571,
+    recovery_score: 66,
+    created_at: "2026-07-10T06:30:00.000Z",
+  },
+  sleeps: [],
+  workouts: [WORKOUT_FIXTURE],
+};
+
+const cyclesResult = (data: unknown): WhoopFetchResult => ({
+  ok: true,
+  status: 200,
+  data,
+});
+
+const makeDeps = (
+  over: Partial<SyncWhoopActivitiesDeps> = {}
+): {
+  deps: SyncWhoopActivitiesDeps;
+  stored: ActivityRecord[];
+  syncPut: ReturnType<typeof vi.fn>;
+  fetchCycles: ReturnType<typeof vi.fn>;
+  fetchSports: ReturnType<typeof vi.fn>;
+} => {
+  const stored: ActivityRecord[] = [];
+  const syncPut = vi.fn(async () => undefined);
+  const fetchCycles = vi.fn(async () => cyclesResult([CYCLE_RECORD]));
+  const fetchSports = vi.fn(async () => SPORTS_RESULT);
+  const deps: SyncWhoopActivitiesDeps = {
+    policyRepo: makePolicyRepo([makePolicy()]),
+    activities: {
+      upsertByExternalId: async (record) => {
+        const exists = stored.some(
+          (s) =>
+            s.sourceBridgeId === record.sourceBridgeId &&
+            s.externalId === record.externalId
+        );
+        if (exists) return { created: false };
+        stored.push(record);
+        return { created: true };
+      },
+      getByProfileAndDateRange: async () => [],
+    },
+    coachingSyncState: {
+      getBySourceAndProfile: async () => undefined,
+      put: syncPut,
+      deleteByProfile: async () => undefined,
+    },
+    fetchCycles,
+    fetchSports,
+    now: () => "2026-07-11T00:00:00.000Z",
+    ...over,
+  };
+  return {
+    deps,
+    stored,
+    syncPut,
+    fetchCycles: deps.fetchCycles as ReturnType<typeof vi.fn>,
+    fetchSports: deps.fetchSports as ReturnType<typeof vi.fn>,
+  };
+};
+
+const input = {
+  profileId: PROFILE_ID,
+  userId: 1629599351,
+  startTime: "2026-07-01T00:00:00.000Z",
+  endTime: "2026-07-10T00:00:00.000Z",
+};
+
+describe("syncWhoopActivities", () => {
+  it("should not fetch when no enabled whoop activity route exists", async () => {
+    // Arrange
+    const { deps, fetchCycles, fetchSports } = makeDeps({
+      policyRepo: makePolicyRepo([makePolicy({ enabled: false })]),
+    });
+
+    // Act
+    const result = await syncWhoopActivities(deps, input);
+
+    // Assert
+    expect(result).toEqual({ ok: false, reason: "route-inactive" });
+    expect(fetchCycles).not.toHaveBeenCalled();
+    expect(fetchSports).not.toHaveBeenCalled();
+  });
+
+  it("should import workouts resolved through the sports catalog and record sync freshness", async () => {
+    // Arrange
+    const { deps, stored, syncPut } = makeDeps();
+
+    // Act
+    const result = await syncWhoopActivities(deps, input);
+
+    // Assert
+    expect(result).toEqual({ ok: true, imported: 1, skipped: 0 });
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      sport: "Swimming",
+      sourceBridgeId: "whoop-bridge",
+      externalId: WORKOUT_ID,
+      avgHeartRate: 142,
+    });
+    expect(syncPut).toHaveBeenCalledWith({
+      source: "whoop-bridge",
+      profileId: PROFILE_ID,
+      lastSyncedAt: "2026-07-11T00:00:00.000Z",
+    });
+  });
+
+  it("should dedupe workouts on re-sync by their stable identity", async () => {
+    // Arrange
+    const { deps, stored } = makeDeps();
+    await syncWhoopActivities(deps, input);
+
+    // Act
+    const result = await syncWhoopActivities(deps, input);
+
+    // Assert
+    expect(result).toEqual({ ok: true, imported: 0, skipped: 1 });
+    expect(stored).toHaveLength(1);
+  });
+
+  it("should fall back to 'Activity' for an unknown sport_id", async () => {
+    // Arrange
+    const { deps, stored } = makeDeps({
+      fetchCycles: vi.fn(async () =>
+        cyclesResult([
+          {
+            ...CYCLE_RECORD,
+            workouts: [{ ...WORKOUT_FIXTURE, sport_id: 9999 }],
+          },
+        ])
+      ),
+    });
+
+    // Act
+    await syncWhoopActivities(deps, input);
+
+    // Assert
+    expect(stored[0]?.sport).toBe("Activity");
+  });
+
+  it("should skip workouts with no activity id or during window", async () => {
+    // Arrange
+    const { deps, stored } = makeDeps({
+      fetchCycles: vi.fn(async () =>
+        cyclesResult([
+          {
+            ...CYCLE_RECORD,
+            workouts: [{ ...WORKOUT_FIXTURE, activity_id: null }],
+          },
+        ])
+      ),
+    });
+
+    // Act
+    const result = await syncWhoopActivities(deps, input);
+
+    // Assert
+    expect(result).toEqual({ ok: true, imported: 0, skipped: 1 });
+    expect(stored).toHaveLength(0);
+  });
+
+  it("should return a transport error when the sports fetch throws", async () => {
+    // Arrange
+    const { deps, fetchCycles } = makeDeps({
+      fetchSports: vi.fn(async () => {
+        throw new Error("Extension did not respond");
+      }),
+    });
+
+    // Act
+    const result = await syncWhoopActivities(deps, input);
+
+    // Assert
+    expect(result).toEqual({
+      ok: false,
+      reason: "transport-error",
+      error: "Extension did not respond",
+    });
+    expect(fetchCycles).not.toHaveBeenCalled();
+  });
+
+  it("should return a transport error when the sports response fails schema validation", async () => {
+    // Arrange
+    const { deps } = makeDeps({
+      fetchSports: vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        data: { unexpected: "shape" },
+      })),
+    });
+
+    // Act
+    const result = await syncWhoopActivities(deps, input);
+
+    // Assert
+    expect(result).toMatchObject({ ok: false, reason: "transport-error" });
+  });
+
+  it("should return a transport error when the cycles fetch reports failure", async () => {
+    // Arrange
+    const { deps, stored } = makeDeps({
+      fetchCycles: vi.fn(async () => ({
+        ok: false,
+        status: 401,
+        error: "Unauthorized",
+      })),
+    });
+
+    // Act
+    const result = await syncWhoopActivities(deps, input);
+
+    // Assert
+    expect(result).toEqual({
+      ok: false,
+      reason: "transport-error",
+      error: "Unauthorized",
+    });
+    expect(stored).toHaveLength(0);
+  });
+
+  it("should chunk a window longer than the cap into multiple cycle reads", async () => {
+    // Arrange
+    const { deps, fetchCycles } = makeDeps({
+      fetchCycles: vi.fn(async () => cyclesResult([])),
+    });
+
+    // Act
+    await syncWhoopActivities(deps, {
+      ...input,
+      startTime: "2026-01-01T00:00:00.000Z",
+      endTime: "2027-05-01T00:00:00.000Z",
+    });
+
+    // Assert
+    expect(fetchCycles.mock.calls.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/workout-spa-editor/src/application/whoop/sync-whoop-activities.use-case.ts
+++ b/packages/workout-spa-editor/src/application/whoop/sync-whoop-activities.use-case.ts
@@ -1,0 +1,100 @@
+/**
+ * syncWhoopActivities — governed import of WHOOP cycle workouts into
+ * executed `activity` records (Wave 3b.2).
+ *
+ * Mirrors `pullGarminActivities`: the `activity←whoop-bridge` import policy
+ * is consulted BEFORE any fetch (fail-closed forward). Once active, the
+ * sports catalog is resolved ONCE per sync via `resolveWhoopSportCatalog`
+ * (a workout carries only a numeric `sport_id`), then each `chunkWindow`
+ * page of `cycles/details` is imported via `importWhoopCycleWorkouts`. A
+ * `coachingSyncState` row records source + timestamp so the matrix cell
+ * shows freshness. Pure application layer: both bridge reads are injected.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { ActivityRepository } from "../../ports/activity-repository";
+import type { CoachingSyncStateRepository } from "../../ports/persistence-port";
+import { WHOOP_BRIDGE_SOURCE } from "../import/map-whoop-activity";
+import type { IntegrationPolicyRepository } from "../integration-policy/integration-policy-repository.port";
+import { resolveImportPolicies } from "../integration-policy/resolve-import-policies.use-case";
+import { importWhoopCycleWorkouts } from "./import-whoop-cycle-workouts";
+import { buildCyclesPath, chunkWindow } from "./whoop-cycles-window";
+import type { WhoopFetchResult } from "./whoop-fetch-result";
+import { resolveWhoopSportCatalog } from "./whoop-sport-catalog";
+
+const ACTIVITY: ManagedDataType = "activity";
+
+export type SyncWhoopActivitiesDeps = {
+  policyRepo: IntegrationPolicyRepository;
+  activities: ActivityRepository;
+  coachingSyncState: CoachingSyncStateRepository;
+  fetchCycles: (path: string) => Promise<WhoopFetchResult>;
+  fetchSports: () => Promise<WhoopFetchResult>;
+  now?: () => string;
+};
+
+export type SyncWhoopActivitiesInput = {
+  profileId: string;
+  userId: number;
+  startTime: string;
+  endTime: string;
+};
+
+export type SyncWhoopActivitiesResult =
+  | { ok: true; imported: number; skipped: number }
+  | { ok: false; reason: "route-inactive" | "transport-error"; error?: string };
+
+const isActiveRoute = async (
+  policyRepo: IntegrationPolicyRepository,
+  profileId: string
+): Promise<boolean> => {
+  const policies = await resolveImportPolicies(
+    { policyRepo },
+    { profileId, dataType: ACTIVITY }
+  );
+  return policies.some((p) => p.enabled && p.bridgeId === WHOOP_BRIDGE_SOURCE);
+};
+
+export const syncWhoopActivities = async (
+  deps: SyncWhoopActivitiesDeps,
+  input: SyncWhoopActivitiesInput
+): Promise<SyncWhoopActivitiesResult> => {
+  if (!(await isActiveRoute(deps.policyRepo, input.profileId))) {
+    return { ok: false, reason: "route-inactive" };
+  }
+
+  const catalogOutcome = await resolveWhoopSportCatalog(deps.fetchSports);
+  if (!catalogOutcome.ok) {
+    return {
+      ok: false,
+      reason: "transport-error",
+      error: catalogOutcome.error,
+    };
+  }
+
+  let imported = 0;
+  let skipped = 0;
+  for (const window of chunkWindow(input.startTime, input.endTime)) {
+    const path = buildCyclesPath(input.userId, window);
+    const outcome = await importWhoopCycleWorkouts(
+      deps.activities,
+      input.profileId,
+      deps.fetchCycles,
+      path,
+      catalogOutcome.catalog
+    );
+    if (!outcome.ok) {
+      return { ok: false, reason: "transport-error", error: outcome.error };
+    }
+    imported += outcome.counts.imported;
+    skipped += outcome.counts.skipped;
+  }
+
+  const now = deps.now?.() ?? new Date().toISOString();
+  await deps.coachingSyncState.put({
+    source: WHOOP_BRIDGE_SOURCE,
+    profileId: input.profileId,
+    lastSyncedAt: now,
+  });
+  return { ok: true, imported, skipped };
+};

--- a/packages/workout-spa-editor/src/application/whoop/whoop-sport-catalog.ts
+++ b/packages/workout-spa-editor/src/application/whoop/whoop-sport-catalog.ts
@@ -1,0 +1,32 @@
+/**
+ * Resolves the WHOOP sports catalog (`activities-service/v1/sports/history`)
+ * into an `id -> name` lookup so `syncWhoopActivities` can label each
+ * workout's numeric `sport_id`. Split out of sync-whoop-activities.use-case.ts
+ * to keep that file under the per-file line cap.
+ */
+import { buildSportCatalog, whoopSportsResponseSchema } from "@kaiord/whoop";
+
+import type { WhoopFetchResult } from "./whoop-fetch-result";
+
+export type WhoopSportCatalogOutcome =
+  { ok: true; catalog: Map<number, string> } | { ok: false; error?: string };
+
+export const resolveWhoopSportCatalog = async (
+  fetchSports: () => Promise<WhoopFetchResult>
+): Promise<WhoopSportCatalogOutcome> => {
+  let result: WhoopFetchResult;
+  try {
+    result = await fetchSports();
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+  if (!result.ok) return { ok: false, error: result.error };
+  const parsed = whoopSportsResponseSchema.safeParse(result.data);
+  if (!parsed.success) {
+    return { ok: false, error: "Malformed WHOOP sports response" };
+  }
+  return { ok: true, catalog: buildSportCatalog(parsed.data) };
+};

--- a/packages/workout-spa-editor/src/hooks/use-whoop-sync.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/use-whoop-sync.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { bridgeDiscovery } from "../adapters/bridge/bridge-discovery";
 import { readWhoopStatus } from "../adapters/bridge/whoop-transport";
+import { syncWhoopActivities } from "../application/whoop/sync-whoop-activities.use-case";
 import { syncWhoopCycles } from "../application/whoop/sync-whoop-cycles.use-case";
 import { syncWhoopHeartRate } from "../application/whoop/sync-whoop-heart-rate.use-case";
 import { PersistenceProvider } from "../contexts/persistence-context";
@@ -25,6 +26,9 @@ vi.mock("../application/whoop/sync-whoop-cycles.use-case", () => ({
 vi.mock("../application/whoop/sync-whoop-heart-rate.use-case", () => ({
   syncWhoopHeartRate: vi.fn(),
 }));
+vi.mock("../application/whoop/sync-whoop-activities.use-case", () => ({
+  syncWhoopActivities: vi.fn(),
+}));
 vi.mock("./use-discovered-bridges", () => ({
   useDiscoveredBridges: vi.fn(),
 }));
@@ -36,6 +40,7 @@ const mockedGetExtensionId = vi.mocked(bridgeDiscovery.getExtensionId);
 const mockedReadStatus = vi.mocked(readWhoopStatus);
 const mockedSyncCycles = vi.mocked(syncWhoopCycles);
 const mockedSyncHeartRate = vi.mocked(syncWhoopHeartRate);
+const mockedSyncActivities = vi.mocked(syncWhoopActivities);
 const mockedUseDiscoveredBridges = vi.mocked(useDiscoveredBridges);
 
 const WHOOP_DISCOVERED: readonly DiscoveredBridge[] = [
@@ -64,13 +69,17 @@ describe("useWhoopSync", () => {
     vi.clearAllMocks();
   });
 
-  it("should fire both syncs once when the bridge is discovered and a session is captured", async () => {
+  it("should fire all three syncs once when the bridge is discovered and a session is captured", async () => {
     // Arrange
     mockedUseDiscoveredBridges.mockReturnValue(WHOOP_DISCOVERED);
     mockedGetExtensionId.mockReturnValue("ext-1");
     mockedReadStatus.mockResolvedValue(connectedStatus);
     mockedSyncCycles.mockResolvedValue({ ok: false, reason: "no-policy" });
     mockedSyncHeartRate.mockResolvedValue({ ok: false, reason: "no-policy" });
+    mockedSyncActivities.mockResolvedValue({
+      ok: false,
+      reason: "route-inactive",
+    });
 
     // Act
     renderHook(() => useWhoopSync("p1"), {
@@ -81,12 +90,17 @@ describe("useWhoopSync", () => {
     await waitFor(() => {
       expect(mockedSyncCycles).toHaveBeenCalledTimes(1);
       expect(mockedSyncHeartRate).toHaveBeenCalledTimes(1);
+      expect(mockedSyncActivities).toHaveBeenCalledTimes(1);
     });
     expect(mockedSyncCycles.mock.calls[0]?.[1]).toMatchObject({
       profileId: "p1",
       userId: 42,
     });
     expect(mockedSyncHeartRate.mock.calls[0]?.[1]).toMatchObject({
+      profileId: "p1",
+      userId: 42,
+    });
+    expect(mockedSyncActivities.mock.calls[0]?.[1]).toMatchObject({
       profileId: "p1",
       userId: 42,
     });
@@ -157,6 +171,7 @@ describe("useWhoopSync", () => {
     // Assert
     expect(mockedSyncCycles).not.toHaveBeenCalled();
     expect(mockedSyncHeartRate).not.toHaveBeenCalled();
+    expect(mockedSyncActivities).not.toHaveBeenCalled();
   });
 
   it("should stay single-shot per profile across re-renders, then fire again for a new profileId", async () => {
@@ -166,6 +181,10 @@ describe("useWhoopSync", () => {
     mockedReadStatus.mockResolvedValue(connectedStatus);
     mockedSyncCycles.mockResolvedValue({ ok: false, reason: "no-policy" });
     mockedSyncHeartRate.mockResolvedValue({ ok: false, reason: "no-policy" });
+    mockedSyncActivities.mockResolvedValue({
+      ok: false,
+      reason: "route-inactive",
+    });
     const { rerender } = renderHook(
       ({ profileId }: { profileId: string | null }) => useWhoopSync(profileId),
       {
@@ -210,5 +229,6 @@ describe("useWhoopSync", () => {
     // Assert
     expect(mockedSyncCycles).not.toHaveBeenCalled();
     expect(mockedSyncHeartRate).not.toHaveBeenCalled();
+    expect(mockedSyncActivities).not.toHaveBeenCalled();
   });
 });

--- a/packages/workout-spa-editor/src/hooks/use-whoop-sync.ts
+++ b/packages/workout-spa-editor/src/hooks/use-whoop-sync.ts
@@ -1,13 +1,15 @@
 /**
  * useWhoopSync — live, once-per-mount governed pull of WHOOP cycles (HRV,
- * sleep, strain, vitals) and heart-rate series into their persisted stores.
+ * sleep, strain, vitals), heart-rate series, and executed workouts into
+ * their persisted stores.
  *
  * Mirrors useGarminActivitiesPull: gates on a discovered whoop-bridge with an
  * active captured session (status.connected + userId present), then defers
  * all governance (route-inactive → no fetch) to the pure
- * `syncWhoopCycles`/`syncWhoopHeartRate` use cases. Errors are swallowed so a
- * failed pull never breaks the calendar mount. The `firedRef` guard keeps it
- * single-shot per profile so re-renders never re-fire the network call.
+ * `syncWhoopCycles`/`syncWhoopHeartRate`/`syncWhoopActivities` use cases.
+ * Errors are swallowed so a failed pull never breaks the calendar mount. The
+ * `firedRef` guard keeps it single-shot per profile so re-renders never
+ * re-fire the network call.
  */
 import { useEffect, useRef } from "react";
 
@@ -16,6 +18,7 @@ import {
   readWhoopFetch,
   readWhoopStatus,
 } from "../adapters/bridge/whoop-transport";
+import { syncWhoopActivities } from "../application/whoop/sync-whoop-activities.use-case";
 import { syncWhoopCycles } from "../application/whoop/sync-whoop-cycles.use-case";
 import { syncWhoopHeartRate } from "../application/whoop/sync-whoop-heart-rate.use-case";
 import { usePersistence } from "../contexts/persistence-context";
@@ -26,6 +29,8 @@ const WHOOP_BRIDGE_ID = "whoop-bridge";
 const CYCLES_WINDOW_DAYS = 30;
 const HR_WINDOW_DAYS = 7;
 const DAY_MS = 86_400_000;
+const SPORTS_HISTORY_PATH =
+  "/activities-service/v1/sports/history?countryCode=US";
 
 const runWhoopSync = async (
   persistence: PersistencePort,
@@ -59,6 +64,16 @@ const runWhoopSync = async (
       fetchMetrics: fetch,
     },
     { profileId, userId: status.userId, startTime: hrStartTime, endTime }
+  );
+  await syncWhoopActivities(
+    {
+      policyRepo: persistence.integrationPolicy,
+      activities: persistence.activities,
+      coachingSyncState: persistence.coachingSyncState,
+      fetchCycles: fetch,
+      fetchSports: () => readWhoopFetch(extensionId, SPORTS_HISTORY_PATH),
+    },
+    { profileId, userId: status.userId, startTime, endTime }
   );
 };
 

--- a/packages/workout-spa-editor/src/types/activity-record.ts
+++ b/packages/workout-spa-editor/src/types/activity-record.ts
@@ -23,6 +23,10 @@ export const activityRecordSchema = z.object({
   externalId: z.string().min(1),
   durationSeconds: z.number().nonnegative().optional(),
   distanceMeters: z.number().nonnegative().optional(),
+  /** bpm; carried by sources (e.g. WHOOP) that report a workout average. */
+  avgHeartRate: z.number().int().min(0).max(300).optional(),
+  /** kcal; carried by sources (e.g. WHOOP) that report workout energy. */
+  totalCalories: z.number().int().nonnegative().optional(),
   /**
    * Id of the transitional twin WorkoutRecord written for the same event
    * (dual-write). The executed-match union excludes this workout from the
@@ -74,11 +78,13 @@ export type BuildSourceActivityRecordInput = {
   externalId: string;
   durationSeconds?: number;
   distanceMeters?: number;
+  avgHeartRate?: number;
+  totalCalories?: number;
 };
 
 /**
- * Build a summary-only ActivityRecord for a source pull (e.g. Garmin): no
- * recorded KRD and no twin WorkoutRecord (`linkedWorkoutId: null`). The
+ * Build a summary-only ActivityRecord for a source pull (e.g. Garmin, WHOOP):
+ * no recorded KRD and no twin WorkoutRecord (`linkedWorkoutId: null`). The
  * calendar renders it natively from the summary fields.
  */
 export const buildSourceActivityRecord = (
@@ -92,6 +98,8 @@ export const buildSourceActivityRecord = (
   externalId: input.externalId,
   durationSeconds: input.durationSeconds,
   distanceMeters: input.distanceMeters,
+  avgHeartRate: input.avgHeartRate,
+  totalCalories: input.totalCalories,
   linkedWorkoutId: null,
   krd: null,
   createdAt: new Date().toISOString(),


### PR DESCRIPTION
## Wave 3b — WHOOP workouts→activity, and a live-verified strain fix

Live-probed the real WHOOP internal API (session bearer) to confirm exact shapes. This (a) fixes a field-name bug in the merged strain converter and (b) adds workouts→activity end to end. Also confirmed **Waves 1/2-vitals/3a field names are correct** against real data.

### 🐛 Strain fix (@kaiord/whoop) — merged Wave 2 bug
Real cycle fields are `day_kilojoules`, `day_avg_heart_rate`, `day_max_heart_rate`. The converter used a non-existent `cycle.kilojoule` (so `energyKilojoules` **never populated**) and never mapped day-HR. Now emits all three (drops the day-HR pair when `day_max < day_avg` to satisfy the KRD refine).

### Workouts → activity
- **@kaiord/whoop**: `whoop-workout` + `whoop-sports` schemas, `workoutToActivity` (parses the `during` range → date/start/duration, kJ→kcal, avg-HR, `source_id = activity_id`; null-skips workouts without id/window), `buildSportCatalog`. Workouts live in `cycles/details` `record.workouts[]` with a numeric `sport_id` resolved via the `sports/history` catalog (203 sports; `-1`="Activity" fallback).
- **workout-spa-editor**: `ActivityRecord` gains optional `avgHeartRate`/`totalCalories` (additive, **no Dexie migration** — the store index is unchanged); `mapWhoopActivity` + `sync-whoop-activities` use case mirroring the Garmin activities pull (policy-gated on `activity`←whoop-bridge, sports fetched once, upserts into the v27 `activities` store deduped by `activity_id`); wired into `useWhoopSync`.
- **whoop-bridge**: announce `read:activities` in both `bridge-identity.js` and the `BRIDGE_MANIFEST` ping.

No new endpoint (cycles/details + sports/history already in the allowlist), no new capability token (`read:activities` already in the frozen enum), no core change.

### Verification (local, all green)
- whoop **45** · whoop-bridge **118** · SPA build (`tsc -b`) ✓ · lint ✓ · SPA **812 files / 5599 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)