### PR TITLE
chore(seo): weekly SEO/GEO observatory snapshot

### DIFF
--- a/reports/seo/DASHBOARD.md
+++ b/reports/seo/DASHBOARD.md
@@ -1,6 +1,6 @@
 # SEO/GEO Dashboard — kaiord.com
 
-_Generated 2026-07-24 17:46 UTC by `scripts/geo/seo-dashboard.mjs`. Do not edit by hand._
+_Generated 2026-07-24 20:34 UTC by `scripts/geo/seo-dashboard.mjs`. Do not edit by hand._
 
 ## KPIs
 

--- a/reports/seo/snapshots/ai-visibility-perplexity-2026-07-24.json
+++ b/reports/seo/snapshots/ai-visibility-perplexity-2026-07-24.json
@@ -9,6 +9,10 @@
     "citedCount": 0,
     "topCompetitors": [
       {
+        "name": "python-fitparse",
+        "count": 1
+      },
+      {
         "name": "Garmin FIT SDK",
         "count": 1
       }
@@ -21,25 +25,24 @@
       "kaiordMentioned": false,
       "kaiordCited": false,
       "competitorsMentioned": [],
-      "answer": "These tools can convert **FIT files to TCX**, and a few also mention **ZWO** support:\n\n- **sport-calculator.com FIT to TCX Converter** — a free online converter that explicitly says it converts FIT to **TCX**, and the same page also advertises a **FIT to ZWO Converter** for Zwift workouts.[1]\n- **Fit File Tools** — an online converter that supports FIT output to **TCX** among other formats.[3]\n- **raacon FIT to TCX Converter** — a browser-based FIT-to-**TCX** tool that preserves common workout fields like GPS, heart rate, cadence, power, and timestamps.[4]\n- **fit2tcx (GitHub)** — a command-line tool that converts FIT to **TCX** and can batch-process files.[2][5]\n- **Fit2Tcx / fit2tcx variants** — smaller command-line utilities on GitHub and related pages that convert Garmin FIT activities to **TCX**.[7][8][13]\n- **FitConvert** — an online converter that supports conversion between **FIT** and **TCX**.[9][14]\n\nIf you specifically need **ZWO**, the only result here that explicitly mentions it is the **sport-calculator.com** page, which says it has a **FIT to ZWO Converter** for power-based FIT workouts.[1]",
+      "answer": "Tools that can convert **FIT to TCX** include these options:\n\n- **Sport Calculator FIT to TCX Converter** — a free online converter that processes files in the browser and says it preserves GPS track, heart rate, power, cadence, and laps.[1]\n- **raacon FIT to TCX Converter** — an online browser-based tool that preserves compatible fields like GPS, heart rate, cadence, power, speed, distance, elevation, and timestamps.[3]\n- **fit2tcx** by imgrant — an open-source command-line converter designed to produce compliant TCX files and preserve lap structure, cadence, and heart rate.[2]\n- **Tigge/FIT-to-TCX** — a command-line GitHub tool for converting FIT files to TCX, with batch conversion support.[4]\n- **Fit2Tcx** by adiesner — a small command-line utility for Garmin FIT activity files to TCX.[6][13]\n- **FIT File Converter** — an online file converter that supports FIT output to **TCX** among other formats.[7]\n- **FitConvert** — a browser-based converter that supports FIT to **TCX** and also offers batch conversion in its Pro version.[8][14]\n- **AI Training Plan FIT to TCX tool** — an in-browser converter that exports FIT to TCX and mentions reverse conversion as well.[10]\n\nFor **FIT to ZWO**, the clearest match in the results is:\n\n- **Sport Calculator FITZWO** — listed as a “FIT to ZWO Converter” for converting power-based FIT files to Zwift ZWO workouts.[1]\n\nIf you want, I can also sort these by **online vs. desktop/CLI**, or by **best for batch conversion**.",
       "citations": [
         "https://sport-calculator.com/converters/fit-to-tcx",
         "https://github.com/imgrant/fit2tcx",
-        "https://www.fitfiletools.com/convert",
         "https://raacon.no/tools/fit-to-tcx",
         "https://github.com/Tigge/FIT-to-TCX",
         "https://raacon.no/pl/tools/fit-to-tcx",
         "https://adiesner.github.io/GarminPlugin/fit2tcx.html",
-        "https://github.com/adiesner/Fit2Tcx",
+        "https://www.fitfiletools.com/convert",
         "https://www.fitconvert.to/articles/how-to-convert-fit-to-tcx",
         "https://filenp.com/fit-to-tcx-converters",
         "https://aitrainingplan.app/en/tools/fit-files/fit-to-tcx/",
         "https://www.file-extension.org/convert/fit-tcx",
         "https://pub.ks-and-ks.ne.jp/cycling/fit2tcx.shtml",
+        "https://github.com/adiesner/Fit2Tcx",
         "https://www.fitconvert.to/",
-        "https://gotoes.org/strava/Combine_GPX_TCX_FIT_Files.php",
-        "https://tcx-converter.software.informer.com/",
-        "https://fitrecovery.wordpress.com/2020/03/11/how-to-convert-downloaded-route-files-to-fit-or-tcx-for-your-garmin-cycling-computer/"
+        "https://forums.garmin.com/apps-software/mobile-apps-web/f/garmin-connect-web/122621/possible-to-export-fit-files-to-tcx",
+        "https://gotoes.org/strava/convert_fit_files_to_csv.php"
       ]
     },
     {
@@ -48,27 +51,28 @@
       "kaiordMentioned": false,
       "kaiordCited": false,
       "competitorsMentioned": [],
-      "answer": "Yes—there are MCP servers for **workout files**, depending on what you mean by “workout files.” If you mean files or data sources that contain workout logs, several MCP servers can read, write, or analyze workout data from fitness platforms or local data files.[1][6][13]\n\nA few relevant options:\n\n- **myHealth MCP Server**: explicitly says it supports fitness data, workout logs, progressive overload calculations, and training plan creation, and it can use external data files via the `MYHEALTH_DATA_PATH` environment variable.[1]\n- **Workout Memory**: an MCP server for workout history and training context, with an account-backed store for workouts, exercises, and related context.[16]\n- **Arvo MCP**: connects AI assistants directly to workout data and can read and write workout records.[6][17]\n- **Hevy MCP servers**: these connect to Hevy workout data and expose workout records, templates, and related analysis tools.[8][12][13]\n- **Garmin workouts MCP servers**: several projects focus on Garmin Connect workouts, including creating and managing structured workouts.[2][4][7][9][10][11][14]\n\nIf by “workout files” you mean **local files such as CSV/JSON exports or custom workout datasets**, the strongest match in your results is **myHealth MCP Server**, because it specifically mentions external data files and a configurable data path.[1]\n\nIf you want, I can narrow this down to:\n- an MCP server for **local workout files**\n- an MCP server for **Garmin/Hevy/Strava**\n- an MCP server that can **create and edit workouts**\n- a **self-hosted open-source** option",
+      "answer": "Yes — there are MCP servers for **workout files** and workout-related fitness data, but the exact fit depends on what you mean by “workout files.” Several servers support creating, listing, or exporting structured workouts such as **ZWO**, **ERG**, and **FIT** files, while others focus on workout history or app-specific workout records.[2][4][13]\n\nIf you mean **structured workout files** for training platforms:\n- **XERT MCP** can **list and export workouts** in **ZWO/ERG** formats and upload **FIT** files.[2]\n- **athletedata** says it can generate and push structured workouts and also offers downloadable **.zwo / .erg** files.[13]\n\nIf you mean an MCP server for a specific fitness platform’s workout data:\n- **Garmin Connect MCP** servers exist for managing workouts and structured training sessions.[12][16][17][19]\n- **Hevy MCP** servers expose workout history and allow fetching/creating/updating workout records.[9][11][14]\n- **myHealth MCP** supports workout logs, workout history, and training plan creation from external data files.[1]\n- **Arvo MCP** connects Claude to workout data for the Arvo app.[6]\n\nIf you want, I can narrow this down to the best MCP server for:\n- **Gym workout files**\n- **Cycling/training files** like **.zwo** or **.erg**\n- **Garmin workouts**\n- **FIT file import/export**",
       "citations": [
         "https://lobehub.com/mcp/maphilipps-myhealth-mcp",
-        "https://mcpmarket.com/server/garmin-workouts",
-        "https://mcpservers.org/servers/westvegh/exerciseapi-mcp-server",
-        "https://github.com/st3v/garmin-workouts-mcp",
+        "https://forum.xertonline.com/t/community-project-xert-mcp-server-for-claude-ai/48886",
         "https://eddmann.com/posts/running-mcps-everywhere-chatting-with-my-workouts/",
+        "https://shapecalendar.com/workout-mcp-server",
+        "https://www.reddit.com/r/mcp/comments/1uy2nu0/showcase_i_put_an_mcp_server_on_my_ios_workout/",
         "https://arvo.guru/developer/mcp",
+        "https://mcpservers.org/servers/westvegh/exerciseapi-mcp-server",
         "https://conare.ai/marketplace/mcp/garmin-workouts",
         "https://mcp.aibase.com/server/1916341151822749698",
         "https://mcpservers.org/servers/charlesfrisbee/garmin-workouts-mcp",
+        "https://raw.githubusercontent.com/chrisdoc/hevy-mcp/HEAD/README.md",
         "https://github.com/Taxuspt/garmin_mcp",
-        "https://www.pulsemcp.com/servers/mcp-dir-garmin",
-        "https://serp.ai/mcp/servers/chrisdoc-hevy-mcp/",
+        "https://www.athletedata.health/mcp",
         "https://www.npmjs.com/package/@vreippainen/hevy-mcp-server",
-        "https://mcpcursor.com/server/garmin-connect-mcp",
-        "https://chatforest.com/reviews/fitness-wearables-mcp-servers/",
-        "https://workoutmcp.com/",
-        "https://arvo.guru/blog/mcp-server-fitness-data",
         "https://www.reddit.com/r/Coros/comments/1r3w9tk/i_built_a_claude_mcp_that_creates_coros_workouts/",
-        "https://github.com/Dinesh-Satram/fitness_coach_MCP"
+        "https://mcpcursor.com/server/garmin-connect-mcp",
+        "https://www.pulsemcp.com/servers/mcp-dir-garmin",
+        "https://vibehackers.io/mcp/garmin-workouts-mcp",
+        "https://mcpservers.org/servers/leewnsdud/garmin-connect-mcp",
+        "https://www.reddit.com/r/ClaudeAI/comments/1rq363z/the_tredict_mcp_server_with_an_mcp_app_for_claude/"
       ]
     },
     {
@@ -77,26 +81,29 @@
       "kaiordMentioned": false,
       "kaiordCited": false,
       "competitorsMentioned": [
+        "python-fitparse",
         "Garmin FIT SDK"
       ],
-      "answer": "The main open-source option is **`@garmin/fitsdk`**, Garmin’s official FIT JavaScript SDK, which supports decoding FIT files and includes TypeScript support.[3][10]\n\nIf you want an unofficial TypeScript-focused parser, **`@samijaber/fit-sdk`** is another open-source library; its repository describes it as an unofficial FIT SDK implementation and says it was refactored to TypeScript.[1]\n\nIf you want, I can also compare the two for browser vs. Node.js use.",
+      "answer": "An open-source TypeScript library that parses Garmin FIT files is **`@samijaber/fit-sdk`**. It is an unofficial TypeScript fork/implementation for Garmin’s `.FIT` file protocol, and the repository is listed as **100% TypeScript**.[1]\n\nIf you want the **official** Garmin option in JavaScript/TypeScript ecosystems, Garmin also provides the **FIT JavaScript SDK** (`@garmin/fitsdk`), which uses ECMAScript modules and can be used from Node.js or compatible browsers.[8][15]\n\nA smaller alternative is **`fit-decoder`**, a zero-dependency JavaScript library for parsing ANT/Garmin `.FIT` files in Node.js and browser environments.[11]",
       "citations": [
         "https://github.com/samijaber/fit-sdk",
-        "https://developer.garmin.com/fit/",
-        "https://github.com/garmin/fit-javascript-sdk",
+        "https://developer.garmin.com/fit/cookbook/decoding-activity-files/",
+        "https://forums.garmin.com/developer/fit-sdk/f/discussion/436873/rust-no_std-library-for-decoding-and-encoding-fit-files",
         "https://ithub.global.ssl.fastly.net/topics/fit-file",
-        "https://github.com/garmin/fit-java-sdk",
+        "https://github.com/lindig/fit",
         "https://www.jsdelivr.com/package/npm/fit-encoder",
+        "https://github.com/garmin/fit-java-sdk",
+        "https://github.com/garmin/fit-javascript-sdk",
         "https://apis.io/apis/garmin/garmin-fit-sdk/",
+        "https://github.com/dtcooper/python-fitparse",
         "https://github.com/ask77nl/fit-decoder",
-        "https://mvnrepository.com/artifact/com.garmin/fit",
-        "https://forums.garmin.com/developer/fit-sdk/b/news-announcements/posts/fit-sdk-21-205-00-release",
+        "https://rdrr.io/github/grimbough/fitFileR/f/vignettes/FITfileR.Rmd",
         "https://github.com/muktihari/fit",
-        "https://forums.garmin.com/developer/fit-sdk/f/discussion/254794/javascript-parser",
-        "https://github.com/garmin/fit-sdk-tools",
         "https://stackoverflow.com/questions/22482774/read-process-fit-files-in-javascript",
-        "https://blog.studioblueplanet.net/software/java-garminant-fit-file-reader",
-        "https://gist.github.com/pryhoda/1c060fbafc94849beb7ee489e97f308e"
+        "https://developer.garmin.com/fit/",
+        "https://github.com/garmin/fit-sdk-tools",
+        "https://www.mathworks.com/matlabcentral/answers/2114196-read-garmin-fit-file-function",
+        "https://www.reddit.com/r/Garmin/comments/1ocam5d/an_open_source_tool_to_backup_and_visualize_your/"
       ]
     },
     {
@@ -105,25 +112,23 @@
       "kaiordMentioned": false,
       "kaiordCited": false,
       "competitorsMentioned": [],
-      "answer": "You can sync Garmin Connect workouts to other platforms in two main ways: **automatic third-party integrations** or **manual export/import**. Garmin also supports sending workouts from Garmin Connect to a Garmin watch directly, which is separate from sharing to outside platforms.[10][15][16]\n\n- **Automatic sync to supported apps**: Garmin Connect can sync activities with many third-party applications, but Garmin says you should use the third-party app’s support instructions to link a specific service.[10]\n- **Link through Connected Apps**: Garmin Connect’s settings include a **Connected Apps** area where you can add partner services; for example, Garmin Connect users can connect apps from the app’s settings menu.[11]\n- **TrainingPeaks example**: TrainingPeaks documents an **AutoSync** integration with Garmin Connect that can send completed activities and planned workouts between the services once the accounts are connected.[6]\n- **Manual export/import**: If a platform is not directly supported, you can export an activity file from Garmin Connect and upload it to another service. A Garmin Connect user guide and community guidance note that activities can be downloaded as files such as **.FIT**, **TCX**, or **GPX** and then imported elsewhere.[13]\n- **To send a workout to your Garmin device**: In Garmin Connect, go to **Training & Planning > Workouts**, select the workout, then choose **Send to Device** and sync the watch.[1][9][16]\n\nIf you mean a specific platform like **Strava, TrainingPeaks, or TrainingPeaks**, I can give you the exact step-by-step setup for that service.",
+      "answer": "You can sync workouts from **Garmin Connect** to other platforms in two main ways: by connecting a compatible third-party app in Garmin Connect, or by manually exporting an activity file and importing it elsewhere.[11][13]\n\n- **For ongoing automatic sync:** open the Garmin Connect app, go to **More** → **Settings** → **Connected Apps**, and link the service you want to use; Garmin says its platform syncs with many third-party applications.[10][11]\n- **For TrainingPeaks specifically:** TrainingPeaks supports Garmin Connect auto-sync, and you can choose whether to sync completed activities from Garmin to TrainingPeaks and/or structured workouts from TrainingPeaks to Garmin.[5][12]\n- **For Strava and similar services:** Garmin Connect can push activities to connected apps, but the connection is typically **one-way** from Garmin to the third-party platform; if you need to move data the other direction, you may need a third-party transfer tool or a manual file export/import process.[10][13]\n- **For manual transfer:** download the workout/activity file from Garmin Connect and upload it to the destination platform if that platform supports file import.[13]\n\nIf your goal is to send a **planned workout from Garmin Connect to your watch/device**, Garmin’s process is: open **Training & Planning** → **Workouts**, select the workout, choose **Send to Device**, then sync the watch via Garmin Connect or Garmin Express.[1][7][9][15]\n\nIf you want, I can give you the exact steps for **Strava**, **TrainingPeaks**, or another specific platform.",
       "citations": [
         "https://support.garmin.com/en-US/?faq=Oyqt6jUjOF8L1Rnuc9Sms8",
         "https://www.youtube.com/watch?v=oVX2k6y0v1w&vl=en",
         "https://www.trainerplan.co/blog/en/sync-workouts-to-your-garmin-device/",
-        "https://www.garmin.com/en-US/blog/general/pre-made-workouts-from-garmin-connect/",
         "https://www.reddit.com/r/Garmin/comments/l468ve/how_to_sync_manually_created_run_work_outs_to/",
         "https://www.trainingpeaks.com/coach-blog/garmin-connect-autosync-integration/",
-        "https://www.youtube.com/watch?v=TyKXlAOI8jU",
         "https://www.youtube.com/watch?v=rvDVAFcjR1s",
+        "https://www.garmin.com/en-US/blog/general/pre-made-workouts-from-garmin-connect/",
+        "https://www.youtube.com/watch?v=TyKXlAOI8jU",
         "https://support.garmin.com/en-US/?faq=IPD6X8JSLBAUQOXvz7zBO6",
-        "https://support.garmin.com/en-US/?faq=8L3Z4gEmTk6sXV7ido1Uz6",
         "https://www.tomsguide.com/how-to/how-to-use-garmin-connect",
-        "https://www8.garmin.com/manuals/webhelp/GUID-25E3235D-44D2-4384-A591-DD1D71BEBCB1/EN-US/GUID-0DC94101-1486-420B-8EA5-EFF3B32C3B0D.html",
+        "https://support.garmin.com/en-US/?faq=8L3Z4gEmTk6sXV7ido1Uz6",
+        "https://help.trainingpeaks.com/hc/en-us/articles/204070854-How-to-Sync-Garmin-Connect-With-TrainingPeaks",
         "https://www.reddit.com/r/Garmin/comments/1hxk8ly/connect_how_to_sync_an_activity_in_connect_to/",
-        "https://www.trainerroad.com/forum/t/sync-planned-workouts-in-garmin-connect-to-tr/113903",
         "https://www8.garmin.com/manuals-apac/webhelp/forerunner970/EN-SG/GUID-E6369156-4442-4DA5-8A59-EE1A01204C91-8848.html",
-        "https://support.garmin.com/en-US/?faq=wZ52AaLbLG2GC1Lxu2l4k7",
-        "https://forums.garmin.com/apps-software/mobile-apps-web/f/garmin-connect-web/161334/sync-problems-training-calendar-runs-don-t-show-up-workouts-don-t-sync-at-all/1017072"
+        "https://support.garmin.com/en-US/?faq=wZ52AaLbLG2GC1Lxu2l4k7"
       ]
     },
     {
@@ -132,12 +137,10 @@
       "kaiordMentioned": false,
       "kaiordCited": false,
       "competitorsMentioned": [],
-      "answer": "The **best open-source toolkit** in your results for **converting workout files** appears to be **`workout-converter`**, because it is explicitly built as a command-line tool to convert between multiple structured workout file formats, especially for cycling/smart-trainer use cases.[1]\n\nIf your main need is **FIT-to-GPX conversion**, then **`fit2gpx`** is the more specialized choice: it is described as a cross-platform utility for converting workout/track files from devices like Garmin, Suunto, Bryton, and Wahoo from **FIT to GPX and CSV**.[3][4]\n\nA practical comparison:\n\n| Toolkit | Best for | Notes |\n|---|---|---|\n| **workout-converter** | Converting between different structured workout formats | Broadly aimed at workout-file format conversion.[1] |\n| **fit2gpx** | Converting **FIT** files to **GPX/CSV** | More specialized; useful if your files are mainly Garmin/FIT-based.[3][4] |\n| **Fitness** | Import/export into a SQLite workout database | More for data management than file-format conversion.[2] |\n| **RuntasticConverter** | Runtastic/Adidas Running exports | Niche tool for one ecosystem.[5] |\n\nIf you want a **single general-purpose converter**, pick **`workout-converter`**.[1] If you mainly work with **Garmin FIT files**, pick **`fit2gpx`**.[3][4]",
+      "answer": "The best **open-source toolkit** in the results is **mherb/workout-converter** if your goal is to **convert structured workout files between formats**. It is described as a command-line tool for converting between different file formats for structured workouts, especially cycling-based workouts for smart trainers.[1]\n\nIf you specifically need **device workout files** like Garmin FIT, then **Fit2gpx** is the stronger fit, because it converts FIT files to GPX and CSV and supports several device ecosystems.[2]\n\nA quick comparison:\n\n| Toolkit | Best for | Notes |\n|---|---|---|\n| **mherb/workout-converter** | Structured workout file conversion | Small CLI tool focused on workout formats[1] |\n| **Fit2gpx** | Garmin/Suunto/Bryton/Wahoo workout file conversion | Converts FIT to GPX and CSV; broader device support[2] |\n| **RuntasticConverter** | Runtastic/Adidas Running exports | More specialized for that ecosystem[3] |\n\nIf you want the **most general-purpose workout-file converter** from the available options, I’d pick **mherb/workout-converter**.[1] If you want **broader device-file import/export**, I’d pick **Fit2gpx**.[2]",
       "citations": [
         "https://github.com/mherb/workout-converter",
-        "https://github.com/kobyv/Fitness",
         "https://wiki.openstreetmap.org/wiki/Fit2gpx",
-        "https://pypi.org/project/fit2gpx/",
         "https://github.com/Griffsano/RuntasticConverter"
       ]
     }


### PR DESCRIPTION
Automated weekly snapshot from the SEO/GEO observatory (`.github/workflows/seo-observatory.yml`). Review `reports/seo/DASHBOARD.md` in this diff for week-over-week movement; raw data lands in `reports/seo/timeseries/` and `reports/seo/snapshots/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the SEO dashboard’s generated timestamp.
  * Refreshed AI-visibility snapshot content with revised answers, recommendations, comparisons, and citations for workout conversion, MCP servers, FIT libraries, Garmin syncing, and workout toolkits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->