### PR TITLE
feat(scripts): add SEO/GEO observatory

### DIFF
--- a/.github/workflows/seo-observatory.yml
+++ b/.github/workflows/seo-observatory.yml
@@ -1,0 +1,92 @@
+# Weekly SEO/GEO measurement for kaiord.com.
+#
+# Collectors write time series to reports/seo/timeseries/*.jsonl and this
+# workflow opens a metrics PR with the refreshed dashboard for the owner to
+# review (reviewing the DASHBOARD.md diff IS the weekly SEO review). Every
+# collector no-ops gracefully when its secret is missing:
+#   GSC_SERVICE_ACCOUNT_JSON   Google Search Console (service account)
+#   BING_WEBMASTER_API_KEY     Bing Webmaster Tools
+#   PERPLEXITY_API_KEY         Perplexity (AI answer-engine visibility)
+# The DDG SERP snapshot needs no secret and always runs. The collectors are
+# stdlib-only Node scripts, so no pnpm install / workspace build is required.
+name: SEO Observatory
+
+on:
+  schedule:
+    # Mondays 07:37 UTC (staggered after sibling repos' observatory runs).
+    - cron: "37 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  observe:
+    name: Collect SEO/GEO metrics
+    runs-on: ubuntu-latest
+    # Network-bound collectors with widely-spaced requests (SERP + AI probe
+    # sleep between calls); 15m bounds a stuck run well under the family
+    # ceiling. Calibration is a human decision per PR.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Google Search Console snapshot
+        env:
+          GSC_SERVICE_ACCOUNT_JSON: ${{ secrets.GSC_SERVICE_ACCOUNT_JSON }}
+        run: node scripts/geo/gsc-snapshot.mjs
+
+      - name: Bing Webmaster snapshot
+        env:
+          BING_WEBMASTER_API_KEY: ${{ secrets.BING_WEBMASTER_API_KEY }}
+        run: node scripts/geo/bing-snapshot.mjs
+
+      - name: SERP snapshot (DDG, keyless)
+        run: node scripts/geo/serp-snapshot.mjs
+
+      - name: AI answer-engine visibility probe
+        env:
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+        run: node scripts/geo/ai-visibility-probe.mjs
+
+      - name: Regenerate dashboard
+        run: node scripts/geo/seo-dashboard.mjs
+
+      - name: Detect changes
+        id: detect
+        run: |
+          if git status --porcelain reports/seo/ | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No metric changes this week."
+          fi
+
+      - name: Open metrics PR
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="auto/seo-observatory-${{ github.run_id }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add reports/seo/
+          git commit -m "chore(seo): weekly SEO/GEO observatory snapshot"
+          git push origin "$BRANCH"
+          gh label create seo --color 0e8a16 --description "SEO/GEO observatory" 2>/dev/null || true
+          gh label create automated --color ededed --description "Automated PR" 2>/dev/null || true
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "chore(seo): weekly SEO/GEO observatory snapshot" \
+            --body "Automated weekly snapshot from the SEO/GEO observatory (\`.github/workflows/seo-observatory.yml\`). Review \`reports/seo/DASHBOARD.md\` in this diff for week-over-week movement; raw data lands in \`reports/seo/timeseries/\` and \`reports/seo/snapshots/\`." \
+            --label seo \
+            --label automated

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,6 +17,14 @@ openspec/changes/archive/README.md
 openspec/specs/README.md
 scripts/fixtures/bridge-privacy-surface.json
 
+# SEO/GEO observatory: script-generated dashboard + append-only time series.
+# The weekly workflow regenerates these without Prettier, so keep the raw
+# `scripts/geo/*.mjs` output canonical and avoid formatting-only churn.
+# (queries.json / directory-status.json are hand-edited and stay formatted.)
+reports/seo/DASHBOARD.md
+reports/seo/timeseries/
+reports/seo/snapshots/
+
 # Tooling state (OMC, agent caches)
 .omc/
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ Welcome to the Kaiord documentation. This directory contains comprehensive guide
 - **[Architecture Guide](architecture.md)** - Hexagonal architecture, ports and adapters, design patterns
 - **[Testing Guide](testing.md)** - Unit testing, integration testing, round-trip testing, TDD workflow
 - **[Deployment Guide](deployment.md)** - CI/CD workflows, GitHub Pages, npm publishing
+- **[SEO/GEO Observatory](seo-observatory.md)** - Weekly search + answer-engine visibility measurement (`scripts/geo/`, `reports/seo/`)
 - **[Contributing Guide](../CONTRIBUTING.md)** - Development workflow, code style, commit conventions, PR process
 - **[AI Agents Guide](../AGENTS.md)** - Guidelines for AI/code agents (GPT, Claude, etc.)
 

--- a/docs/seo-observatory.md
+++ b/docs/seo-observatory.md
@@ -1,0 +1,87 @@
+# SEO/GEO Observatory
+
+A lightweight, self-hosted measurement loop for how discoverable kaiord.com is
+on classic search (Google, Bing) and on generative answer engines (Perplexity,
+ChatGPT Search / Copilot via the Bing index). It ports the pattern used by
+sibling projects: stdlib-only Node collectors append time series under
+`reports/seo/`, a generated dashboard makes trends reviewable in the repo, and a
+weekly GitHub Actions job opens a metrics PR for the owner to review.
+
+Nothing here touches the product packages — it lives entirely in
+`scripts/geo/`, `reports/seo/`, and `.github/workflows/seo-observatory.yml`.
+
+## Why "GEO" too
+
+Answer engines cite what their index already trusts. Bing's index feeds ChatGPT
+Search and Copilot, so Bing coverage is the hard gate for GEO visibility
+regardless of on-page quality. The observatory therefore tracks both classic
+ranking signals and whether AI answers actually mention or cite kaiord.
+
+## Collectors
+
+| Script                    | Source                    | Needs                                    | Day-one?  |
+| ------------------------- | ------------------------- | ---------------------------------------- | --------- |
+| `serp-snapshot.mjs`       | DuckDuckGo HTML (≈ Bing)  | nothing (keyless)                        | ✅ yes    |
+| `ai-visibility-probe.mjs` | Perplexity / OpenAI       | `PERPLEXITY_API_KEY` or `OPENAI_API_KEY` | ✅ if key |
+| `bing-snapshot.mjs`       | Bing Webmaster Tools API  | `BING_WEBMASTER_API_KEY`                 | ⏳ later  |
+| `gsc-snapshot.mjs`        | Google Search Console API | `GSC_SERVICE_ACCOUNT_JSON`               | ⏳ later  |
+| `seo-dashboard.mjs`       | the time series above     | nothing                                  | ✅ yes    |
+
+Every collector **no-ops gracefully when its credential is absent**, so the
+weekly workflow is green from day one. kaiord has no GSC property and is likely
+not yet in Bing Webmaster Tools, so initially only the SERP snapshot and (if a
+Perplexity key is present) the AI-visibility probe produce data.
+
+There is deliberately **no crawler-log collector**: the site is served from
+GitHub Pages, which exposes no server-side access logs to mine for AI-bot hits.
+
+## Cadence
+
+`.github/workflows/seo-observatory.yml` runs Mondays 07:37 UTC (and on
+`workflow_dispatch`) and opens a metrics PR labeled `seo` / `automated`.
+Reviewing the `DASHBOARD.md` diff is the weekly SEO review. Local runs are
+idempotent per day:
+
+```bash
+node scripts/geo/serp-snapshot.mjs          # keyless (DDG = Bing proxy)
+# optional, if you have keys in your environment:
+export PERPLEXITY_API_KEY=...                # AI answer-engine probe
+export BING_WEBMASTER_API_KEY=...            # once kaiord is verified in Bing
+export GSC_SERVICE_ACCOUNT_JSON="$(cat sa.json)"   # once a GSC property exists
+node scripts/geo/ai-visibility-probe.mjs
+node scripts/geo/bing-snapshot.mjs
+node scripts/geo/gsc-snapshot.mjs
+node scripts/geo/seo-dashboard.mjs          # regenerate reports/seo/DASHBOARD.md
+```
+
+## Configuration
+
+`reports/seo/queries.json` holds the tracked query set:
+
+- `serpQueries` — brand + ownable-niche queries checked for kaiord's position.
+- `aiQuestions` — buyer/discovery questions posed to answer engines.
+- `competitors` — name + lowercased match tokens counted in AI answers.
+
+Environment overrides (all optional):
+
+| Var                | Default                          | Used by               |
+| ------------------ | -------------------------------- | --------------------- |
+| `GSC_PROPERTY`     | `sc-domain:kaiord.com`           | `gsc-snapshot`        |
+| `GEO_SITEMAP_URL`  | `https://kaiord.com/sitemap.xml` | `gsc-snapshot`        |
+| `BING_SITE_URL`    | `https://kaiord.com`             | `bing-snapshot`       |
+| `PERPLEXITY_MODEL` | `sonar`                          | `ai-visibility-probe` |
+
+## One-time setup (owner)
+
+Repo secrets, added as they become available (the workflow skips each collector
+until its secret exists):
+
+1. **Perplexity** — add `PERPLEXITY_API_KEY` to enable the AI-visibility probe.
+2. **Google Search Console** — verify a `sc-domain:kaiord.com` property, submit
+   `https://kaiord.com/sitemap.xml`, then add a read-only service account as a
+   user and store its key JSON as `GSC_SERVICE_ACCOUNT_JSON`.
+3. **Bing Webmaster Tools** — import from GSC, then add
+   `BING_WEBMASTER_API_KEY` (Settings → API access).
+
+The GEO entity checklist lives in `reports/seo/directory-status.json` — update
+it as MCP-registry, npm, and directory listings go live.

