### PR TITLE
fix(docs): emit rel=canonical on every docs page

### DIFF
--- a/.changeset/docs-rel-canonical.md
+++ b/.changeset/docs-rel-canonical.md
@@ -1,0 +1,8 @@
+---
+"@kaiord/docs": patch
+---
+
+Emit `rel=canonical` on every docs page and align TechArticle URLs with the
+clean URLs actually served. Each docs page is reachable under three variants
+(clean, `.html`, and the `.md` LLM mirror); without a canonical, search
+engines pick arbitrarily across ~330 pages.

--- a/packages/docs/.vitepress/config.ts
+++ b/packages/docs/.vitepress/config.ts
@@ -8,6 +8,15 @@ const SITE_URL = "https://kaiord.com";
 const DOCS_BASE = "/docs/";
 const OG_IMAGE = `${SITE_URL}${DOCS_BASE}og-image-docs.png`;
 
+// One canonical URL per page, matching what cleanUrls actually serves
+// (extensionless, directory-style for index pages). Every docs page renders
+// under three reachable variants (clean, .html, and the .md mirror for LLMs);
+// without a canonical, engines pick arbitrarily.
+function pageCanonicalUrl(relativePath: string): string {
+  const path = relativePath.replace(/\.md$/, "").replace(/(^|\/)index$/, "$1");
+  return `${SITE_URL}${DOCS_BASE}${path}`;
+}
+
 const AUTHOR = {
   name: "Pablo Albaladejo",
   linkedin: "https://www.linkedin.com/in/pabloalbaladejomestre",
@@ -18,7 +27,7 @@ function buildJsonLd(
   pageData: { relativePath: string; title: string; description: string },
   isHome: boolean
 ): string[] {
-  const pageUrl = `${SITE_URL}${DOCS_BASE}${pageData.relativePath.replace(/\.md$/, ".html").replace(/index\.html$/, "")}`;
+  const pageUrl = pageCanonicalUrl(pageData.relativePath);
   const segments = pageData.relativePath
     .replace(/\.md$/, "")
     .replace(/\/index$/, "")
@@ -257,6 +266,11 @@ const config = {
   transformHead({ pageData }: TransformContext) {
     const head: HeadConfig[] = [];
     const isHome = pageData.relativePath === "index.md";
+
+    head.push([
+      "link",
+      { rel: "canonical", href: pageCanonicalUrl(pageData.relativePath) },
+    ]);
 
     if (pageData.frontmatter.title) {
       head.push([


### PR DESCRIPTION
From today's SEO/GEO audit of kaiord.com (3-agent team: live technical + SERP + repo): the single systemic SEO defect found is that **all ~330 docs pages lack `rel=canonical`** while each is reachable under three URL variants (clean, `.html`, and the `.md` LLM mirror) — and `TechArticle.url` pointed at the `.html` form, contradicting `cleanUrls`. Canonical ambiguity across 3 variants × 330 pages is the kind of thing that suppresses Google indexation (where kaiord.com is currently near-invisible, vs #1-brand on Bing).

## What
- `transformHead` emits one `<link rel=canonical>` per page via a shared `pageCanonicalUrl()` helper that mirrors what `cleanUrls` serves (extensionless; directory form for index pages).
- `buildJsonLd` TechArticle URLs now use the same helper (were `.html`-suffixed).
- Changeset: `@kaiord/docs` patch.

## Verification
`pnpm --filter "@kaiord/docs..." build` green; **375 dist pages** carry the canonical (`/docs/` home, clean inner URLs); TechArticle `url` verified clean in output HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)