### PR TITLE
feat(spa-editor): live values on Settings rows, honest privacy copy (Wave S1)

### DIFF
--- a/openspec/changes/add-settings-row-values/.openspec.yaml
+++ b/openspec/changes/add-settings-row-values/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/add-settings-row-values/design.md
+++ b/openspec/changes/add-settings-row-values/design.md
@@ -1,0 +1,182 @@
+## Context
+
+`SettingsGroupList` renders `SETTINGS_GROUPS`, a flat registry of
+`{ icon, key, to?, detailKey? }` rows. `detailKey` has exactly one legal value,
+`"defaultProvider"`, and `useRowDetail()` — eight lines inside the list
+component — is the whole live-value engine: it calls `useAiProvidersLive()` and
+returns the default provider's label for the one row that asks.
+
+The data every other row would want already exists behind hooks the detail
+panels use: `useSync()` (sync context), `useUserPreferences({ profileId })` +
+`useNotificationPermission()` (Preferences tab), and, for usage, a `useLiveQuery`
+written inline in `UsageTab.tsx` over `createDexieUsageEventRepository(db)`.
+
+The SPA caps files at 80 lines and functions at 60 (ESLint, `skipBlankLines` +
+`skipComments`), so "one hook that reads everything" is not available.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every value the index shows is read from the same source its detail panel
+  reads, so the two can never disagree.
+- Adding a value is declaring a key on a row, not editing the list component.
+- The grouping matches the design's four user-shaped groups without deleting any
+  reachable route, testid or i18n entry.
+- Every string rendered is true.
+
+**Non-Goals:**
+
+- The desktop split layout.
+- Any attention/health model behind the new `status` prop.
+- Building the Connections page, or touching Extensions / Data Hub internals.
+- Localising relative time.
+
+## Decisions
+
+### D1 — `valueKey` names a value, `useSettingsRowValues` owns resolution
+
+`detailKey?: "defaultProvider"` becomes `valueKey?: SettingsValueKey`, a union of
+the seven values that ship. `useSettingsRowValues()` returns
+`Record<SettingsValueKey, string | undefined>` and `SettingsGroupList` indexes it
+— the list component no longer knows what a provider or a sync engine is.
+
+The union (rather than `string`) is what makes the registry safe: a row naming a
+value nobody resolves is a compile-time error, and the returned `Record` is
+exhaustive by construction, so adding a key to the union without resolving it
+also fails to type-check. Both directions are mechanical.
+
+### D2 — One hook per value family, not one hook per value
+
+`useSettingsRowValues` composes `useSyncValue`, `useUsageValue` and
+`usePreferenceValues`, and inlines the two cheap ones (`provider` is a `.find()`
+over `useAiProvidersLive()`; `privacy` is a single `t()`). The split is by
+_source_, not by row: `usePreferenceValues` returns all three preference values
+because they come from one `useUserPreferences` read, and splitting them would
+mean three identical live queries.
+
+### D3 — `useUsageSummary` moves to `hooks/`, and the tab adopts it
+
+The Usage query is extracted to `hooks/use-usage-summary.ts` returning
+`{ months, events }`, parameterised by window size: the tab passes 6, the index
+row passes 1. One implementation, two surfaces: the tab's per-month table and
+the index row's single-month total fold the same events, so they cannot report
+different numbers. `hooks/` is where the SPA's other live reads live
+(`use-ai-providers-live`, `use-user-preferences`, `use-active-profile-live`),
+which is what makes it the destination — the index row would otherwise have had
+to import `adapters/dexie` a second time.
+
+`recentYearMonths` moves with it and takes an injected `now`, so its boundary
+behaviour (year rollover, zero-padding) is unit-testable without fake timers.
+
+### D4 — Usage renders nothing rather than "0 tokens"
+
+`useUsageValue` returns `undefined` both while the live query resolves and when
+the current month folded to zero tokens. A "0 tokens · July" row is noise on the
+overwhelmingly common path (a user who has not run AI this month), and an empty
+value slot is already the norm for the rows that carry none. The Usage _tab_
+still explains itself with `UsageEmptyState`; the index row just stays quiet.
+
+### D5 — Relative time reuses `formatRelativeTime`, and stays English
+
+`utils/format-relative-time.ts` already exists and is already composed exactly
+this way by `coaching-sync-button-tooltip.ts` (`${label} · ${relative}`), so the
+sync row reuses it rather than growing a second humaniser. Its return values are
+hardcoded English literals ("5m ago", "yesterday"), deliberately — the file's
+own contract note ties that to the repo's `R-PIIInterpolation` guard.
+
+The consequence is honest and bounded: under `es`, the sync row reads
+"Drive · 5m ago". The Spanish catalog therefore keeps `values.sync.connected` as
+`"Drive · {{relative}}"` with no Spanish framing around the fragment, so the
+string never reads as broken grammar. Localising `formatRelativeTime` is a
+separate change with its own blast radius (`CoachingSyncButton` shares it) and is
+not smuggled in here.
+
+Connected-but-never-synced does _not_ go through the humaniser: it returns the
+existing `sync.connectedNotSynced` string, because "Drive · never synced" is
+worse copy than "Connected — not synced yet" and the key already exists.
+
+### D6 — The privacy row's value is "Stored in this browser"
+
+**The design's at-rest encryption claim was not implementable as written, and
+shipping it would have been a false security claim.** The reference renders
+"Encrypted on device" on the privacy row and "Passphrase set · AES-GCM on every
+stored record" in the section body. What the SPA actually does:
+
+- `EncryptionSection` / `use-encryption-section` encrypt the **sync snapshot
+  before upload to Drive**, and only when the user turns the toggle on and
+  supplies a passphrase (off by default; the passphrase is memory-only).
+- Local Dexie is **not** encrypted. Any record in IndexedDB is readable by
+  anything with access to the origin.
+- The only local secrets with protection are AI provider keys, under the
+  `kaiord_secure_*` localStorage prefix (`PrivacyTab`).
+
+So the row ships `values.privacy.localFirst` = "Stored in this browser", which is
+both true and the thing a privacy-minded user actually wants confirmed. Rendering
+no value at all was the alternative; a true value beats an empty slot, and it
+does not overclaim.
+
+The audit of the neighbouring copy found one string worth narrowing:
+`sync.encryption` read "End-to-end encryption" with no object. Sitting beside a
+passphrase field it is readable as "everything is encrypted", so it is now
+"End-to-end encryption for sync snapshots". `sync.plaintextWarning` and every
+`privacy.info*` bullet were checked and are accurate as written — they describe
+upload and credential handling, never storage at rest — so they are untouched.
+
+### D7 — Connections points at `/athlete`, and says so in code
+
+`/settings/connections` does not exist; Wave 1 builds it. The row ships pointing
+at `/athlete` — the closest real surface for "who am I connected to" — with a
+one-line comment at the registry entry naming the wave that re-points it. A
+disabled row, or omitting the row until the page lands, would both mean shipping
+the new grouping twice.
+
+### D8 — Extensions and Data Hub survive the re-group as legacy rows
+
+The design's "Your data" group has three rows; the shipped one has six.
+Extensions and Data Hub are live routes with live e2e coverage
+(`settings-row-extensions` in `e2e/settings.spec.ts` 8.8,
+`settings-row-dataHub` in `e2e/data-hub.spec.ts`), and "Manage your data" is the
+only entry point to the `?section=data-management` deep link. Deleting rows the
+design happened not to draw would break working journeys to make a mockup match.
+They are demoted, not removed; a later wave can fold them into the Connections
+page once it exists.
+
+### D9 — `status` ships unused on purpose
+
+`SettingsRow` gains `status?: "attention"` rendering an amber dot before the
+chevron, and nothing passes it. The alternative — landing the prop in the same
+change that computes attention — would put a layout change and a new live data
+source in one diff. The prop is covered by a component test in both directions
+(rendered when passed, absent by default) so it cannot rot before it is wired.
+
+### D10 — External rows are `href`, not a router destination
+
+The About group's only row is an external docs link, and `SettingsRow`'s
+contract was "`to` + `onNavigate`". Rather than teach the list component to
+sniff `https://`, the row def gains `href` and `SettingsRow` renders an
+`<a target="_blank" rel="noopener noreferrer">` branch — same body, same testid,
+same chevron. "About" is deliberately one row: this repo has no `APP_VERSION`
+constant to display and Help's fate belongs to another wave.
+
+## Risks / Trade-offs
+
+- **Six live reads on the index** → The index now mounts `useAiProvidersLive`,
+  `useSync`, `useUserPreferences`, `useActiveProfileLive`, `useUsageSummary` and
+  `useNotificationPermission`. All but the last were already mounted somewhere in
+  the Settings subtree; the usage read is scoped to a single month over the
+  `[yearMonth+purpose]` index, which is the cheapest form of the query the tab
+  already ran.
+- **Spanish sync row shows an English time fragment** → Accepted and bounded by
+  D5; the catalog string is shaped so it degrades to a legible compound rather
+  than to broken Spanish.
+- **`groups.*` keys replaced, not renamed** → The five retired group keys were
+  grepped to confirm `SettingsGroupList` was their only consumer before removal.
+  Row keys are all preserved, which is what the e2e testids key off.
+- **"Your data" is a six-row group** → Denser than the design. Justified by D8;
+  it is the honest cost of not deleting reachable routes.
+
+## Migration Plan
+
+None. No persisted data, no schema version, no public API. Rollback is restoring
+`detailKey` on the registry and the previous `groups.*` block in both locales.

