### PR TITLE
refactor(tcx): reduce to minimal code

### DIFF
--- a/.changeset/tcx-code-reduction.md
+++ b/.changeset/tcx-code-reduction.md
@@ -1,0 +1,5 @@
+---
+"@kaiord/tcx": patch
+---
+
+Internal code reduction, no behavior change.

--- a/packages/tcx/src/adapters/workout/target-to-tcx.converter.ts
+++ b/packages/tcx/src/adapters/workout/target-to-tcx.converter.ts
@@ -2,12 +2,11 @@ import type { Sport, WorkoutStep } from "@kaiord/core";
 
 import { convertCadenceToTcx } from "./cadence-to-tcx.converter";
 
-export const convertHeartRateToTcx = (value: {
-  unit: string;
-  value?: number;
-  min?: number;
-  max?: number;
-}): Record<string, unknown> => {
+type TargetValue = { unit: string; value?: number; min?: number; max?: number };
+
+export const convertHeartRateToTcx = (
+  value: TargetValue
+): Record<string, unknown> => {
   if (value.unit === "zone") {
     return {
       "@_xsi:type": "HeartRate_t",
@@ -34,12 +33,9 @@ export const convertHeartRateToTcx = (value: {
   return { "@_xsi:type": "None_t" };
 };
 
-export const convertPaceToTcx = (value: {
-  unit: string;
-  value?: number;
-  min?: number;
-  max?: number;
-}): Record<string, unknown> => {
+export const convertPaceToTcx = (
+  value: TargetValue
+): Record<string, unknown> => {
   if (value.unit === "mps" || value.unit === "range") {
     const min = "min" in value ? value.min : value.value;
     const max = "max" in value ? value.max : value.value;
@@ -60,7 +56,7 @@ const NONE_TCX = { "@_xsi:type": "None_t" };
 
 const convertTargetValueToTcx = (
   type: string,
-  value: { unit: string; value?: number; min?: number; max?: number },
+  value: TargetValue,
   sport: Sport
 ): Record<string, unknown> => {
   if (type === "heart_rate") return convertHeartRateToTcx(value);


### PR DESCRIPTION
Automated nightly code-reduction of @kaiord/tcx (rotation). Local gate passed: build green, tcx coverage >= baseline (base[98.01 96.33 100 97.68] now[98.01 96.33 100 97.68]), lint clean. The watcher will fix any CI findings and merge on green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal workout target-value handling without changing behavior or generated TCX output.
  * No user-facing functionality or supported unit behavior has changed.

* **Chores**
  * Prepared a patch release for the TCX package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->