### PR TITLE
docs: document llms.txt format conventions for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,21 @@ Before any non-trivial change:
 5. Update docs if public API changes.
 6. After merge: `/opsx:archive`; then `pnpm archive:index` to refresh the index.
 
+### llms.txt / GEO surfaces
+
+The site serves `llms.txt` files for AI answer engines per the
+[llms.txt spec](https://llmstxt.org/): `packages/landing/public/llms.txt`
+(served at `https://kaiord.com/llms.txt`) plus the VitePress-generated
+`/docs/llms.txt` and `/docs/llms-full.txt` corpus mirrors. Format rules the
+hand-maintained landing file MUST keep (Lighthouse's "Agent Accessibility"
+audit enforces them):
+
+- A single H1 title followed by a `>` blockquote summary.
+- H2 sections listing **markdown links** — `- [Name](https://url): description`.
+  Bare URLs are not recognized as links by the spec or the audit.
+- New product surfaces (packages, docs sections, the Chrome extension) get a
+  link entry when they ship.
+
 ## Automated nightly maintenance (maintainer machine)
 
 Autonomous **launchd jobs** run on the maintainer's Mac (not CI, not part of the


### PR DESCRIPTION
Records the [llms.txt spec](https://llmstxt.org/) format rules in AGENTS.md so the hand-maintained `packages/landing/public/llms.txt` stays conformant: single H1 + blockquote summary, and **markdown link lists** under H2 sections — Lighthouse's "Agent Accessibility" audit rejects bare URLs ("File does not appear to contain any links"). kaiord's current llms.txt already complies; this pins the convention.

Docs-only change (no code, no changeset — AGENTS.md is repo guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for maintaining AI-readable documentation surfaces.
  * Documented the locations and formatting requirements for landing and generated `llms.txt` files.
  * Clarified that newly released product surfaces should include corresponding documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->