### PR TITLE
fix(landing): add Organization and Chrome-extension SoftwareApplication to the JSON-LD graph

### DIFF
--- a/.changeset/landing-entity-schema.md
+++ b/.changeset/landing-entity-schema.md
@@ -1,0 +1,10 @@
+---
+"@kaiord/landing": patch
+---
+
+Extend the JSON-LD @graph with an Organization node (Kaiord, founded by Pablo
+Albaladejo) and a SoftwareApplication node for the "Kaiord Garmin Bridge" Chrome
+extension, and cross-link every node through @id anchors (publisher/author/
+founder). This consolidates the site's entities for search engines and LLMs —
+tying the npm org, GitHub repo, and Chrome Web Store listing to a single
+Organization, and surfacing the extension as a discoverable, free application.

--- a/packages/landing/index.html
+++ b/packages/landing/index.html
@@ -73,22 +73,17 @@
         "@graph": [
           {
             "@type": "WebSite",
+            "@id": "https://kaiord.com/#website",
             "name": "Kaiord",
             "url": "https://kaiord.com/",
             "description": "Open-source, local-first training platform and TypeScript SDK for FIT, TCX, ZWO, and Garmin Connect fitness data formats.",
             "inLanguage": ["en", "es"],
-            "author": {
-              "@type": "Person",
-              "name": "Pablo Albaladejo",
-              "sameAs": [
-                "https://www.linkedin.com/in/pabloalbaladejomestre",
-                "https://pabloalbaladejo.com",
-                "https://github.com/pablo-albaladejo"
-              ]
-            }
+            "publisher": { "@id": "https://kaiord.com/#organization" },
+            "author": { "@id": "https://kaiord.com/#pablo" }
           },
           {
             "@type": "WebApplication",
+            "@id": "https://kaiord.com/#editor",
             "name": "Kaiord Editor",
             "description": "Local-first training platform: weekly calendar, an AI assistant that acts on your data, Garmin and WHOOP sync, health and lab analytics — all in your browser.",
             "url": "https://kaiord.com/editor/",
@@ -99,15 +94,8 @@
               "price": "0",
               "priceCurrency": "USD"
             },
-            "author": {
-              "@type": "Person",
-              "name": "Pablo Albaladejo",
-              "sameAs": [
-                "https://www.linkedin.com/in/pabloalbaladejomestre",
-                "https://pabloalbaladejo.com",
-                "https://github.com/pablo-albaladejo"
-              ]
-            }
+            "publisher": { "@id": "https://kaiord.com/#organization" },
+            "author": { "@id": "https://kaiord.com/#pablo" }
           },
           {
             "@type": "FAQPage",
@@ -164,21 +152,57 @@
           },
           {
             "@type": "SoftwareSourceCode",
+            "@id": "https://kaiord.com/#sourcecode",
             "name": "Kaiord",
             "description": "Open-source TypeScript framework for converting between FIT, TCX, ZWO, and Garmin Connect fitness data formats.",
             "url": "https://kaiord.com",
             "codeRepository": "https://github.com/pablo-albaladejo/kaiord",
             "programmingLanguage": "TypeScript",
             "license": "https://opensource.org/licenses/MIT",
-            "author": {
-              "@type": "Person",
-              "name": "Pablo Albaladejo",
-              "sameAs": [
-                "https://www.linkedin.com/in/pabloalbaladejomestre",
-                "https://pabloalbaladejo.com",
-                "https://github.com/pablo-albaladejo"
-              ]
-            }
+            "publisher": { "@id": "https://kaiord.com/#organization" },
+            "author": { "@id": "https://kaiord.com/#pablo" }
+          },
+          {
+            "@type": "Organization",
+            "@id": "https://kaiord.com/#organization",
+            "name": "Kaiord",
+            "url": "https://kaiord.com",
+            "logo": "https://kaiord.com/apple-touch-icon.png",
+            "description": "Open-source, local-first training platform and TypeScript SDK for FIT, TCX, ZWO, and Garmin Connect fitness data formats.",
+            "founder": { "@id": "https://kaiord.com/#pablo" },
+            "sameAs": [
+              "https://github.com/pablo-albaladejo/kaiord",
+              "https://www.npmjs.com/org/kaiord",
+              "https://chromewebstore.google.com/detail/kaiord-garmin-bridge/innelncjhkdokailkinkchppgekennoe"
+            ]
+          },
+          {
+            "@type": "Person",
+            "@id": "https://kaiord.com/#pablo",
+            "name": "Pablo Albaladejo",
+            "url": "https://pabloalbaladejo.com",
+            "sameAs": [
+              "https://www.linkedin.com/in/pabloalbaladejomestre",
+              "https://pabloalbaladejo.com",
+              "https://github.com/pablo-albaladejo"
+            ]
+          },
+          {
+            "@type": "SoftwareApplication",
+            "@id": "https://kaiord.com/#garmin-bridge",
+            "name": "Kaiord Garmin Bridge",
+            "description": "Chrome extension that syncs Kaiord workouts into Garmin Connect through your own logged-in session — no third-party server in the middle.",
+            "applicationCategory": "BrowserApplication",
+            "operatingSystem": "Chrome",
+            "url": "https://chromewebstore.google.com/detail/kaiord-garmin-bridge/innelncjhkdokailkinkchppgekennoe",
+            "installUrl": "https://chromewebstore.google.com/detail/kaiord-garmin-bridge/innelncjhkdokailkinkchppgekennoe",
+            "offers": {
+              "@type": "Offer",
+              "price": "0",
+              "priceCurrency": "USD"
+            },
+            "publisher": { "@id": "https://kaiord.com/#organization" },
+            "author": { "@id": "https://kaiord.com/#pablo" }
           }
         ]
       }


