### PR TITLE
fix(landing): complete social-card metadata and surface the Chrome extension

### DIFF
--- a/.changeset/landing-og-cws.md
+++ b/.changeset/landing-og-cws.md
@@ -1,0 +1,8 @@
+---
+"@kaiord/landing": patch
+---
+
+Complete the social-card metadata (og:image width/height/alt,
+twitter:image:alt) and make the Chrome extension discoverable: the Web Store
+listing was linked nowhere on the site, so search engines and LLMs could not
+associate it with Kaiord. Footer gains the store link and llms.txt lists it.

--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -39,6 +39,12 @@
       content="Open-source, local-first training platform: calendar, an AI assistant that acts on your data, Garmin &amp; WHOOP sync, health and lab analytics — plus a TypeScript SDK for FIT, TCX, ZWO, and Garmin Connect formats. By Pablo Albaladejo."
     />
     <meta property="og:image" content="https://kaiord.com/og-image.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta
+      property="og:image:alt"
+      content="Kaiord — Your training cockpit. Every fitness format."
+    />
     <meta property="og:url" content="https://kaiord.com/" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
@@ -55,6 +61,10 @@
       content="Open-source, local-first training platform: calendar, an AI assistant that acts on your data, Garmin &amp; WHOOP sync, health and lab analytics — plus a TypeScript SDK for FIT, TCX, ZWO, and Garmin Connect formats. By Pablo Albaladejo."
     />
     <meta name="twitter:image" content="https://kaiord.com/og-image.png" />
+    <meta
+      name="twitter:image:alt"
+      content="Kaiord — Your training cockpit. Every fitness format."
+    />
 
     <!-- JSON-LD -->
     <script type="application/ld+json">
@@ -2488,6 +2498,13 @@
               rel="noopener noreferrer"
               class="transition-colors hover:text-[var(--brand-text-secondary)] focus-visible:outline-2 focus-visible:outline-[var(--brand-accent-blue)]"
               >npm</a
+            >
+            <a
+              href="https://chromewebstore.google.com/detail/kaiord-garmin-bridge/innelncjhkdokailkinkchppgekennoe"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="transition-colors hover:text-[var(--brand-text-secondary)] focus-visible:outline-2 focus-visible:outline-[var(--brand-accent-blue)]"
+              >Chrome Extension</a
             >
             <span>MIT License</span>
           </div>

--- a/packages/landing/public/llms.txt
+++ b/packages/landing/public/llms.txt
@@ -21,6 +21,8 @@ Key facts:
 - [Landing page (Spanish)](https://kaiord.com/es/): product overview in Spanish
 - [Kaiord Editor](https://kaiord.com/editor/): the web app — training
   calendar, visual workout editor, AI assistant, Garmin & WHOOP sync
+- [Kaiord Garmin Bridge (Chrome extension)](https://chromewebstore.google.com/detail/kaiord-garmin-bridge/innelncjhkdokailkinkchppgekennoe):
+  one-tap sync of Kaiord workouts into Garmin Connect
 
 ## Documentation
 


### PR DESCRIPTION
From today's SEO/GEO audit: the homepage HTML contained **zero references to the Chrome extension** (the Web Store listing was undiscoverable from the site — engines and LLMs couldn't associate it with Kaiord), and the landing's social card lacked `og:image` dimensions/alt that the docs pages already carry.

## What
- `og:image:width/height/alt` + `twitter:image:alt` on the landing head.
- Footer links gain **Chrome Extension** → the live Kaiord Garmin Bridge listing (verified via its canonical slug URL).
- `llms.txt` lists the extension under Product.
- Changeset: `@kaiord/landing` patch.

## Verification
Full `pnpm -r build` green; both locale outputs (`dist/`, `dist/es/`) carry the store link and OG dimensions; landing 12/12 tests; prettier clean; build-locales unaffected by the new strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a footer link to the Kaiord Garmin Bridge Chrome Web Store listing.
  * Added the Chrome extension to the site’s product information.

* **Enhancements**
  * Improved social media previews with image dimensions and alternative text for Open Graph and Twitter cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->