### PR TITLE
feat(spa-editor): live getting-set-up checklist on Daily (Wave K3)

### DIFF
--- a/openspec/changes/add-setup-checklist/.openspec.yaml
+++ b/openspec/changes/add-setup-checklist/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/add-setup-checklist/design.md
+++ b/openspec/changes/add-setup-checklist/design.md
@@ -1,0 +1,160 @@
+## Context
+
+Four independent pieces of persisted state answer "is this user set up?", and
+each already has a home in the SPA:
+
+- `workouts`, profile-scoped since Dexie v13 (`[profileId+date]`, `profileId`).
+- `profiles[].sportZones.<sport>.thresholds`, read reactively by
+  `useActiveProfileLive`.
+- Bridge presence: the in-memory `bridgeDiscovery` singleton (exposed by
+  `useDiscoveredBridges`, bootstrapped by `use-store-hydration`) plus the v24
+  `connections` store.
+- `exportLedger`, whose Dexie repository already exposes
+  `countByDataType(dataType)` against the v18 `dataType` index.
+
+`userPreferences` is a per-profile row keyed on `profileId`, lazily created,
+and already carries four optional unindexed fields added without a schema bump
+(`aiBannerExpanded`, `units`, `labDashboardParams`, `locale`).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Items tick from state the user actually produced, never from a "seen it" flag.
+- One Dexie query for the checklist, per the repo's one-query-per-page rule.
+- A dismissal that survives a reload AND follows the profile across devices.
+- Respect the SPA caps: ≤80 lines/file, ≤60 lines/React component function.
+
+**Non-Goals:**
+
+- Retiring `OnboardingTutorial` (a later wave in the Help redesign).
+- Any bridge polling, session-liveness check, or connection repair.
+- Making the item set configurable, or adding a fifth item.
+
+## Decisions
+
+### D1 — Item 2 reads a THRESHOLD, never the zone arrays
+
+Every profile is seeded with `DEFAULT_POWER_ZONES` (7 entries) and
+`DEFAULT_HEART_RATE_ZONES` (5 entries) from `types/profile-defaults.ts`. A
+`zones.length > 0` predicate therefore ticks "Set your FTP and zones" for a
+brand-new profile on day zero, which is exactly the false-positive that makes a
+self-ticking checklist worse than no checklist. `hasAnyThreshold` reads
+`thresholds.ftp`, `thresholds.lthr` and `thresholds.thresholdPace` across every
+sport in `sportZones`, and any one of them being non-null ticks the item.
+
+Three thresholds rather than `ftp` alone because `SPORT_ZONE_CAPABILITIES`
+gives power to cycling and running only: a swimmer's meaningful setup act is a
+threshold pace, and an FTP-only predicate would leave them permanently
+un-ticked. The item's copy still names FTP because it is the term the majority
+of the audience searches for.
+
+The corresponding regression test seeds a profile carrying the full default
+zone arrays and asserts the item is NOT done.
+
+### D2 — Discovery presence is enough; no polling is started
+
+Item 3 could in principle assert a _live_ bridge session. It deliberately does
+not. `useBridgeConnectionsBootstrap` (Wave 0b's polling store) is intentionally
+unmounted in production until the Connections UI is wired, and mounting it from
+an onboarding card would start background polling as a side effect of visiting
+`/daily` — a scope and cost the checklist has no business incurring.
+
+The question the item asks is "has this user connected anything at all", and
+both a discovered bridge (`useDiscoveredBridges`, backed by a discovery
+singleton the app already bootstraps) and a `connected` record in the v24
+`connections` store answer it. A source that is connected but currently
+unreachable still means the setup step is done; repairing it is the Connections
+UI's job, not the checklist's.
+
+### D3 — One aggregate `useLiveQuery`, not four
+
+`use-setup-checklist-facts.ts` reads the workout count, the connected-provider
+count, the export-ledger count and the dismissal preference inside a single
+`useLiveQuery` callback. Dexie tracks every table touched inside one callback,
+so a write to any of the four re-fires the aggregate — four separate hooks would
+buy nothing but four subscriptions. `useActiveProfileLive` stays a separate
+call because it is a pre-existing shared hook whose result is already cached
+across the page, and `useDiscoveredBridges` is a `useSyncExternalStore` over an
+in-memory singleton, not a Dexie read at all.
+
+### D4 — Unresolved state reads as dismissed
+
+The aggregate's `defaultResult` is `{ …zeroes, dismissed: true }`, and a null
+`profileId` resolves to the same shape. A card that renders on the first frame
+and vanishes once a stored dismissal resolves is worse than one that appears a
+frame late, and this also gives the "no active profile yet" gate for free
+without a second flag in the hook's return type.
+
+### D5 — The dismissal is an optional field on `userPreferences`
+
+`localStorage` would pin the dismissal to one browser; `userPreferences` is
+profile-keyed and rides the cloud snapshot, so dismissing on the phone also
+dismisses on the laptop. `setupChecklistDismissed` is optional and unindexed,
+which is the same shape as `labDashboardParams` and `locale` — Dexie only needs
+a version bump for index changes, so this is purely additive with no migration
+and no backfill. Absence reads as "not dismissed", which is the correct default
+for every pre-existing row.
+
+`complete` hides the card independently of the flag, so a user who finishes all
+four items never has to dismiss anything and no write happens on their behalf.
+
+### D6 — The push signal is the export ledger, which is device-scoped
+
+`exportLedger` carries no `profileId`; `countByDataType("workout")` is therefore
+device-global. This is accepted: the item asks whether the user has ever pushed
+a session, and knowing how to push is a property of the person, not of the
+profile row. The alternative — scanning the profile's workouts for a non-null
+`garminPushId` — is profile-scoped but needs a non-indexed filter over every
+workout the profile owns, and would miss pushes recorded only in the ledger.
+The ledger read is an index count. A second profile on the same device seeing
+item 4 pre-ticked is a benign false positive on a dismissible hint.
+
+### D7 — Rows link, the card does not navigate
+
+The next action is a `wouter` `<Link>` to the href the item model composed.
+Only item 1 carries `?from=daily` via `withOrigin`, matching `PlannedEmpty` on
+the same page, because the editor is the only target that parses `BackOrigin`;
+`/athlete` ignores the query and `/calendar` redirects to the current week and
+drops it, so adding it there would be decorative. Done rows render as plain
+text, not disabled links: there is nothing to do there, and a struck-through
+link invites a click that leads nowhere useful. Items 2 and 3 both target
+`/athlete`, which is where `ThresholdCard` and `AthleteConnections` both live
+today.
+
+### D8 — Module layout is cap-driven
+
+The 80-line file cap splits the feature into five files: the pure model
+(`lib/setup-checklist.ts` — item ids, i18n keys, hrefs, `hasAnyThreshold`), the
+aggregate query, the composing hook, and three components (card, progress rail,
+row). The pure model in `lib/` is what lets the card test build realistic item
+arrays without touching Dexie.
+
+## Risks / Trade-offs
+
+- **Device-scoped push signal** → see D6. Bounded to a false "done" on an
+  onboarding hint; never blocks or hides anything.
+- **A user with real zones but no threshold sees item 2 un-ticked** → Someone
+  who hand-edited zone boundaries without recording the threshold they derive
+  from is asked to record it. That is the intended nudge, not a bug: the rest
+  of the app scales from the threshold.
+- **The card competes with `OnboardingTutorial`** → Both can appear for a
+  first-run user until the tutorial is retired in a later wave. The checklist
+  is non-blocking, so the overlap is visual clutter, not a trap.
+- **Mounted only on `/daily`** → A user who lives on `/calendar` never sees it.
+  `/daily` is the app's "what now" surface and the natural home for a "what's
+  left" card; a second mount point can be added without touching the hook.
+
+## Migration Plan
+
+None. The new preference field is optional and unindexed, so existing rows stay
+valid and the Dexie schema version is unchanged. Rollback is deleting the new
+files, unmounting the card from `Daily.tsx`, and dropping the field from
+`userPreferences` — stale values in existing rows are ignored by the schema's
+`.optional()` and by the cloud snapshot.
+
+## Open Questions
+
+- None blocking. Whether the checklist should also surface on `/calendar`, and
+  whether it should replace `OnboardingTutorial` outright, are decisions for
+  the Help-redesign wave that owns the tutorial.

--- a/openspec/changes/add-setup-checklist/design.md
+++ b/openspec/changes/add-setup-checklist/design.md
@@ -124,7 +124,7 @@ today.
 
 ### D8 — Module layout is cap-driven
 
-The 80-line file cap splits the feature into five files: the pure model
+The 80-line file cap splits the feature into six files: the pure model
 (`lib/setup-checklist.ts` — item ids, i18n keys, hrefs, `hasAnyThreshold`), the
 aggregate query, the composing hook, and three components (card, progress rail,
 row). The pure model in `lib/` is what lets the card test build realistic item

--- a/openspec/changes/add-setup-checklist/proposal.md
+++ b/openspec/changes/add-setup-checklist/proposal.md
@@ -1,0 +1,73 @@
+## Why
+
+First-run guidance in the SPA is a six-step centred modal (`OnboardingTutorial`)
+whose steps are all `position: "center"`, point at nothing, and are gated on a
+single "have you seen it" flag. It cannot know whether the user already created
+a workout, already set an FTP, or already pushed a session to a watch — so it
+replays the same tour to someone who is three weeks in, and stays silent for
+someone who dismissed it on day one and never finished setting up.
+
+The state that answers "is this user set up?" is already persisted and already
+reactive: the profile's workout count, its sport thresholds, the discovered
+bridges plus the v24 `connections` store, and the export ledger. Nothing reads
+it for onboarding purposes.
+
+## What Changes
+
+- Add a **live setup checklist** — four items that tick themselves from real
+  persisted state, rendered as a card on `/daily`, never as a modal:
+  1. _Create your first workout_ — the active profile's `workouts` count.
+  2. _Set your FTP and zones_ — a **threshold** (`ftp` / `lthr` /
+     `thresholdPace`) on any sport, deliberately NOT the zone arrays.
+  3. _Connect a source_ — a discovered bridge, or a `connected` record in the
+     v24 `connections` store.
+  4. _Push a session to your watch_ — a `workout` entry in the export ledger.
+- Add `hooks/use-setup-checklist.ts`, which composes ONE aggregate
+  `useLiveQuery` (`use-setup-checklist-facts.ts`) with the existing
+  `useActiveProfileLive` and `useDiscoveredBridges` hooks, and a pure item
+  model in `lib/setup-checklist.ts`.
+- Add `components/molecules/SetupChecklist/` — the card, a progress rail and a
+  row component. Done rows are struck-through inert text; the first not-done
+  row is the next action, showing its hint and linking to the surface that
+  completes it. A `✕` dismisses the card.
+- Persist the dismissal in the existing per-profile `userPreferences` row as a
+  new optional, unindexed `setupChecklistDismissed` boolean — **no Dexie
+  version bump** — so it rides the cloud snapshot instead of being pinned to
+  one device's `localStorage`.
+- Add a `setup` i18n namespace in `en` and `es`.
+
+Out of scope: the Help dialog, `HelpSection`, `OnboardingTutorial` (the modal
+this eventually retires), the command palette, Settings, and any bridge
+session-liveness polling.
+
+## Capabilities
+
+### New Capabilities
+
+- `spa-setup-checklist`: a dismissible, self-ticking onboarding checklist
+  derived from persisted state, with its dismissal stored per profile in the
+  cloud-synced preferences row.
+
+### Modified Capabilities
+
+<!-- None. The onboarding tutorial keeps its current behaviour in this change. -->
+
+## Impact
+
+- **Package**: `@kaiord/workout-spa-editor` (private SPA) only. No domain,
+  port, adapter or dependency change.
+- **New files**: `lib/setup-checklist.ts`,
+  `hooks/use-setup-checklist{,-facts}.ts`, `hooks/use-setup-checklist.test.tsx`,
+  `components/molecules/SetupChecklist/{SetupChecklist,SetupChecklistProgress,SetupChecklistRow}.tsx`,
+  `components/molecules/SetupChecklist/SetupChecklist.test.tsx`,
+  `i18n/locales/{en,es}/setup.json`.
+- **Modified files**: `types/user-preferences.ts` and
+  `application/set-user-preference-fields.ts` (one optional field each),
+  `components/pages/Daily/Daily.tsx` (mounts the card).
+- **Persistence**: additive optional field on an existing table. No schema
+  version, no migration, no backfill; absence reads as "not dismissed".
+- **i18n**: new `setup` namespace, `en` + `es` at key parity
+  (`resource-parity.test.ts` stays green). Namespaces are glob-discovered, so
+  no registry edit.
+- **No** public-API impact and no changeset — the SPA is private and excluded
+  from the changeset-bot PUBLISHABLE set.

--- a/openspec/changes/add-setup-checklist/specs/spa-setup-checklist/spec.md
+++ b/openspec/changes/add-setup-checklist/specs/spa-setup-checklist/spec.md
@@ -1,0 +1,181 @@
+## ADDED Requirements
+
+### Requirement: The setup checklist derives every item from persisted state
+
+The SPA SHALL present a four-item setup checklist whose items are each derived
+from state the user already produced, and SHALL NOT derive any item from a
+"tutorial seen" flag. The items SHALL be: creating a first workout, setting a
+training threshold, connecting a source, and pushing a session to a device.
+Every item SHALL be scoped to the active profile except where the underlying
+record carries no profile, and the checklist SHALL produce no items at all
+while no profile is active.
+
+#### Scenario: A workout the profile owns ticks the first item
+
+- **GIVEN** the active profile owns at least one row in the `workouts` table
+- **WHEN** the checklist is derived
+- **THEN** the "create your first workout" item SHALL be done
+
+#### Scenario: Another profile's workout does not tick the first item
+
+- **GIVEN** the only stored workout belongs to a different profile
+- **WHEN** the checklist is derived
+- **THEN** the "create your first workout" item SHALL NOT be done
+
+#### Scenario: A connected connection record ticks the source item
+
+- **GIVEN** a `connections` row for the active profile whose status is `connected`
+- **WHEN** the checklist is derived
+- **THEN** the "connect a source" item SHALL be done
+
+#### Scenario: A disconnected connection record does not tick the source item
+
+- **GIVEN** a `connections` row for the active profile whose status is `disconnected` and no discovered bridge
+- **WHEN** the checklist is derived
+- **THEN** the "connect a source" item SHALL NOT be done
+
+#### Scenario: A discovered bridge ticks the source item
+
+- **GIVEN** the bridge-discovery singleton knows at least one bridge
+- **WHEN** the checklist is derived
+- **THEN** the "connect a source" item SHALL be done, without any connection record being required
+
+#### Scenario: A workout export ledger entry ticks the push item
+
+- **GIVEN** an `exportLedger` entry whose `dataType` is `workout`
+- **WHEN** the checklist is derived
+- **THEN** the "push a session to your watch" item SHALL be done
+
+### Requirement: The zones item is answered by a threshold, not by zone arrays
+
+The "set your FTP and zones" item SHALL be derived from the presence of a
+threshold value on any sport in the profile's `sportZones` — a functional
+threshold power, a lactate-threshold heart rate, or a threshold pace. It SHALL
+NOT be derived from the length or contents of any zone array, because every
+profile is seeded with populated default power and heart-rate zones and would
+otherwise tick the item before the user has entered anything.
+
+#### Scenario: A fresh profile with default zones does not tick the item
+
+- **GIVEN** a profile whose sport zones carry the seeded default power and heart-rate zone arrays and no threshold value
+- **WHEN** the checklist is derived
+- **THEN** the "set your FTP and zones" item SHALL NOT be done
+
+#### Scenario: A functional threshold power ticks the item
+
+- **GIVEN** a profile whose cycling thresholds carry an `ftp`
+- **WHEN** the checklist is derived
+- **THEN** the "set your FTP and zones" item SHALL be done
+
+#### Scenario: A non-power threshold ticks the item
+
+- **GIVEN** a profile whose only threshold is a swimming `thresholdPace`
+- **WHEN** the checklist is derived
+- **THEN** the "set your FTP and zones" item SHALL be done, because power is not defined for every sport
+
+### Requirement: The checklist reads persisted state in a single live query
+
+The checklist's Dexie-backed signals SHALL be read inside one live-query
+callback rather than one query per item, so that a write to any of the
+underlying tables re-fires a single subscription. The derived state SHALL
+update without a reload when the user completes an item. While the query has
+not yet resolved, and while no profile is active, the checklist SHALL report
+itself as dismissed so that the card never renders and then disappears.
+
+#### Scenario: Completing an item updates the checklist live
+
+- **GIVEN** the checklist is rendered with the workout item not done
+- **WHEN** a workout is written for the active profile
+- **THEN** the item SHALL become done without a reload
+
+#### Scenario: No active profile hides the checklist
+
+- **GIVEN** no active profile is set
+- **WHEN** the checklist is derived
+- **THEN** it SHALL report itself as dismissed and no item SHALL be done
+
+### Requirement: The checklist is a card, never a modal
+
+The checklist SHALL render inline in the page flow as a dismissible card, and
+SHALL NOT render as a modal, overlay or blocking dialog. It SHALL show its
+title, a "N of M done" caption, a progress indicator exposing the item counts
+to assistive technology, one row per item, and an explicit dismiss control.
+Done rows SHALL be rendered as inert struck-through text; the first not-done
+row SHALL be rendered as the next action, showing its hint and linking to the
+surface on which it is completed.
+
+#### Scenario: Progress is reported as items, not percent
+
+- **GIVEN** two of the four items are done
+- **WHEN** the card renders
+- **THEN** the caption SHALL read "2 of 4 done" and the progress indicator SHALL report a current value of 2 out of a maximum of 4
+
+#### Scenario: Only the first not-done item is the next action
+
+- **GIVEN** the first two items are done and the last two are not
+- **WHEN** the card renders
+- **THEN** only the third item SHALL show its hint and its next-action affordance
+
+#### Scenario: The next action links to where it is completed
+
+- **GIVEN** the "create your first workout" item is the next action
+- **WHEN** the card renders
+- **THEN** its row SHALL link to the new-workout route, carrying the originating surface so that Back returns there
+
+#### Scenario: A done row is not a link
+
+- **GIVEN** the "create your first workout" item is done
+- **WHEN** the card renders
+- **THEN** the row SHALL NOT be a link
+
+### Requirement: Dismissal persists per profile and completion is permanent
+
+Dismissing the checklist SHALL write a flag onto the active profile's
+`userPreferences` row, so the dismissal survives a reload and travels with the
+profile rather than with one browser. The flag SHALL be an optional, unindexed
+field that requires no Dexie schema version bump, and its absence SHALL read as
+"not dismissed". Once every item is done the checklist SHALL hide itself
+without requiring an explicit dismissal, and SHALL NOT write anything to do so.
+
+#### Scenario: Dismissing writes the preference
+
+- **GIVEN** the card is rendered
+- **WHEN** the user activates the dismiss control
+- **THEN** the active profile's `userPreferences` row SHALL record the checklist as dismissed
+
+#### Scenario: A dismissed checklist stays hidden
+
+- **GIVEN** the active profile's `userPreferences` row records the checklist as dismissed
+- **WHEN** the page is loaded again
+- **THEN** the card SHALL NOT render
+
+#### Scenario: A completed checklist hides itself
+
+- **GIVEN** all four items are done and the checklist was never dismissed
+- **WHEN** the card renders
+- **THEN** it SHALL render nothing
+
+#### Scenario: A pre-existing preferences row stays valid
+
+- **GIVEN** a `userPreferences` row written before this change, with no checklist field
+- **WHEN** the checklist is derived
+- **THEN** the checklist SHALL read as not dismissed and no migration SHALL be required
+
+### Requirement: The checklist starts no background work
+
+Deriving or rendering the checklist SHALL NOT start bridge connection polling,
+SHALL NOT mount the bridge-connections bootstrap, and SHALL NOT perform any
+network request. Source detection SHALL rely only on the bridge-discovery
+snapshot the application already maintains and on stored connection records.
+
+#### Scenario: Visiting the page starts no polling
+
+- **GIVEN** the checklist is rendered on the daily page
+- **WHEN** it derives the "connect a source" item
+- **THEN** no bridge connection polling SHALL be started
+
+#### Scenario: An unreachable source still counts as connected
+
+- **GIVEN** a stored connection record whose status is `connected` but whose provider session is no longer live
+- **WHEN** the checklist is derived
+- **THEN** the "connect a source" item SHALL be done, because the item asks whether a source was ever connected

--- a/openspec/changes/add-setup-checklist/tasks.md
+++ b/openspec/changes/add-setup-checklist/tasks.md
@@ -1,0 +1,38 @@
+## 1. Persistence
+
+- [x] 1.1 Add the optional, unindexed `setupChecklistDismissed` boolean to `userPreferencesSchema` in `types/user-preferences.ts`, documenting that absence reads as "not dismissed" and that no Dexie version bump is needed.
+- [x] 1.2 Add `setupChecklistDismissed` to `UserPreferenceFieldsPatch` and to the explicit merge in `application/set-user-preference-fields.ts`, so a partial patch preserves it like every other optional field.
+
+## 2. Pure model
+
+- [x] 2.1 Create `lib/setup-checklist.ts`: `SetupChecklistItemId`, `SetupChecklistItem` (`id`, `titleKey`, `hintKey`, `done`, `href`), `SetupChecklistSignals`, and `buildSetupChecklistItems`.
+- [x] 2.2 Implement `hasAnyThreshold(profile)` over `sportZones.<sport>.thresholds` (`ftp` / `lthr` / `thresholdPace`), with the default-zone trap recorded in the module docblock.
+
+## 3. Live state
+
+- [x] 3.1 Create `hooks/use-setup-checklist-facts.ts`: ONE `useLiveQuery` returning `{ workoutCount, connectedCount, pushCount, dismissed }` from the `workouts`, `connections`, `exportLedger` and `userPreferences` tables; `dismissed: true` as the unresolved / no-profile value.
+- [x] 3.2 Read the push signal through `createDexieExportLedgerRepository(db).countByDataType("workout")` rather than re-implementing the query.
+- [x] 3.3 Create `hooks/use-setup-checklist.ts` composing the aggregate with `useActiveProfileLive` and `useDiscoveredBridges`, returning `{ items, doneCount, total, complete, dismissed, dismiss }`; `dismiss` writes through `useSetUserPreferenceFields`.
+- [x] 3.4 Do NOT mount `useBridgeConnectionsBootstrap` or start any polling.
+
+## 4. UI
+
+- [x] 4.1 Create `components/molecules/SetupChecklist/SetupChecklistProgress.tsx` — a progress rail exposing `aria-valuenow`/`aria-valuemax` as item counts.
+- [x] 4.2 Create `components/molecules/SetupChecklist/SetupChecklistRow.tsx` — done rows inert and struck through, the next action a link showing its hint and a `›` affordance; the href comes from the item model, which attaches `?from=daily` only to the editor target that actually parses it.
+- [x] 4.3 Create `components/molecules/SetupChecklist/SetupChecklist.tsx` — card with title, "N of 4 done", progress, the four rows and a dismiss `✕`; returns `null` when dismissed or complete.
+- [x] 4.4 Mount `<SetupChecklist />` on `/daily`, directly under `DailyHeader`.
+
+## 5. i18n
+
+- [x] 5.1 Add the `setup` namespace to `locales/en` and `locales/es` with identical key trees (`checklist.*` and `items.<id>.{title,hint}`); `resource-parity.test.ts` stays green.
+
+## 6. Tests
+
+- [x] 6.1 `hooks/use-setup-checklist.test.tsx`: per-item done-detection, the default-zones trap (a fresh profile with populated default zones does NOT tick item 2), the non-power threshold path, profile scoping of the workout count, connected vs disconnected records, a discovered bridge ticking the source item on its own (discovery hook mocked; connections table asserted empty), a post-mount write ticking its item live (the D3 aggregate re-fire), dismissal persistence and re-read, the no-profile gate, and `complete`.
+- [x] 6.2 `components/molecules/SetupChecklist/SetupChecklist.test.tsx`: title and caption, progress-bar item counts, all four rows, next-action highlight and its hint, the next-action href, done rows not being links, dismiss calling through, and the two hidden states.
+
+## 7. Quality gates
+
+- [x] 7.1 Full SPA suite green.
+- [x] 7.2 `tsc -p tsconfig.app.json --noEmit` clean; ESLint clean; Prettier clean on every touched file; `pnpm test:scripts` unchanged-green.
+- [x] 7.3 `npx openspec validate add-setup-checklist` passes. No changeset — `@kaiord/workout-spa-editor` is private and excluded from the changeset-bot PUBLISHABLE set.

--- a/packages/workout-spa-editor/src/application/set-user-preference-fields.ts
+++ b/packages/workout-spa-editor/src/application/set-user-preference-fields.ts
@@ -25,6 +25,7 @@ export type UserPreferenceFieldsPatch = Partial<
     | "notificationsEnabled"
     | "labDashboardParams"
     | "locale"
+    | "setupChecklistDismissed"
   >
 >;
 
@@ -58,6 +59,7 @@ export async function setUserPreferenceFields(
     notificationsEnabled: existing?.notificationsEnabled,
     labDashboardParams: existing?.labDashboardParams,
     locale: existing?.locale,
+    setupChecklistDismissed: existing?.setupChecklistDismissed,
     ...input.patch,
     updatedAt: deps.clock(),
   };

--- a/packages/workout-spa-editor/src/components/molecules/SetupChecklist/SetupChecklist.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SetupChecklist/SetupChecklist.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Card-level test. `useSetupChecklist` is mocked so each rendering rule
+ * (progress caption, next-action highlight, dismiss wiring, the two hidden
+ * states) is asserted independently of Dexie; the hook's own state derivation
+ * is covered by `hooks/use-setup-checklist.test.tsx`.
+ */
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Router } from "wouter";
+import { memoryLocation } from "wouter/memory-location";
+
+import type { SetupChecklist as SetupChecklistState } from "../../../hooks/use-setup-checklist";
+import { buildSetupChecklistItems } from "../../../lib/setup-checklist";
+import { renderWithProviders } from "../../../test-utils";
+import { SetupChecklist } from "./SetupChecklist";
+
+const useSetupChecklist = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../hooks/use-setup-checklist", () => ({ useSetupChecklist }));
+
+const dismiss = vi.fn();
+
+const stateWith = (
+  done: [boolean, boolean, boolean, boolean],
+  overrides: Partial<SetupChecklistState> = {}
+): SetupChecklistState => {
+  const items = buildSetupChecklistItems({
+    hasWorkout: done[0],
+    hasThreshold: done[1],
+    hasSource: done[2],
+    hasPush: done[3],
+  });
+  const doneCount = items.filter((item) => item.done).length;
+  return {
+    items,
+    doneCount,
+    total: items.length,
+    complete: doneCount === items.length,
+    dismissed: false,
+    dismiss,
+    ...overrides,
+  };
+};
+
+const renderCard = () => {
+  const { hook } = memoryLocation({ path: "/daily", record: true });
+  return renderWithProviders(
+    <Router hook={hook}>
+      <SetupChecklist />
+    </Router>
+  );
+};
+
+describe("SetupChecklist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render the title and the done-of-total progress caption", () => {
+    // Arrange
+    useSetupChecklist.mockReturnValue(stateWith([true, true, false, false]));
+
+    // Act
+    renderCard();
+
+    // Assert
+    expect(screen.getByText("Getting set up")).toBeInTheDocument();
+    expect(screen.getByText("2 of 4 done")).toBeInTheDocument();
+  });
+
+  it("should expose the progress bar with item counts, not percent", () => {
+    // Arrange
+    useSetupChecklist.mockReturnValue(stateWith([true, true, false, false]));
+
+    // Act
+    renderCard();
+
+    // Assert
+    const bar = screen.getByRole("progressbar", { name: "Setup progress" });
+    expect(bar).toHaveAttribute("aria-valuenow", "2");
+    expect(bar).toHaveAttribute("aria-valuemax", "4");
+  });
+
+  it("should render every item title", () => {
+    // Arrange
+    useSetupChecklist.mockReturnValue(stateWith([false, false, false, false]));
+
+    // Act
+    renderCard();
+
+    // Assert
+    expect(screen.getByText("Create your first workout")).toBeInTheDocument();
+    expect(screen.getByText("Set your FTP and zones")).toBeInTheDocument();
+    expect(screen.getByText("Connect a source")).toBeInTheDocument();
+    expect(
+      screen.getByText("Push a session to your watch")
+    ).toBeInTheDocument();
+  });
+
+  it("should highlight the first not-done item as the next action with its hint", () => {
+    // Arrange
+    useSetupChecklist.mockReturnValue(stateWith([true, true, false, false]));
+
+    // Act
+    renderCard();
+
+    // Assert
+    expect(
+      screen.getByText("Garmin, Train2Go or WHOOP — 2 minutes")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Open a planned session and send it to your device")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should link the next action to the surface that completes it", () => {
+    // Arrange
+    useSetupChecklist.mockReturnValue(stateWith([false, false, false, false]));
+
+    // Act
+    renderCard();
+
+    // Assert
+    expect(
+      screen.getByTestId("setup-checklist-link-create-workout")
+    ).toHaveAttribute("href", "/workout/new?from=daily");
+  });
+
+  it("should render done items as inert text, not as links", () => {
+    // Arrange
+    useSetupChecklist.mockReturnValue(stateWith([true, false, false, false]));
+
+    // Act
+    renderCard();
+
+    // Assert
+    expect(
+      screen.queryByTestId("setup-checklist-link-create-workout")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should call dismiss when the close control is pressed", async () => {
+    // Arrange
+    useSetupChecklist.mockReturnValue(stateWith([false, false, false, false]));
+    renderCard();
+
+    // Act
+    await userEvent.click(screen.getByTestId("setup-checklist-dismiss"));
+
+    // Assert
+    expect(dismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("should render nothing when the checklist was dismissed", () => {
+    // Arrange
+    useSetupChecklist.mockReturnValue(
+      stateWith([false, false, false, false], { dismissed: true })
+    );
+
+    // Act
+    renderCard();
+
+    // Assert
+    expect(screen.queryByTestId("setup-checklist")).not.toBeInTheDocument();
+  });
+
+  it("should render nothing once every item is done", () => {
+    // Arrange
+    useSetupChecklist.mockReturnValue(stateWith([true, true, true, true]));
+
+    // Act
+    renderCard();
+
+    // Assert
+    expect(screen.queryByTestId("setup-checklist")).not.toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/molecules/SetupChecklist/SetupChecklist.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SetupChecklist/SetupChecklist.tsx
@@ -1,0 +1,63 @@
+import { useSetupChecklist } from "../../../hooks/use-setup-checklist";
+import { useTranslate } from "../../../i18n/use-translate";
+import { Card } from "../../atoms/Card";
+import { Icon, ICON_MAP } from "../../atoms/Icon";
+import { SetupChecklistProgress } from "./SetupChecklistProgress";
+import { SetupChecklistRow } from "./SetupChecklistRow";
+
+/**
+ * The "Getting set up" card: four onboarding steps that tick themselves from
+ * real persisted state. Deliberately NOT a modal — it sits in the page flow,
+ * never blocks anything, and disappears for good once every item is done or
+ * the user dismisses it.
+ */
+export function SetupChecklist() {
+  const t = useTranslate("setup");
+  const checklist = useSetupChecklist();
+  const { items, doneCount, total } = checklist;
+
+  if (checklist.dismissed || checklist.complete) return null;
+
+  const nextId = items.find((item) => !item.done)?.id ?? null;
+
+  return (
+    <Card className="bg-surface border-edge p-4" data-testid="setup-checklist">
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-ink-strong m-0 text-[15px] font-bold">
+            {t("checklist.title")}
+          </p>
+          <p className="text-ink-muted m-0 mt-0.5 text-[13px]">
+            {t("checklist.progress", { done: doneCount, total })}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={checklist.dismiss}
+          aria-label={t("checklist.dismiss")}
+          data-testid="setup-checklist-dismiss"
+          className="text-ink-muted shrink-0"
+        >
+          <Icon icon={ICON_MAP.x} size="sm" color="inherit" />
+        </button>
+      </div>
+      <SetupChecklistProgress
+        done={doneCount}
+        total={total}
+        label={t("checklist.progressLabel")}
+      />
+      <ul className="m-0 mt-3 flex list-none flex-col gap-0.5 p-0">
+        {items.map((item) => (
+          <SetupChecklistRow
+            key={item.id}
+            item={item}
+            isNext={item.id === nextId}
+          />
+        ))}
+      </ul>
+      <p className="border-edge text-ink-muted m-0 mt-3 border-t pt-3 text-[12px]">
+        {t("checklist.footnote")}
+      </p>
+    </Card>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/SetupChecklist/SetupChecklistProgress.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SetupChecklist/SetupChecklistProgress.tsx
@@ -1,0 +1,35 @@
+export type SetupChecklistProgressProps = {
+  done: number;
+  total: number;
+  label: string;
+};
+
+/**
+ * Thin progress rail for the setup checklist. `aria-valuenow` counts items,
+ * not percent, so a screen reader announces "2 of 4" the same way the caption
+ * does; the width is the only place percent is used.
+ */
+export function SetupChecklistProgress({
+  done,
+  total,
+  label,
+}: SetupChecklistProgressProps) {
+  const percent = total === 0 ? 0 : Math.round((done / total) * 100);
+
+  return (
+    <div
+      role="progressbar"
+      aria-label={label}
+      aria-valuenow={done}
+      aria-valuemin={0}
+      aria-valuemax={total}
+      data-testid="setup-checklist-progress"
+      className="bg-surface-elevated mt-3 h-1.5 w-full overflow-hidden rounded-full"
+    >
+      <div
+        className="h-full rounded-full bg-emerald-400 transition-[width]"
+        style={{ width: `${percent}%` }}
+      />
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/molecules/SetupChecklist/SetupChecklistRow.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/SetupChecklist/SetupChecklistRow.tsx
@@ -1,0 +1,60 @@
+import { Link } from "wouter";
+
+import { useTranslate } from "../../../i18n/use-translate";
+import type { SetupChecklistItem } from "../../../lib/setup-checklist";
+import { Icon, ICON_MAP } from "../../atoms/Icon";
+
+export type SetupChecklistRowProps = {
+  item: SetupChecklistItem;
+  /** First not-done item: rendered as the next action, with its hint. */
+  isNext: boolean;
+};
+
+const rowClasses = (item: SetupChecklistItem, isNext: boolean): string => {
+  if (item.done) return "text-ink-muted line-through";
+  if (isNext) return "bg-surface-elevated text-ink-strong rounded-lg";
+  return "text-ink-body";
+};
+
+/**
+ * One checklist row. Done rows are inert struck-through text; the next action
+ * is a link into the surface that completes it, using the href the item model
+ * already composed.
+ */
+export function SetupChecklistRow({ item, isNext }: SetupChecklistRowProps) {
+  const t = useTranslate("setup");
+  const label = (
+    <span className="flex items-center gap-2">
+      {item.done ? (
+        <Icon icon={ICON_MAP.check} size="sm" color="success" />
+      ) : (
+        <span className="border-edge-strong h-3.5 w-3.5 shrink-0 rounded-full border" />
+      )}
+      <span className={item.done ? "" : "font-semibold"}>
+        {t(item.titleKey)}
+      </span>
+    </span>
+  );
+
+  return (
+    <li className={`px-2 py-2.5 text-[13.5px] ${rowClasses(item, isNext)}`}>
+      {item.done ? (
+        label
+      ) : (
+        <Link
+          href={item.href}
+          className="block"
+          data-testid={`setup-checklist-link-${item.id}`}
+        >
+          {label}
+          {isNext && (
+            <span className="text-ink-muted mt-0.5 flex items-center gap-1 pl-6 text-[12px]">
+              {t(item.hintKey)}
+              <Icon icon={ICON_MAP.chevR} size="xs" color="primary" />
+            </span>
+          )}
+        </Link>
+      )}
+    </li>
+  );
+}

--- a/packages/workout-spa-editor/src/components/pages/Daily/Daily.tsx
+++ b/packages/workout-spa-editor/src/components/pages/Daily/Daily.tsx
@@ -1,3 +1,4 @@
+import { SetupChecklist } from "../../molecules/SetupChecklist/SetupChecklist";
 import { CalendarDialogs } from "../CalendarDialogs";
 import { DailyHeader } from "./DailyHeader";
 import { EnergyBalanceCard } from "./EnergyBalanceCard";
@@ -32,6 +33,7 @@ export default function Daily() {
         isFocusToday={isFocusToday}
         onBackToToday={nav.backToToday}
       />
+      <SetupChecklist />
       <ReadinessCard readiness={readiness} />
       <EnergyBalanceCard profileId={profile?.id ?? null} date={focusIso} />
       <WeekStrip

--- a/packages/workout-spa-editor/src/hooks/use-setup-checklist-facts.ts
+++ b/packages/workout-spa-editor/src/hooks/use-setup-checklist-facts.ts
@@ -1,0 +1,70 @@
+/**
+ * The setup checklist's single Dexie read.
+ *
+ * Every persisted signal the checklist needs — the profile's workout count,
+ * its connected-provider count, the device's workout export ledger and the
+ * dismissal preference — is folded into ONE `useLiveQuery` callback, per the
+ * repo's one-query-per-page rule. Dexie tracks every table touched inside the
+ * callback, so a write to any of them re-fires the whole aggregate.
+ *
+ * The unresolved value is `HIDDEN` (`dismissed: true`): the checklist must not
+ * flash on mount and then vanish once a stored dismissal resolves. A null
+ * profile resolves to the same shape, which is what gates the card off before
+ * a profile exists.
+ */
+
+import { useLiveQuery } from "dexie-react-hooks";
+
+import { db } from "../adapters/dexie/dexie-database";
+import { createDexieExportLedgerRepository } from "../adapters/dexie/dexie-export-ledger-repository";
+import type { ConnectionRecord } from "../types/connection";
+import type { UserPreferences } from "../types/user-preferences";
+
+export type SetupChecklistFacts = {
+  readonly workoutCount: number;
+  readonly connectedCount: number;
+  readonly pushCount: number;
+  readonly dismissed: boolean;
+};
+
+const ledger = createDexieExportLedgerRepository(db);
+
+const HIDDEN: SetupChecklistFacts = {
+  workoutCount: 0,
+  connectedCount: 0,
+  pushCount: 0,
+  dismissed: true,
+};
+
+const read = async (profileId: string): Promise<SetupChecklistFacts> => {
+  const workoutCount = await db
+    .table("workouts")
+    .where("profileId")
+    .equals(profileId)
+    .count();
+  const connectedCount = await db
+    .table<ConnectionRecord>("connections")
+    .where("profileId")
+    .equals(profileId)
+    .filter((record) => record.status === "connected")
+    .count();
+  const pushCount = await ledger.countByDataType("workout");
+  const prefs = await db
+    .table<UserPreferences>("userPreferences")
+    .get(profileId);
+  return {
+    workoutCount,
+    connectedCount,
+    pushCount,
+    dismissed: prefs?.setupChecklistDismissed ?? false,
+  };
+};
+
+export const useSetupChecklistFacts = (
+  profileId: string | null
+): SetupChecklistFacts =>
+  useLiveQuery(
+    async () => (profileId ? read(profileId) : HIDDEN),
+    [profileId],
+    HIDDEN
+  );

--- a/packages/workout-spa-editor/src/hooks/use-setup-checklist.test.tsx
+++ b/packages/workout-spa-editor/src/hooks/use-setup-checklist.test.tsx
@@ -1,0 +1,378 @@
+/**
+ * Dexie-backed hook test: the checklist must tick from real persisted state,
+ * never from a "seen it" flag. The load-bearing case is `set-thresholds` —
+ * every profile ships fully populated default zone arrays, so a zone-array
+ * test would tick on day zero.
+ */
+import "fake-indexeddb/auto";
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { db } from "../adapters/dexie/dexie-database";
+import type { ConnectionRecord } from "../types/connection";
+import type { ExportLedgerEntry } from "../types/export-ledger";
+import type { Profile } from "../types/profile";
+import {
+  DEFAULT_HEART_RATE_ZONES,
+  DEFAULT_POWER_ZONES,
+} from "../types/profile-defaults";
+import type { UserPreferences } from "../types/user-preferences";
+import type { DiscoveredBridge } from "./use-discovered-bridges";
+import { useSetupChecklist } from "./use-setup-checklist";
+
+// The discovery singleton is an in-memory store with no seeding surface, so
+// the `bridges.length > 0` branch of the source item is only reachable through
+// a mock. Every test but one runs with an empty snapshot.
+const useDiscoveredBridges = vi.hoisted(() => vi.fn());
+
+vi.mock("./use-discovered-bridges", () => ({ useDiscoveredBridges }));
+
+const NO_BRIDGES: readonly DiscoveredBridge[] = [];
+const ONE_BRIDGE: readonly DiscoveredBridge[] = [
+  { bridgeId: "garmin-bridge", extensionId: "extension-id" },
+];
+
+const PROFILE_ID = "33333333-3333-3333-3333-333333333333";
+const TOTAL_ITEMS = 4;
+
+const DEFAULT_CYCLING_ZONES = {
+  thresholds: {},
+  heartRateZones: { method: "default", zones: DEFAULT_HEART_RATE_ZONES },
+  powerZones: { method: "default", zones: DEFAULT_POWER_ZONES },
+};
+
+const DEFAULT_ZONED_PROFILE: Profile = {
+  id: PROFILE_ID,
+  name: "Fresh Rider",
+  sportZones: { cycling: DEFAULT_CYCLING_ZONES },
+  linkedAccounts: [],
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const PROFILE_WITH_FTP: Profile = {
+  ...DEFAULT_ZONED_PROFILE,
+  sportZones: {
+    cycling: { ...DEFAULT_CYCLING_ZONES, thresholds: { ftp: 250 } },
+  },
+};
+
+const TABLES = [
+  "profiles",
+  "meta",
+  "workouts",
+  "connections",
+  "exportLedger",
+  "userPreferences",
+];
+
+const clearTables = async (): Promise<void> => {
+  for (const table of TABLES) await db.table(table).clear();
+};
+
+const seedProfile = async (profile: Profile = DEFAULT_ZONED_PROFILE) => {
+  await db.table<Profile>("profiles").put(profile);
+  await db.table("meta").put({ key: "activeProfileId", value: PROFILE_ID });
+};
+
+const itemById = (
+  result: ReturnType<typeof useSetupChecklist>,
+  id: string
+): boolean => result.items.find((item) => item.id === id)?.done ?? false;
+
+describe("useSetupChecklist", () => {
+  beforeEach(async () => {
+    useDiscoveredBridges.mockReturnValue(NO_BRIDGES);
+    await clearTables();
+  });
+  afterEach(clearTables);
+
+  it("should report nothing done for a fresh profile", async () => {
+    // Arrange
+    await seedProfile();
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.dismissed).toBe(false);
+    });
+    expect(result.current.doneCount).toBe(0);
+    expect(result.current.total).toBe(TOTAL_ITEMS);
+    expect(result.current.complete).toBe(false);
+  });
+
+  it("should NOT tick the zones item for a profile carrying only default zones", async () => {
+    // Arrange
+    await seedProfile();
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.dismissed).toBe(false);
+    });
+    expect(DEFAULT_POWER_ZONES.length).toBeGreaterThan(0);
+    expect(itemById(result.current, "set-thresholds")).toBe(false);
+  });
+
+  it("should tick the zones item once a threshold is set", async () => {
+    // Arrange
+    await seedProfile(PROFILE_WITH_FTP);
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(itemById(result.current, "set-thresholds")).toBe(true);
+    });
+  });
+
+  it("should tick the zones item from a non-power threshold", async () => {
+    // Arrange
+    await seedProfile({
+      ...DEFAULT_ZONED_PROFILE,
+      sportZones: {
+        swimming: {
+          thresholds: { thresholdPace: 95 },
+          heartRateZones: { method: "default", zones: [] },
+        },
+      },
+    });
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(itemById(result.current, "set-thresholds")).toBe(true);
+    });
+  });
+
+  it("should tick the workout item from the profile's workout count", async () => {
+    // Arrange
+    await seedProfile();
+    await db
+      .table("workouts")
+      .put({ id: "w1", profileId: PROFILE_ID, date: "2026-07-28" });
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(itemById(result.current, "create-workout")).toBe(true);
+    });
+  });
+
+  it("should NOT tick the workout item for another profile's workouts", async () => {
+    // Arrange
+    await seedProfile();
+    await db
+      .table("workouts")
+      .put({ id: "w2", profileId: "other-profile", date: "2026-07-28" });
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.dismissed).toBe(false);
+    });
+    expect(itemById(result.current, "create-workout")).toBe(false);
+  });
+
+  it("should tick the source item from a connected connection record", async () => {
+    // Arrange
+    await seedProfile();
+    const record: ConnectionRecord = {
+      profileId: PROFILE_ID,
+      providerId: "garmin",
+      status: "connected",
+      mechanism: "bridge",
+      updatedAt: "2026-07-28T00:00:00.000Z",
+    };
+    await db.table<ConnectionRecord>("connections").put(record);
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(itemById(result.current, "connect-source")).toBe(true);
+    });
+  });
+
+  it("should tick the source item from a discovered bridge alone", async () => {
+    // Arrange
+    await seedProfile();
+    useDiscoveredBridges.mockReturnValue(ONE_BRIDGE);
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(itemById(result.current, "connect-source")).toBe(true);
+    });
+    expect(await db.table("connections").count()).toBe(0);
+  });
+
+  it("should NOT tick the source item for a disconnected connection record", async () => {
+    // Arrange
+    await seedProfile();
+    const record: ConnectionRecord = {
+      profileId: PROFILE_ID,
+      providerId: "garmin",
+      status: "disconnected",
+      mechanism: "bridge",
+      updatedAt: "2026-07-28T00:00:00.000Z",
+    };
+    await db.table<ConnectionRecord>("connections").put(record);
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.dismissed).toBe(false);
+    });
+    expect(itemById(result.current, "connect-source")).toBe(false);
+  });
+
+  it("should tick an item written after mount, without a re-render from the caller", async () => {
+    // Arrange
+    await seedProfile();
+    const { result } = renderHook(() => useSetupChecklist());
+    await waitFor(() => {
+      expect(result.current.dismissed).toBe(false);
+    });
+    expect(itemById(result.current, "create-workout")).toBe(false);
+
+    // Act
+    await db
+      .table("workouts")
+      .put({ id: "w4", profileId: PROFILE_ID, date: "2026-07-28" });
+
+    // Assert
+    await waitFor(() => {
+      expect(itemById(result.current, "create-workout")).toBe(true);
+    });
+  });
+
+  it("should tick the push item from a workout export-ledger entry", async () => {
+    // Arrange
+    await seedProfile();
+    const entry: ExportLedgerEntry = {
+      id: "11111111-1111-1111-1111-111111111111",
+      kaiordRecordId: "22222222-2222-2222-2222-222222222222",
+      dataType: "workout",
+      destinationBridgeId: "garmin-bridge",
+      destinationExternalId: "gc-1",
+      contentHash: "hash",
+      exportedAt: "2026-07-28T00:00:00.000Z",
+    };
+    await db.table<ExportLedgerEntry>("exportLedger").put(entry);
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(itemById(result.current, "push-session")).toBe(true);
+    });
+  });
+
+  it("should report dismissed when the preference row says so", async () => {
+    // Arrange
+    await seedProfile();
+    const prefs: UserPreferences = {
+      profileId: PROFILE_ID,
+      calendarView: "grid",
+      setupChecklistDismissed: true,
+      updatedAt: "2026-07-28T00:00:00.000Z",
+    };
+    await db.table<UserPreferences>("userPreferences").put(prefs);
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.dismissed).toBe(true);
+    });
+  });
+
+  it("should persist the dismissal to the userPreferences row", async () => {
+    // Arrange
+    await seedProfile();
+    const { result } = renderHook(() => useSetupChecklist());
+    await waitFor(() => {
+      expect(result.current.dismissed).toBe(false);
+    });
+
+    // Act
+    result.current.dismiss();
+
+    // Assert
+    await waitFor(async () => {
+      const row = await db
+        .table<UserPreferences>("userPreferences")
+        .get(PROFILE_ID);
+      expect(row?.setupChecklistDismissed).toBe(true);
+    });
+    await waitFor(() => {
+      expect(result.current.dismissed).toBe(true);
+    });
+  });
+
+  it("should report dismissed while no profile is active", async () => {
+    // Arrange
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.doneCount).toBe(0);
+    });
+    expect(result.current.dismissed).toBe(true);
+  });
+
+  it("should report complete once every item is done", async () => {
+    // Arrange
+    await seedProfile(PROFILE_WITH_FTP);
+    await db
+      .table("workouts")
+      .put({ id: "w3", profileId: PROFILE_ID, date: "2026-07-28" });
+    await db.table("connections").put({
+      profileId: PROFILE_ID,
+      providerId: "garmin",
+      status: "connected",
+      mechanism: "bridge",
+      updatedAt: "2026-07-28T00:00:00.000Z",
+    });
+    await db.table("exportLedger").put({
+      id: "44444444-4444-4444-4444-444444444444",
+      kaiordRecordId: "55555555-5555-5555-5555-555555555555",
+      dataType: "workout",
+      destinationBridgeId: "garmin-bridge",
+      destinationExternalId: "gc-2",
+      contentHash: "hash",
+      exportedAt: "2026-07-28T00:00:00.000Z",
+    });
+
+    // Act
+    const { result } = renderHook(() => useSetupChecklist());
+
+    // Assert
+    await waitFor(() => {
+      expect(result.current.complete).toBe(true);
+    });
+    expect(result.current.doneCount).toBe(TOTAL_ITEMS);
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/use-setup-checklist.ts
+++ b/packages/workout-spa-editor/src/hooks/use-setup-checklist.ts
@@ -1,0 +1,72 @@
+/**
+ * useSetupChecklist — the live "Getting set up" checklist.
+ *
+ * Composes the aggregate Dexie read (`use-setup-checklist-facts`) with the
+ * existing profile and bridge-discovery hooks, and folds them into the four
+ * onboarding items. Nothing here polls: bridge presence comes from the
+ * discovery singleton that `use-store-hydration` already bootstraps, and
+ * connection records come from the v24 `connections` store. Session liveness
+ * is deliberately NOT consulted — the question is "has this user connected
+ * anything at all", not "is a session valid right now".
+ *
+ * `complete` is what hides the card once every item ticks, so a finished
+ * checklist needs no explicit dismissal.
+ */
+
+import { useCallback, useMemo } from "react";
+
+import {
+  buildSetupChecklistItems,
+  hasAnyThreshold,
+  type SetupChecklistItem,
+} from "../lib/setup-checklist";
+import { logger } from "../utils/logger";
+import { useActiveProfileLive } from "./use-active-profile-live";
+import { useDiscoveredBridges } from "./use-discovered-bridges";
+import { useSetUserPreferenceFields } from "./use-set-user-preference-fields";
+import { useSetupChecklistFacts } from "./use-setup-checklist-facts";
+
+export type SetupChecklist = {
+  readonly items: readonly SetupChecklistItem[];
+  readonly doneCount: number;
+  readonly total: number;
+  readonly complete: boolean;
+  readonly dismissed: boolean;
+  readonly dismiss: () => void;
+};
+
+export function useSetupChecklist(): SetupChecklist {
+  const active = useActiveProfileLive();
+  const profile = active?.profile ?? null;
+  const facts = useSetupChecklistFacts(active?.id ?? null);
+  const bridges = useDiscoveredBridges();
+  const setPrefs = useSetUserPreferenceFields(active?.id ?? null);
+
+  const items = useMemo(
+    () =>
+      buildSetupChecklistItems({
+        hasWorkout: facts.workoutCount > 0,
+        hasThreshold: hasAnyThreshold(profile),
+        hasSource: bridges.length > 0 || facts.connectedCount > 0,
+        hasPush: facts.pushCount > 0,
+      }),
+    [facts, profile, bridges]
+  );
+
+  const dismiss = useCallback(() => {
+    void setPrefs({ setupChecklistDismissed: true }).catch((error: unknown) => {
+      logger.warn("Failed to persist setup-checklist dismissal", { error });
+    });
+  }, [setPrefs]);
+
+  const doneCount = items.filter((item) => item.done).length;
+
+  return {
+    items,
+    doneCount,
+    total: items.length,
+    complete: doneCount === items.length,
+    dismissed: facts.dismissed,
+    dismiss,
+  };
+}

--- a/packages/workout-spa-editor/src/i18n/locales/en/setup.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/setup.json
@@ -1,0 +1,27 @@
+{
+  "checklist": {
+    "title": "Getting set up",
+    "progress": "{{done}} of {{total}} done",
+    "progressLabel": "Setup progress",
+    "dismiss": "Dismiss the setup checklist",
+    "footnote": "Ticks itself as you go. Nothing to replay, nothing to sit through."
+  },
+  "items": {
+    "createWorkout": {
+      "title": "Create your first workout",
+      "hint": "Build one step by step, or let the AI draft it"
+    },
+    "setThresholds": {
+      "title": "Set your FTP and zones",
+      "hint": "Your zones are derived from a threshold — 1 minute"
+    },
+    "connectSource": {
+      "title": "Connect a source",
+      "hint": "Garmin, Train2Go or WHOOP — 2 minutes"
+    },
+    "pushSession": {
+      "title": "Push a session to your watch",
+      "hint": "Open a planned session and send it to your device"
+    }
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/setup.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/setup.json
@@ -1,0 +1,27 @@
+{
+  "checklist": {
+    "title": "Primeros pasos",
+    "progress": "{{done}} de {{total}} hechos",
+    "progressLabel": "Progreso de configuración",
+    "dismiss": "Descartar la lista de primeros pasos",
+    "footnote": "Se marca sola según avanzas. Nada que repetir, nada que aguantar."
+  },
+  "items": {
+    "createWorkout": {
+      "title": "Crea tu primer entrenamiento",
+      "hint": "Constrúyelo paso a paso o deja que la IA lo redacte"
+    },
+    "setThresholds": {
+      "title": "Configura tu FTP y tus zonas",
+      "hint": "Tus zonas se derivan de un umbral — 1 minuto"
+    },
+    "connectSource": {
+      "title": "Conecta una fuente",
+      "hint": "Garmin, Train2Go o WHOOP — 2 minutos"
+    },
+    "pushSession": {
+      "title": "Envía una sesión a tu reloj",
+      "hint": "Abre una sesión planificada y mándala a tu dispositivo"
+    }
+  }
+}

--- a/packages/workout-spa-editor/src/lib/setup-checklist.ts
+++ b/packages/workout-spa-editor/src/lib/setup-checklist.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure model behind the "Getting set up" checklist.
+ *
+ * Four onboarding steps, each derived from real persisted state rather than
+ * from a "seen the tour" flag. The hook layer (`use-setup-checklist`) reads
+ * the state; this module owns the item vocabulary, the hrefs and the
+ * threshold predicate, so all of it is unit-testable without Dexie.
+ */
+
+import { withOrigin } from "../routing/with-origin";
+import type { Profile } from "../types/profile";
+
+export type SetupChecklistItemId =
+  "create-workout" | "set-thresholds" | "connect-source" | "push-session";
+
+export type SetupChecklistItem = {
+  readonly id: SetupChecklistItemId;
+  readonly titleKey: string;
+  readonly hintKey: string;
+  readonly done: boolean;
+  readonly href: string;
+};
+
+export type SetupChecklistSignals = {
+  readonly hasWorkout: boolean;
+  readonly hasThreshold: boolean;
+  readonly hasSource: boolean;
+  readonly hasPush: boolean;
+};
+
+/**
+ * "Zones are configured" is answered by a THRESHOLD, never by the zone
+ * arrays. A brand-new profile is seeded with `DEFAULT_POWER_ZONES` /
+ * `DEFAULT_HEART_RATE_ZONES` (see `types/profile-defaults.ts`), so a
+ * `zones.length > 0` test would tick on day zero for every user. Any of
+ * `ftp` / `lthr` / `thresholdPace` on any sport counts, because power is
+ * only meaningful for cycling and running — swimmers set a threshold pace.
+ */
+export const hasAnyThreshold = (profile: Profile | null): boolean =>
+  Object.values(profile?.sportZones ?? {}).some((config) => {
+    const thresholds = config?.thresholds;
+    if (!thresholds) return false;
+    return (
+      thresholds.ftp != null ||
+      thresholds.lthr != null ||
+      thresholds.thresholdPace != null
+    );
+  });
+
+export const buildSetupChecklistItems = (
+  signals: SetupChecklistSignals
+): readonly SetupChecklistItem[] => [
+  {
+    id: "create-workout",
+    titleKey: "items.createWorkout.title",
+    hintKey: "items.createWorkout.hint",
+    done: signals.hasWorkout,
+    // Only the editor parses `?from=`; the other two targets ignore it and
+    // `/calendar` redirects to the current week, dropping the query entirely.
+    href: withOrigin("/workout/new", "daily"),
+  },
+  {
+    id: "set-thresholds",
+    titleKey: "items.setThresholds.title",
+    hintKey: "items.setThresholds.hint",
+    done: signals.hasThreshold,
+    href: "/athlete",
+  },
+  {
+    id: "connect-source",
+    titleKey: "items.connectSource.title",
+    hintKey: "items.connectSource.hint",
+    done: signals.hasSource,
+    href: "/athlete",
+  },
+  {
+    id: "push-session",
+    titleKey: "items.pushSession.title",
+    hintKey: "items.pushSession.hint",
+    done: signals.hasPush,
+    href: "/calendar",
+  },
+];

--- a/packages/workout-spa-editor/src/types/user-preferences.ts
+++ b/packages/workout-spa-editor/src/types/user-preferences.ts
@@ -48,6 +48,12 @@ export const userPreferencesSchema = z.object({
   labDashboardParams: z.array(z.string()).optional(),
   /** UI language preference; absent reads as `auto`. Optional, unindexed — no Dexie version bump. */
   locale: localePreferenceSchema.optional(),
+  /**
+   * User dismissed the "Getting set up" checklist. Absent reads as not
+   * dismissed. Optional and unindexed — no Dexie version bump, and it rides
+   * the cloud snapshot so the dismissal follows the profile across devices.
+   */
+  setupChecklistDismissed: z.boolean().optional(),
   updatedAt: z.iso.datetime(),
 });
 


### PR DESCRIPTION
## Summary

Wave K3 of the Help redesign (`add-setup-checklist` OpenSpec change included). The design's premise: replace a tutorial nobody replays with four items that **know whether you already did them**.

- **Card on `/daily`, never a modal** — title, "N of 4 done", progress bar, the next undone item highlighted with a link to where it's done, dismiss ✕. Hides for good once complete or dismissed.
- **One aggregate `useLiveQuery`** covers all four Dexie-backed facts (workouts · connections · export ledger · preferences), keeping the page's one-query budget. A post-mount write test locks the live ticking so a future refactor can't silently break it.
- **The thresholds trap**: the item reads `ftp`/`lthr`/`thresholdPace`, never the zone arrays — `DEFAULT_POWER_ZONES`/`DEFAULT_HEART_RATE_ZONES` always populate those, so a zone check would tick on day zero. The regression test seeds the **real** defaults. It also spans all three thresholds rather than FTP alone, so a swimmer can tick it.
- **Dismissal** persists in the existing `userPreferences` store as an optional unindexed field → no Dexie version bump; the write path merges rather than replaces (omitting the field there would have silently wiped the dismissal on any later preference write).
- **No background work**: Wave 0b's connection store stays unmounted until the wave that renders it.

## Known, accepted trade-offs (documented in design.md)

- The push item reads the **export ledger**, which carries no `profileId` — so a second profile on a shared device sees it pre-ticked. The profile-scoped alternative (`garminPushId`) is worse: review confirmed the primary UI push path writes the ledger but never sets that field, so it would miss the most common push entirely.
- The source item ticks on **extension-discovered**, not signed-in — matching `AthleteConnections`' existing shipped semantics. Diverging here would be the worse bug; if tightened later it belongs in one shared predicate.

## Review trail
Adversarial review → **APPROVE, zero blockers** (4 minors). The two claims most likely to be wishful — the aggregate re-firing on all four tables, and the ledger-vs-garminPushId cost — were both verified by direct probing rather than accepted. Recommended regression locks added in a fix round.

## Verification
840 files / **5874 tests** green · `tsc -b` clean · lint clean end-to-end · `test:scripts` 577/577 · `openspec validate add-setup-checklist` valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live setup checklist to the Daily page covering workouts, training thresholds, source connections, and session exports.
  * Checklist progress updates automatically as setup steps are completed.
  * Added actionable links for the next unfinished step and an option to dismiss the checklist.
  * Dismissal is saved per profile and remains hidden after reloads.
  * Added English and Spanish translations.

* **Bug Fixes**
  * Completed checklists now hide automatically.
  * Checklist state is correctly scoped to the active profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->