### PR DESCRIPTION
## What

Small SEO/entity-schema improvements for the landing page, plus an audit of the
adapter-package READMEs and the sitemap `lastmod` situation.

### 1. Landing JSON-LD `@graph` — Organization + Chrome-extension SoftwareApplication

Extends the existing `@graph` (WebSite + WebApplication + FAQPage +
SoftwareSourceCode) **in place** — no duplicated nodes:

- **`Organization` node** (`#organization`) for **Kaiord**: `url`, `logo`
  (`apple-touch-icon.png`), `founder` → Pablo Albaladejo, and `sameAs` linking
  the entity to its owned profiles — the **GitHub repo**, the **npm org**, and
  the **Chrome Web Store** listing.
- **`SoftwareApplication` node** (`#garmin-bridge`) for the **"Kaiord Garmin
  Bridge"** Chrome extension: `applicationCategory: BrowserApplication`,
  `operatingSystem: Chrome`, a free `Offer` (price 0), and
  `installUrl`/`url` → the Chrome Web Store listing.
- **Cross-linking via `@id` anchors**: the Person, previously inlined three
  times, is now a single `#pablo` node. `WebSite`, `WebApplication`,
  `SoftwareSourceCode`, and the new `SoftwareApplication` all reference it via
  `author`, and reference `#organization` via `publisher`; the Organization
  references `#pablo` via `founder`. This consolidates the site's entities so
  search engines and LLMs resolve one Organization tied to one founder and all
  its distribution channels.

The same graph serves both the English and Spanish pages — the locale build's
text-swap skips `<script>` subtrees, so the JSON-LD is emitted identically on
`/` and `/es/`.

**A note on `sameAs`:** the founder's personal site (`pabloalbaladejo.com`) is
attached to the **Person** node (`#pablo`), not to the Organization's `sameAs`.
`sameAs` should assert *the same entity's* identity; putting the founder's site
on the Organization would tell Google the org and the person are one entity and
muddy the very disambiguation this change is meant to sharpen. The
`Organization → founder → Person → pabloalbaladejo.com` chain already connects
them correctly.

### 2. Adapter-package READMEs — audited, no changes needed

`packages/fit`, `packages/tcx`, `packages/zwo`, `packages/garmin`, and
`packages/garmin-connect` **already ship complete, multi-section READMEs**
(npm/license badges, install, "with core providers" + "standalone adapter"
usage, an `## API` reference, and a supported-features list; 72–176 lines each).
None were thin or single-line, so there was nothing to write. No README churn
and therefore no per-package changesets.

### 3. Sitemap `lastmod` — SKIPPED (would require custom plumbing)

Investigated and intentionally skipped, per the "attempt only if straightforward"
scope:

- **Docs (`packages/docs`, VitePress `2.0.0-alpha.17`):** the built
  `docs/sitemap.xml` contains **zero** `<lastmod>` entries, and this VitePress
  version's sitemap generator emits no `lastmod` at all (no `lastmod` reference
  anywhere in its dist). Adding it would need a custom `sitemap.transformItems`
  hook shelling out to `git log` per page — and most docs URLs are
  auto-generated TypeDoc API pages (`/docs/api/core/...`) where a per-file git
  mtime is noisy/misleading rather than useful.
- **Landing (`sitemap-landing.xml` + `sitemap.xml` index):** these are static,
  hand-maintained files. A hardcoded `<lastmod>` would go stale on the next
  edit; keeping it fresh needs CI plumbing.

Both paths are "custom plumbing", so this is deferred rather than half-done with
stale dates.

## Verification

- `pnpm install` + `pnpm -r build` — green.
- `pnpm --filter @kaiord/landing build` — green; `build-locales` reports
  **en visible copy unchanged** and writes both `/` and `/es/`.
- Extracted the JSON-LD from **both** built pages (`dist/index.html` and
  `dist/es/index.html`) and `JSON.parse`d it — **valid, 7 nodes each**; every
  `@id` reference resolves to a defined node.
- `pnpm --filter @kaiord/landing test` — 12/12 pass.
- `npx prettier --check packages/landing/index.html` — clean.
- Rebased onto `origin/main` **after #1016 merged**; confirmed #1016's
  `og:image:width` meta and footer "Chrome Extension" link coexist with this
  change in both built pages.

## Notes

- Changeset added: `.changeset/landing-entity-schema.md` (`@kaiord/landing: patch`).
- Does not touch bridge manifests, `package.json` versions, workflows, or
  `scripts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