--- a/reports/seo/DASHBOARD.md
+++ b/reports/seo/DASHBOARD.md
@@ -1,0 +1,56 @@
+# SEO/GEO Dashboard — kaiord.com
+
+_Generated 2026-07-22 21:00 UTC by `scripts/geo/seo-dashboard.mjs`. Do not edit by hand._
+
+## KPIs
+
+| Metric | Current | Target | Source |
+| --- | --- | --- | --- |
+| Pages indexed on Google | — (needs GSC creds) | all pages | gsc.jsonl |
+| Google impressions (7d) | — | growing | gsc.jsonl |
+| Google clicks (7d) | — | growing | gsc.jsonl |
+| Google avg position | — | top 10 on 3+ non-brand queries | gsc.jsonl |
+| Bing pages in index | — (needs Bing key) | all pages | bing.jsonl |
+| Bing impressions (7d) | — | growing | bing.jsonl |
+| Tracked queries where site appears (DDG/Bing proxy) | 1/12 | 12/12 | serp.jsonl |
+| AI answer-engine mention rate | perplexity 0 | growing | ai-visibility.jsonl |
+
+## Tracked query positions (DDG — Bing-index proxy)
+
+| Query | Position | Prev | History (last 5) |
+| --- | --- | --- | --- |
+| kaiord | #1 | ABSENT | #1 |
+| fit file converter | ABSENT | ABSENT | · |
+| convert fit to tcx | ABSENT | ABSENT | · |
+| fit to zwo converter | ABSENT | ABSENT | · |
+| workout file converter open source | ABSENT | ABSENT | · |
+| garmin workout file format | ABSENT | ABSENT | · |
+| zwo workout editor | ABSENT | ABSENT | · |
+| typescript fit file parser | ABSENT | ABSENT | · |
+| mcp server fitness workouts | ABSENT | ABSENT | · |
+| garmin connect workout sync chrome extension | ABSENT | ABSENT | · |
+| whoop garmin sync | ABSENT | ABSENT | · |
+| training calendar local first | ABSENT | ABSENT | · |
+
+## Top Google queries (latest GSC window)
+
+_No GSC query data yet (needs credentials and impressions)._
+
+## AI answer-engine visibility (GEO end-goal)
+
+| Provider | Date | Mentions | Rate | Cited | Top competitors |
+| --- | --- | --- | --- | --- | --- |
+| perplexity | 2026-07-22 | 0/5 | 0 | 0 | Garmin FIT SDK (1) |
+
+## Directory / entity presence (GEO substrate)
+
+_Last manual check: 2026-07-22. Update `reports/seo/directory-status.json` when a listing goes live._
+
+- [x] MCP registry listing (registry.modelcontextprotocol.io) — https://registry.modelcontextprotocol.io
+- [ ] mcp.so listing
+- [ ] awesome-mcp-servers list entry
+- [ ] npm @kaiord/* packages discoverable — https://www.npmjs.com/org/kaiord
+- [ ] GitHub repo topics set (fit, tcx, zwo, garmin, mcp, workout) — https://github.com/pablo-albaladejo/kaiord
+- [ ] Chrome Web Store: Garmin bridge extension
+- [ ] Product Hunt launch
+

--- a/reports/seo/README.md
+++ b/reports/seo/README.md
@@ -1,0 +1,16 @@
+# SEO/GEO observatory data
+
+Weekly measurement for kaiord.com. Collectors in `scripts/geo/` write one
+entry per day to `timeseries/*.jsonl`; `DASHBOARD.md` is generated — never edit
+it by hand. Full guide: [`docs/seo-observatory.md`](../../docs/seo-observatory.md).
+
+| File                    | What                                                       |
+| ----------------------- | ---------------------------------------------------------- |
+| `DASHBOARD.md`          | Generated summary — the weekly review surface.             |
+| `queries.json`          | Tracked SERP queries, AI questions, competitor match list. |
+| `directory-status.json` | Manual GEO entity / directory presence checklist.          |
+| `timeseries/*.jsonl`    | Append-only daily time series (one entry per source/day).  |
+| `snapshots/*.json`      | Full raw payload per collector run.                        |
+
+Collectors are idempotent per day (a second run on the same date is a no-op),
+so local runs and the weekly workflow can overlap safely.

--- a/reports/seo/directory-status.json
+++ b/reports/seo/directory-status.json
@@ -1,0 +1,24 @@
+{
+  "checkedAt": "2026-07-22",
+  "directories": {
+    "MCP registry listing (registry.modelcontextprotocol.io)": {
+      "present": true,
+      "url": "https://registry.modelcontextprotocol.io"
+    },
+    "mcp.so listing": { "present": false, "url": null },
+    "awesome-mcp-servers list entry": { "present": false, "url": null },
+    "npm @kaiord/* packages discoverable": {
+      "present": false,
+      "url": "https://www.npmjs.com/org/kaiord"
+    },
+    "GitHub repo topics set (fit, tcx, zwo, garmin, mcp, workout)": {
+      "present": false,
+      "url": "https://github.com/pablo-albaladejo/kaiord"
+    },
+    "Chrome Web Store: Garmin bridge extension": {
+      "present": false,
+      "url": null
+    },
+    "Product Hunt launch": { "present": false, "url": null }
+  }
+}

--- a/reports/seo/queries.json
+++ b/reports/seo/queries.json
@@ -1,0 +1,64 @@
+{
+  "site": "https://kaiord.com",
+  "serpQueries": [
+    { "id": "brand", "lang": "en", "q": "kaiord" },
+    { "id": "fit-converter", "lang": "en", "q": "fit file converter" },
+    { "id": "fit-to-tcx", "lang": "en", "q": "convert fit to tcx" },
+    { "id": "fit-to-zwo", "lang": "en", "q": "fit to zwo converter" },
+    {
+      "id": "workout-converter-oss",
+      "lang": "en",
+      "q": "workout file converter open source"
+    },
+    {
+      "id": "garmin-workout-format",
+      "lang": "en",
+      "q": "garmin workout file format"
+    },
+    { "id": "zwo-editor", "lang": "en", "q": "zwo workout editor" },
+    { "id": "ts-fit-parser", "lang": "en", "q": "typescript fit file parser" },
+    { "id": "mcp-fitness", "lang": "en", "q": "mcp server fitness workouts" },
+    {
+      "id": "garmin-sync-extension",
+      "lang": "en",
+      "q": "garmin connect workout sync chrome extension"
+    },
+    { "id": "whoop-garmin-sync", "lang": "en", "q": "whoop garmin sync" },
+    {
+      "id": "training-calendar-local",
+      "lang": "en",
+      "q": "training calendar local first"
+    }
+  ],
+  "aiQuestions": [
+    {
+      "id": "convert-fit",
+      "q": "What tools can convert FIT files to TCX or ZWO?"
+    },
+    { "id": "mcp-workout", "q": "Is there an MCP server for workout files?" },
+    {
+      "id": "ts-fit-lib",
+      "q": "What open-source library parses Garmin FIT files in TypeScript?"
+    },
+    {
+      "id": "garmin-connect-sync",
+      "q": "How can I sync workouts from Garmin Connect to other platforms?"
+    },
+    {
+      "id": "workout-toolkit",
+      "q": "What is the best open-source toolkit for converting and editing workout files?"
+    }
+  ],
+  "competitors": [
+    { "name": "tapiriik", "match": ["tapiriik"] },
+    { "name": "GoldenCheetah", "match": ["goldencheetah", "golden cheetah"] },
+    { "name": "python-fitparse", "match": ["fitparse", "python-fitparse"] },
+    { "name": "fit-file-parser", "match": ["fit-file-parser"] },
+    { "name": "sports-lib", "match": ["sports-lib", "sports-alliance"] },
+    {
+      "name": "Garmin FIT SDK",
+      "match": ["fit sdk", "garmin/fit-javascript-sdk"]
+    },
+    { "name": "RunGap", "match": ["rungap"] }
+  ]
+}

--- a/reports/seo/snapshots/ai-visibility-perplexity-2026-07-22.json
+++ b/reports/seo/snapshots/ai-visibility-perplexity-2026-07-22.json
@@ -1,0 +1,146 @@
+{
+  "entry": {
+    "date": "2026-07-22",
+    "source": "ai-visibility",
+    "provider": "perplexity",
+    "questions": 5,
+    "kaiordMentions": 0,
+    "mentionRate": 0,
+    "citedCount": 0,
+    "topCompetitors": [
+      {
+        "name": "Garmin FIT SDK",
+        "count": 1
+      }
+    ]
+  },
+  "runs": [
+    {
+      "id": "convert-fit",
+      "q": "What tools can convert FIT files to TCX or ZWO?",
+      "kaiordMentioned": false,
+      "kaiordCited": false,
+      "competitorsMentioned": [],
+      "answer": "These are the main tools in the results that can convert **FIT to TCX**:\n\n- **FitConvert** — a web-based converter that can convert FIT to TCX, and also supports GPX and CSV; it runs client-side in the browser.[14][11]\n- **FIT File Converter** — an online converter that explicitly offers FIT to **TCX** output.[6]\n- **AI Training Plan FIT File Tools** — provides a FIT to **TCX** converter in the browser, with support for preserving workout fields like heart rate, power, cadence, laps, and GPS.[7][12]\n- **Tigge/FIT-to-TCX** — an open-source command-line tool that converts FIT files to TCX; it includes batch conversion support.[2]\n- **imgrant/fit2tcx** — another open-source converter designed to produce compliant TCX files from FIT activities.[3]\n- **Fit2Tcx by adiesner** — a tiny command-line utility for converting Garmin FIT activity files to TCX.[5][15]\n- **Fit2tcx (pub.ks-and-ks.ne.jp)** — a small converter that reads a FIT activity file and writes TCX output.[8]\n\nFor **FIT to ZWO**, the only result that explicitly mentions that capability is:\n\n- **sport-calculator.com FIT converter** — it includes a **FIT to ZWO Converter** for converting power-based FIT files to Zwift ZWO workouts.[1]\n\nIf you want, I can also sort these into **online tools vs. command-line tools**.",
+      "citations": [
+        "https://sport-calculator.com/converters/fit-to-tcx",
+        "https://github.com/Tigge/FIT-to-TCX",
+        "https://github.com/imgrant/fit2tcx",
+        "https://raacon.no/pl/tools/fit-to-tcx",
+        "https://adiesner.github.io/GarminPlugin/fit2tcx.html",
+        "https://www.fitfiletools.com/convert",
+        "https://aitrainingplan.app/en/tools/fit-files/",
+        "https://pub.ks-and-ks.ne.jp/cycling/fit2tcx.shtml",
+        "https://raacon.no/hu/tools/fit-to-tcx",
+        "https://filenp.com/fit-to-tcx-converters",
+        "https://www.fitconvert.to/articles/how-to-convert-fit-to-tcx",
+        "https://aitrainingplan.app/en/tools/fit-files/fit-to-tcx/",
+        "https://www.file-extension.org/convert/fit-tcx",
+        "https://www.fitconvert.to/",
+        "https://github.com/adiesner/Fit2Tcx",
+        "https://tcx-converter.software.informer.com/2.0/",
+        "https://forums.garmin.com/apps-software/mobile-apps-web/f/garmin-connect-web/122621/possible-to-export-fit-files-to-tcx",
+        "https://gotoes.org/strava/convert_fit_files_to_csv.php"
+      ]
+    },
+    {
+      "id": "mcp-workout",
+      "q": "Is there an MCP server for workout files?",
+      "kaiordMentioned": false,
+      "kaiordCited": false,
+      "competitorsMentioned": [],
+      "answer": "Yes — there are **multiple MCP servers** that work with workout data and workout files, depending on what you mean by “workout files.” For example, some servers expose workout logs and training plans, while others specifically **import/export structured workout files** like **.zwo** and **.erg**.[1][2][8][14]\n\nA few relevant options from the results:\n\n- **myHealth MCP Server**: supports workout logs, progressive overload calculations, and training plan creation, and it uses an external data file path via `MYHEALTH_DATA_PATH`.[1]\n- **XERT MCP Server**: can **list and export workouts** in **ZWO/ERG** formats and upload FIT files.[2]\n- **Strava MCP**: includes a tool to turn a workout into a **Zwift `.zwo`** file.[8]\n- **Intervals.icu MCP**: offers structured workout generation and a workout library.[10]\n- **athletedata**: advertises downloadable workout files **`.zwo` / `.erg`** for Zwift, Wahoo, and TrainerRoad.[14]\n\nIf you mean **local workout files on disk** rather than a fitness platform’s API, **myHealth** is the closest match from the results because it explicitly mentions external data files configured by path.[1] If you mean **exporting workout files**, then **XERT** and **Strava MCP** are the clearest matches.[2][8]\n\nIf you want, I can narrow this down to the best MCP server for:\n- **Zwift `.zwo` files**\n- **`.erg` files**\n- **FIT file import/export**\n- **local JSON/CSV workout logs**",
+      "citations": [
+        "https://lobehub.com/mcp/maphilipps-myhealth-mcp",
+        "https://forum.xertonline.com/t/community-project-xert-mcp-server-for-claude-ai/48886",
+        "https://eddmann.com/posts/running-mcps-everywhere-chatting-with-my-workouts/",
+        "https://mcpservers.org/servers/Taxuspt/garmin_mcp",
+        "https://mcpmarket.com/server/garmin-workouts",
+        "https://arvo.guru/developer/mcp",
+        "https://mcpservers.org/servers/westvegh/exerciseapi-mcp-server",
+        "https://github.com/r-huijts/strava-mcp",
+        "https://github.com/jlwainwright/garmin-connect-mcp-server",
+        "https://mcpservers.org/servers/hhopke/intervals-icu-mcp",
+        "https://mcp.aibase.com/server/1916341151822749698",
+        "https://www.reddit.com/r/mcp/comments/1uy2nu0/showcase_i_put_an_mcp_server_on_my_ios_workout/",
+        "https://github.com/st3v/garmin-workouts-mcp",
+        "https://www.athletedata.health/mcp",
+        "https://raw.githubusercontent.com/chrisdoc/hevy-mcp/HEAD/README.md",
+        "https://www.reddit.com/r/ClaudeAI/comments/1rq363z/the_tredict_mcp_server_with_an_mcp_app_for_claude/",
+        "https://www.reddit.com/r/Coros/comments/1r3w9tk/i_built_a_claude_mcp_that_creates_coros_workouts/",
+        "https://mcpservers.org/servers/charlesfrisbee/garmin-workouts-mcp",
+        "https://github.com/Taxuspt/garmin_mcp",
+        "https://github.com/Dinesh-Satram/fitness_coach_MCP"
+      ]
+    },
+    {
+      "id": "ts-fit-lib",
+      "q": "What open-source library parses Garmin FIT files in TypeScript?",
+      "kaiordMentioned": false,
+      "kaiordCited": false,
+      "competitorsMentioned": [
+        "Garmin FIT SDK"
+      ],
+      "answer": "An open-source **TypeScript/JavaScript** option is **`@garmin/fitsdk`**, Garmin’s official FIT JavaScript SDK, which uses ECMAScript modules and can decode FIT files in Node.js or the browser.[3]\n\nIf you want a more community-made parser rather than the official SDK, **`fit-decoder`** is a zero-dependency JavaScript library for parsing Garmin `.FIT` files and supports Node.js and browser environments.[7]\n\nOne caveat: the Garmin SDK is officially documented as JavaScript rather than TypeScript specifically, but it is usable from TypeScript projects because it is an npm package with module exports.[3]",
+      "citations": [
+        "https://developer.garmin.com/fit/",
+        "https://github.laiyagushi.com/topics/fit",
+        "https://github.com/garmin/fit-javascript-sdk",
+        "https://github.com/garmin/fit-java-sdk",
+        "https://apis.io/apis/garmin/garmin-fit-sdk/",
+        "https://github.com/muktihari/fit",
+        "https://github.com/ask77nl/fit-decoder",
+        "https://mvnrepository.com/artifact/com.garmin/fit",
+        "https://www.nuget.org/packages/Garmin.FIT.Sdk/21.171.0",
+        "https://gist.github.com/pryhoda/1c060fbafc94849beb7ee489e97f308e",
+        "https://forums.garmin.com/developer/fit-sdk/f/discussion/254794/javascript-parser",
+        "https://www.npmjs.com/package/@samijaber/fit-sdk",
+        "https://github.com/garmin/fit-sdk-tools",
+        "https://stackoverflow.com/questions/22482774/read-process-fit-files-in-javascript",
+        "https://www.reddit.com/r/AdvancedRunning/comments/18w7nxr/diving_deeper_into_garminfit_files_to_create_some/"
+      ]
+    },
+    {
+      "id": "garmin-connect-sync",
+      "q": "How can I sync workouts from Garmin Connect to other platforms?",
+      "kaiordMentioned": false,
+      "kaiordCited": false,
+      "competitorsMentioned": [],
+      "answer": "You can sync Garmin workouts to other platforms in two main ways: **connect Garmin Connect to a third-party app** for automatic sharing, or **send a workout from Garmin Connect to your Garmin device** and then let the activity sync onward from the device/app ecosystem.[10][14][1]\n\n- **For third-party platforms**, Garmin says Garmin Connect syncs with many third-party applications, and instructions for linking a specific app are handled by that app’s support team.[14]\n- **For TrainingPeaks specifically**, Garmin Connect Autosync can send planned structured workouts from TrainingPeaks to your Garmin Connect calendar and compatible Garmin device, while completed activities can sync back from Garmin to TrainingPeaks.[7][12][13]\n- To set up that kind of integration, TrainingPeaks says to connect the Garmin account permissions from a computer and choose whether you want completed workouts, planned workouts, and/or body composition data to sync.[13]\n\nIf your goal is to move a workout **from Garmin Connect onto a watch**, Garmin’s official steps are:\n- Open **Garmin Connect**.\n- Go to **Training & Planning > Workouts**.\n- Select the workout.\n- Use **Send to Device** / the transfer icon.\n- Choose your compatible device, then sync.[1][5][6][11]\n\nIf your goal is to get Garmin workouts into apps like **Strava, TrainingPeaks, or others**, the exact setup depends on the destination app, but Garmin Connect’s **Connected Apps** area is where you typically link supported services.[10][14]\n\nIf you want, I can give you the exact steps for a specific platform, like **Strava, TrainingPeaks, Komoot, Final Surge, or Today’s Plan**.",
+      "citations": [
+        "https://support.garmin.com/en-US/?faq=Oyqt6jUjOF8L1Rnuc9Sms8",
+        "https://www.trainerplan.co/blog/en/sync-workouts-to-your-garmin-device/",
+        "https://www.youtube.com/watch?v=oVX2k6y0v1w&vl=en",
+        "https://www.reddit.com/r/Garmin/comments/l468ve/how_to_sync_manually_created_run_work_outs_to/",
+        "https://support.garmin.com/en-US/?faq=wZ52AaLbLG2GC1Lxu2l4k7",
+        "https://support.garmin.com/en-US/?faq=IPD6X8JSLBAUQOXvz7zBO6",
+        "https://www.trainingpeaks.com/coach-blog/garmin-connect-autosync-integration/",
+        "https://www.youtube.com/watch?v=rvDVAFcjR1s",
+        "https://forums.garmin.com/apps-software/mobile-apps-web/f/garmin-connect-web/161334/sync-problems-training-calendar-runs-don-t-show-up-workouts-don-t-sync-at-all/1017072",
+        "https://www.tomsguide.com/how-to/how-to-use-garmin-connect",
+        "https://www.youtube.com/watch?v=TyKXlAOI8jU",
+        "https://support.garmin.com/en-US/?faq=jnm4aY5LM880wNP6LWm1n8",
+        "https://help.trainingpeaks.com/hc/en-us/articles/204070854-How-to-Sync-Garmin-Connect-With-TrainingPeaks",
+        "https://support.garmin.com/en-US/?faq=8L3Z4gEmTk6sXV7ido1Uz6"
+      ]
+    },
+    {
+      "id": "workout-toolkit",
+      "q": "What is the best open-source toolkit for converting and editing workout files?",
+      "kaiordMentioned": false,
+      "kaiordCited": false,
+      "competitorsMentioned": [],
+      "answer": "For **converting and editing workout files**, the best open-source choice from these results is **mherb/workout-converter** if your main need is structured workout format conversion, especially for cycling platforms like Zwift and Wahoo.[1]\n\nIf you specifically need **FIT file conversion** rather than workout-plan editing, **fit2gpx** is the strongest match because it converts FIT files from devices like Garmin, Suunto, Bryton, and Wahoo into GPX/CSV and related formats.[2][8]\n\nA practical way to choose:\n\n- **Workout file format conversion/editing for smart-trainer workouts:** **workout-converter**[1]\n- **Device activity/workout track conversion from FIT:** **fit2gpx**[2][8]\n- **Samsung Health workout export conversion:** **shealth_to_gpx** or **gpxmaker**[3][6]\n- **Runtastic/Adidas Running export analysis/import:** **RuntasticConverter**[4]\n\nIf you want one default recommendation, **workout-converter** is the best fit for *editing/converting structured workout files*, while **fit2gpx** is better for *activity file conversion*.[1][2]",
+      "citations": [
+        "https://github.com/mherb/workout-converter",
+        "https://wiki.openstreetmap.org/wiki/Fit2gpx",
+        "http://github.com/shaderzz/gpxmaker",
+        "https://github.com/Griffsano/RuntasticConverter",
+        "https://gist.github.com/jfmlima/8f5e2a50b557c3a0345e217382c9d9d3",
+        "https://github.com/DrA1ex/shealth_to_gpx",
+        "https://www.libhunt.com/l/python/topic/garmin",
+        "https://pypi.org/project/fit2gpx/"
+      ]
+    }
+  ]
+}

--- a/reports/seo/snapshots/serp-2026-07-22.json
+++ b/reports/seo/snapshots/serp-2026-07-22.json
@@ -1,0 +1,120 @@
+{
+  "entry": {
+    "date": "2026-07-22",
+    "source": "serp-ddg",
+    "queries": 12,
+    "found": 1,
+    "positions": {
+      "brand": 1,
+      "fit-converter": null,
+      "fit-to-tcx": null,
+      "fit-to-zwo": null,
+      "workout-converter-oss": null,
+      "garmin-workout-format": null,
+      "zwo-editor": null,
+      "ts-fit-parser": null,
+      "mcp-fitness": null,
+      "garmin-sync-extension": null,
+      "whoop-garmin-sync": null,
+      "training-calendar-local": null
+    }
+  },
+  "results": [
+    {
+      "id": "brand",
+      "q": "kaiord",
+      "position": 1,
+      "blocked": false,
+      "top": [
+        "kaiord.com",
+        "kaiord.com",
+        "github.com",
+        "github.com",
+        "devpost.com"
+      ]
+    },
+    {
+      "id": "fit-converter",
+      "q": "fit file converter",
+      "position": null,
+      "blocked": false,
+      "top": [
+        "fitfiletools.com",
+        "fitfiletools.com",
+        "fitfileviewer.com",
+        "aitrainingplan.app",
+        "fitconvert.to"
+      ]
+    },
+    {
+      "id": "fit-to-tcx",
+      "q": "convert fit to tcx",
+      "position": null,
+      "blocked": false,
+      "top": []
+    },
+    {
+      "id": "fit-to-zwo",
+      "q": "fit to zwo converter",
+      "position": null,
+      "blocked": false,
+      "top": []
+    },
+    {
+      "id": "workout-converter-oss",
+      "q": "workout file converter open source",
+      "position": null,
+      "blocked": false,
+      "top": []
+    },
+    {
+      "id": "garmin-workout-format",
+      "q": "garmin workout file format",
+      "position": null,
+      "blocked": false,
+      "top": []
+    },
+    {
+      "id": "zwo-editor",
+      "q": "zwo workout editor",
+      "position": null,
+      "blocked": false,
+      "top": []
+    },
+    {
+      "id": "ts-fit-parser",
+      "q": "typescript fit file parser",
+      "position": null,
+      "blocked": false,
+      "top": []
+    },
+    {
+      "id": "mcp-fitness",
+      "q": "mcp server fitness workouts",
+      "position": null,
+      "blocked": false,
+      "top": []
+    },
+    {
+      "id": "garmin-sync-extension",
+      "q": "garmin connect workout sync chrome extension",
+      "position": null,
+      "blocked": false,
+      "top": []
+    },
+    {
+      "id": "whoop-garmin-sync",
+      "q": "whoop garmin sync",
+      "position": null,
+      "blocked": false,
+      "top": []
+    },
+    {
+      "id": "training-calendar-local",
+      "q": "training calendar local first",
+      "position": null,
+      "blocked": false,
+      "top": []
+    }
+  ]
+}

--- a/reports/seo/timeseries/ai-visibility.jsonl
+++ b/reports/seo/timeseries/ai-visibility.jsonl
@@ -1,0 +1,1 @@
+{"date":"2026-07-22","source":"ai-visibility","provider":"perplexity","questions":5,"kaiordMentions":0,"mentionRate":0,"citedCount":0,"topCompetitors":[{"name":"Garmin FIT SDK","count":1}]}

--- a/reports/seo/timeseries/serp.jsonl
+++ b/reports/seo/timeseries/serp.jsonl
@@ -1,0 +1,1 @@
+{"date":"2026-07-22","source":"serp-ddg","queries":12,"found":1,"positions":{"brand":1,"fit-converter":null,"fit-to-tcx":null,"fit-to-zwo":null,"workout-converter-oss":null,"garmin-workout-format":null,"zwo-editor":null,"ts-fit-parser":null,"mcp-fitness":null,"garmin-sync-extension":null,"whoop-garmin-sync":null,"training-calendar-local":null}}

--- a/scripts/geo/ai-visibility-probe.mjs
+++ b/scripts/geo/ai-visibility-probe.mjs
@@ -84,6 +84,17 @@ if (providers.length === 0) {
 
 const { aiQuestions, competitors } = loadQueries();
 
+// Exact host or subdomain only — substring matching would also count
+// citations on unrelated hosts that merely contain "kaiord.com".
+const isKaiordUrl = (value) => {
+  try {
+    const host = new URL(String(value)).hostname.replace(/^www\./, "");
+    return host === "kaiord.com" || host.endsWith(".kaiord.com");
+  } catch {
+    return false;
+  }
+};
+
 for (const provider of providers) {
   const runs = [];
   for (const { id, q } of aiQuestions) {
@@ -97,9 +108,7 @@ for (const provider of providers) {
         id,
         q,
         kaiordMentioned: haystack.includes("kaiord"),
-        kaiordCited: citations.some((url) =>
-          String(url).includes("kaiord.com")
-        ),
+        kaiordCited: citations.some(isKaiordUrl),
         competitorsMentioned,
         answer,
         citations,

--- a/scripts/geo/ai-visibility-probe.mjs
+++ b/scripts/geo/ai-visibility-probe.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// Asks answer engines the discovery questions from reports/seo/queries.json and
+// records whether kaiord (vs. competitors) is mentioned or cited — the end-goal
+// GEO metric. Providers activate by env var; with none set this is a no-op so
+// the weekly workflow can run before any key exists.
+//   PERPLEXITY_API_KEY  Perplexity sonar (web-grounded — primary signal)
+//   OPENAI_API_KEY      OpenAI Responses API with the web_search tool
+// Setup: docs/seo-observatory.md
+import { join } from "node:path";
+import {
+  appendJsonl,
+  loadQueries,
+  sleep,
+  timeseriesDir,
+  todayIso,
+  writeSnapshot,
+} from "./observatory-lib.mjs";
+
+const askPerplexity = async (question) => {
+  const response = await fetch("https://api.perplexity.ai/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.PERPLEXITY_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: process.env.PERPLEXITY_MODEL ?? "sonar",
+      messages: [{ role: "user", content: question }],
+    }),
+  });
+  if (!response.ok)
+    throw new Error(
+      `perplexity -> ${response.status} ${await response.text()}`
+    );
+  const data = await response.json();
+  return {
+    answer: data.choices?.[0]?.message?.content ?? "",
+    citations: data.citations ?? [],
+  };
+};
+
+const askOpenAI = async (question) => {
+  const response = await fetch("https://api.openai.com/v1/responses", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: process.env.OPENAI_MODEL ?? "gpt-4o-mini",
+      tools: [{ type: "web_search" }],
+      input: question,
+    }),
+  });
+  if (!response.ok)
+    throw new Error(`openai -> ${response.status} ${await response.text()}`);
+  const data = await response.json();
+  const answer = (data.output ?? [])
+    .filter((item) => item.type === "message")
+    .flatMap((item) => item.content ?? [])
+    .filter((part) => part.type === "output_text")
+    .map((part) => part.text)
+    .join("\n");
+  const citations = (data.output ?? [])
+    .flatMap((item) => item.content ?? [])
+    .flatMap((part) => part.annotations ?? [])
+    .map((annotation) => annotation.url)
+    .filter(Boolean);
+  return { answer, citations };
+};
+
+const providers = [
+  ...(process.env.PERPLEXITY_API_KEY
+    ? [{ name: "perplexity", ask: askPerplexity }]
+    : []),
+  ...(process.env.OPENAI_API_KEY ? [{ name: "openai", ask: askOpenAI }] : []),
+];
+if (providers.length === 0) {
+  console.log(
+    "[ai-visibility] no provider keys (PERPLEXITY_API_KEY / OPENAI_API_KEY) — skipping. Setup: docs/seo-observatory.md"
+  );
+  process.exit(0);
+}
+
+const { aiQuestions, competitors } = loadQueries();
+
+for (const provider of providers) {
+  const runs = [];
+  for (const { id, q } of aiQuestions) {
+    try {
+      const { answer, citations } = await provider.ask(q);
+      const haystack = `${answer}\n${citations.join("\n")}`.toLowerCase();
+      const competitorsMentioned = competitors
+        .filter((c) => c.match.some((token) => haystack.includes(token)))
+        .map((c) => c.name);
+      runs.push({
+        id,
+        q,
+        kaiordMentioned: haystack.includes("kaiord"),
+        kaiordCited: citations.some((url) =>
+          String(url).includes("kaiord.com")
+        ),
+        competitorsMentioned,
+        answer,
+        citations,
+      });
+    } catch (error) {
+      console.warn(
+        `[ai-visibility] ${provider.name} failed for "${q}": ${error.message}`
+      );
+      runs.push({ id, q, error: error.message });
+    }
+    await sleep(1000);
+  }
+
+  const answered = runs.filter((r) => r.error === undefined);
+  const mentions = answered.filter((r) => r.kaiordMentioned).length;
+  const competitorCounts = {};
+  for (const run of answered) {
+    for (const name of run.competitorsMentioned ?? []) {
+      competitorCounts[name] = (competitorCounts[name] ?? 0) + 1;
+    }
+  }
+  const entry = {
+    date: todayIso(),
+    source: "ai-visibility",
+    provider: provider.name,
+    questions: answered.length,
+    kaiordMentions: mentions,
+    mentionRate:
+      answered.length === 0
+        ? null
+        : Number((mentions / answered.length).toFixed(2)),
+    citedCount: answered.filter((r) => r.kaiordCited).length,
+    topCompetitors: Object.entries(competitorCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5)
+      .map(([name, count]) => ({ name, count })),
+  };
+
+  writeSnapshot(`ai-visibility-${provider.name}-${todayIso()}`, {
+    entry,
+    runs,
+  });
+  const appended = appendJsonl(
+    join(timeseriesDir, "ai-visibility.jsonl"),
+    entry,
+    ["date", "source", "provider"]
+  );
+  console.log(
+    `[ai-visibility] ${provider.name} ${appended ? "recorded" : "already recorded today"}: ` +
+      `${mentions}/${answered.length} answers mention kaiord`
+  );
+}

--- a/scripts/geo/bing-snapshot.mjs
+++ b/scripts/geo/bing-snapshot.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Pulls Bing Webmaster Tools stats for kaiord.com into reports/seo/.
+// Bing's index feeds ChatGPT Search and Copilot, so Bing coverage is the
+// hard gate for GEO visibility regardless of on-page quality.
+//
+// Auth: BING_WEBMASTER_API_KEY (Bing Webmaster Tools → Settings → API access).
+// kaiord may not be verified in Bing Webmaster yet — with no key this no-ops.
+// Setup: docs/seo-observatory.md
+import { join } from "node:path";
+import {
+  appendJsonl,
+  timeseriesDir,
+  todayIso,
+  writeSnapshot,
+} from "./observatory-lib.mjs";
+
+const apiKey = process.env.BING_WEBMASTER_API_KEY;
+if (!apiKey) {
+  console.log(
+    "[bing] no BING_WEBMASTER_API_KEY — skipping. Setup: docs/seo-observatory.md"
+  );
+  process.exit(0);
+}
+
+const siteUrl = process.env.BING_SITE_URL ?? "https://kaiord.com";
+
+const api = async (method) => {
+  const url = `https://ssl.bing.com/webmaster/api.svc/json/${method}?siteUrl=${encodeURIComponent(siteUrl)}&apikey=${apiKey}`;
+  const response = await fetch(url);
+  if (!response.ok)
+    throw new Error(`${method} -> ${response.status} ${await response.text()}`);
+  return (await response.json()).d;
+};
+
+// Bing serializes dates as "/Date(1234567890000)/".
+const parseBingDate = (value) =>
+  new Date(Number(/\d+/.exec(String(value))?.[0] ?? 0))
+    .toISOString()
+    .slice(0, 10);
+
+const traffic = (await api("GetRankAndTrafficStats")) ?? [];
+const queries = (await api("GetQueryStats")) ?? [];
+const crawl = (await api("GetCrawlStats")) ?? [];
+
+const byDate = [...traffic].sort((a, b) =>
+  parseBingDate(a.Date).localeCompare(parseBingDate(b.Date))
+);
+const last7 = byDate.slice(-7);
+const sum = (rows, key) => rows.reduce((acc, row) => acc + (row[key] ?? 0), 0);
+const latestCrawl = [...crawl]
+  .sort((a, b) => parseBingDate(a.Date).localeCompare(parseBingDate(b.Date)))
+  .at(-1);
+
+const entry = {
+  date: todayIso(),
+  source: "bing",
+  impressions7d: sum(last7, "Impressions"),
+  clicks7d: sum(last7, "Clicks"),
+  crawledPages: latestCrawl?.CrawledPages ?? null,
+  inIndexPages: latestCrawl?.InIndexPages ?? null,
+  crawlErrors: latestCrawl?.AllOtherCodes ?? null,
+  topQueries: [...queries]
+    .sort((a, b) => (b.Impressions ?? 0) - (a.Impressions ?? 0))
+    .slice(0, 10)
+    .map((row) => ({
+      query: row.Query,
+      clicks: row.Clicks ?? 0,
+      impressions: row.Impressions ?? 0,
+      position: row.AvgImpressionPosition ?? null,
+    })),
+};
+
+writeSnapshot(`bing-${todayIso()}`, { entry, traffic, queries, crawl });
+const appended = appendJsonl(join(timeseriesDir, "bing.jsonl"), entry);
+console.log(
+  `[bing] ${appended ? "recorded" : "already recorded today"}: ${entry.impressions7d} impressions / ` +
+    `${entry.clicks7d} clicks (7d), inIndexPages=${entry.inIndexPages ?? "n/a"}`
+);

--- a/scripts/geo/gsc-snapshot.mjs
+++ b/scripts/geo/gsc-snapshot.mjs
@@ -93,8 +93,9 @@ const api = async (url, body) => {
   // property yet, so skip cleanly instead of failing the weekly run.
   if (response.status === 403) {
     console.warn(
-      `[gsc] 403 from ${url} — service account ${credentials.client_email} is not authorized on ${property}. ` +
-        "Add it under Search Console → Settings → Users and permissions, then this collector will run. Skipping."
+      `[gsc] 403 from ${url} — the service account is not authorized on ${property}. ` +
+        "Add the client_email from the GSC_SERVICE_ACCOUNT_JSON key under " +
+        "Search Console → Settings → Users and permissions, then this collector will run. Skipping."
     );
     process.exit(0);
   }

--- a/scripts/geo/gsc-snapshot.mjs
+++ b/scripts/geo/gsc-snapshot.mjs
@@ -88,6 +88,16 @@ const api = async (url, body) => {
     },
     body: body === undefined ? undefined : JSON.stringify(body),
   });
+  // A 403 means the credentials are valid but the service account is not yet a
+  // user on the property — a setup state, not a code failure. kaiord has no GSC
+  // property yet, so skip cleanly instead of failing the weekly run.
+  if (response.status === 403) {
+    console.warn(
+      `[gsc] 403 from ${url} — service account ${credentials.client_email} is not authorized on ${property}. ` +
+        "Add it under Search Console → Settings → Users and permissions, then this collector will run. Skipping."
+    );
+    process.exit(0);
+  }
   if (!response.ok)
     throw new Error(`${url} -> ${response.status} ${await response.text()}`);
   return response.json();

--- a/scripts/geo/gsc-snapshot.mjs
+++ b/scripts/geo/gsc-snapshot.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// Pulls Google Search Console data for kaiord.com into reports/seo/:
+// search analytics (clicks / impressions / average position by query and page)
+// plus per-URL index coverage for every sitemap URL. Ground truth for "are we
+// ranking on Google" — runs weekly via the seo-observatory workflow.
+//
+// kaiord has no GSC property yet, so with no credentials this no-ops. Once the
+// property exists, set GSC_PROPERTY (default sc-domain:kaiord.com).
+//
+// Auth: a Google service account added as a user on the GSC property.
+//   GSC_SERVICE_ACCOUNT_JSON       service-account key JSON, inline; or
+//   GOOGLE_APPLICATION_CREDENTIALS path to the key file.
+// Setup: docs/seo-observatory.md
+import { createSign } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  appendJsonl,
+  fetchSitemapUrls,
+  sleep,
+  timeseriesDir,
+  todayIso,
+  writeSnapshot,
+} from "./observatory-lib.mjs";
+
+const property = process.env.GSC_PROPERTY ?? "sc-domain:kaiord.com";
+
+const loadCredentials = () => {
+  if (process.env.GSC_SERVICE_ACCOUNT_JSON)
+    return JSON.parse(process.env.GSC_SERVICE_ACCOUNT_JSON);
+  if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    return JSON.parse(
+      readFileSync(process.env.GOOGLE_APPLICATION_CREDENTIALS, "utf8")
+    );
+  }
+  return undefined;
+};
+
+const credentials = loadCredentials();
+if (!credentials) {
+  console.log(
+    "[gsc] no credentials (GSC_SERVICE_ACCOUNT_JSON or GOOGLE_APPLICATION_CREDENTIALS) — skipping. Setup: docs/seo-observatory.md"
+  );
+  process.exit(0);
+}
+
+const base64url = (input) => Buffer.from(input).toString("base64url");
+
+const getAccessToken = async () => {
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const claims = base64url(
+    JSON.stringify({
+      iss: credentials.client_email,
+      scope: "https://www.googleapis.com/auth/webmasters.readonly",
+      aud: credentials.token_uri,
+      iat: now,
+      exp: now + 3600,
+    })
+  );
+  const signer = createSign("RSA-SHA256");
+  signer.update(`${header}.${claims}`);
+  const signature = signer.sign(credentials.private_key, "base64url");
+  const response = await fetch(credentials.token_uri, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion: `${header}.${claims}.${signature}`,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `token exchange failed: ${response.status} ${await response.text()}`
+    );
+  }
+  return (await response.json()).access_token;
+};
+
+const token = await getAccessToken();
+
+const api = async (url, body) => {
+  const response = await fetch(url, {
+    method: body === undefined ? "GET" : "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!response.ok)
+    throw new Error(`${url} -> ${response.status} ${await response.text()}`);
+  return response.json();
+};
+
+// Search-analytics data lags ~3 days; use the freshest complete 7-day window.
+const end = new Date(Date.now() - 3 * 86_400_000).toISOString().slice(0, 10);
+const start = new Date(Date.now() - 9 * 86_400_000).toISOString().slice(0, 10);
+const site = encodeURIComponent(property);
+const analyticsUrl = `https://www.googleapis.com/webmasters/v3/sites/${site}/searchAnalytics/query`;
+
+const totals = await api(analyticsUrl, { startDate: start, endDate: end });
+const byQuery = await api(analyticsUrl, {
+  startDate: start,
+  endDate: end,
+  dimensions: ["query"],
+  rowLimit: 100,
+});
+const byPage = await api(analyticsUrl, {
+  startDate: start,
+  endDate: end,
+  dimensions: ["page"],
+  rowLimit: 100,
+});
+const sitemaps = await api(
+  `https://www.googleapis.com/webmasters/v3/sites/${site}/sitemaps`
+);
+
+const sitemapUrls = await fetchSitemapUrls();
+const inspections = [];
+for (const url of sitemapUrls) {
+  const result = await api(
+    "https://searchconsole.googleapis.com/v1/urlInspection/index:inspect",
+    {
+      inspectionUrl: url,
+      siteUrl: property,
+    }
+  );
+  const status = result.inspectionResult?.indexStatusResult ?? {};
+  inspections.push({
+    url,
+    verdict: status.verdict ?? "UNKNOWN",
+    coverageState: status.coverageState ?? null,
+    lastCrawlTime: status.lastCrawlTime ?? null,
+  });
+  await sleep(250);
+}
+const indexed = inspections.filter((i) => i.verdict === "PASS").length;
+
+const totalsRow = totals.rows?.[0] ?? {};
+const entry = {
+  date: todayIso(),
+  source: "gsc",
+  window: { start, end },
+  clicks: totalsRow.clicks ?? 0,
+  impressions: totalsRow.impressions ?? 0,
+  ctr: totalsRow.ctr ?? 0,
+  position:
+    totalsRow.position === undefined
+      ? null
+      : Number(totalsRow.position.toFixed(1)),
+  indexed,
+  sitemapUrlCount: sitemapUrls.length,
+  sitemapSubmitted: (sitemaps.sitemap ?? []).length > 0,
+  topQueries: (byQuery.rows ?? []).slice(0, 10).map((row) => ({
+    query: row.keys[0],
+    clicks: row.clicks,
+    impressions: row.impressions,
+    position: Number(row.position.toFixed(1)),
+  })),
+};
+
+writeSnapshot(`gsc-${todayIso()}`, {
+  entry,
+  byQuery: byQuery.rows ?? [],
+  byPage: byPage.rows ?? [],
+  sitemaps,
+  inspections,
+});
+const appended = appendJsonl(join(timeseriesDir, "gsc.jsonl"), entry);
+console.log(
+  `[gsc] ${appended ? "recorded" : "already recorded today"}: ${indexed}/${sitemapUrls.length} indexed, ` +
+    `${entry.impressions} impressions, ${entry.clicks} clicks (${start}..${end})`
+);
+if (!entry.sitemapSubmitted) {
+  console.warn(
+    "[gsc] WARNING: sitemap.xml is not submitted in Search Console — submit https://kaiord.com/sitemap.xml there."
+  );
+}

--- a/scripts/geo/observatory-lib.mjs
+++ b/scripts/geo/observatory-lib.mjs
@@ -1,0 +1,80 @@
+// Shared helpers for the SEO/GEO observatory collectors (reports/seo/).
+// Node stdlib only on purpose: the weekly GitHub Actions workflow runs these
+// without a pnpm install, and local runs must not depend on workspace state.
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const repoRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  ".."
+);
+export const seoDir = join(repoRoot, "reports", "seo");
+export const timeseriesDir = join(seoDir, "timeseries");
+export const snapshotsDir = join(seoDir, "snapshots");
+
+export const todayIso = () => new Date().toISOString().slice(0, 10);
+
+export const loadQueries = () =>
+  JSON.parse(readFileSync(join(seoDir, "queries.json"), "utf8"));
+
+export const readJsonl = (file) => {
+  if (!existsSync(file)) return [];
+  return readFileSync(file, "utf8")
+    .split("\n")
+    .filter((line) => line.trim() !== "")
+    .map((line) => JSON.parse(line));
+};
+
+// One entry per key (default: date+source) — same-day re-runs are no-ops so
+// the weekly workflow and manual runs stay idempotent.
+export const appendJsonl = (file, entry, keyFields = ["date", "source"]) => {
+  const duplicate = readJsonl(file).some((row) =>
+    keyFields.every((k) => row[k] === entry[k])
+  );
+  if (duplicate) return false;
+  mkdirSync(dirname(file), { recursive: true });
+  appendFileSync(file, `${JSON.stringify(entry)}\n`);
+  return true;
+};
+
+export const writeSnapshot = (name, data) => {
+  mkdirSync(snapshotsDir, { recursive: true });
+  const file = join(snapshotsDir, `${name}.json`);
+  writeFileSync(file, `${JSON.stringify(data, null, 2)}\n`);
+  return file;
+};
+
+const parseLocs = (xml) =>
+  Array.from(xml.matchAll(/<loc>\s*([^\s<]+)\s*<\/loc>/g), (m) => m[1]);
+
+// VitePress emits a single flat sitemap of page URLs; other generators emit a
+// sitemap INDEX whose <loc>s point at child sitemaps. Resolve one level of
+// nesting so callers always get page URLs regardless of the generator.
+export const fetchSitemapUrls = async (
+  sitemapUrl = process.env.GEO_SITEMAP_URL ?? "https://kaiord.com/sitemap.xml"
+) => {
+  const xml = await fetch(sitemapUrl).then((res) => res.text());
+  let urls = parseLocs(xml);
+  if (urls.length > 0 && urls.every((u) => u.endsWith(".xml"))) {
+    const children = await Promise.all(
+      urls.map((u) =>
+        fetch(u)
+          .then((res) => res.text())
+          .then(parseLocs)
+      )
+    );
+    urls = children.flat();
+  }
+  if (urls.length === 0) throw new Error(`no <loc> entries in ${sitemapUrl}`);
+  return urls;
+};
+
+export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/scripts/geo/seo-dashboard.mjs
+++ b/scripts/geo/seo-dashboard.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+// Renders reports/seo/DASHBOARD.md from the observatory time series so trends
+// are reviewable in the repo (and in the weekly PR diff) without tooling.
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  loadQueries,
+  readJsonl,
+  seoDir,
+  timeseriesDir,
+} from "./observatory-lib.mjs";
+
+const gsc = readJsonl(join(timeseriesDir, "gsc.jsonl"));
+const bing = readJsonl(join(timeseriesDir, "bing.jsonl"));
+const serp = readJsonl(join(timeseriesDir, "serp.jsonl"));
+const aiVisibility = readJsonl(join(timeseriesDir, "ai-visibility.jsonl"));
+const { serpQueries } = loadQueries();
+const directoryStatus = JSON.parse(
+  readFileSync(join(seoDir, "directory-status.json"), "utf8")
+);
+
+const latest = (rows) => rows.at(-1);
+const previous = (rows) => rows.at(-2);
+
+const fmt = (value) =>
+  value === null || value === undefined ? "—" : String(value);
+const delta = (current, prior) => {
+  if (
+    current === null ||
+    current === undefined ||
+    prior === null ||
+    prior === undefined
+  )
+    return "";
+  const diff = current - prior;
+  if (diff === 0) return " (=)";
+  return diff > 0
+    ? ` (+${Math.round(diff * 100) / 100})`
+    : ` (${Math.round(diff * 100) / 100})`;
+};
+
+const g = latest(gsc);
+const gPrev = previous(gsc);
+const b = latest(bing);
+const bPrev = previous(bing);
+const s = latest(serp);
+const sPrev = previous(serp);
+
+// One row per (date, provider); keep the newest entry for each provider.
+const latestByProvider = new Map();
+for (const row of aiVisibility) latestByProvider.set(row.provider, row);
+const aiRows = [...latestByProvider.values()];
+
+const lines = [];
+lines.push("# SEO/GEO Dashboard — kaiord.com");
+lines.push("");
+lines.push(
+  `_Generated ${new Date().toISOString().slice(0, 16).replace("T", " ")} UTC by \`scripts/geo/seo-dashboard.mjs\`. Do not edit by hand._`
+);
+lines.push("");
+lines.push("## KPIs");
+lines.push("");
+lines.push("| Metric | Current | Target | Source |");
+lines.push("| --- | --- | --- | --- |");
+lines.push(
+  `| Pages indexed on Google | ${g ? `${g.indexed}/${g.sitemapUrlCount}${delta(g.indexed, gPrev?.indexed)}` : "— (needs GSC creds)"} | all pages | gsc.jsonl |`
+);
+lines.push(
+  `| Google impressions (7d) | ${g ? `${g.impressions}${delta(g.impressions, gPrev?.impressions)}` : "—"} | growing | gsc.jsonl |`
+);
+lines.push(
+  `| Google clicks (7d) | ${g ? `${g.clicks}${delta(g.clicks, gPrev?.clicks)}` : "—"} | growing | gsc.jsonl |`
+);
+lines.push(
+  `| Google avg position | ${g ? `${fmt(g.position)}${delta(gPrev?.position, g.position)}` : "—"} | top 10 on 3+ non-brand queries | gsc.jsonl |`
+);
+lines.push(
+  `| Bing pages in index | ${b ? `${fmt(b.inIndexPages)}${delta(b.inIndexPages, bPrev?.inIndexPages)}` : "— (needs Bing key)"} | all pages | bing.jsonl |`
+);
+lines.push(
+  `| Bing impressions (7d) | ${b ? `${b.impressions7d}${delta(b.impressions7d, bPrev?.impressions7d)}` : "—"} | growing | bing.jsonl |`
+);
+lines.push(
+  `| Tracked queries where site appears (DDG/Bing proxy) | ${s ? `${s.found}/${s.queries}${delta(s.found, sPrev?.found)}` : "—"} | ${serpQueries.length}/${serpQueries.length} | serp.jsonl |`
+);
+lines.push(
+  `| AI answer-engine mention rate | ${aiRows.length === 0 ? "— (needs Perplexity/OpenAI key)" : aiRows.map((r) => `${r.provider} ${r.mentionRate ?? "—"}`).join(", ")} | growing | ai-visibility.jsonl |`
+);
+lines.push("");
+
+lines.push("## Tracked query positions (DDG — Bing-index proxy)");
+lines.push("");
+if (serp.length === 0) {
+  lines.push(
+    "_No SERP snapshots yet — run `node scripts/geo/serp-snapshot.mjs`._"
+  );
+} else {
+  lines.push("| Query | Position | Prev | History (last 5) |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const { id, q } of serpQueries) {
+    const history = serp
+      .map((row) => row.positions?.[id])
+      .filter((p) => p !== undefined);
+    const current = history.at(-1) ?? null;
+    const prior = history.at(-2) ?? null;
+    const spark = history
+      .slice(-5)
+      .map((p) => (p === null ? "·" : `#${p}`))
+      .join(" ");
+    lines.push(
+      `| ${q} | ${current === null ? "ABSENT" : `#${current}`} | ${prior === null ? "ABSENT" : `#${prior}`} | ${spark} |`
+    );
+  }
+}
+lines.push("");
+
+lines.push("## Top Google queries (latest GSC window)");
+lines.push("");
+if (g === undefined || (g.topQueries ?? []).length === 0) {
+  lines.push("_No GSC query data yet (needs credentials and impressions)._");
+} else {
+  lines.push("| Query | Clicks | Impressions | Position |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const row of g.topQueries) {
+    lines.push(
+      `| ${row.query} | ${row.clicks} | ${row.impressions} | ${row.position} |`
+    );
+  }
+}
+lines.push("");
+
+lines.push("## AI answer-engine visibility (GEO end-goal)");
+lines.push("");
+if (aiRows.length === 0) {
+  lines.push(
+    "_No AI-visibility data yet — run `node scripts/geo/ai-visibility-probe.mjs` (needs `PERPLEXITY_API_KEY` or `OPENAI_API_KEY`)._"
+  );
+} else {
+  lines.push("| Provider | Date | Mentions | Rate | Cited | Top competitors |");
+  lines.push("| --- | --- | --- | --- | --- | --- |");
+  for (const r of aiRows) {
+    const comp = (r.topCompetitors ?? [])
+      .map((c) => `${c.name} (${c.count})`)
+      .join(", ");
+    lines.push(
+      `| ${r.provider} | ${r.date} | ${r.kaiordMentions}/${r.questions} | ${fmt(r.mentionRate)} | ${r.citedCount} | ${comp || "—"} |`
+    );
+  }
+}
+lines.push("");
+
+lines.push("## Directory / entity presence (GEO substrate)");
+lines.push("");
+lines.push(
+  `_Last manual check: ${directoryStatus.checkedAt}. Update \`reports/seo/directory-status.json\` when a listing goes live._`
+);
+lines.push("");
+for (const [name, status] of Object.entries(directoryStatus.directories)) {
+  lines.push(
+    `- [${status.present ? "x" : " "}] ${name}${status.url ? ` — ${status.url}` : ""}`
+  );
+}
+lines.push("");
+
+writeFileSync(join(seoDir, "DASHBOARD.md"), `${lines.join("\n")}\n`);
+console.log(`[dashboard] wrote reports/seo/DASHBOARD.md`);

--- a/scripts/geo/serp-snapshot.mjs
+++ b/scripts/geo/serp-snapshot.mjs
@@ -28,6 +28,10 @@ const domainOf = (url) => {
   }
 };
 
+// Exact host or subdomain only — a bare endsWith would also match
+// unrelated hosts like "notkaiord.com".
+const isTargetHost = (host) => host === TARGET || host.endsWith(`.${TARGET}`);
+
 // DDG's HTML endpoint wraps result links as /l/?uddg=<encoded-target-url>.
 const resultUrls = (html) =>
   Array.from(
@@ -64,7 +68,7 @@ for (const { id, q, lang } of serpQueries) {
     console.warn(`[serp] blocked or failed for "${q}" — recording null`);
     results.push({ id, q, position: null, blocked: true, top: [] });
   } else {
-    const index = urls.findIndex((url) => domainOf(url).endsWith(TARGET));
+    const index = urls.findIndex((url) => isTargetHost(domainOf(url)));
     results.push({
       id,
       q,

--- a/scripts/geo/serp-snapshot.mjs
+++ b/scripts/geo/serp-snapshot.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Records where kaiord.com ranks for the tracked query set
+// (reports/seo/queries.json) using DuckDuckGo's HTML endpoint. DDG results
+// derive largely from Bing's index, so this is a Bing-side proxy that needs no
+// API key and can run weekly in CI without secrets. Google positions come from
+// gsc-snapshot.mjs (real Search Console data), not from here.
+import { join } from "node:path";
+import {
+  appendJsonl,
+  loadQueries,
+  sleep,
+  timeseriesDir,
+  todayIso,
+  writeSnapshot,
+} from "./observatory-lib.mjs";
+
+const TARGET = "kaiord.com";
+// A browser-like UA avoids the endpoint's bot heuristics for this low-volume,
+// widely-spaced query pattern.
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+
+const domainOf = (url) => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+};
+
+// DDG's HTML endpoint wraps result links as /l/?uddg=<encoded-target-url>.
+const resultUrls = (html) =>
+  Array.from(
+    html.matchAll(/class="result__a"[^>]*href="([^"]+)"/g),
+    (m) => m[1]
+  )
+    .map((href) => {
+      const uddg = /[?&]uddg=([^&]+)/.exec(href)?.[1];
+      return uddg ? decodeURIComponent(uddg) : href;
+    })
+    .filter((url) => url.startsWith("http"));
+
+const search = async (query, lang) => {
+  const response = await fetch("https://html.duckduckgo.com/html/", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": USER_AGENT,
+    },
+    body: new URLSearchParams({
+      q: query,
+      kl: lang === "es" ? "es-es" : "us-en",
+    }),
+  });
+  if (!response.ok) return undefined;
+  return resultUrls(await response.text());
+};
+
+const { serpQueries } = loadQueries();
+const results = [];
+for (const { id, q, lang } of serpQueries) {
+  const urls = await search(q, lang);
+  if (urls === undefined) {
+    console.warn(`[serp] blocked or failed for "${q}" — recording null`);
+    results.push({ id, q, position: null, blocked: true, top: [] });
+  } else {
+    const index = urls.findIndex((url) => domainOf(url).endsWith(TARGET));
+    results.push({
+      id,
+      q,
+      position: index === -1 ? null : index + 1,
+      blocked: false,
+      top: urls.slice(0, 5).map(domainOf),
+    });
+  }
+  await sleep(2500);
+}
+
+const found = results.filter((r) => r.position !== null).length;
+const entry = {
+  date: todayIso(),
+  source: "serp-ddg",
+  queries: results.length,
+  found,
+  positions: Object.fromEntries(results.map((r) => [r.id, r.position])),
+};
+
+writeSnapshot(`serp-${todayIso()}`, { entry, results });
+const appended = appendJsonl(join(timeseriesDir, "serp.jsonl"), entry);
+console.log(
+  `[serp] ${appended ? "recorded" : "already recorded today"}: found in ${found}/${results.length} tracked queries`
+);
+for (const r of results) {
+  console.log(
+    `  ${r.position === null ? (r.blocked ? "BLOCKED" : "ABSENT ") : `#${r.position}`.padEnd(7)} ${r.q}`
+  );
+}


### PR DESCRIPTION
## What

Ports the SEO/GEO measurement observatory (used by sibling projects) to kaiord. Stdlib-only Node collectors under `scripts/geo/` append a per-day time series to `reports/seo/timeseries/*.jsonl` and regenerate `reports/seo/DASHBOARD.md`; a weekly GitHub Actions job (Mondays 07:37 UTC + `workflow_dispatch`) opens a metrics PR for the owner to review. The `DASHBOARD.md` diff is the weekly SEO review.

Scope is confined to `scripts/geo/`, `reports/seo/`, `.github/workflows/`, and a small docs addition — no product package, manifest, or source file is touched.

## Collectors

| Script | Source | Needs | Day one? |
| --- | --- | --- | --- |
| `serp-snapshot.mjs` | DuckDuckGo HTML (≈ Bing index) | nothing (keyless) | ✅ |
| `ai-visibility-probe.mjs` | Perplexity / OpenAI | `PERPLEXITY_API_KEY` or `OPENAI_API_KEY` | ✅ if key |
| `bing-snapshot.mjs` | Bing Webmaster Tools API | `BING_WEBMASTER_API_KEY` | ⏳ later |
| `gsc-snapshot.mjs` | Google Search Console API | `GSC_SERVICE_ACCOUNT_JSON` | ⏳ later |
| `seo-dashboard.mjs` | the time series above | nothing | ✅ |

Every collector **no-ops gracefully when its credential is absent**, so the workflow is green from day one. kaiord has no GSC property and is likely not yet in Bing Webmaster Tools, so initially only the SERP snapshot and the AI-visibility probe (Perplexity) produce data.

There is deliberately **no crawler-log collector** (the reference repo mines CloudFront logs for AI-bot hits): kaiord.com is served from GitHub Pages, which exposes no server-side access logs.

## t0 baseline (committed)

Captured locally on 2026-07-22:

- **SERP (DuckDuckGo, keyless):** kaiord ranks **#1 for the brand term `kaiord`**, **absent** for all 11 non-brand niche queries (e.g. "fit file converter", "convert fit to tcx", "mcp server fitness workouts").
- **AI-visibility (Perplexity `sonar`):** kaiord mentioned in **0/5** discovery questions; the competitor scan already caught "Garmin FIT SDK" in one answer.

Both baselines are the realistic starting point: strong brand presence, invisible on the ownable "AI/MCP-native workout file toolkit" niche. GSC and Bing rows show `—` until their credentials exist.

## Notes / deviations

- **No changeset** — the change is root-only (scripts / reports / workflow / docs) and touches no publishable package, so the `Check for Changeset` gate does not require one.
- **No file-splitting under the 100-line cap** — `scripts/**` is explicitly ESLint- and jscpd-ignored in this repo, so the collectors are kept as single files matching the reference (and the sibling port), which is cleaner than an artificial split.
- **Weekly PR is opened via `gh`** (dependency-free, matching the repo's `github-script`/CLI convention) rather than a new `peter-evans/create-pull-request` action.
- `reports/seo/DASHBOARD.md` + the append-only data dirs are added to `.prettierignore` so the raw script output stays canonical across the Prettier-less weekly workflow runs (otherwise every week would show a formatting-only diff).
- Verified locally: `check-scripts-orphans` and `check-workflow-timeouts` pass, `pnpm test:scripts` (540) passes, `pnpm -r build` and the pre-commit/pre-push type checks are green.

## Setup (owner, later)

Add repo secrets as they become available (each unlocks its collector): `PERPLEXITY_API_KEY`, then `GSC_SERVICE_ACCOUNT_JSON` (after verifying a `sc-domain:kaiord.com` property + submitting `https://kaiord.com/sitemap.xml`), then `BING_WEBMASTER_API_KEY`. Full guide: `docs/seo-observatory.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
