### PR TITLE
fix(scripts): author the weekly metrics PR with a PAT when available

### DIFF
--- a/.github/workflows/seo-observatory.yml
+++ b/.github/workflows/seo-observatory.yml
@@ -72,7 +72,11 @@ jobs:
       - name: Open metrics PR
         if: steps.detect.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A PAT makes the weekly PR user-authored, so pull_request workflows,
+          # the required changeset check, and code-owner review behave like on
+          # any normal PR. PRs authored with github.token trigger none of those
+          # and cannot merge without manual intervention.
+          GH_TOKEN: ${{ secrets.SEO_OBSERVATORY_PR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="auto/seo-observatory-${{ github.run_id }}"
           git config user.name "github-actions[bot]"

--- a/.github/workflows/seo-observatory.yml
+++ b/.github/workflows/seo-observatory.yml
@@ -74,8 +74,9 @@ jobs:
         env:
           # A PAT makes the weekly PR user-authored, so pull_request workflows,
           # the required changeset check, and code-owner review behave like on
-          # any normal PR. PRs authored with github.token trigger none of those
-          # and cannot merge without manual intervention.
+          # any normal PR. With github.token the PR's workflow runs are held in
+          # an approval-required state, so required checks sit pending and the
+          # PR cannot merge without manual intervention.
           GH_TOKEN: ${{ secrets.SEO_OBSERVATORY_PR_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="auto/seo-observatory-${{ github.run_id }}"

--- a/docs/seo-observatory.md
+++ b/docs/seo-observatory.md
@@ -82,6 +82,14 @@ until its secret exists):
    user and store its key JSON as `GSC_SERVICE_ACCOUNT_JSON`.
 3. **Bing Webmaster Tools** — import from GSC, then add
    `BING_WEBMASTER_API_KEY` (Settings → API access).
+4. **Weekly PR token** — add `SEO_OBSERVATORY_PR_TOKEN`, a fine-grained PAT
+   scoped to this repo with _Contents_ and _Pull requests_ write. With the
+   default `github.token` the metrics PR is authored by `github-actions[bot]`:
+   `pull_request` workflows never fire, the required "Check for Changeset"
+   context stays `expected`, and code-owner review blocks the merge (the
+   2026-07-24 smoke-run needed a manual approve plus an empty retrigger
+   commit to land). Without the secret the workflow still runs and falls back
+   to `github.token`; only the PR merge becomes manual.
 
 The GEO entity checklist lives in `reports/seo/directory-status.json` — update
 it as MCP-registry, npm, and directory listings go live.

--- a/docs/seo-observatory.md
+++ b/docs/seo-observatory.md
@@ -85,8 +85,9 @@ until its secret exists):
 4. **Weekly PR token** — add `SEO_OBSERVATORY_PR_TOKEN`, a fine-grained PAT
    scoped to this repo with _Contents_ and _Pull requests_ write. With the
    default `github.token` the metrics PR is authored by `github-actions[bot]`:
-   `pull_request` workflows never fire, the required "Check for Changeset"
-   context stays `expected`, and code-owner review blocks the merge (the
+   its `pull_request` workflow runs are held in an approval-required state, so
+   the required "Check for Changeset" context stays `expected` until someone
+   approves the runs, and code-owner review blocks the merge (the
    2026-07-24 smoke-run needed a manual approve plus an empty retrigger
    commit to land). Without the secret the workflow still runs and falls back
    to `github.token`; only the PR merge becomes manual.


### PR DESCRIPTION
The first in-CI observatory run (30114225384) produced a metrics PR authored by `github-actions[bot]`, which is unmergeable without manual surgery: PRs created with the default `github.token` do not trigger `pull_request` workflows, so the required **Check for Changeset** context never reports, and code-owner review additionally blocks bot-authored PRs (#1024 needed a manual approve + an empty retrigger commit).

- The "Open metrics PR" step now prefers `secrets.SEO_OBSERVATORY_PR_TOKEN` (fine-grained PAT: this repo, Contents + Pull requests write) and falls back to `github.token` when the secret is absent — zero behavior change until the secret exists.
- `docs/seo-observatory.md` documents the token as setup item 4 and records the failure mode.

One-time setup for @pablo-albaladejo: create the PAT and add it as the `SEO_OBSERVATORY_PR_TOKEN` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup guidance for configuring the SEO observatory’s optional pull request token.
  * Clarified how token configuration affects weekly metrics pull request authorship, workflow behavior, and merging.
  * Documented fallback behavior when the dedicated token is not configured.

* **Chores**
  * Improved automated weekly metrics pull request handling with support for a dedicated token and a default fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->