--- a/openspec/changes/add-settings-row-values/proposal.md
+++ b/openspec/changes/add-settings-row-values/proposal.md
@@ -1,0 +1,74 @@
+## Why
+
+The SPA's Settings index is a list of eleven labels that answer nothing. To find
+out which AI provider is default, when the last cross-device sync ran, whether
+notifications are on, or how many tokens this month cost, the user must open the
+row, read the panel, and navigate back — once per question. Only one row carries
+a value today (`defaultProvider`), through a `useRowDetail()` hook hard-wired to
+that single key.
+
+The grouping compounds it. Six eyebrows ("AI generation", "Cross-device sync",
+"Data routing", "Preferences", "Privacy & data", "Advanced") split eleven rows so
+finely that four groups hold one or two rows each, and the names describe the
+implementation ("Data routing", "Advanced") rather than what the user came for.
+
+## What Changes
+
+- Generalise the one-key `useRowDetail()` into a **value engine**: rows declare a
+  `valueKey`, and `useSettingsRowValues()` resolves every key to a display
+  string. Seven keys ship: `provider`, `sync`, `privacy`, `usage`, `units`,
+  `language`, `notifications`.
+- Extract the Usage tab's inline `usageEvents` query into
+  `hooks/use-usage-summary.ts`, so the tab and the index row fold **one**
+  implementation. The tab keeps its six-month window; the row asks for one month.
+- Preferences values mirror `PreferencesTab` exactly, including its fallback to
+  the defaults when no profile is active, so the index and the tab cannot
+  disagree.
+- Re-group the index into the design's **four** groups: Your data / AI /
+  Preferences / About. Extensions and Data Hub are demoted into "Your data" as
+  legacy rows — their routes, testids and `tabs.*` labels are untouched.
+- Add an optional `status?: "attention"` prop to `SettingsRow` (amber dot before
+  the chevron) and an optional `href` for external destinations. Nothing sets
+  `status` in this change; it is the seam a later wave wires to a real attention
+  model.
+- **Correct a false security claim.** The design reference labels the privacy row
+  "Encrypted on device" and its section copy claims "AES-GCM on every stored
+  record". Neither is true: `EncryptionSection` encrypts _sync snapshots before
+  upload to Drive_, local Dexie is not encrypted at all. The row ships "Stored in
+  this browser" instead, and the sync toggle's own label is narrowed from
+  "End-to-end encryption" to "End-to-end encryption for sync snapshots".
+
+Out of scope: the desktop split layout, any attention/health state behind the new
+`status` prop, the Connections page itself (this change points the Connections
+row at `/athlete` until that page exists), the Connections/Extensions/Data Hub
+page internals, and the Help dialog.
+
+## Capabilities
+
+### New Capabilities
+
+- `spa-settings-shell`: the Settings index answers itself — a declarative row
+  registry whose entries name a live value key, a hook per value family that
+  resolves those keys from the surface that owns each source, and four
+  user-shaped groups.
+
+### Modified Capabilities
+
+<!-- None. No existing capability spec covered the Settings index. -->
+
+## Impact
+
+- **Package**: `@kaiord/workout-spa-editor` (private SPA) only. No domain,
+  application, port or adapter contract changes; no dependency added.
+- **New files**: `components/pages/SettingsPage/settings-group-types.ts`,
+  `use-settings-row-values.ts`, `use-preference-values.ts`, `use-sync-value.ts`,
+  `use-usage-value.ts`, `hooks/use-usage-summary.ts`, plus five test modules.
+- **i18n**: `settings.groups.*` replaced (`yourData`, `ai`, `preferences`,
+  `about`); `settings.rows.{connections,helpDocs}` added; `settings.values.*`
+  added; `settings.rows.{provider,googleDriveSync,dataPrivacy}` and
+  `settings.sync.encryption` re-worded. `en` and `es` both, so
+  `resource-parity.test.ts` stays green.
+- **e2e**: no testid changes. `settings-row-{provider,extensions,dataHub}` and
+  `settings-panel-{extensions,usage,…}` all keep their identity and their routes.
+- **No** schema/version bump, no public-API impact, no changeset (the SPA is
+  private and excluded from the changeset-bot PUBLISHABLE set).

--- a/openspec/changes/add-settings-row-values/specs/spa-settings-shell/spec.md
+++ b/openspec/changes/add-settings-row-values/specs/spa-settings-shell/spec.md
@@ -1,0 +1,210 @@
+## ADDED Requirements
+
+### Requirement: Settings rows declare a live value key
+
+Each row of the Settings index SHALL optionally declare a `valueKey` naming a
+live value, and a single hook SHALL resolve every declared key to a display
+string or to `undefined`. The set of legal keys SHALL be a closed union, so a row
+naming an unresolved value and a resolved value no row declares are both
+compile-time errors. The list component SHALL NOT read any data source directly;
+it SHALL index the resolved values by the row's key.
+
+#### Scenario: A row renders its resolved value inline
+
+- **GIVEN** the Settings index and a row declaring the `provider` value key
+- **WHEN** the list renders
+- **THEN** the row SHALL display the default AI provider's label beside its own label
+
+#### Scenario: A row without a value key renders no value
+
+- **GIVEN** a row that declares no `valueKey`
+- **WHEN** the list renders
+- **THEN** the row SHALL render its label and chevron only, with no value slot
+
+#### Scenario: An unresolved value renders nothing rather than a placeholder
+
+- **GIVEN** a row whose value hook returns `undefined` because its source is still loading
+- **WHEN** the list renders
+- **THEN** the row SHALL render no value text, and SHALL NOT render a spinner, a dash or an empty-string placeholder
+
+### Requirement: One usage read serves both the Usage tab and the index row
+
+The `usageEvents` query SHALL live in exactly one hook, parameterised by how many
+recent months it reads, and both the Settings → Usage tab and the Settings index
+usage row SHALL consume it. The hook SHALL return the year-month keys it queried
+alongside the raw events, most recent month first, so each caller folds them for
+its own surface. Events SHALL be `undefined` while the live query resolves, and
+callers SHALL treat that as loading rather than as absence of usage.
+
+#### Scenario: The tab and the row fold the same events
+
+- **GIVEN** the usage log holds events for the current month
+- **WHEN** the Usage tab and the Settings index both render
+- **THEN** both SHALL derive their totals from the same hook, the tab over its six-month window and the row over the current month only
+
+#### Scenario: The index row summarises the current month
+
+- **GIVEN** the current month folded to 1,214,880 tokens
+- **WHEN** the Settings index renders the usage row
+- **THEN** the row SHALL display the total in compact notation with the month name, e.g. "1.2M tokens · July"
+
+#### Scenario: A month with no usage renders no value
+
+- **GIVEN** the current month has no usage events
+- **WHEN** the Settings index renders the usage row
+- **THEN** the row SHALL render no value, rather than a zero total
+
+### Requirement: Preferences values mirror the preferences panel
+
+The units, language and notification values on the Settings index SHALL be
+derived from the same per-profile preferences read the Preferences panel uses,
+including its fallback to the defaults when no profile is active. A `language`
+preference of `auto` SHALL be resolved to the display name of the locale actually
+in effect, never rendered as the literal `auto`. The notification value SHALL
+reflect both the stored intent and the browser permission, so a row can never
+claim notifications are on while the browser is blocking them.
+
+#### Scenario: No active profile falls back to the defaults
+
+- **GIVEN** no active profile, so the preferences read resolves to `undefined`
+- **WHEN** the Settings index renders
+- **THEN** the units row SHALL read "Metric" and the notifications row SHALL read "Off"
+
+#### Scenario: An automatic language resolves to a display name
+
+- **GIVEN** a stored language preference of `auto` and an active locale of English
+- **WHEN** the Settings index renders the language row
+- **THEN** the row SHALL display "English"
+
+#### Scenario: A blocked browser permission overrides the stored intent
+
+- **GIVEN** notifications enabled in preferences and a denied browser permission
+- **WHEN** the Settings index renders the notifications row
+- **THEN** the row SHALL display "Blocked", not "On"
+
+#### Scenario: Notifications read on only when both agree
+
+- **GIVEN** notifications enabled in preferences and a granted browser permission
+- **WHEN** the Settings index renders the notifications row
+- **THEN** the row SHALL display "On"
+
+### Requirement: The cross-device sync row reports the live sync engine
+
+The sync row's value SHALL be read from the app-wide sync engine, so it tracks
+connect, disconnect and every completed cycle without a second source of truth.
+A disconnected account SHALL render as not connected; a connected account that
+has never completed a cycle SHALL say so explicitly; a connected account with a
+completed cycle SHALL render the destination and the time of that cycle in
+relative form.
+
+#### Scenario: A disconnected account says so
+
+- **GIVEN** no Google account connected for sync
+- **WHEN** the Settings index renders the sync row
+- **THEN** the row SHALL display "Not connected"
+
+#### Scenario: A connected account that never synced is not reported as synced
+
+- **GIVEN** a connected account whose last successful sync is absent
+- **WHEN** the Settings index renders the sync row
+- **THEN** the row SHALL display "Connected — not synced yet", and SHALL NOT display a relative time
+
+#### Scenario: A completed cycle renders relatively
+
+- **GIVEN** a connected account whose last successful sync was five minutes ago
+- **WHEN** the Settings index renders the sync row
+- **THEN** the row SHALL display "Drive · 5m ago"
+
+### Requirement: The Settings index is grouped into four user-shaped groups
+
+The Settings index SHALL present its rows in exactly four groups — Your data, AI,
+Preferences and About — named for what the user came to change rather than for
+the implementation behind it. Every route reachable from the previous grouping
+SHALL remain reachable from the new one, and every row SHALL keep its stable key,
+which is simultaneously its i18n key, its React key and its test id. Group labels
+that no longer name a group SHALL be removed from every locale catalog only after
+confirming no surface reads them.
+
+#### Scenario: Every group eyebrow renders
+
+- **GIVEN** the Settings index
+- **WHEN** it renders
+- **THEN** it SHALL render the four eyebrows "Your data", "AI", "Preferences" and "About"
+
+#### Scenario: Legacy rows stay reachable
+
+- **GIVEN** the Extensions and Data Hub rows, demoted into "Your data"
+- **WHEN** the user activates either
+- **THEN** navigation SHALL reach `/settings/extensions` and `/settings/data-hub` respectively, from row test ids `settings-row-extensions` and `settings-row-dataHub`
+
+#### Scenario: The Connections row has an interim destination
+
+- **GIVEN** that the dedicated connections page does not exist yet
+- **WHEN** the user activates the Connections row
+- **THEN** navigation SHALL reach `/athlete`, and the row definition SHALL carry a comment naming the wave that re-points it
+
+#### Scenario: Deep links keep their entry point
+
+- **GIVEN** the "Manage your data" row
+- **WHEN** the user activates it
+- **THEN** navigation SHALL reach `/settings/privacy?section=data-management` and the target section SHALL take focus
+
+### Requirement: A settings row can be flagged as needing attention
+
+A settings row SHALL accept an optional attention status that renders a visual
+marker between the row's value and its chevron. The marker SHALL be absent unless
+the status is set explicitly, so no row is marked by default. The status SHALL be
+purely presentational in this capability: nothing computes it, and no data source
+is mounted to derive it.
+
+#### Scenario: An attention row renders the marker
+
+- **GIVEN** a settings row rendered with the attention status
+- **WHEN** it renders
+- **THEN** it SHALL render an attention marker addressable as `settings-row-<key>-attention`
+
+#### Scenario: A row without a status renders no marker
+
+- **GIVEN** a settings row rendered without a status
+- **WHEN** it renders
+- **THEN** no attention marker SHALL be present
+
+### Requirement: Storage copy states only what is encrypted
+
+User-visible copy about data protection SHALL describe only the protection that
+exists. Local records are held unencrypted in the browser's database; encryption
+applies to the cross-device sync snapshot before upload, and only when the user
+has enabled it with a passphrase. The Settings surfaces SHALL NOT claim
+encryption at rest for stored records, and any control that offers encryption
+SHALL name what it encrypts.
+
+#### Scenario: The privacy row describes local storage truthfully
+
+- **GIVEN** the Privacy & data row on the Settings index
+- **WHEN** it renders its value
+- **THEN** the value SHALL describe where the data lives — "Stored in this browser" — and SHALL NOT claim the stored records are encrypted
+
+#### Scenario: The encryption control names its object
+
+- **GIVEN** the encryption toggle in the cross-device sync panel
+- **WHEN** its label renders
+- **THEN** the label SHALL identify sync snapshots as what is encrypted, rather than reading as a blanket encryption claim
+
+### Requirement: External settings destinations open in a new tab
+
+A settings row SHALL be able to point at an external destination instead of an
+in-app route. Such a row SHALL render as a link that opens in a new browsing
+context with `rel="noopener noreferrer"`, SHALL keep the same body, chevron and
+test id as an in-app row, and SHALL NOT be handed to the in-app router.
+
+#### Scenario: The docs row is an external link
+
+- **GIVEN** the "Help & docs" row in the About group
+- **WHEN** the Settings index renders
+- **THEN** the row SHALL be an anchor to the documentation site carrying `target="_blank"` and `rel="noopener noreferrer"`
+
+#### Scenario: In-app rows are unaffected
+
+- **GIVEN** a row declaring an in-app destination
+- **WHEN** the user activates it
+- **THEN** the in-app router SHALL handle the navigation and no new browsing context SHALL open

--- a/openspec/changes/add-settings-row-values/tasks.md
+++ b/openspec/changes/add-settings-row-values/tasks.md
@@ -1,0 +1,54 @@
+## 1. Value engine
+
+- [x] 1.1 Extract the row/group types to `components/pages/SettingsPage/settings-group-types.ts`, replacing `detailKey?: "defaultProvider"` with `valueKey?: SettingsValueKey` (closed union of `provider`, `sync`, `privacy`, `usage`, `units`, `language`, `notifications`) and adding `href?` for external destinations.
+- [x] 1.2 Add `use-settings-row-values.ts`: returns `Record<SettingsValueKey, string | undefined>`; inlines `provider` (default from `useAiProvidersLive()`, preserving today's behaviour) and `privacy`, composes the three family hooks.
+- [x] 1.3 Add `use-sync-value.ts`: `useSync()` → not connected / connected-not-synced / `values.sync.connected` with `formatRelativeTime` (the existing helper, shared with `CoachingSyncButton`).
+- [x] 1.4 Add `use-preference-values.ts`: mirrors `PreferencesTab` — `useActiveProfileLive` + `useUserPreferences({ profileId, defaultView: "grid" })` with the `profileId === null` fallback, `auto` locale resolved via `useActiveLocale`, notifications folded with `useNotificationPermission`.
+- [x] 1.5 Add `use-usage-value.ts`: current month only, compact token notation + month name.
+- [x] 1.6 Delete `useRowDetail()` from `SettingsGroupList.tsx`; the list indexes `useSettingsRowValues()` by `row.valueKey`.
+
+## 2. Shared usage read
+
+- [x] 2.1 Add `hooks/use-usage-summary.ts` with `recentYearMonths(count, now)` and `useUsageSummary(monthsWindow)` returning `{ months, events }`.
+- [x] 2.2 Rewrite `UsageTab.tsx` to consume it, dropping its inline `useLiveQuery` and its private `recentYearMonths` — the tab and the index row now share one implementation.
+- [x] 2.3 Write `hooks/use-usage-summary.test.ts`: current month first, year-boundary walk-back, zero-padded months.
+
+## 3. Row presentation
+
+- [x] 3.1 Add `status?: "attention"` to `SettingsRow`, rendering an amber dot between the value and the chevron, addressable as `settings-row-<key>-attention`. Nothing sets it in this change.
+- [x] 3.2 Add the `href` branch to `SettingsRow` (`<a target="_blank" rel="noopener noreferrer">`), same body/chevron/testid as an in-app row.
+- [x] 3.3 Add `help: HelpCircle` to `ICON_MAP` for the About row.
+- [x] 3.4 Write `SettingsRow.test.tsx`: attention dot present when passed and absent by default; the external row is an anchor with `target`/`rel`.
+
+## 4. Re-grouping
+
+- [x] 4.1 Rewrite `settings-groups.ts` into four groups — Your data (Connections, Cross-device sync, Privacy & data, Manage your data, Extensions, Data Hub), AI (Provider & models, Custom instructions, Usage), Preferences (Units, Language, Notifications), About (Help & docs).
+- [x] 4.2 Point the Connections row at `/athlete` with a comment naming Wave 1 as the wave that re-points it at `/settings/connections`.
+- [x] 4.3 Keep Extensions and Data Hub reachable as legacy rows: routes, `settings-row-extensions` / `settings-row-dataHub` testids and `tabs.*` entries untouched.
+
+## 5. Honest copy
+
+- [x] 5.1 Read `EncryptionSection.tsx`, `use-encryption-section.ts`, `PrivacyInformationSection.tsx` and `PrivacyTab.tsx` and establish what is actually encrypted: sync snapshots before upload (opt-in, passphrase in memory only); local Dexie not encrypted; AI keys under `kaiord_secure_*`.
+- [x] 5.2 Ship `values.privacy.localFirst` = "Stored in this browser" instead of the design's "Encrypted on device"; do not ship the "AES-GCM on every stored record" section copy.
+- [x] 5.3 Narrow `sync.encryption` from "End-to-end encryption" to "End-to-end encryption for sync snapshots" in both locales. `sync.plaintextWarning` and the `privacy.info*` bullets audited and left as-is — they describe upload and credential handling, not storage at rest.
+- [x] 5.4 Record the decision in `design.md` D6: the design's at-rest encryption claim was not implementable as written and shipping it would have been a false security claim.
+
+## 6. i18n
+
+- [x] 6.1 Replace `settings.groups.*` with `yourData`, `ai`, `preferences`, `about` in `en` and `es`; the five retired keys grepped first to confirm `SettingsGroupList` was their only consumer.
+- [x] 6.2 Add `settings.rows.connections` and `settings.rows.helpDocs`; re-word `rows.provider`, `rows.googleDriveSync` and `rows.dataPrivacy`.
+- [x] 6.3 Add the `settings.values.*` sub-tree (`sync.connected`, `usage.tokens`, `notifications.{on,off,blocked,unsupported}`, `privacy.localFirst`) to both locales; `resource-parity.test.ts` green.
+
+## 7. Tests
+
+- [x] 7.1 Update `SettingsPage.test.tsx`: the eyebrow assertion now names the four groups; the row→destination `it.each` covers the new grouping and keeps the extensions case alive, adding connections, googleDriveSync, dataHub and usage.
+- [x] 7.2 Add index assertions for the privacy value and the external docs link.
+- [x] 7.3 Write `use-preference-values.test.tsx` (persisted units/locale, `auto` resolution, the no-profile fallback, the four notification states), `use-sync-value.test.tsx` (three branches) and `use-usage-value.test.tsx` (formatting, loading, empty month).
+- [x] 7.4 Confirm the untouched suites still pass — the `?section=` deep-link focus tests and the `settings-panel-<tab>` testid contract in particular.
+
+## 8. Quality gates
+
+- [x] 8.1 Full SPA suite green, `resource-parity.test.ts` included.
+- [x] 8.2 `tsc -p tsconfig.app.json --noEmit` clean; ESLint clean; Prettier clean on every touched file; `pnpm test:scripts` unchanged-green.
+- [x] 8.3 e2e neutrality verified by grep: `settings-row-provider` (`e2e/settings.spec.ts`, `e2e/ai-generate-workout.spec.ts`), `settings-row-extensions` + `settings-panel-extensions` (`e2e/settings.spec.ts`), `settings-row-dataHub` (`e2e/data-hub.spec.ts`), `/settings/extensions` (`e2e/tanita-garmin-sync-via-policy.spec.ts`), `/settings/data-hub` (`e2e/data-flows-density.spec.ts`) — all preserved.
+- [x] 8.4 `npx openspec validate add-settings-row-values` passes. No changeset — `@kaiord/workout-spa-editor` is private and excluded from the changeset-bot PUBLISHABLE set.

--- a/packages/workout-spa-editor/src/components/atoms/Icon/icon-map.ts
+++ b/packages/workout-spa-editor/src/components/atoms/Icon/icon-map.ts
@@ -15,6 +15,7 @@ import {
   FlaskConical,
   Footprints,
   Heart,
+  HelpCircle,
   LayoutGrid,
   Link,
   MessageCircle,
@@ -78,6 +79,7 @@ export const ICON_MAP = {
   nutrition: Utensils,
   chat: MessageCircle,
   labs: FlaskConical,
+  help: HelpCircle,
 } as const satisfies Record<string, LucideIcon>;
 
 export type IconName = keyof typeof ICON_MAP;

--- a/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/SettingsPanel/UsageTab.tsx
@@ -1,16 +1,13 @@
 /**
  * Settings → Usage tab. Displays accumulated AI token usage and estimated cost
  * for the current month plus the previous five, read from the synced
- * `usageEvents` log via `useLiveQuery` and folded per month by
+ * `usageEvents` log via `useUsageSummary` and folded per month by
  * `foldUsageEvents` — a per-month total plus a per-purpose breakdown. Updates
  * automatically as new runs append events.
  */
 
-import { useLiveQuery } from "dexie-react-hooks";
-
-import { db } from "../../../adapters/dexie/dexie-database";
-import { createDexieUsageEventRepository } from "../../../adapters/dexie/dexie-usage-event-repository";
 import { foldUsageEvents } from "../../../application/usage/fold-usage-events";
+import { useUsageSummary } from "../../../hooks/use-usage-summary";
 import type { UsageEventRecord } from "../../../types/usage-event-schemas";
 import type { MonthUsage } from "./usage-table-types";
 import { USAGE_PURPOSES } from "./usage-table-types";
@@ -18,20 +15,6 @@ import { UsageEmptyState } from "./UsageEmptyState";
 import { UsageTable } from "./UsageTable";
 
 const MONTHS_WINDOW = 6;
-
-function recentYearMonths(): string[] {
-  const now = new Date();
-  const months: string[] = [];
-  for (let i = 0; i < MONTHS_WINDOW; i++) {
-    const d = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1)
-    );
-    months.push(
-      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`
-    );
-  }
-  return months;
-}
 
 function foldByMonth(
   events: UsageEventRecord[],
@@ -53,11 +36,7 @@ function foldByMonth(
 }
 
 export const UsageTab: React.FC = () => {
-  const months = recentYearMonths();
-  const events = useLiveQuery(
-    () => createDexieUsageEventRepository(db).listByMonths(months),
-    [months.join(",")]
-  );
+  const { months, events } = useUsageSummary(MONTHS_WINDOW);
 
   if (!events) return <UsageEmptyState monthsWindow={MONTHS_WINDOW} />;
   const rows = foldByMonth(events, months);

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsGroupList.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsGroupList.tsx
@@ -1,28 +1,15 @@
-import { useAiProvidersLive } from "../../../hooks/use-ai-providers-live";
 import { useTranslate } from "../../../i18n/use-translate";
 import { SectionHead } from "../../molecules/SectionHead/SectionHead";
-import {
-  SETTINGS_GROUPS,
-  SETTINGS_VERSION_LABEL,
-  type SettingsRowDef,
-} from "./settings-groups";
+import { SETTINGS_GROUPS, SETTINGS_VERSION_LABEL } from "./settings-groups";
 import { SettingsRow } from "./SettingsRow";
+import { useSettingsRowValues } from "./use-settings-row-values";
 
 type SettingsGroupListProps = {
   onNavigate: (to: string) => void;
 };
 
-const useRowDetail = () => {
-  const providers = useAiProvidersLive() ?? [];
-  const defaultProvider =
-    providers.find((p) => p.isDefault)?.label ?? providers[0]?.label;
-
-  return (row: SettingsRowDef): string | undefined =>
-    row.detailKey === "defaultProvider" ? defaultProvider : undefined;
-};
-
 export const SettingsGroupList = ({ onNavigate }: SettingsGroupListProps) => {
-  const detailFor = useRowDetail();
+  const values = useSettingsRowValues();
   const t = useTranslate("settings");
 
   return (
@@ -37,8 +24,11 @@ export const SettingsGroupList = ({ onNavigate }: SettingsGroupListProps) => {
                 icon={row.icon}
                 label={t(`rows.${row.key}`)}
                 testId={row.key}
-                detail={detailFor(row)}
+                detail={
+                  row.valueKey === undefined ? undefined : values[row.valueKey]
+                }
                 to={row.to}
+                href={row.href}
                 onNavigate={row.to !== undefined ? onNavigate : undefined}
               />
             ))}

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsPage.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsPage.test.tsx
@@ -78,12 +78,7 @@ describe("SettingsPage", () => {
 
     it("should render every group eyebrow", () => {
       // Arrange
-      const eyebrows = [
-        "AI generation",
-        "Preferences",
-        "Privacy & data",
-        "Advanced",
-      ];
+      const eyebrows = ["Your data", "AI", "Preferences", "About"];
 
       // Act
       renderAtPath("/settings");
@@ -94,8 +89,38 @@ describe("SettingsPage", () => {
       }
     });
 
+    it("should show the truthful local-storage value on the privacy row", () => {
+      // Arrange
+
+      // Act
+      renderAtPath("/settings");
+
+      // Assert
+      expect(screen.getByTestId("settings-row-dataPrivacy")).toHaveTextContent(
+        "Stored in this browser"
+      );
+    });
+
+    it("should link Help & docs out to the documentation site", () => {
+      // Arrange
+
+      // Act
+      renderAtPath("/settings");
+
+      // Assert
+      expect(screen.getByTestId("settings-row-helpDocs")).toHaveAttribute(
+        "href",
+        "https://kaiord.com/docs/"
+      );
+    });
+
     it.each([
+      // TODO(S3): destination becomes /settings/connections once it exists.
+      { row: "connections", destination: "/athlete" },
+      { row: "googleDriveSync", destination: "/settings/sync" },
       { row: "extensions", destination: "/settings/extensions" },
+      { row: "dataHub", destination: "/settings/data-hub" },
+      { row: "usage", destination: "/settings/usage" },
       { row: "units", destination: "/settings/preferences" },
       { row: "language", destination: "/settings/preferences" },
       {

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsRow.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsRow.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SettingsRow } from "./SettingsRow";
+
+describe("SettingsRow", () => {
+  it("should render an attention dot when the status says so", () => {
+    // Arrange
+
+    // Act
+    render(
+      <SettingsRow
+        icon="link"
+        label="Connections"
+        testId="connections"
+        status="attention"
+        to="/settings/connections"
+        onNavigate={vi.fn()}
+      />
+    );
+
+    // Assert
+    expect(
+      screen.getByTestId("settings-row-connections-attention")
+    ).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByText("Needs attention")).toBeInTheDocument();
+  });
+
+  it("should render no attention dot by default", () => {
+    // Arrange
+
+    // Act
+    render(
+      <SettingsRow
+        icon="link"
+        label="Connections"
+        testId="connections"
+        to="/settings/connections"
+        onNavigate={vi.fn()}
+      />
+    );
+
+    // Assert
+    expect(
+      screen.queryByTestId("settings-row-connections-attention")
+    ).toBeNull();
+    expect(screen.queryByText("Needs attention")).toBeNull();
+  });
+
+  it("should render an external destination as a new-tab link", () => {
+    // Arrange
+
+    // Act
+    render(
+      <SettingsRow
+        icon="help"
+        label="Help & docs"
+        testId="helpDocs"
+        href="https://kaiord.com/docs/"
+      />
+    );
+
+    // Assert
+    const row = screen.getByTestId("settings-row-helpDocs");
+    expect(row).toHaveAttribute("href", "https://kaiord.com/docs/");
+    expect(row).toHaveAttribute("target", "_blank");
+    expect(row).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsRow.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsRow.tsx
@@ -1,4 +1,5 @@
-import { Icon, ICON_MAP, type IconName } from "../../atoms/Icon";
+import type { IconName } from "../../atoms/Icon";
+import { SettingsRowBody } from "./SettingsRowBody";
 
 export type SettingsRowProps = {
   icon: IconName;
@@ -6,47 +7,59 @@ export type SettingsRowProps = {
   /** Locale-independent testid suffix; falls back to the label. */
   testId?: string;
   detail?: string;
+  /** `"attention"` marks the row with an amber dot before the chevron. */
+  status?: "attention";
   to?: string;
+  /** External destination opened in a new tab; mutually exclusive with `to`. */
+  href?: string;
   onNavigate?: (to: string) => void;
 };
 
-const TILE_CLASS =
-  "flex h-7 w-7 items-center justify-center rounded-md bg-primary-600 text-white";
+const BASE_CLASS =
+  "flex w-full items-center gap-3 px-4 py-3 text-left first:rounded-t-xl last:rounded-b-xl";
+
+const LINK_CLASS = `${BASE_CLASS} transition-colors hover:bg-gray-50 dark:hover:bg-slate-800`;
 
 export const SettingsRow = ({
   icon,
   label,
   testId,
   detail,
+  status,
   to,
+  href,
   onNavigate,
 }: SettingsRowProps) => {
-  const interactive = to !== undefined && onNavigate !== undefined;
+  const navigable = to !== undefined && onNavigate !== undefined;
   const rowTestId = `settings-row-${testId ?? label}`;
-
   const body = (
-    <>
-      <span className={TILE_CLASS}>
-        <Icon icon={ICON_MAP[icon]} size="sm" color="inherit" />
-      </span>
-      <span className="min-w-0 flex-1 truncate text-sm text-gray-900 dark:text-white">
-        {label}
-      </span>
-      {detail !== undefined && (
-        <span className="truncate text-sm text-gray-500 dark:text-gray-400">
-          {detail}
-        </span>
-      )}
-      {interactive && <Icon icon={ICON_MAP.chevR} size="sm" color="muted" />}
-    </>
+    <SettingsRowBody
+      icon={icon}
+      label={label}
+      detail={detail}
+      status={status}
+      rowTestId={rowTestId}
+      chevron={navigable || href !== undefined}
+    />
   );
 
-  const base =
-    "flex w-full items-center gap-3 px-4 py-3 text-left first:rounded-t-xl last:rounded-b-xl";
-
-  if (!interactive) {
+  if (href !== undefined) {
     return (
-      <div className={base} data-testid={rowTestId}>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={LINK_CLASS}
+        data-testid={rowTestId}
+      >
+        {body}
+      </a>
+    );
+  }
+
+  if (!navigable) {
+    return (
+      <div className={BASE_CLASS} data-testid={rowTestId}>
         {body}
       </div>
     );
@@ -56,7 +69,7 @@ export const SettingsRow = ({
     <button
       type="button"
       onClick={() => onNavigate(to)}
-      className={`${base} transition-colors hover:bg-gray-50 dark:hover:bg-slate-800`}
+      className={LINK_CLASS}
       data-testid={rowTestId}
     >
       {body}

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsRowBody.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/SettingsRowBody.tsx
@@ -1,0 +1,54 @@
+import { useTranslate } from "../../../i18n/use-translate";
+import { Icon, ICON_MAP, type IconName } from "../../atoms/Icon";
+
+export type SettingsRowBodyProps = {
+  icon: IconName;
+  label: string;
+  detail?: string;
+  status?: "attention";
+  rowTestId: string;
+  chevron: boolean;
+};
+
+const TILE_CLASS =
+  "flex h-7 w-7 items-center justify-center rounded-md bg-primary-600 text-white";
+
+const DOT_CLASS = "h-2 w-2 flex-none rounded-full bg-amber-500";
+
+export const SettingsRowBody = ({
+  icon,
+  label,
+  detail,
+  status,
+  rowTestId,
+  chevron,
+}: SettingsRowBodyProps) => {
+  const t = useTranslate("settings");
+
+  return (
+    <>
+      <span className={TILE_CLASS}>
+        <Icon icon={ICON_MAP[icon]} size="sm" color="inherit" />
+      </span>
+      <span className="min-w-0 flex-1 truncate text-sm text-gray-900 dark:text-white">
+        {label}
+      </span>
+      {detail !== undefined && (
+        <span className="truncate text-sm text-gray-500 dark:text-gray-400">
+          {detail}
+        </span>
+      )}
+      {status === "attention" && (
+        <>
+          <span
+            aria-hidden="true"
+            className={DOT_CLASS}
+            data-testid={`${rowTestId}-attention`}
+          />
+          <span className="sr-only">{t("rowStatus.attention")}</span>
+        </>
+      )}
+      {chevron && <Icon icon={ICON_MAP.chevR} size="sm" color="muted" />}
+    </>
+  );
+};

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-group-types.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-group-types.ts
@@ -1,0 +1,31 @@
+import type { IconName } from "../../atoms/Icon";
+
+/**
+ * Identifies a live value rendered inline on a settings row. Every key is
+ * resolved by `useSettingsRowValues`; a row without one renders no value.
+ */
+export type SettingsValueKey =
+  | "provider"
+  | "sync"
+  | "privacy"
+  | "usage"
+  | "units"
+  | "language"
+  | "notifications";
+
+export type SettingsRowDef = {
+  icon: IconName;
+  /** Stable identity: i18n key under `settings.rows.*`, React key, and testid. */
+  key: string;
+  /** In-app destination handed to the router. */
+  to?: string;
+  /** External destination opened in a new tab; mutually exclusive with `to`. */
+  href?: string;
+  valueKey?: SettingsValueKey;
+};
+
+export type SettingsGroupDef = {
+  /** Stable identity: i18n key under `settings.groups.*` and React key. */
+  key: string;
+  rows: ReadonlyArray<SettingsRowDef>;
+};

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-groups.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/settings-groups.ts
@@ -1,70 +1,77 @@
-import type { IconName } from "../../atoms/Icon";
+import type { SettingsGroupDef, SettingsRowDef } from "./settings-group-types";
 
-export type SettingsRowDef = {
-  icon: IconName;
-  /** Stable identity: i18n key under `settings.rows.*`, React key, and testid. */
-  key: string;
-  to?: string;
-  detailKey?: "defaultProvider";
-};
+const DOCS_URL = "https://kaiord.com/docs/";
 
-export type SettingsGroupDef = {
-  /** Stable identity: i18n key under `settings.groups.*` and React key. */
-  key: string;
-  rows: ReadonlyArray<SettingsRowDef>;
-};
+const YOUR_DATA_ROWS: ReadonlyArray<SettingsRowDef> = [
+  // TODO(S3): re-point at /settings/connections once that page exists;
+  // /athlete is the interim destination.
+  { icon: "link", key: "connections", to: "/athlete" },
+  {
+    icon: "sync",
+    key: "googleDriveSync",
+    to: "/settings/sync",
+    valueKey: "sync",
+  },
+  {
+    icon: "shield",
+    key: "dataPrivacy",
+    to: "/settings/privacy",
+    valueKey: "privacy",
+  },
+  {
+    icon: "shield",
+    key: "manageYourData",
+    to: "/settings/privacy?section=data-management",
+  },
+  { icon: "link", key: "extensions", to: "/settings/extensions" },
+  { icon: "route", key: "dataHub", to: "/settings/data-hub" },
+];
+
+const AI_ROWS: ReadonlyArray<SettingsRowDef> = [
+  {
+    icon: "sparkle",
+    key: "provider",
+    to: "/settings/ai?section=providers",
+    valueKey: "provider",
+  },
+  {
+    icon: "edit",
+    key: "customInstructions",
+    to: "/settings/ai?section=custom-instructions",
+  },
+  { icon: "trend", key: "usage", to: "/settings/usage", valueKey: "usage" },
+];
+
+const PREFERENCES_ROWS: ReadonlyArray<SettingsRowDef> = [
+  {
+    icon: "target",
+    key: "units",
+    to: "/settings/preferences",
+    valueKey: "units",
+  },
+  {
+    icon: "chat",
+    key: "language",
+    to: "/settings/preferences",
+    valueKey: "language",
+  },
+  {
+    icon: "bell",
+    key: "notifications",
+    to: "/settings/preferences",
+    valueKey: "notifications",
+  },
+];
+
+const ABOUT_ROWS: ReadonlyArray<SettingsRowDef> = [
+  { icon: "help", key: "helpDocs", href: DOCS_URL },
+];
 
 export const SETTINGS_GROUPS: ReadonlyArray<SettingsGroupDef> = [
-  {
-    key: "aiGeneration",
-    rows: [
-      {
-        icon: "sparkle",
-        key: "provider",
-        to: "/settings/ai?section=providers",
-        detailKey: "defaultProvider",
-      },
-      {
-        icon: "edit",
-        key: "customInstructions",
-        to: "/settings/ai?section=custom-instructions",
-      },
-    ],
-  },
-  {
-    key: "crossDeviceSync",
-    rows: [{ icon: "sync", key: "googleDriveSync", to: "/settings/sync" }],
-  },
-  {
-    key: "dataRouting",
-    rows: [{ icon: "route", key: "dataHub", to: "/settings/data-hub" }],
-  },
-  {
-    key: "preferences",
-    rows: [
-      { icon: "target", key: "units", to: "/settings/preferences" },
-      { icon: "chat", key: "language", to: "/settings/preferences" },
-      { icon: "bell", key: "notifications", to: "/settings/preferences" },
-    ],
-  },
-  {
-    key: "privacyData",
-    rows: [
-      { icon: "shield", key: "dataPrivacy", to: "/settings/privacy" },
-      {
-        icon: "shield",
-        key: "manageYourData",
-        to: "/settings/privacy?section=data-management",
-      },
-    ],
-  },
-  {
-    key: "advanced",
-    rows: [
-      { icon: "link", key: "extensions", to: "/settings/extensions" },
-      { icon: "trend", key: "usage", to: "/settings/usage" },
-    ],
-  },
+  { key: "yourData", rows: YOUR_DATA_ROWS },
+  { key: "ai", rows: AI_ROWS },
+  { key: "preferences", rows: PREFERENCES_ROWS },
+  { key: "about", rows: ABOUT_ROWS },
 ];
 
 export const SETTINGS_VERSION_LABEL = "Kaiord";

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/use-preference-values.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/use-preference-values.test.tsx
@@ -1,0 +1,117 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { UseUserPreferencesArgs } from "../../../hooks/use-user-preferences";
+import { usePreferenceValues } from "./use-preference-values";
+
+const profileId = vi.hoisted(() => ({ value: "p1" as string | null }));
+const prefs = vi.hoisted(() => ({ value: undefined as unknown }));
+const permission = vi.hoisted(() => ({ value: "default" as string }));
+
+vi.mock("../../../hooks/use-active-profile-live", () => ({
+  useActiveProfileLive: () => ({ id: profileId.value, profile: null }),
+}));
+
+// Mirrors the real contract: a null profileId resolves to `undefined`, which
+// is what drives the caller's fallback to the defaults.
+vi.mock("../../../hooks/use-user-preferences", () => ({
+  useUserPreferences: (args: UseUserPreferencesArgs) =>
+    args.profileId === null ? undefined : prefs.value,
+}));
+
+vi.mock("../../organisms/SettingsPanel/use-notification-permission", () => ({
+  useNotificationPermission: () => ({
+    permission: permission.value,
+    request: vi.fn(),
+  }),
+}));
+
+const setUp = (over: {
+  id?: string | null;
+  prefs?: unknown;
+  permission?: string;
+}) => {
+  profileId.value = over.id === undefined ? "p1" : over.id;
+  prefs.value = over.prefs;
+  permission.value = over.permission ?? "default";
+  return renderHook(() => usePreferenceValues()).result;
+};
+
+describe("usePreferenceValues", () => {
+  it("should render the persisted units and locale as display names", () => {
+    // Arrange
+    const persisted = {
+      profileId: "p1",
+      calendarView: "grid",
+      units: "imperial",
+      locale: "es",
+    };
+
+    // Act
+    const { current } = setUp({ prefs: persisted });
+
+    // Assert
+    expect(current.units).toBe("Imperial");
+    expect(current.language).toBe("Spanish");
+  });
+
+  it("should resolve an auto locale preference to the active locale", () => {
+    // Arrange
+    const persisted = { profileId: "p1", calendarView: "grid", locale: "auto" };
+
+    // Act
+    const { current } = setUp({ prefs: persisted });
+
+    // Assert
+    expect(current.language).toBe("English");
+  });
+
+  it("should fall back to the defaults when no profile is active", () => {
+    // Arrange
+
+    // Act
+    const { current } = setUp({ id: null, prefs: undefined });
+
+    // Assert
+    expect(current.units).toBe("Metric");
+    expect(current.language).toBe("English");
+    expect(current.notifications).toBe("Off");
+  });
+
+  it("should report notifications on only when enabled and granted", () => {
+    // Arrange
+    const persisted = {
+      profileId: "p1",
+      calendarView: "grid",
+      notificationsEnabled: true,
+    };
+
+    // Act
+    const granted = setUp({ prefs: persisted, permission: "granted" }).current;
+    const pending = setUp({ prefs: persisted, permission: "default" }).current;
+
+    // Assert
+    expect(granted.notifications).toBe("On");
+    expect(pending.notifications).toBe("Off");
+  });
+
+  it("should report notifications blocked when the permission is denied", () => {
+    // Arrange
+
+    // Act
+    const { current } = setUp({ prefs: undefined, permission: "denied" });
+
+    // Assert
+    expect(current.notifications).toBe("Blocked");
+  });
+
+  it("should report notifications unsupported outside a browser", () => {
+    // Arrange
+
+    // Act
+    const { current } = setUp({ prefs: undefined, permission: "unsupported" });
+
+    // Assert
+    expect(current.notifications).toBe("Unsupported");
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/use-preference-values.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/use-preference-values.ts
@@ -1,0 +1,57 @@
+/**
+ * Values rendered on the Settings index Preferences rows. Mirrors
+ * `PreferencesTab` exactly, including its fallback to the defaults when no
+ * profile is active (`useUserPreferences` returns `undefined` for a null
+ * profileId), so the index and the tab can never disagree.
+ */
+
+import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useUserPreferences } from "../../../hooks/use-user-preferences";
+import { useActiveLocale } from "../../../i18n/LocaleProvider";
+import { type Translate, useTranslate } from "../../../i18n/use-translate";
+import type { LocalePreference, Units } from "../../../types/user-preferences";
+import type { NotificationPermissionState } from "../../organisms/SettingsPanel/use-notification-permission";
+import { useNotificationPermission } from "../../organisms/SettingsPanel/use-notification-permission";
+
+export type PreferenceValues = {
+  units: string;
+  language: string;
+  notifications: string;
+};
+
+const notificationValue = (
+  t: Translate,
+  enabled: boolean,
+  permission: NotificationPermissionState
+): string => {
+  if (permission === "unsupported")
+    return t("values.notifications.unsupported");
+  if (permission === "denied") return t("values.notifications.blocked");
+  const on = enabled && permission === "granted";
+  return t(on ? "values.notifications.on" : "values.notifications.off");
+};
+
+export const usePreferenceValues = (): PreferenceValues => {
+  const t = useTranslate("settings");
+  const common = useTranslate("common");
+  const activeLocale = useActiveLocale();
+  const active = useActiveProfileLive();
+  const prefs = useUserPreferences({
+    profileId: active?.id ?? null,
+    defaultView: "grid",
+  });
+  const { permission } = useNotificationPermission();
+
+  const units: Units = prefs?.units ?? "metric";
+  const locale: LocalePreference = prefs?.locale ?? "auto";
+
+  return {
+    units: t(`preferences.${units}`),
+    language: common(`language.${locale === "auto" ? activeLocale : locale}`),
+    notifications: notificationValue(
+      t,
+      prefs?.notificationsEnabled ?? false,
+      permission
+    ),
+  };
+};

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/use-settings-row-values.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/use-settings-row-values.ts
@@ -1,0 +1,36 @@
+/**
+ * Resolves every inline value the Settings index renders. One hook per row
+ * family keeps each source (Dexie, the sync engine, the browser permission)
+ * behind the surface that owns it; the row registry only names a
+ * `SettingsValueKey`.
+ */
+
+import { useAiProvidersLive } from "../../../hooks/use-ai-providers-live";
+import { useTranslate } from "../../../i18n/use-translate";
+import type { SettingsValueKey } from "./settings-group-types";
+import { usePreferenceValues } from "./use-preference-values";
+import { useSyncValue } from "./use-sync-value";
+import { useUsageValue } from "./use-usage-value";
+
+export type SettingsRowValues = Record<SettingsValueKey, string | undefined>;
+
+export const useSettingsRowValues = (): SettingsRowValues => {
+  const t = useTranslate("settings");
+  const providers = useAiProvidersLive() ?? [];
+  const sync = useSyncValue();
+  const usage = useUsageValue();
+  const preferences = usePreferenceValues();
+
+  // `...preferences` stays LAST on purpose: TypeScript raises TS2783 on an
+  // explicit property a later spread would overwrite, so a future key
+  // collision fails to compile. Spreading first would silently override.
+  return {
+    provider: providers.find((p) => p.isDefault)?.label ?? providers[0]?.label,
+    sync,
+    // Local records are NOT encrypted at rest; only sync snapshots are, and
+    // only when the user sets a passphrase. This value stays truthful.
+    privacy: t("values.privacy.localFirst"),
+    usage,
+    ...preferences,
+  };
+};

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/use-sync-value.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/use-sync-value.test.tsx
@@ -1,0 +1,52 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useSyncValue } from "./use-sync-value";
+
+const engine = vi.hoisted(() => ({
+  value: { connected: false, lastSyncedAt: null as string | null },
+}));
+
+vi.mock("../../../contexts/sync-context", () => ({
+  useSync: () => engine.value,
+}));
+
+const FIVE_MINUTES_MS = 300_000;
+
+describe("useSyncValue", () => {
+  it("should report a disconnected account truthfully", () => {
+    // Arrange
+    engine.value = { connected: false, lastSyncedAt: null };
+
+    // Act
+    const { result } = renderHook(() => useSyncValue());
+
+    // Assert
+    expect(result.current).toBe("Not connected");
+  });
+
+  it("should report a connected account that has never synced", () => {
+    // Arrange
+    engine.value = { connected: true, lastSyncedAt: null };
+
+    // Act
+    const { result } = renderHook(() => useSyncValue());
+
+    // Assert
+    expect(result.current).toBe("Connected — not synced yet");
+  });
+
+  it("should render the last sync as a relative time", () => {
+    // Arrange
+    engine.value = {
+      connected: true,
+      lastSyncedAt: new Date(Date.now() - FIVE_MINUTES_MS).toISOString(),
+    };
+
+    // Act
+    const { result } = renderHook(() => useSyncValue());
+
+    // Assert
+    expect(result.current).toBe("Drive · 5m ago");
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/use-sync-value.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/use-sync-value.ts
@@ -1,0 +1,20 @@
+/**
+ * Value rendered on the Settings index "Cross-device sync" row. Reads the live
+ * sync engine, so it tracks connect/disconnect and every completed cycle
+ * without a second source of truth.
+ */
+
+import { useSync } from "../../../contexts/sync-context";
+import { useTranslate } from "../../../i18n/use-translate";
+import { formatRelativeTime } from "../../../utils/format-relative-time";
+
+export const useSyncValue = (): string => {
+  const t = useTranslate("settings");
+  const { connected, lastSyncedAt } = useSync();
+
+  if (!connected) return t("sync.notConnected");
+  if (lastSyncedAt === null) return t("sync.connectedNotSynced");
+  return t("values.sync.connected", {
+    relative: formatRelativeTime(new Date(lastSyncedAt), new Date()),
+  });
+};

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/use-usage-value.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/use-usage-value.test.tsx
@@ -1,0 +1,68 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { UsageEventRecord } from "../../../types/usage-event-schemas";
+import { useUsageValue } from "./use-usage-value";
+
+const summary = vi.hoisted(() => ({
+  value: {
+    months: ["2026-07"],
+    events: [] as UsageEventRecord[] | undefined,
+  },
+}));
+
+vi.mock("../../../hooks/use-usage-summary", () => ({
+  useUsageSummary: () => summary.value,
+}));
+
+const PROMPT_TOKENS = 1_000_000;
+const COMPLETION_TOKENS = 214_880;
+const COST = 3.5;
+
+const event = (over: Partial<UsageEventRecord> = {}): UsageEventRecord => ({
+  id: "e1",
+  yearMonth: "2026-07",
+  date: "2026-07-01",
+  purpose: "chat",
+  promptTokens: PROMPT_TOKENS,
+  completionTokens: COMPLETION_TOKENS,
+  tokens: PROMPT_TOKENS + COMPLETION_TOKENS,
+  cost: COST,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  ...over,
+});
+
+describe("useUsageValue", () => {
+  it("should format the current month total compactly", () => {
+    // Arrange
+    summary.value = { months: ["2026-07"], events: [event()] };
+
+    // Act
+    const { result } = renderHook(() => useUsageValue());
+
+    // Assert
+    expect(result.current).toBe("1.2M tokens · July");
+  });
+
+  it("should render no value while the usage query resolves", () => {
+    // Arrange
+    summary.value = { months: ["2026-07"], events: undefined };
+
+    // Act
+    const { result } = renderHook(() => useUsageValue());
+
+    // Assert
+    expect(result.current).toBeUndefined();
+  });
+
+  it("should render no value when the month has no usage", () => {
+    // Arrange
+    summary.value = { months: ["2026-07"], events: [] };
+
+    // Act
+    const { result } = renderHook(() => useUsageValue());
+
+    // Assert
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/use-usage-value.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/use-usage-value.ts
@@ -1,0 +1,44 @@
+/**
+ * Value rendered on the Settings index "Usage" row: the current month's token
+ * total, e.g. "1.2M tokens · July". Shares `useUsageSummary` with the Usage
+ * tab so both surfaces fold the same events; renders nothing while the query
+ * resolves or when the month has no usage.
+ */
+
+import { foldUsageEvents } from "../../../application/usage/fold-usage-events";
+import { useUsageSummary } from "../../../hooks/use-usage-summary";
+import { useActiveLocale } from "../../../i18n/LocaleProvider";
+import { useTranslate } from "../../../i18n/use-translate";
+
+const CURRENT_MONTH_ONLY = 1;
+const MAX_FRACTION_DIGITS = 1;
+
+const compactTokens = (value: number, locale: string): string =>
+  new Intl.NumberFormat(locale, {
+    notation: "compact",
+    maximumFractionDigits: MAX_FRACTION_DIGITS,
+  }).format(value);
+
+const monthName = (yearMonth: string, locale: string): string => {
+  const [year, month] = yearMonth.split("-").map(Number);
+  if (year === undefined || month === undefined) return yearMonth;
+  return new Date(Date.UTC(year, month - 1, 1)).toLocaleString(locale, {
+    month: "long",
+    timeZone: "UTC",
+  });
+};
+
+export const useUsageValue = (): string | undefined => {
+  const t = useTranslate("settings");
+  const locale = useActiveLocale();
+  const { months, events } = useUsageSummary(CURRENT_MONTH_ONLY);
+  const yearMonth = months[0];
+
+  if (events === undefined || yearMonth === undefined) return undefined;
+  const { totalTokens } = foldUsageEvents(events);
+  if (totalTokens === 0) return undefined;
+  return t("values.usage.tokens", {
+    tokens: compactTokens(totalTokens, locale),
+    month: monthName(yearMonth, locale),
+  });
+};

--- a/packages/workout-spa-editor/src/hooks/use-usage-summary.test.ts
+++ b/packages/workout-spa-editor/src/hooks/use-usage-summary.test.ts
@@ -1,0 +1,84 @@
+import { renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { recentYearMonths, useUsageSummary } from "./use-usage-summary";
+
+vi.mock("dexie-react-hooks", () => ({
+  useLiveQuery: () => [],
+}));
+
+vi.mock("../adapters/dexie/dexie-database", () => ({
+  db: {},
+}));
+
+vi.mock("../adapters/dexie/dexie-usage-event-repository", () => ({
+  createDexieUsageEventRepository: () => ({
+    listByMonths: () => Promise.resolve([]),
+  }),
+}));
+
+const SIX_MONTHS = 6;
+const ONE_MONTH = 1;
+
+describe("recentYearMonths", () => {
+  it("should return the current month first", () => {
+    // Arrange
+    const now = new Date("2026-07-28T10:00:00.000Z");
+
+    // Act
+    const months = recentYearMonths(ONE_MONTH, now);
+
+    // Assert
+    expect(months).toEqual(["2026-07"]);
+  });
+
+  it("should walk backwards across a year boundary", () => {
+    // Arrange
+    const now = new Date("2026-02-15T00:00:00.000Z");
+
+    // Act
+    const months = recentYearMonths(SIX_MONTHS, now);
+
+    // Assert
+    expect(months).toEqual([
+      "2026-02",
+      "2026-01",
+      "2025-12",
+      "2025-11",
+      "2025-10",
+      "2025-09",
+    ]);
+  });
+
+  it("should zero-pad single-digit months", () => {
+    // Arrange
+    const now = new Date("2026-09-30T23:59:59.000Z");
+
+    // Act
+    const months = recentYearMonths(ONE_MONTH, now);
+
+    // Assert
+    expect(months).toEqual(["2026-09"]);
+  });
+});
+
+describe("useUsageSummary", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("should roll its window forward when the month changes mid-session", () => {
+    // Arrange
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-31T23:59:00.000Z"));
+    const { result, rerender } = renderHook(() => useUsageSummary(ONE_MONTH));
+    expect(result.current.months).toEqual(["2026-07"]);
+
+    // Act
+    vi.setSystemTime(new Date("2026-08-01T00:01:00.000Z"));
+    rerender();
+
+    // Assert
+    expect(result.current.months).toEqual(["2026-08"]);
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/use-usage-summary.ts
+++ b/packages/workout-spa-editor/src/hooks/use-usage-summary.ts
@@ -1,0 +1,50 @@
+/**
+ * useUsageSummary — the single read of the `usageEvents` log shared by the
+ * Settings → Usage tab and the Settings index row. Returns the month keys it
+ * queried (most recent first) alongside the raw events, so callers fold them
+ * however they need: per-month tables, or a single current-month total.
+ *
+ * `events` is `undefined` while the live query resolves; callers SHALL treat
+ * that as loading and not as "no usage".
+ */
+
+import { useLiveQuery } from "dexie-react-hooks";
+
+import { db } from "../adapters/dexie/dexie-database";
+import { createDexieUsageEventRepository } from "../adapters/dexie/dexie-usage-event-repository";
+import type { UsageEventRecord } from "../types/usage-event-schemas";
+
+export type UsageSummary = {
+  months: string[];
+  events: UsageEventRecord[] | undefined;
+};
+
+const MONTH_DIGITS = 2;
+
+/** Year-month keys (`YYYY-MM`, UTC) for the `count` most recent months. */
+export const recentYearMonths = (
+  count: number,
+  now: Date = new Date()
+): string[] =>
+  Array.from({ length: count }, (_unused, index) => {
+    const month = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - index, 1)
+    );
+    return `${month.getUTCFullYear()}-${String(
+      month.getUTCMonth() + 1
+    ).padStart(MONTH_DIGITS, "0")}`;
+  });
+
+export const useUsageSummary = (monthsWindow: number): UsageSummary => {
+  // Recomputed every render rather than memoized on `monthsWindow`: a session
+  // left open across midnight of the 1st must roll its window forward instead
+  // of querying and labelling the month that just ended. The live query is
+  // keyed on the joined string, so an unstable array identity costs nothing.
+  const months = recentYearMonths(monthsWindow);
+  const events = useLiveQuery(
+    () => createDexieUsageEventRepository(db).listByMonths(months),
+    [months.join(",")]
+  );
+
+  return { months, events };
+};

--- a/packages/workout-spa-editor/src/i18n/locales/en/settings.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/settings.json
@@ -2,25 +2,42 @@
   "title": "Settings",
   "back": "Settings",
   "groups": {
-    "aiGeneration": "AI generation",
-    "crossDeviceSync": "Cross-device sync",
-    "dataRouting": "Data routing",
+    "yourData": "Your data",
+    "ai": "AI",
     "preferences": "Preferences",
-    "privacyData": "Privacy & data",
-    "advanced": "Advanced"
+    "about": "About"
   },
   "rows": {
-    "provider": "Provider",
+    "connections": "Connections",
+    "provider": "Provider & models",
     "customInstructions": "Custom instructions",
-    "googleDriveSync": "Google Drive sync",
+    "googleDriveSync": "Cross-device sync",
     "dataHub": "Data Hub",
     "units": "Units",
     "language": "Language",
     "notifications": "Notifications",
-    "dataPrivacy": "Data & privacy",
+    "dataPrivacy": "Privacy & data",
     "manageYourData": "Manage your data",
     "extensions": "Extensions",
-    "usage": "Usage"
+    "usage": "Usage",
+    "helpDocs": "Help & docs"
+  },
+  "values": {
+    "sync": {
+      "connected": "Drive · {{relative}}"
+    },
+    "usage": {
+      "tokens": "{{tokens}} tokens · {{month}}"
+    },
+    "notifications": {
+      "on": "On",
+      "off": "Off",
+      "blocked": "Blocked",
+      "unsupported": "Unsupported"
+    },
+    "privacy": {
+      "localFirst": "Stored in this browser"
+    }
   },
   "tabs": {
     "ai": "AI",
@@ -76,13 +93,13 @@
     "offline": "Last sync failed — working offline",
     "lastSynced": "Last synced {{date}}",
     "connectedNotSynced": "Connected — not synced yet",
-    "encryption": "End-to-end encryption",
+    "encryption": "End-to-end encryption for sync snapshots",
     "passphrase": "Passphrase",
     "plaintextWarning": "Your saved AI API keys will be uploaded without end-to-end encryption. Enable encryption below to protect them."
   },
   "privacy": {
     "information": "Privacy Information",
-    "infoNoServer": "We do not store your credentials on any server.",
+    "infoNoServer": "We do not operate a server that stores your credentials. When cross-device sync is on, your saved AI API keys are uploaded to your own Google Drive unless you enable encryption.",
     "infoGarmin": "Garmin integration uses a browser extension that piggybacks on your existing Garmin Connect session. No credentials leave your browser.",
     "infoTrain2go": "Train2Go import uses a browser extension that reads the coaching plan displayed on Train2Go pages you are already viewing. It does not read your password or authentication tokens.",
     "infoLlmKeys": "LLM API keys are sent directly to the provider (Anthropic, OpenAI, or Google) — Kaiord does not receive or relay this data.",
@@ -94,7 +111,7 @@
     "analyticsOutro": "to track aggregate usage (page views, workout generation, exports). No cookies are set and no personal data is collected.",
     "dataManagement": "Data Management",
     "clearAllApiKeys": "Clear All API Keys",
-    "clearAllHint": "This removes all stored API keys from your browser."
+    "clearAllHint": "This removes all stored API keys from your browser. Keys already uploaded to your Google Drive by cross-device sync are not deleted by this action."
   },
   "usage": {
     "title": "AI Usage",
@@ -147,5 +164,8 @@
     "unsupported": "Notifications aren't supported in this browser.",
     "enable": "Enable notifications",
     "blocked": "Notifications are blocked in your browser settings."
+  },
+  "rowStatus": {
+    "attention": "Needs attention"
   }
 }

--- a/packages/workout-spa-editor/src/i18n/locales/es/settings.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/settings.json
@@ -2,25 +2,42 @@
   "title": "Ajustes",
   "back": "Ajustes",
   "groups": {
-    "aiGeneration": "Generación con IA",
-    "crossDeviceSync": "Sincronización entre dispositivos",
-    "dataRouting": "Enrutamiento de datos",
+    "yourData": "Tus datos",
+    "ai": "IA",
     "preferences": "Preferencias",
-    "privacyData": "Privacidad y datos",
-    "advanced": "Avanzado"
+    "about": "Acerca de"
   },
   "rows": {
-    "provider": "Proveedor",
+    "connections": "Conexiones",
+    "provider": "Proveedor y modelos",
     "customInstructions": "Instrucciones personalizadas",
-    "googleDriveSync": "Sincronización con Google Drive",
+    "googleDriveSync": "Sincronización entre dispositivos",
     "dataHub": "Data Hub",
     "units": "Unidades",
     "language": "Idioma",
     "notifications": "Notificaciones",
-    "dataPrivacy": "Datos y privacidad",
+    "dataPrivacy": "Privacidad y datos",
     "manageYourData": "Gestiona tus datos",
     "extensions": "Extensiones",
-    "usage": "Uso"
+    "usage": "Uso",
+    "helpDocs": "Ayuda y documentación"
+  },
+  "values": {
+    "sync": {
+      "connected": "Drive · {{relative}}"
+    },
+    "usage": {
+      "tokens": "{{tokens}} tokens · {{month}}"
+    },
+    "notifications": {
+      "on": "Activadas",
+      "off": "Desactivadas",
+      "blocked": "Bloqueadas",
+      "unsupported": "No compatible"
+    },
+    "privacy": {
+      "localFirst": "Guardado en este navegador"
+    }
   },
   "tabs": {
     "ai": "IA",
@@ -76,13 +93,13 @@
     "offline": "La última sincronización falló — trabajando sin conexión",
     "lastSynced": "Última sincronización {{date}}",
     "connectedNotSynced": "Conectado — aún sin sincronizar",
-    "encryption": "Cifrado de extremo a extremo",
+    "encryption": "Cifrado de extremo a extremo de las copias de sincronización",
     "passphrase": "Frase de contraseña",
     "plaintextWarning": "Tus claves de API de IA guardadas se subirán sin cifrado de extremo a extremo. Activa el cifrado abajo para protegerlas."
   },
   "privacy": {
     "information": "Información de privacidad",
-    "infoNoServer": "No almacenamos tus credenciales en ningún servidor.",
+    "infoNoServer": "No operamos ningún servidor que almacene tus credenciales. Cuando la sincronización entre dispositivos está activada, tus claves de API de IA guardadas se suben a tu propio Google Drive salvo que actives el cifrado.",
     "infoGarmin": "La integración con Garmin usa una extensión del navegador que se apoya en tu sesión existente de Garmin Connect. Ninguna credencial sale de tu navegador.",
     "infoTrain2go": "La importación de Train2Go usa una extensión del navegador que lee el plan de entrenamiento mostrado en las páginas de Train2Go que ya estás viendo. No lee tu contraseña ni tus tokens de autenticación.",
     "infoLlmKeys": "Las claves de API de LLM se envían directamente al proveedor (Anthropic, OpenAI o Google) — Kaiord no recibe ni retransmite estos datos.",
@@ -94,7 +111,7 @@
     "analyticsOutro": "para hacer un seguimiento del uso agregado (visitas de página, generación de entrenamientos, exportaciones). No se establecen cookies ni se recopilan datos personales.",
     "dataManagement": "Gestión de datos",
     "clearAllApiKeys": "Borrar todas las claves de API",
-    "clearAllHint": "Esto elimina todas las claves de API almacenadas de tu navegador."
+    "clearAllHint": "Esto elimina todas las claves de API almacenadas de tu navegador. Las claves que la sincronización entre dispositivos ya haya subido a tu Google Drive no se eliminan con esta acción."
   },
   "usage": {
     "title": "Uso de IA",
@@ -147,5 +164,8 @@
     "unsupported": "Las notificaciones no son compatibles con este navegador.",
     "enable": "Activar notificaciones",
     "blocked": "Las notificaciones están bloqueadas en la configuración de tu navegador."
+  },
+  "rowStatus": {
+    "attention": "Requiere atención"
   }
 }


### PR DESCRIPTION
## Summary

Wave S1 of the Settings redesign (`add-settings-row-values` OpenSpec change included). The design's premise: **every row answers itself**, so you only open one to change something. No layout change — the desktop split is S2, the attention wiring is S3.

- **Value-provider registry** replaces the single-value `detailKey`. The exhaustive `Record<SettingsValueKey, string | undefined>` makes "a row names a value nobody resolves" a compile error rather than a silent blank. Rows now show: default AI provider · Drive sync freshness · current-month tokens · units · language · notification state.
- **`useUsageSummary` extracted** from `UsageTab` so tab and row share one implementation. Its month window recomputes per render — a session left open across midnight of the 1st previously kept querying the stale window and labelling the previous month.
- **Re-grouped** into Your data / AI / Preferences / About. Extensions and Data Hub stay routed with their testids intact; Connections points at `/athlete` until the wave that builds `/settings/connections`.
- **Attention slot** on `SettingsRow` (aria-hidden dot + sr-only label), unset — the seam S3 plugs into.

## Honest privacy copy

The design mock forced three claims into the open. None survived contact with the code:

| Claim | Reality | Shipped |
|---|---|---|
| "Encrypted on device" / "AES-GCM on every stored record" | Local Dexie is **not** encrypted; the passphrase encrypts sync snapshots *before upload* | "Stored in this browser" |
| "End-to-end encryption" (no object, beside a passphrase field) | Reads as a claim about everything | "End-to-end encryption for sync snapshots" |
| "We do not store your credentials on any server" | `aiProviders` is absent from `DEVICE_LOCAL`, so with sync on and encryption off (**the default**) API keys reach the user's Drive, keyed by a passphrase hardcoded in open-source code | Says exactly that, and `clearAllHint` no longer implies the Drive copy is cleared |

## Review trail

Adversarial review → **APPROVE, zero blockers**. The honest-copy fix was audited four ways (every locale in every package, hardcoded TSX strings, the enabled-toggle-without-passphrase path, and what actually lands in the Drive snapshot) and held. Two of my own fix-round instructions were wrong and the executor pushed back with tsc/eslint evidence rather than complying — both corrections are in.

## Verification

843 files / **5875 tests** green · `tsc -b` clean · lint clean end-to-end · EN/ES parity 127 keys · every settings e2e testid independently re-verified · `openspec validate` valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)