### PR TITLE
feat(spa-editor): command palette, and one exact guard per editor command (Wave K2)

### DIFF
--- a/openspec/changes/add-command-palette/.openspec.yaml
+++ b/openspec/changes/add-command-palette/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-28

--- a/openspec/changes/add-command-palette/design.md
+++ b/openspec/changes/add-command-palette/design.md
@@ -1,0 +1,187 @@
+## Context
+
+`useEditorContextMenu` is today's action list. It calls `buildKeyboardHandlers`
+(the same guard-aware thunks the keyboard chain uses) and pairs them with seven
+booleans — `showCut`, `showCopy`, `showPaste`, `showDelete`, `showSelectAll`,
+`showGroup` (`selectedStepIds.length >= 2`), `showUngroup` — plus `hasAnyAction`,
+which suppresses the menu entirely when nothing applies. `EditorContextMenu.tsx`
+spread those fourteen props by hand into `EditorContextMenuContent`.
+
+The keyboard chain is two `window` `keydown` listeners bound once by
+`useKeyboardShortcuts`. Both open with `isFormElement(event.target)`, the
+invariant that keeps typing untouched. Handlers return `boolean`; `true` means
+handled and the listener calls `preventDefault()`.
+
+`SHORTCUT_CATALOG` (K1) already owns every key literal and is mechanically
+paired to `KeyboardShortcutHandlers` by `shortcut-catalog.test.ts`.
+`ShortcutSheet` establishes the overlay pattern: Radix `Dialog`, `useLazyDialog`
+
+- `React.lazy` from `LayoutHeader`, `<Suspense fallback={null}>`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One enumerable command list, consumed by both the context menu and the
+  palette, so a third copy of "what the editor can do" cannot appear.
+- `⌘K` reaches the user mid-typing, without changing any other binding.
+- Rows that are honest about running vs. opening a dialog, and that explain
+  themselves when disabled.
+- Respect the SPA caps: ≤80 lines/file, ≤60 lines/React component function.
+
+**Non-Goals:**
+
+- A direct-group store action. `⌘G` opens the dialog; that stays true.
+- Rebindable shortcuts, fuzzy/ranked search, recents or command history.
+- Touching `HelpDialog`/`HelpSection`, coach marks or the header layout.
+
+## Decisions
+
+### D1 — The context menu becomes a projection, not a peer
+
+The alternative was to leave `useEditorContextMenu` alone and build the palette
+on a second list "derived from the same handlers". That is the drift the
+shortcut catalog was created to end, one level up: two lists over one handler
+surface, agreeing only by review. Instead `useEditorCommands` is the single
+producer and `contextMenuPropsFrom(commands)` is a pure projection onto the
+menu's existing prop shape. `hasAnyContextMenuAction` replaces the old
+`hasSelection || hasClipboard || hasSteps` with "any menu command available",
+which is the same question asked of the authoritative source.
+
+The projection is behaviour-preserving; the guards it projects are not, on
+purpose — see D3. Making one list serve both surfaces is what exposed the menu
+bug, because a guard that only had to look plausible next to a `show*` prop had
+to become exactly right once a row could also render disabled and explain
+itself.
+
+Keeping the projection in the `EditorContextMenu` folder (not in the hook) means
+the shared list stays free of context-menu vocabulary, and
+`EditorContextMenuContent`'s props — and its existing test — are untouched.
+
+### D2 — Command ids ARE catalog row ids
+
+`shortcutId` could have been a free-form field with its own mapping table. It is
+instead literally the command id (`cut`, `create-block`, `ungroup-block`, …),
+which are already the `SHORTCUT_CATALOG` row ids, so the chips resolve with a
+`find` and no second table exists to drift. A test asserts every `shortcutId`
+resolves to a catalog row. `learn` rows carry no `shortcutId` and render no
+chips.
+
+### D3 — `enabled` mirrors each thunk's own guard, one field per command
+
+The context menu's guards were **wrong**, and this change fixes them rather than
+inheriting them. `showCut`/`showCopy` tested `!sid.startsWith("block-")` and
+`showUngroup` tested `sid.startsWith("block-")`, but block ids are UUIDs from
+`defaultIdProvider()` (`create-repetition-block-action.ts`); `generateBlockId()`
+only ever runs for legacy blocks in `workout-migration.ts`. So with an in-app
+block selected the menu offered Cut/Copy/Delete (all no-ops, since
+`getSelectedStepIndex` returns `null` for a block) and withheld Ungroup, the one
+action that would have worked. `build-step-handlers.ts` already carried a
+comment saying the prefix test is unreliable; the guards next to it had not been
+updated.
+
+`editor-command-guards.ts` therefore derives availability with `findById` — the
+same predicate `getSelectedStepIndex` uses — and gives every command its own
+field, because commands that look alike do not share a guard:
+
+- `canCut` is `canCopy` **and** `selectedStepIds.length <= 1` (`onCut` bails on a
+  multi-selection).
+- `canDelete` equals `canCopy`, not "anything is selected": `onDelete` deletes
+  the single top-level `selectedStepId` and does nothing for a block.
+- `canPaste` needs a workout as well as clipboard content (`onPaste`'s final
+  `else return false`).
+- `canSelectAll` needs a step carrying `stepIndex`, not merely a non-empty
+  `steps` array — a blocks-only workout yields no ids and `onSelectAll` returns
+  `false`.
+
+A shared coarse flag is what produced the original defect, so the type has no
+`hasSelection`-style field left to share.
+
+Ten `do` commands: the seven the menu shows, plus `undo`, `redo` and `save`,
+whose guards (`canUndo`, `canRedo`, `!!currentWorkout`) are already live in the
+store selectors. `move-up`/`move-down` are deliberately **not** palette rows:
+their guard is positional (`stepIndex() > 0`, `< steps.length - 1`) and depends
+on state the row would have to re-derive, so a row could only approximate it.
+They stay documented in the shortcut sheet, which the footer links to.
+
+### D4 — `subtitleKey` flips to `.requires` when the guard is closed
+
+The type carries one subtitle slot, and a disabled row needs to say _why_, so
+the builder picks `commands.<id>.subtitle` when enabled and
+`commands.<id>.requires` when not. Every command therefore has both keys in the
+`palette` namespace, which also makes the honesty rule mechanical rather than a
+copy-review convention: `create-block.subtitle` is "Opens the repetition-block
+dialog", asserted by test.
+
+`create-block` additionally swaps its _title_ key: `titleCount` ("Group the
+{{count}} selected steps into a block") when groupable, and the count-free
+`title` when not, so a closed guard never renders "the 1 selected steps".
+
+### D5 — `⌘K` is dispatched before the form-field guard
+
+`?` sits behind `isFormElement` because a literal `?` must reach the input. `⌘K`
+is a modifier chord with no textual meaning, and the palette's whole point is to
+be reachable from wherever the user is — including a workout-name field. So
+`handleCommandPaletteKey` runs first in `createKeyDownHandler` and returns
+`true` for any matched chord, handled or not, which stops the chain: `Ctrl+K`
+means nothing else in the app. `Shift`/`Alt` variants return `false` and fall
+through untouched, so `Ctrl+Shift+K` still reaches the browser.
+
+The handler joins `KeyboardShortcutHandlers` and `HANDLER_KEY_MAP`, which makes
+K1's parity test _require_ the `show-command-palette` catalog row — the binding
+cannot ship undocumented.
+
+### D6 — Focus stays in the input; the active row is `aria-activedescendant`
+
+`ExportFormatSelector/useKeyboardNavigation` moves DOM focus onto the focused
+option via `optionRefs`. That is right for a listbox with no text entry and
+wrong here: moving focus off the search input would stop the user typing after
+the first arrow key. The palette therefore uses the combobox pattern — the input
+keeps focus, `aria-activedescendant` publishes the active row, and arrow keys
+only move an index. `Escape` is left entirely to the Radix dialog, which already
+owns dismissal and focus restore for `ShortcutSheet`.
+
+`useOverlayFocusStash` is deliberately not wired here, and it would not help if
+it were: `lib/focus/overlay-count.ts` queries _within_ the `editor-root`
+element, while `Dialog.Portal` mounts on `document.body`, so no portalled Radix
+dialog is visible to that observer. `ShortcutSheet` and `HelpDialog` portal
+identically and have never participated either. Focus restore on close comes
+from Radix's own `FocusScope`, which returns focus to the element that had it
+when the dialog opened — the behaviour the shortcut sheet already relies on.
+Extending the overlay observer to portalled dialogs is a focus-system change,
+not a palette change.
+
+### D7 — Filtering is substring over the _translated_ title
+
+`normalizeSearchText` (NFD + diacritic strip + lowercase) already exists for
+chat search, so accent- and case-insensitivity comes free and no dependency is
+added. Matching runs against `t(titleKey, titleParams)` — the text the user is
+reading — not against the key or the id. Subtitles are excluded to keep a query
+like "block" from dragging in every row whose subtitle mentions blocks.
+
+## Risks / Trade-offs
+
+- **Two `keydown` subscriptions see every `⌘K`.** `LayoutHeader` binds
+  `onShowCommandPalette`; `useAppKeyboardHandlers` binds the editor handlers and
+  has no palette handler. Both listeners now early-return on `⌘K`; only the one
+  with the handler acts, and `preventDefault` is applied by that one. No
+  double-open, no swallowed binding — covered by a test that `Ctrl+S`/`Ctrl+C`/
+  `Ctrl+G` are unaffected while `⌘K` is bound.
+- **`useEditorCommands` allocates ten closures per render** in both the menu and
+  the palette. This is what `useEditorContextMenu` already did with
+  `buildKeyboardHandlers`; the list is 13 entries and the palette only exists
+  while open.
+- **`learn` rows are hardcoded docs links.** The docs site has no
+  repetition-block page today, so the three entries point at pages that exist
+  (quick start, KRD format, converters) rather than inventing routes. Adding a
+  row is one line in `LEARN_PAGES` plus its two i18n keys.
+
+## Migration Plan
+
+Additive. `useEditorContextMenu` keeps its name and its selection helpers; only
+its shape changes (`menu` replaces the seven `show*` props, and the `handlers`
+escape hatch is gone) and its one consumer is updated in the same change.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-command-palette/proposal.md
+++ b/openspec/changes/add-command-palette/proposal.md
@@ -1,0 +1,88 @@
+## Why
+
+The SPA's editor actions exist twice and are enumerable nowhere. The right-click
+menu (`useEditorContextMenu` + `EditorContextMenuContent`) is the de-facto list —
+seven items, each with a live visibility flag — but it only appears if you know
+to right-click, and it hides everything that is not currently applicable, so it
+teaches nothing. Everything else (undo, redo, save) is reachable only by knowing
+the key already. `?` documents the bindings but cannot run them, and the Help
+dialog answers "how do I…" with four stacked prose sections.
+
+Most "how do I…" questions are really "do this for me". Nothing in the SPA
+answers both, and nothing lets a user search for an action by the words they
+would use for it.
+
+There is also a structural problem waiting: adding a second surface over the
+same actions without a shared list would create a third hand-maintained copy of
+"what the editor can do", the same drift the shortcut catalog was introduced to
+end for key bindings.
+
+## What Changes
+
+- Add **one enumerable command source**, `hooks/use-editor-commands.ts` plus
+  `build-do-commands.ts` / `build-learn-commands.ts`. An `EditorCommand` carries
+  an id, a group (`do` / `learn`), i18n keys for title and subtitle, an optional
+  `SHORTCUT_CATALOG` row id for its key chips, a live `enabled` flag and a `run`
+  thunk. `run` always delegates to a `buildKeyboardHandlers` thunk; no surface
+  re-implements a store action.
+- **Rewire the context menu onto that list.** `useEditorContextMenu` becomes a
+  projection: `contextMenuPropsFrom(commands)` maps command ids onto the
+  existing `show*`/`on*` props, and `hasAnyContextMenuAction` replaces the
+  hand-written `hasSelection || hasClipboard || hasSteps` expression with the
+  equivalent "any menu command enabled". The rendered menu is unchanged.
+- Add the **`⌘K` command palette** (`organisms/CommandPalette`), a Radix dialog
+  lazy-mounted from `LayoutHeader` like `ShortcutSheet`: search input, `Do it` /
+  `Learn` sections, per-row key chips resolved from the shortcut catalog, and a
+  footer with `↵ run`, `? all shortcuts` and a link to the docs site.
+- **Honest row copy.** A row states what it actually does. `⌘G` opens the
+  repetition-block dialog, so its subtitle reads "Opens the repetition-block
+  dialog" and never "Runs now · undo with ⌘Z". No direct-group store action is
+  added. A disabled row still renders and explains its guard ("Select 2 or more
+  steps") instead of disappearing the way the context menu's items do.
+- **Bind `Ctrl+K`/`⌘K` in front of the form-field guard.** Unlike every other
+  binding, the palette must answer while the user is typing, so
+  `handleCommandPaletteKey` is dispatched at the top of `createKeyDownHandler`,
+  before the `isFormElement` early return. `onShowCommandPalette` joins
+  `KeyboardShortcutHandlers` and `HANDLER_KEY_MAP`, which makes the existing
+  catalog-parity test require a `show-command-palette` row in the `help` group.
+- Add the **`palette` i18n namespace** (`en` + `es`), covering every command
+  title, its enabled subtitle and its closed-guard `requires` line.
+
+Out of scope: the Help dialog and Help page (`HelpDialog` / `HelpSection`),
+coach marks, the setup checklist, the header layout and the avatar menu.
+
+## Capabilities
+
+### New Capabilities
+
+- `spa-command-palette`: one enumerable, guard-aware command source shared by
+  the right-click menu and a `⌘K` palette that searches, explains and runs
+  editor actions, states honestly whether a row runs or opens a dialog, and
+  reaches the user even while they are typing.
+
+### Modified Capabilities
+
+<!-- None. `spa-shortcut-catalog` gains a row through its existing mechanism;
+     every pre-existing binding keeps its behaviour. -->
+
+## Impact
+
+- **Package**: `@kaiord/workout-spa-editor` (private SPA) only. No domain,
+  application, port or adapter change; no dependency added (Radix Dialog,
+  lucide and `normalizeSearchText` are already in the tree).
+- **New files**: `hooks/editor-command.types.ts`, `hooks/build-do-commands.ts`,
+  `hooks/build-learn-commands.ts`, `hooks/use-editor-commands.ts`,
+  `components/organisms/EditorContextMenu/context-menu-props-from-commands.ts`,
+  `components/organisms/CommandPalette/*`,
+  `components/templates/MainLayout/use-header-overlays.ts`,
+  `i18n/locales/{en,es}/palette.json`, and their test suites.
+- **Modified files**: `constants/shortcut-rows-global.ts`,
+  `hooks/keyboard-shortcut-handlers.ts`, `hooks/modifier-shortcut-handlers.ts`,
+  `hooks/use-editor-context-menu.ts`,
+  `components/organisms/EditorContextMenu/EditorContextMenu.tsx`,
+  `components/templates/MainLayout/LayoutHeader.tsx`,
+  `i18n/locales/{en,es}/help.json`, `hooks/use-keyboard-shortcuts.test.ts`.
+- **Bundle**: the palette is `React.lazy`-imported, so it ships as its own
+  chunk and costs nothing until `⌘K` is pressed.
+- **No** schema/version bump, no public-API impact, no changeset (the SPA is
+  private and excluded from the changeset-bot PUBLISHABLE set).

--- a/openspec/changes/add-command-palette/specs/spa-command-palette/spec.md
+++ b/openspec/changes/add-command-palette/specs/spa-command-palette/spec.md
@@ -1,0 +1,287 @@
+## ADDED Requirements
+
+### Requirement: One enumerable source of editor commands
+
+The SPA SHALL describe every editor action it offers outside a dedicated form as
+one enumerable list of commands, and every surface that offers those actions
+SHALL render from that list rather than from its own copy. Each command SHALL
+carry a unique id, a display group, an i18n key for its title in the `palette`
+namespace with optional interpolation parameters, an optional subtitle key, an
+optional shortcut-catalog row id, a live `enabled` flag and a `run` thunk. `run`
+SHALL delegate to an existing keyboard-handler thunk, so no surface
+re-implements a store action.
+
+#### Scenario: The right-click menu renders from the command list
+
+- **GIVEN** the editor context menu
+- **WHEN** it decides which items to show and what they do
+- **THEN** it SHALL project the shared command list onto its items, and SHALL NOT hold its own list of actions or its own store calls
+
+#### Scenario: A command runs through the keyboard-handler thunk
+
+- **GIVEN** the `ungroup-block` command
+- **WHEN** its `run` is invoked
+- **THEN** it SHALL call the `onUngroupBlock` handler thunk, which owns the guard and the store action
+
+#### Scenario: Both surfaces agree on availability
+
+- **GIVEN** a selection of exactly one step
+- **WHEN** the palette and the context menu each decide whether grouping is available
+- **THEN** both SHALL resolve it from the same `enabled` flag on the same command, and both SHALL treat it as unavailable
+
+#### Scenario: Command shortcut ids resolve in the shortcut catalog
+
+- **GIVEN** a command that names a shortcut row
+- **WHEN** its key chips are rendered
+- **THEN** the id SHALL resolve to exactly one `SHORTCUT_CATALOG` row, so no second id-to-keys mapping exists
+
+### Requirement: Command availability mirrors the handler's own guard
+
+Each command's `enabled` flag SHALL equal the condition under which its handler
+thunk actually performs its action, so a command is never offered when invoking
+it would do nothing. Commands SHALL NOT share a guard field with each other,
+even where two of them evaluate the same condition, so that tightening one can
+never silently change another: cut, copy
+and delete each require a top-level step carrying a positional index, cut
+additionally requires that no more than one id is selected, paste requires both
+clipboard content and a workout to paste into, select-all requires a workout
+containing at least one such step, grouping requires two or more selected ids,
+ungrouping requires a selected repetition block, and undo, redo and save follow
+the history and loaded-workout state. Selected items SHALL be identified by
+resolving the selection id against the workout tree, and SHALL NOT be classified
+by pattern-matching the id string.
+
+#### Scenario: A repetition block created in the app is recognised as a block
+
+- **GIVEN** a repetition block whose id is a UUID rather than the legacy `block-…` format
+- **WHEN** it is selected and the commands are read
+- **THEN** ungrouping SHALL be available, and cut, copy and delete SHALL NOT, because none of them can act on a block
+
+#### Scenario: A step inside a block offers no clipboard command
+
+- **GIVEN** a step nested inside a repetition block is selected
+- **WHEN** the commands are read
+- **THEN** cut, copy and delete SHALL be unavailable, because the clipboard handlers only address top-level steps
+
+#### Scenario: Cut withdraws from a multi-selection
+
+- **GIVEN** two or more selected ids
+- **WHEN** the cut command is read
+- **THEN** it SHALL be unavailable, because its handler refuses a multi-selection, while copy remains available for the focused step
+
+#### Scenario: Select-all withdraws from a blocks-only workout
+
+- **GIVEN** a workout whose items are all repetition blocks
+- **WHEN** the select-all command is read
+- **THEN** it SHALL be unavailable, because the handler finds no selectable step
+
+#### Scenario: Paste needs somewhere to paste
+
+- **GIVEN** clipboard content but no loaded workout
+- **WHEN** the paste command is read
+- **THEN** it SHALL be unavailable
+
+#### Scenario: Grouping needs two steps
+
+- **GIVEN** one step selected
+- **WHEN** the group command is read
+- **THEN** it SHALL be disabled, and SHALL become enabled once a second step is selected
+
+#### Scenario: The selected count reaches the command title
+
+- **GIVEN** three selected steps
+- **WHEN** the group command is read
+- **THEN** its title parameters SHALL carry the count `3`, so the row can name what it will act on
+
+#### Scenario: Invoking a disabled command is a no-op
+
+- **GIVEN** the group command with one step selected
+- **WHEN** its `run` is invoked anyway
+- **THEN** no store action SHALL be performed, because the guard lives in the handler thunk
+
+#### Scenario: Paste follows the clipboard
+
+- **GIVEN** an empty editor clipboard
+- **WHEN** the paste command is read
+- **THEN** it SHALL be disabled, and SHALL become enabled once a step has been copied or cut
+
+### Requirement: Command rows state what they will actually do
+
+A command row SHALL describe its real effect, and SHALL NOT claim to run an
+action it only opens a dialog for. The group command SHALL state that it opens
+the repetition-block dialog and SHALL NOT be described as running immediately or
+as undoable; no direct-group store action SHALL be added to satisfy the copy.
+When a command is unavailable, its subtitle SHALL explain the condition that
+would make it available instead of describing the effect.
+
+#### Scenario: Grouping is described as opening a dialog
+
+- **GIVEN** two or more selected steps
+- **WHEN** the group row is rendered
+- **THEN** its subtitle SHALL say that it opens the repetition-block dialog, not that it runs now
+
+#### Scenario: A disabled row explains its guard
+
+- **GIVEN** fewer than two selected steps
+- **WHEN** the group row is rendered
+- **THEN** the row SHALL still render, and its subtitle SHALL state that two or more steps must be selected
+
+#### Scenario: A count-free title while the guard is closed
+
+- **GIVEN** one selected step
+- **WHEN** the group row's title is rendered
+- **THEN** it SHALL use the count-free title, so the row never reads as "the 1 selected steps"
+
+### Requirement: The command palette searches, explains and runs
+
+The SPA SHALL provide a command palette that lists the commands grouped into a
+"do" section and a "learn" section, filters them as the user types, and runs the
+active command. Filtering SHALL be a case- and accent-insensitive substring
+match over the translated title. Each row SHALL render its title, its subtitle
+when it has one, and the key chips of its shortcut-catalog row when it names
+one. A group with no matching command SHALL NOT render. The palette SHALL be
+lazy-mounted so it costs nothing until it is first opened.
+
+#### Scenario: Typing narrows the list
+
+- **GIVEN** the palette open with every command listed
+- **WHEN** the user types a word that appears in one command's title
+- **THEN** only the matching row SHALL remain, and empty groups SHALL disappear
+
+#### Scenario: Search ignores case and accents
+
+- **GIVEN** a command whose translated title contains an accented character
+- **WHEN** the user types the unaccented, lowercased form
+- **THEN** the command SHALL match
+
+#### Scenario: No match shows an empty state
+
+- **GIVEN** the palette open
+- **WHEN** the query matches no command
+- **THEN** the palette SHALL say so rather than render empty groups
+
+#### Scenario: Learn rows open the documentation
+
+- **GIVEN** a row in the "learn" group
+- **WHEN** it is run
+- **THEN** the documentation page SHALL open in a new tab, and the palette SHALL close
+
+#### Scenario: The footer offers the shortcut sheet and the docs
+
+- **GIVEN** the palette open
+- **WHEN** the user reads the footer
+- **THEN** it SHALL offer running the active row with Enter, opening the full shortcut sheet, and a link to the documentation site
+
+### Requirement: The palette is driven from the keyboard without losing the query
+
+Arrow keys SHALL move the active row and Enter SHALL run it; `Escape` SHALL
+close the palette. Keyboard focus SHALL remain in the search input while the
+active row moves, so typing continues to filter, and the active row SHALL be
+published to assistive technology through `aria-activedescendant` rather than by
+moving focus. A disabled row SHALL be reachable as an active row but SHALL NOT
+be runnable, by keyboard or by pointer.
+
+#### Scenario: Arrow keys move the active row
+
+- **GIVEN** the palette open with the first row active
+- **WHEN** the user presses ArrowDown then ArrowUp
+- **THEN** the active row SHALL move to the second row and back to the first
+
+#### Scenario: Enter runs the active command and closes
+
+- **GIVEN** an enabled row is active
+- **WHEN** the user presses Enter
+- **THEN** the command SHALL run and the palette SHALL close
+
+#### Scenario: Enter on a disabled row does nothing
+
+- **GIVEN** a disabled row is active
+- **WHEN** the user presses Enter
+- **THEN** no command SHALL run and the palette SHALL stay open
+
+#### Scenario: Clicking a disabled row does nothing
+
+- **GIVEN** a disabled row
+- **WHEN** the user clicks it
+- **THEN** no command SHALL run, and the row SHALL be marked disabled to assistive technology
+
+#### Scenario: Focus stays in the search input
+
+- **GIVEN** the palette open
+- **WHEN** the user moves the active row with the arrow keys
+- **THEN** the search input SHALL keep focus and SHALL name the active row via `aria-activedescendant`
+
+#### Scenario: Escape closes the palette
+
+- **GIVEN** the palette open
+- **WHEN** the user presses Escape
+- **THEN** the palette SHALL request to close
+
+### Requirement: Ctrl+K opens the palette even while typing
+
+`Ctrl+K` and `⌘K` SHALL open the command palette, and SHALL do so regardless of
+whether the event target is a form field — unlike every other binding, which is
+suppressed inside inputs, textareas, selects and contenteditable regions. The
+binding SHALL be dispatched from the SPA's existing global keydown chain ahead
+of the form-field guard, SHALL only call `preventDefault()` when its handler
+reports that it handled the event, and SHALL NOT match when `Shift` or `Alt` is
+held. Adding the binding SHALL NOT change the behaviour of any existing
+shortcut, including the `?` sheet's own form-field suppression.
+
+#### Scenario: The palette opens from inside a text field
+
+- **GIVEN** focus inside a workout-name input
+- **WHEN** the user presses `⌘K`
+- **THEN** the palette SHALL open, because this binding is dispatched before the form-field guard
+
+#### Scenario: The palette opens from inside a contenteditable region
+
+- **GIVEN** focus inside a contenteditable element
+- **WHEN** the user presses `Ctrl+K`
+- **THEN** the palette SHALL open
+
+#### Scenario: Unmodified k is passed through
+
+- **WHEN** the user presses `k` with no modifier
+- **THEN** the palette SHALL NOT open, and the character SHALL reach whatever has focus
+
+#### Scenario: Shift and Alt variants are not claimed
+
+- **WHEN** the user presses `Ctrl+Shift+K` or `Ctrl+Alt+K`
+- **THEN** the palette SHALL NOT open, and the chord SHALL fall through to the browser
+
+#### Scenario: Existing bindings are unaffected
+
+- **GIVEN** both the palette handler and the editor handlers are bound
+- **WHEN** the user presses `Ctrl+S`, `Ctrl+C` or `Ctrl+G` outside a form field
+- **THEN** the matching editor handler SHALL be called and the palette handler SHALL NOT
+
+#### Scenario: `?` keeps its form-field guard
+
+- **GIVEN** focus inside a text field and both bindings bound
+- **WHEN** the user types `?`
+- **THEN** the shortcut sheet SHALL NOT open, because only the palette binding sits ahead of the guard
+
+#### Scenario: The binding is documented by the catalog
+
+- **GIVEN** the palette handler added to the handler surface
+- **WHEN** the shortcut-catalog parity test runs
+- **THEN** it SHALL require a `help`-group catalog row for the binding, so the palette shortcut cannot ship undocumented
+
+### Requirement: The palette namespace covers every command in every locale
+
+Every command title, enabled subtitle and closed-guard subtitle SHALL resolve in
+the `palette` i18n namespace, and the namespace SHALL exist at key parity across
+every supported locale. No command copy SHALL be hardcoded in a component.
+
+#### Scenario: Every rendered key resolves
+
+- **GIVEN** the full command list
+- **WHEN** its title and subtitle keys are resolved against the English `palette` namespace
+- **THEN** every key SHALL resolve to a string
+
+#### Scenario: Locales stay at parity
+
+- **GIVEN** the `palette` namespace added for English
+- **WHEN** the resource-parity test runs
+- **THEN** every other supported locale SHALL expose the identical key tree

--- a/openspec/changes/add-command-palette/tasks.md
+++ b/openspec/changes/add-command-palette/tasks.md
@@ -1,0 +1,67 @@
+## 1. One enumerable command source
+
+- [x] 1.1 Create `hooks/editor-command.types.ts`: `EditorCommandGroup`, `EditorCommand` (`id`, `group`, `titleKey`, `titleParams?`, `subtitleKey?`, `shortcutId?`, `enabled`, `run`), `EditorCommandGuards` and `EditorCommandInput`.
+- [x] 1.2 Create `hooks/build-do-commands.ts`: a `doCommand` factory that derives `titleKey`/`subtitleKey`/`shortcutId` from the id, plus the ten `do` commands wired to the `buildKeyboardHandlers` thunks. `create-block` overrides its title key so a closed guard renders the count-free variant.
+- [x] 1.3 Create `hooks/build-learn-commands.ts`: `DOCS_URL`, `openDocs(path)` and three data-driven `learn` rows pointing at pages that exist on the docs site.
+- [x] 1.4 Create `hooks/use-editor-commands.ts`: compose `useContextMenuStore` → `buildEditorCommandGuards` → `buildDoCommands` + `buildLearnCommands`, and keep returning the selection helpers the context menu needs.
+- [x] 1.5 Write `hooks/build-do-commands.test.ts`: every guard opens exactly its own command, every `run` reaches its thunk, absent thunks do not throw, `shortcutId === id`, and the `create-block` title/subtitle switch.
+- [x] 1.6 Write `hooks/use-editor-commands.test.ts`: selection-aware guards and count, clipboard-driven paste, `run` delegation to the store, a closed guard performing no store action, learn rows opening the docs, every `shortcutId` resolving in `SHORTCUT_CATALOG`, every title/subtitle key resolving in `palette.json`, ids unique.
+
+## 2. The context menu as a projection
+
+- [x] 2.1 Create `components/organisms/EditorContextMenu/context-menu-props-from-commands.ts`: `contextMenuPropsFrom(commands)` mapping command ids onto the existing `show*`/`on*` props, and `hasAnyContextMenuAction(props)`.
+- [x] 2.2 Rewrite `hooks/use-editor-context-menu.ts` as a projection over `useEditorCommands` — no second guard set, no `handlers` escape hatch.
+- [x] 2.3 Collapse `EditorContextMenu.tsx` to `<EditorContextMenuContent {...ctx.menu} />`; `EditorContextMenuContent` and its existing test are untouched.
+- [x] 2.4 Write `context-menu-props-from-commands.test.ts`: each command id maps to its `show*` and `on*` pair, a missing command hides its item, and `hasAnyContextMenuAction` is false only when every menu command is disabled.
+
+## 3. The palette
+
+- [x] 3.1 Create `components/organisms/CommandPalette/command-palette-filter.ts`: `PALETTE_GROUPS`, `filterCommands` (accent/case-insensitive substring over the translated title, empty sections dropped) and `flattenSections`.
+- [x] 3.2 Create `use-command-palette-nav.ts`: active-index state reset on re-filter, ArrowUp/ArrowDown, Enter-runs-if-enabled, `runAt`. Focus is not moved; `Escape` is left to Radix.
+- [x] 3.3 Create `CommandPaletteRow.tsx` (title, subtitle, `KeyChips` from the catalog row, `role="option"` with `aria-selected`/`aria-disabled`), `CommandPaletteList.tsx` (grouped `role="listbox"` with `role="group"` headings) and `CommandPaletteFooter.tsx` (`↵ run`, `? all shortcuts`, docs link).
+- [x] 3.4 Create `CommandPalette.tsx`: Radix `Dialog` portal/overlay/content, autofocused search input wired as a combobox with `aria-activedescendant`, the list or the empty state, and the footer. Styles extracted to `palette-styles.ts` for the 80-line cap.
+- [x] 3.5 Write `command-palette-filter.test.ts`: group order, empty groups dropped, blank query keeps everything, substring/case/accent matching, no-match returns nothing.
+- [x] 3.6 Write `CommandPalette.test.tsx`: both group headings, closed renders nothing, input autofocus, key chips, docs link, filter-on-typing, empty state, Enter runs the first row and closes, ArrowDown/ArrowUp move the active row, `aria-activedescendant` follows it, Escape closes, disabled rows are not runnable by click or Enter and explain their guard, click runs an enabled row, and the footer hands over to the shortcut sheet.
+
+## 4. The `Ctrl+K` binding
+
+- [x] 4.1 Add `onShowCommandPalette` to `KeyboardShortcutHandlers` and to `HANDLER_KEY_MAP`, so K1's parity test demands a catalog row.
+- [x] 4.2 Add `handleCommandPaletteKey` to `modifier-shortcut-handlers.ts` and dispatch it at the top of `createKeyDownHandler`, ahead of the `isFormElement` guard; `Shift`/`Alt` variants fall through, `preventDefault` only on a handled event.
+- [x] 4.3 Add the `show-command-palette` row to `constants/shortcut-rows-global.ts` in the `help` group (`Ctrl K` / `⌘ K`).
+- [x] 4.4 Extend `hooks/use-keyboard-shortcuts.test.ts` with a `command palette shortcut` block: fires on Ctrl/Cmd/uppercase K, fires inside input, textarea and contenteditable, ignores unmodified `k`, ignores `Ctrl+Shift+K` and `Ctrl+Alt+K`, no `preventDefault` when unhandled, `Ctrl+S`/`Ctrl+C`/`Ctrl+G` unaffected, and `?` keeps its form-field suppression.
+
+## 5. Mounting and i18n
+
+- [x] 5.1 Extract `components/templates/MainLayout/use-header-overlays.ts`: the help/shortcuts/palette lazy dialogs, the `onShowShortcuts` and `onShowCommandPalette` handlers, the palette→sheet handover, and the single `useKeyboardShortcuts` subscription.
+- [x] 5.2 Lazy-mount `CommandPalette` from `LayoutHeader` with `React.lazy` inside the existing `<Suspense fallback={null}>`, exactly like `ShortcutSheet`.
+- [x] 5.3 Add `i18n/locales/{en,es}/palette.json`: title, search labels, empty state, group headings, footer, `commands.<id>.{title,subtitle,requires}` for all ten commands (plus `create-block.titleCount`) and `learn.<id>.{title,subtitle}`.
+- [x] 5.4 Add `shortcuts.help.showCommandPalette` to `i18n/locales/{en,es}/help.json`; `resource-parity.test.ts` and `shortcut-catalog.test.ts` stay green.
+
+## 6. Review round: exact guards and reopen state
+
+- [x] 6.1 Create `hooks/editor-command-guards.ts`: derive availability with `findById` instead of prefix-matching the legacy `block-*` id format, one field per command. Fixes the shipped right-click-menu bug where an in-app block (a `defaultIdProvider()` UUID) offered Cut/Copy/Delete — all no-ops — and withheld Ungroup.
+- [x] 6.2 Fold in the same defect class: `canCut` also requires a single selected id, `canDelete` equals `canCopy` (not "anything selected"), `canPaste` also requires a workout, `canSelectAll` requires a step carrying `stepIndex` so a blocks-only workout is disabled.
+- [x] 6.3 Replace `EditorCommandGuards`' shared coarse flags (`hasSingleStep`, `hasSelection`, `hasSteps`, `hasWorkout`) with one field per command, so no two commands can share a guard again.
+- [x] 6.4 Write `hooks/editor-command-guards.test.ts` (16 cases): block / step / step-inside-block / blocks-only / empty selection / multi-selection, plus each paste and select-all branch.
+- [x] 6.5 Write `hooks/use-editor-context-menu.test.ts`: the composite store → guards → `show*`/`on*` chain that `EditorContextMenuContent.test.tsx` (presentational) cannot cover.
+- [x] 6.6 Extract `CommandPaletteBody.tsx` so the query and active row live inside `Dialog.Content`, which Radix unmounts on close — `useLazyDialog` latches `mounted`, so state held in `CommandPalette` leaked across openings. Regression test reopens the palette and asserts Enter runs the first row again.
+- [x] 6.7 a11y: thread `hasResults` into `CommandPaletteInput` so `aria-controls`/`aria-expanded` do not dangle in the empty state, add `aria-autocomplete="list"`, and give the empty-state paragraph `role="status"` so it is announced.
+- [x] 6.8 Drop the `useMemo` around `filterCommands` — `t` was a fresh closure and `commands` a fresh array every render, so it never memoized and only implied a guarantee it did not provide.
+- [x] 6.9 Correct `design.md`: portalled Radix dialogs are invisible to `useOverlayFocusStash` (it queries within `editor-root`); focus restore comes from Radix's own `FocusScope`. Rewrite D1/D3 to record that the guards were fixed, not inherited.
+- [x] 6.10 Make `commands.delete` singular in `en`/`es` — `onDelete` removes the one `selectedStepId`, not the whole multi-selection.
+
+## 7. Review nits
+
+- [x] 7.1 Cover the one visible menu change in `use-editor-context-menu.test.ts`: a multi-selection with no focused step offers group but not delete, and the menu still opens. `toggleStepSelection` and `selectAllSteps` both leave `selectedStepId` null, so `onDelete` never had a step to act on — the item was always a no-op.
+- [x] 7.2 Drop the dead `animate-in`/`animate-out`/`fade-in-0`/`fade-out-0` classes from `palette-styles.ts` (they emit no CSS in this tree) and record why the palette must stay un-animated: `CommandPaletteBody` resets its state by unmounting, and an exit animation would hold it mounted through `Presence`, reopening the stale-query window. Cross-referenced from the `CommandPaletteBody` comment.
+- [x] 7.3 Make the cut/copy/delete `requires` copy exact for a step inside a block — "Select a step in the main list" rather than "Select a single step first", which was false for a nested selection. Cut keeps "a single step" because its guard also refuses a multi-selection.
+- [x] 7.4 Clarify in `spec.md` that commands must not share a guard _field_, even where two evaluate the same condition.
+
+## 8. Verification
+
+- [x] 8.1 `pnpm --filter @kaiord/workout-spa-editor test` — full suite passing.
+- [x] 8.2 `tsc -p tsconfig.app.json --noEmit` clean.
+- [x] 8.3 `pnpm --filter @kaiord/workout-spa-editor lint` clean, including the 80-line file and 60-line component caps.
+- [x] 8.4 `pnpm test:scripts` unchanged-green; Prettier clean on every touched file.
+- [x] 8.5 `npx openspec validate add-command-palette` passes.
+- [x] 8.6 Production build emits the palette as its own lazy chunk.

--- a/packages/workout-spa-editor/e2e/modal-interactions.spec.ts
+++ b/packages/workout-spa-editor/e2e/modal-interactions.spec.ts
@@ -314,9 +314,12 @@ test.describe("Modal Interactions - Mobile Viewport", () => {
       expect(modalBox.width).toBeLessThanOrEqual(viewportWidth + tolerance);
     }
 
-    // Verify buttons are accessible on mobile
-    const cancelButton = page.getByRole("button", { name: /cancel/i });
-    const confirmButton = page.getByRole("button", { name: /delete/i });
+    // Verify buttons are accessible on mobile. Scope to the dialog: the
+    // cards behind it also carry delete buttons, and whether those are
+    // hidden from the a11y tree depends on incidental aria-hidden left by
+    // the dropdown that opened this modal.
+    const cancelButton = modal.getByRole("button", { name: /cancel/i });
+    const confirmButton = modal.getByRole("button", { name: /delete/i });
 
     await expect(cancelButton).toBeVisible();
     await expect(confirmButton).toBeVisible();

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPalette.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPalette.test.tsx
@@ -1,0 +1,412 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EditorCommand } from "../../../hooks/editor-command.types";
+import { CommandPalette } from "./CommandPalette";
+
+const hoisted = vi.hoisted(() => ({
+  runGroup: vi.fn(),
+  runUndo: vi.fn(),
+  runLearn: vi.fn(),
+  groupEnabled: true,
+}));
+
+vi.mock("../../../hooks/use-editor-commands", () => ({
+  useEditorCommands: () => ({
+    commands: [
+      {
+        id: "create-block",
+        group: "do",
+        titleKey: "commands.create-block.title",
+        subtitleKey: hoisted.groupEnabled
+          ? "commands.create-block.subtitle"
+          : "commands.create-block.requires",
+        shortcutId: "create-block",
+        enabled: hoisted.groupEnabled,
+        run: hoisted.runGroup,
+      },
+      {
+        id: "undo",
+        group: "do",
+        titleKey: "commands.undo.title",
+        shortcutId: "undo",
+        enabled: true,
+        run: hoisted.runUndo,
+      },
+      {
+        id: "learn-formats",
+        group: "learn",
+        titleKey: "learn.formats.title",
+        enabled: true,
+        run: hoisted.runLearn,
+      },
+    ] satisfies ReadonlyArray<EditorCommand>,
+  }),
+}));
+
+const open = (onOpenChange = vi.fn(), onShowShortcuts = vi.fn()) => {
+  render(
+    <CommandPalette
+      open
+      onOpenChange={onOpenChange}
+      onShowShortcuts={onShowShortcuts}
+    />
+  );
+  return { onOpenChange, onShowShortcuts };
+};
+
+describe("CommandPalette", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.groupEnabled = true;
+  });
+
+  describe("rendering", () => {
+    it("should render both group headings", () => {
+      // Arrange
+
+      // Act
+      open();
+
+      // Assert
+      expect(
+        screen.getByRole("heading", { name: "Do it" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("heading", { name: "Learn" })
+      ).toBeInTheDocument();
+    });
+
+    it("should not render anything when closed", () => {
+      // Arrange
+
+      // Act
+      render(
+        <CommandPalette
+          open={false}
+          onOpenChange={vi.fn()}
+          onShowShortcuts={vi.fn()}
+        />
+      );
+
+      // Assert
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    it("should focus the search input on open", () => {
+      // Arrange
+
+      // Act
+      open();
+
+      // Assert
+      expect(screen.getByRole("combobox")).toHaveFocus();
+    });
+
+    it("should render the key chips of a command with a catalog row", () => {
+      // Arrange
+
+      // Act
+      open();
+
+      // Assert
+      const row = screen.getByTestId("command-palette-row-undo");
+      expect(row.querySelectorAll("kbd").length).toBeGreaterThan(0);
+    });
+
+    it("should link out to the documentation", () => {
+      // Arrange
+
+      // Act
+      open();
+
+      // Assert
+      expect(
+        screen.getByRole("link", { name: /full documentation/i })
+      ).toHaveAttribute("href", "https://kaiord.com/docs/");
+    });
+  });
+
+  describe("filtering", () => {
+    it("should keep only the matching rows while typing", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      open();
+
+      // Act
+      await user.type(screen.getByRole("combobox"), "undo");
+
+      // Assert
+      expect(
+        screen.getByTestId("command-palette-row-undo")
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId("command-palette-row-create-block")
+      ).not.toBeInTheDocument();
+    });
+
+    it("should show the empty state when nothing matches", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      open();
+
+      // Act
+      await user.type(screen.getByRole("combobox"), "zzzzz");
+
+      // Assert
+      expect(screen.getByText(/nothing matches/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("keyboard", () => {
+    it("should run the first command on Enter", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const { onOpenChange } = open();
+
+      // Act
+      await user.keyboard("{Enter}");
+
+      // Assert
+      expect(hoisted.runGroup).toHaveBeenCalledOnce();
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it("should move the active row with ArrowDown before running", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      open();
+
+      // Act
+      await user.keyboard("{ArrowDown}{Enter}");
+
+      // Assert
+      expect(hoisted.runUndo).toHaveBeenCalledOnce();
+      expect(hoisted.runGroup).not.toHaveBeenCalled();
+    });
+
+    it("should move back up with ArrowUp", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      open();
+
+      // Act
+      await user.keyboard("{ArrowDown}{ArrowUp}{Enter}");
+
+      // Assert
+      expect(hoisted.runGroup).toHaveBeenCalledOnce();
+    });
+
+    it("should publish the active row through aria-activedescendant", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      open();
+
+      // Act
+      await user.keyboard("{ArrowDown}");
+
+      // Assert
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-activedescendant",
+        "command-palette-option-undo"
+      );
+    });
+
+    it("should request close on Escape", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const { onOpenChange } = open();
+
+      // Act
+      await user.keyboard("{Escape}");
+
+      // Assert
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe("disabled rows", () => {
+    it("should render a disabled command without running it on click", async () => {
+      // Arrange
+      hoisted.groupEnabled = false;
+      const user = userEvent.setup();
+      open();
+
+      // Act
+      await user.click(screen.getByTestId("command-palette-row-create-block"));
+
+      // Assert
+      expect(hoisted.runGroup).not.toHaveBeenCalled();
+      expect(
+        screen.getByTestId("command-palette-row-create-block")
+      ).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("should not run a disabled command on Enter", async () => {
+      // Arrange
+      hoisted.groupEnabled = false;
+      const user = userEvent.setup();
+      const { onOpenChange } = open();
+
+      // Act
+      await user.keyboard("{Enter}");
+
+      // Assert
+      expect(hoisted.runGroup).not.toHaveBeenCalled();
+      expect(onOpenChange).not.toHaveBeenCalled();
+    });
+
+    it("should explain the closed guard in the subtitle", () => {
+      // Arrange
+      hoisted.groupEnabled = false;
+
+      // Act
+      open();
+
+      // Assert
+      expect(screen.getByText("Select 2 or more steps")).toBeInTheDocument();
+    });
+  });
+
+  describe("running by click", () => {
+    it("should run an enabled command and close", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const { onOpenChange } = open();
+
+      // Act
+      await user.click(screen.getByTestId("command-palette-row-learn-formats"));
+
+      // Assert
+      expect(hoisted.runLearn).toHaveBeenCalledOnce();
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe("footer", () => {
+    it("should hand over to the shortcut sheet", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const { onShowShortcuts } = open();
+
+      // Act
+      await user.click(screen.getByRole("button", { name: /all shortcuts/i }));
+
+      // Assert
+      expect(onShowShortcuts).toHaveBeenCalledOnce();
+    });
+  });
+
+  // The parent never unmounts (useLazyDialog latches `mounted`), so the query
+  // and the active row must reset by living inside Dialog.Content.
+  describe("state across openings", () => {
+    const reopen = async (typed: string) => {
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <CommandPalette open onOpenChange={vi.fn()} onShowShortcuts={vi.fn()} />
+      );
+      await user.type(screen.getByRole("combobox"), typed);
+      rerender(
+        <CommandPalette
+          open={false}
+          onOpenChange={vi.fn()}
+          onShowShortcuts={vi.fn()}
+        />
+      );
+      rerender(
+        <CommandPalette open onOpenChange={vi.fn()} onShowShortcuts={vi.fn()} />
+      );
+      return user;
+    };
+
+    it("should clear the query when reopened", async () => {
+      // Arrange
+
+      // Act
+      await reopen("undo");
+
+      // Assert
+      expect(screen.getByRole("combobox")).toHaveValue("");
+    });
+
+    it("should show every row again when reopened", async () => {
+      // Arrange
+
+      // Act
+      await reopen("undo");
+
+      // Assert
+      expect(
+        screen.getByTestId("command-palette-row-create-block")
+      ).toBeInTheDocument();
+    });
+
+    it("should reset the active row, so Enter runs the first command again", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <CommandPalette open onOpenChange={vi.fn()} onShowShortcuts={vi.fn()} />
+      );
+      await user.keyboard("{ArrowDown}");
+      rerender(
+        <CommandPalette
+          open={false}
+          onOpenChange={vi.fn()}
+          onShowShortcuts={vi.fn()}
+        />
+      );
+
+      // Act
+      rerender(
+        <CommandPalette open onOpenChange={vi.fn()} onShowShortcuts={vi.fn()} />
+      );
+      await user.keyboard("{Enter}");
+
+      // Assert
+      expect(hoisted.runGroup).toHaveBeenCalledOnce();
+      expect(hoisted.runUndo).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("combobox wiring", () => {
+    it("should control the listbox while there are results", () => {
+      // Arrange
+
+      // Act
+      open();
+
+      // Assert
+      expect(screen.getByRole("combobox")).toHaveAttribute(
+        "aria-controls",
+        "command-palette-list"
+      );
+    });
+
+    it("should drop the dangling controls and expanded state when empty", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      open();
+
+      // Act
+      await user.type(screen.getByRole("combobox"), "zzzzz");
+
+      // Assert
+      const input = screen.getByRole("combobox");
+      expect(input).not.toHaveAttribute("aria-controls");
+      expect(input).toHaveAttribute("aria-expanded", "false");
+    });
+
+    it("should announce the empty state through a live region", async () => {
+      // Arrange
+      const user = userEvent.setup();
+      open();
+
+      // Act
+      await user.type(screen.getByRole("combobox"), "zzzzz");
+
+      // Assert
+      expect(screen.getByRole("status")).toHaveTextContent(/nothing matches/i);
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPalette.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPalette.tsx
@@ -1,0 +1,45 @@
+/**
+ * CommandPalette Component
+ *
+ * The ⌘K palette: one searchable list that both runs editor commands and
+ * links out to the docs, over the app rather than in place of it.
+ */
+
+import * as Dialog from "@radix-ui/react-dialog";
+
+import { useTranslate } from "../../../i18n/use-translate";
+import { CommandPaletteBody } from "./CommandPaletteBody";
+import { CONTENT_CLASS, OVERLAY_CLASS } from "./palette-styles";
+
+export type CommandPaletteProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onShowShortcuts: () => void;
+};
+
+export function CommandPalette({
+  open,
+  onOpenChange,
+  onShowShortcuts,
+}: CommandPaletteProps) {
+  const t = useTranslate("palette");
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={OVERLAY_CLASS} />
+        <Dialog.Content
+          aria-describedby={undefined}
+          data-testid="command-palette"
+          className={CONTENT_CLASS}
+        >
+          <Dialog.Title className="sr-only">{t("title")}</Dialog.Title>
+          <CommandPaletteBody
+            onClose={() => onOpenChange(false)}
+            onShowShortcuts={onShowShortcuts}
+          />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPaletteBody.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPaletteBody.tsx
@@ -1,0 +1,67 @@
+import { useState } from "react";
+
+import { useEditorCommands } from "../../../hooks/use-editor-commands";
+import { useTranslate } from "../../../i18n/use-translate";
+import { filterCommands, flattenSections } from "./command-palette-filter";
+import { CommandPaletteFooter } from "./CommandPaletteFooter";
+import { CommandPaletteInput } from "./CommandPaletteInput";
+import { CommandPaletteList } from "./CommandPaletteList";
+import { useCommandPaletteNav } from "./use-command-palette-nav";
+
+export type CommandPaletteBodyProps = {
+  onClose: () => void;
+  onShowShortcuts: () => void;
+};
+
+/**
+ * Lives INSIDE `Dialog.Content`, which Radix unmounts on close, so the query
+ * and the active row reset by unmounting. Holding them in `CommandPalette`
+ * would leak them across openings — `useLazyDialog` latches `mounted`, so the
+ * outer component never unmounts once the palette has been opened.
+ *
+ * That makes the reset depend on the unmount being immediate, which is why
+ * this dialog carries no exit animation — see `palette-styles.ts`.
+ */
+export function CommandPaletteBody({
+  onClose,
+  onShowShortcuts,
+}: CommandPaletteBodyProps) {
+  const t = useTranslate("palette");
+  const { commands } = useEditorCommands();
+  const [query, setQuery] = useState("");
+
+  const sections = filterCommands(commands, query, t);
+  const flat = flattenSections(sections);
+  const nav = useCommandPaletteNav({ commands: flat, onRun: onClose });
+  const active = flat[nav.activeIndex];
+
+  return (
+    <>
+      <CommandPaletteInput
+        value={query}
+        onChange={setQuery}
+        onKeyDown={nav.handleKeyDown}
+        hasResults={sections.length > 0}
+        activeOptionId={
+          active ? `command-palette-option-${active.id}` : undefined
+        }
+      />
+      {sections.length === 0 ? (
+        <p
+          role="status"
+          className="px-4 py-6 text-sm text-gray-500 dark:text-gray-400"
+        >
+          {t("empty")}
+        </p>
+      ) : (
+        <CommandPaletteList
+          sections={sections}
+          activeIndex={nav.activeIndex}
+          onActivate={nav.runAt}
+          onHover={nav.setActiveIndex}
+        />
+      )}
+      <CommandPaletteFooter onShowShortcuts={onShowShortcuts} />
+    </>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPaletteFooter.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPaletteFooter.tsx
@@ -1,0 +1,34 @@
+import { DOCS_URL } from "../../../hooks/build-learn-commands";
+import { useTranslate } from "../../../i18n/use-translate";
+
+export type CommandPaletteFooterProps = {
+  onShowShortcuts: () => void;
+};
+
+export function CommandPaletteFooter({
+  onShowShortcuts,
+}: CommandPaletteFooterProps) {
+  const t = useTranslate("palette");
+
+  return (
+    <div className="flex items-center gap-4 border-t border-gray-200 bg-gray-50 px-4 py-2.5 text-xs text-gray-500 dark:border-slate-800 dark:bg-slate-950 dark:text-gray-400">
+      <span>{t("footer.run")}</span>
+      <button
+        type="button"
+        onClick={onShowShortcuts}
+        className="rounded hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:hover:text-gray-200"
+      >
+        {t("footer.shortcuts")}
+      </button>
+      <span className="flex-1" />
+      <a
+        href={DOCS_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-primary-600 hover:underline dark:text-primary-400"
+      >
+        {t("footer.docs")}
+      </a>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPaletteInput.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPaletteInput.tsx
@@ -1,0 +1,46 @@
+import { Search } from "lucide-react";
+import type { KeyboardEvent } from "react";
+
+import { useTranslate } from "../../../i18n/use-translate";
+import { INPUT_CLASS } from "./palette-styles";
+
+export type CommandPaletteInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onKeyDown: (event: KeyboardEvent) => void;
+  /** False in the empty state, where the listbox is not rendered at all. */
+  hasResults: boolean;
+  /** Id of the active row, published instead of moving focus onto it. */
+  activeOptionId?: string;
+};
+
+export function CommandPaletteInput({
+  value,
+  onChange,
+  onKeyDown,
+  hasResults,
+  activeOptionId,
+}: CommandPaletteInputProps) {
+  const t = useTranslate("palette");
+
+  return (
+    <div className="flex items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-slate-800">
+      <Search className="h-4 w-4 text-gray-400" aria-hidden="true" />
+      <input
+        autoFocus
+        type="text"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={hasResults}
+        aria-controls={hasResults ? "command-palette-list" : undefined}
+        aria-activedescendant={activeOptionId}
+        aria-label={t("searchLabel")}
+        placeholder={t("searchPlaceholder")}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={onKeyDown}
+        className={INPUT_CLASS}
+      />
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPaletteList.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPaletteList.tsx
@@ -1,0 +1,58 @@
+import { useTranslate } from "../../../i18n/use-translate";
+import type { CommandPaletteSection } from "./command-palette-filter";
+import { CommandPaletteRow } from "./CommandPaletteRow";
+
+export type CommandPaletteListProps = {
+  sections: ReadonlyArray<CommandPaletteSection>;
+  /** Index into the flattened sections. */
+  activeIndex: number;
+  onActivate: (index: number) => void;
+  onHover: (index: number) => void;
+};
+
+const HEADING =
+  "px-3 pb-1 pt-2 text-[10.5px] font-bold uppercase tracking-widest text-gray-500 dark:text-gray-400";
+
+export function CommandPaletteList({
+  sections,
+  activeIndex,
+  onActivate,
+  onHover,
+}: CommandPaletteListProps) {
+  const t = useTranslate("palette");
+  let index = -1;
+
+  return (
+    <div
+      role="listbox"
+      id="command-palette-list"
+      aria-label={t("listLabel")}
+      className="max-h-[50vh] overflow-y-auto p-2"
+    >
+      {sections.map((section) => (
+        <div
+          key={section.group}
+          role="group"
+          aria-labelledby={`command-palette-group-${section.group}`}
+        >
+          <h3 id={`command-palette-group-${section.group}`} className={HEADING}>
+            {t(`groups.${section.group}`)}
+          </h3>
+          {section.commands.map((command) => {
+            index += 1;
+            const at = index;
+            return (
+              <CommandPaletteRow
+                key={command.id}
+                command={command}
+                active={at === activeIndex}
+                onActivate={() => onActivate(at)}
+                onHover={() => onHover(at)}
+              />
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPaletteRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/CommandPaletteRow.tsx
@@ -1,0 +1,54 @@
+import { SHORTCUT_CATALOG } from "../../../constants/shortcut-catalog";
+import type { EditorCommand } from "../../../hooks/editor-command.types";
+import { useTranslate } from "../../../i18n/use-translate";
+import { KeyChips } from "../../atoms/KeyChips";
+
+export type CommandPaletteRowProps = {
+  command: EditorCommand;
+  active: boolean;
+  onActivate: () => void;
+  onHover: () => void;
+};
+
+const ROW_BASE =
+  "flex cursor-pointer items-center gap-3 rounded-lg px-3 py-2.5 text-sm";
+
+export function CommandPaletteRow({
+  command,
+  active,
+  onActivate,
+  onHover,
+}: CommandPaletteRowProps) {
+  const t = useTranslate("palette");
+  const def = SHORTCUT_CATALOG.find((row) => row.id === command.shortcutId);
+  const tone = command.enabled
+    ? "text-gray-800 dark:text-gray-100"
+    : "cursor-not-allowed text-gray-400 dark:text-gray-500";
+
+  return (
+    <div
+      role="option"
+      id={`command-palette-option-${command.id}`}
+      aria-selected={active}
+      aria-disabled={!command.enabled}
+      data-testid={`command-palette-row-${command.id}`}
+      onClick={command.enabled ? onActivate : undefined}
+      onMouseEnter={onHover}
+      className={`${ROW_BASE} ${tone} ${
+        active ? "bg-primary-50 dark:bg-primary-900/40" : ""
+      }`}
+    >
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="font-semibold">
+          {t(command.titleKey, command.titleParams)}
+        </span>
+        {command.subtitleKey && (
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {t(command.subtitleKey)}
+          </span>
+        )}
+      </span>
+      {def && <KeyChips def={def} />}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/command-palette-filter.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/command-palette-filter.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { EditorCommand } from "../../../hooks/editor-command.types";
+import type { Translate } from "../../../i18n/use-translate";
+import { filterCommands, flattenSections } from "./command-palette-filter";
+
+const TITLES: Record<string, string> = {
+  "commands.create-block.title": "Group the selected steps into a block",
+  "commands.undo.title": "Undo the last change",
+  "learn.formats.title": "Cómo se guardan los entrenamientos",
+};
+
+const t: Translate = (key) => TITLES[key] ?? key;
+
+const COMMANDS: ReadonlyArray<EditorCommand> = [
+  {
+    id: "create-block",
+    group: "do",
+    titleKey: "commands.create-block.title",
+    enabled: true,
+    run: vi.fn(),
+  },
+  {
+    id: "undo",
+    group: "do",
+    titleKey: "commands.undo.title",
+    enabled: true,
+    run: vi.fn(),
+  },
+  {
+    id: "learn-formats",
+    group: "learn",
+    titleKey: "learn.formats.title",
+    enabled: true,
+    run: vi.fn(),
+  },
+];
+
+describe("filterCommands", () => {
+  describe("grouping", () => {
+    it("should return the do section before the learn section", () => {
+      // Arrange
+
+      // Act
+      const sections = filterCommands(COMMANDS, "", t);
+
+      // Assert
+      expect(sections.map((section) => section.group)).toEqual(["do", "learn"]);
+    });
+
+    it("should drop a section that has no match", () => {
+      // Arrange
+
+      // Act
+      const sections = filterCommands(COMMANDS, "undo", t);
+
+      // Assert
+      expect(sections.map((section) => section.group)).toEqual(["do"]);
+    });
+
+    it("should keep every command when the query is blank", () => {
+      // Arrange
+
+      // Act
+      const flat = flattenSections(filterCommands(COMMANDS, "   ", t));
+
+      // Assert
+      expect(flat).toHaveLength(COMMANDS.length);
+    });
+  });
+
+  describe("matching", () => {
+    it("should match a substring of the translated title", () => {
+      // Arrange
+
+      // Act
+      const flat = flattenSections(filterCommands(COMMANDS, "block", t));
+
+      // Assert
+      expect(flat.map((command) => command.id)).toEqual(["create-block"]);
+    });
+
+    it("should ignore case", () => {
+      // Arrange
+
+      // Act
+      const flat = flattenSections(filterCommands(COMMANDS, "UNDO", t));
+
+      // Assert
+      expect(flat.map((command) => command.id)).toEqual(["undo"]);
+    });
+
+    it("should ignore accents", () => {
+      // Arrange
+
+      // Act
+      const flat = flattenSections(filterCommands(COMMANDS, "como", t));
+
+      // Assert
+      expect(flat.map((command) => command.id)).toEqual(["learn-formats"]);
+    });
+
+    it("should return no section when nothing matches", () => {
+      // Arrange
+
+      // Act
+      const sections = filterCommands(COMMANDS, "zzz", t);
+
+      // Assert
+      expect(sections).toEqual([]);
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/command-palette-filter.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/command-palette-filter.ts
@@ -1,0 +1,49 @@
+import { normalizeSearchText } from "../../../application/chat/normalize-search-text";
+import type {
+  EditorCommand,
+  EditorCommandGroup,
+} from "../../../hooks/editor-command.types";
+import type { Translate } from "../../../i18n/use-translate";
+
+/** Render order of the palette's sections. */
+export const PALETTE_GROUPS = [
+  "do",
+  "learn",
+] as const satisfies ReadonlyArray<EditorCommandGroup>;
+
+export type CommandPaletteSection = {
+  group: EditorCommandGroup;
+  commands: ReadonlyArray<EditorCommand>;
+};
+
+/**
+ * Case- and accent-insensitive substring match over the TRANSLATED title, so
+ * the query the user reads is the text they are searching. Empty sections are
+ * dropped; an empty query keeps everything.
+ */
+export const filterCommands = (
+  commands: ReadonlyArray<EditorCommand>,
+  query: string,
+  t: Translate
+): ReadonlyArray<CommandPaletteSection> => {
+  const needle = normalizeSearchText(query.trim());
+  const matches =
+    needle.length === 0
+      ? commands
+      : commands.filter((command) =>
+          normalizeSearchText(
+            t(command.titleKey, command.titleParams)
+          ).includes(needle)
+        );
+
+  return PALETTE_GROUPS.map((group) => ({
+    group,
+    commands: matches.filter((command) => command.group === group),
+  })).filter((section) => section.commands.length > 0);
+};
+
+/** The sections flattened into keyboard-navigation order. */
+export const flattenSections = (
+  sections: ReadonlyArray<CommandPaletteSection>
+): ReadonlyArray<EditorCommand> =>
+  sections.flatMap((section) => section.commands);

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/palette-styles.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/palette-styles.ts
@@ -1,0 +1,18 @@
+/**
+ * The palette carries no `animate-in`/`animate-out` classes, unlike
+ * `ShortcutSheet`. Those classes emit no CSS in this tree (no
+ * `tailwindcss-animate`, no keyframes), so they were dead — and here they
+ * would be a trap rather than a no-op: `CommandPaletteBody` resets the query
+ * and the active row by unmounting, and an exit animation would make Radix's
+ * `Presence` hold it mounted for the animation's duration, so a close-then-
+ * reopen inside that window would show the previous query again. Animating
+ * this dialog means resetting that state explicitly first.
+ */
+
+export const OVERLAY_CLASS = "fixed inset-0 z-50 bg-black/50";
+
+export const CONTENT_CLASS =
+  "fixed left-[50%] top-[15%] z-50 w-full max-w-xl translate-x-[-50%] overflow-hidden border border-gray-200 bg-white shadow-lg sm:rounded-xl dark:border-slate-700 dark:bg-slate-900";
+
+export const INPUT_CLASS =
+  "flex-1 bg-transparent text-sm text-gray-900 outline-none placeholder:text-gray-400 dark:text-white";

--- a/packages/workout-spa-editor/src/components/organisms/CommandPalette/use-command-palette-nav.ts
+++ b/packages/workout-spa-editor/src/components/organisms/CommandPalette/use-command-palette-nav.ts
@@ -1,0 +1,52 @@
+import type { KeyboardEvent } from "react";
+import { useEffect, useState } from "react";
+
+import type { EditorCommand } from "../../../hooks/editor-command.types";
+
+type CommandPaletteNavOptions = {
+  /** Commands in render order; index 0 is the initial active row. */
+  commands: ReadonlyArray<EditorCommand>;
+  onRun: () => void;
+};
+
+/**
+ * Arrow/Enter navigation for the palette list. Unlike the export-format
+ * dropdown this does NOT move DOM focus onto rows — focus stays in the search
+ * input so typing keeps working, and the active row is published through
+ * `aria-activedescendant`. `Escape` is left to the Radix dialog.
+ */
+export function useCommandPaletteNav({
+  commands,
+  onRun,
+}: CommandPaletteNavOptions) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  // Re-filtering re-orders the list, so the previous index is meaningless.
+  useEffect(() => setActiveIndex(0), [commands.length]);
+
+  const runAt = (index: number): void => {
+    const command = commands[index];
+    if (!command?.enabled) return;
+    command.run();
+    onRun();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent): void => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((i) => Math.min(i + 1, commands.length - 1));
+      return;
+    }
+    if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((i) => Math.max(i - 1, 0));
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      runAt(activeIndex);
+    }
+  };
+
+  return { activeIndex, setActiveIndex, runAt, handleKeyDown };
+}

--- a/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/EditorContextMenu.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/EditorContextMenu.tsx
@@ -48,22 +48,7 @@ export const EditorContextMenu = ({ children }: EditorContextMenuProps) => {
         {children}
       </ContextMenu.Trigger>
       <ContextMenu.Portal>
-        <EditorContextMenuContent
-          showCut={ctx.showCut}
-          showCopy={ctx.showCopy}
-          showPaste={ctx.showPaste}
-          showDelete={ctx.showDelete}
-          showSelectAll={ctx.showSelectAll}
-          showGroup={ctx.showGroup}
-          showUngroup={ctx.showUngroup}
-          onCut={() => ctx.handlers.onCut?.()}
-          onCopy={() => ctx.handlers.onCopy?.()}
-          onPaste={() => ctx.handlers.onPaste?.()}
-          onDelete={() => ctx.handlers.onDelete?.()}
-          onSelectAll={() => ctx.handlers.onSelectAll?.()}
-          onGroup={() => ctx.handlers.onCreateBlock?.()}
-          onUngroup={() => ctx.handlers.onUngroupBlock?.()}
-        />
+        <EditorContextMenuContent {...ctx.menu} />
       </ContextMenu.Portal>
     </ContextMenu.Root>
   );

--- a/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/context-menu-props-from-commands.test.ts
+++ b/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/context-menu-props-from-commands.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { EditorCommand } from "../../../hooks/editor-command.types";
+import {
+  contextMenuPropsFrom,
+  hasAnyContextMenuAction,
+} from "./context-menu-props-from-commands";
+
+const MENU_IDS = [
+  "cut",
+  "copy",
+  "paste",
+  "delete",
+  "select-all",
+  "create-block",
+  "ungroup-block",
+] as const;
+
+const command = (
+  id: string,
+  enabled: boolean,
+  run = vi.fn()
+): EditorCommand => ({
+  id,
+  group: "do",
+  titleKey: `commands.${id}.title`,
+  enabled,
+  run,
+});
+
+const listWith = (enabledIds: ReadonlyArray<string>) =>
+  MENU_IDS.map((id) => command(id, enabledIds.includes(id)));
+
+describe("contextMenuPropsFrom", () => {
+  describe("visibility", () => {
+    it.each([
+      { id: "cut", prop: "showCut" },
+      { id: "copy", prop: "showCopy" },
+      { id: "paste", prop: "showPaste" },
+      { id: "delete", prop: "showDelete" },
+      { id: "select-all", prop: "showSelectAll" },
+      { id: "create-block", prop: "showGroup" },
+      { id: "ungroup-block", prop: "showUngroup" },
+    ])("should map the $id command onto $prop", ({ id, prop }) => {
+      // Arrange
+      const commands = listWith([id]);
+
+      // Act
+      const props = contextMenuPropsFrom(commands);
+
+      // Assert
+      expect(props[prop as keyof typeof props]).toBe(true);
+    });
+
+    it("should hide an item whose command is missing from the list", () => {
+      // Arrange
+      const commands: ReadonlyArray<EditorCommand> = [];
+
+      // Act
+      const props = contextMenuPropsFrom(commands);
+
+      // Assert
+      expect(props.showCut).toBe(false);
+    });
+  });
+
+  describe("action delegation", () => {
+    it.each([
+      { id: "cut", prop: "onCut" },
+      { id: "copy", prop: "onCopy" },
+      { id: "paste", prop: "onPaste" },
+      { id: "delete", prop: "onDelete" },
+      { id: "select-all", prop: "onSelectAll" },
+      { id: "create-block", prop: "onGroup" },
+      { id: "ungroup-block", prop: "onUngroup" },
+    ])("should route $prop to the $id command run", ({ id, prop }) => {
+      // Arrange
+      const run = vi.fn();
+      const commands = MENU_IDS.map((menuId) =>
+        command(menuId, true, menuId === id ? run : vi.fn())
+      );
+
+      // Act
+      contextMenuPropsFrom(commands)[prop as "onCut"]();
+
+      // Assert
+      expect(run).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("hasAnyContextMenuAction", () => {
+    it("should be false when no command is enabled", () => {
+      // Arrange
+      const props = contextMenuPropsFrom(listWith([]));
+
+      // Act
+      const any = hasAnyContextMenuAction(props);
+
+      // Assert
+      expect(any).toBe(false);
+    });
+
+    it.each(MENU_IDS)("should be true when only %s is enabled", (id) => {
+      // Arrange
+      const props = contextMenuPropsFrom(listWith([id]));
+
+      // Act
+      const any = hasAnyContextMenuAction(props);
+
+      // Assert
+      expect(any).toBe(true);
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/context-menu-props-from-commands.ts
+++ b/packages/workout-spa-editor/src/components/organisms/EditorContextMenu/context-menu-props-from-commands.ts
@@ -1,0 +1,45 @@
+import type { EditorCommand } from "../../../hooks/editor-command.types";
+import type { ContextMenuContentProps } from "./context-menu-content.types";
+
+/**
+ * Projection of the shared command list onto the right-click menu. The menu
+ * renders a subset of the `do` group; it owns no action list of its own.
+ */
+export const contextMenuPropsFrom = (
+  commands: ReadonlyArray<EditorCommand>
+): ContextMenuContentProps => {
+  const at = (id: string): EditorCommand | undefined =>
+    commands.find((command) => command.id === id);
+  const show = (id: string): boolean => at(id)?.enabled ?? false;
+  const on =
+    (id: string): (() => void) =>
+    () =>
+      at(id)?.run();
+
+  return {
+    showCut: show("cut"),
+    showCopy: show("copy"),
+    showPaste: show("paste"),
+    showDelete: show("delete"),
+    showSelectAll: show("select-all"),
+    showGroup: show("create-block"),
+    showUngroup: show("ungroup-block"),
+    onCut: on("cut"),
+    onCopy: on("copy"),
+    onPaste: on("paste"),
+    onDelete: on("delete"),
+    onSelectAll: on("select-all"),
+    onGroup: on("create-block"),
+    onUngroup: on("ungroup-block"),
+  };
+};
+
+/** The menu suppresses itself entirely when it would render no item. */
+export const hasAnyContextMenuAction = (p: ContextMenuContentProps): boolean =>
+  p.showCut ||
+  p.showCopy ||
+  p.showPaste ||
+  p.showDelete ||
+  p.showSelectAll ||
+  p.showGroup ||
+  p.showUngroup;

--- a/packages/workout-spa-editor/src/components/templates/MainLayout/LayoutHeader.tsx
+++ b/packages/workout-spa-editor/src/components/templates/MainLayout/LayoutHeader.tsx
@@ -1,9 +1,8 @@
-import { lazy, Suspense, useCallback } from "react";
+import { lazy, Suspense } from "react";
 
-import { useKeyboardShortcuts } from "../../../hooks/use-keyboard-shortcuts";
-import { useLazyDialog } from "../../../hooks/use-lazy-dialog";
 import { StatusHeader } from "../../molecules/StatusHeader/StatusHeader";
 import { HeaderLogo } from "./components/HeaderLogo";
+import { useHeaderOverlays } from "./use-header-overlays";
 
 const HelpDialog = lazy(() =>
   import("./components/HelpDialog").then((m) => ({ default: m.HelpDialog }))
@@ -15,21 +14,18 @@ const ShortcutSheet = lazy(() =>
   }))
 );
 
+const CommandPalette = lazy(() =>
+  import("../../organisms/CommandPalette/CommandPalette").then((m) => ({
+    default: m.CommandPalette,
+  }))
+);
+
 type LayoutHeaderProps = {
   onReplayTutorial?: () => void;
 };
 
 export const LayoutHeader = ({ onReplayTutorial }: LayoutHeaderProps) => {
-  const help = useLazyDialog();
-  const shortcuts = useLazyDialog();
-
-  const showShortcuts = shortcuts.show;
-  const onShowShortcuts = useCallback(() => {
-    showShortcuts();
-    return true;
-  }, [showShortcuts]);
-
-  useKeyboardShortcuts({ onShowShortcuts });
+  const { help, shortcuts, palette, onPaletteShortcuts } = useHeaderOverlays();
 
   return (
     <header className="sticky top-0 z-50 border-b border-gray-200 bg-white shadow-sm dark:border-slate-800 dark:bg-slate-900">
@@ -49,6 +45,13 @@ export const LayoutHeader = ({ onReplayTutorial }: LayoutHeaderProps) => {
           <ShortcutSheet
             open={shortcuts.open}
             onOpenChange={shortcuts.setOpen}
+          />
+        )}
+        {palette.mounted && (
+          <CommandPalette
+            open={palette.open}
+            onOpenChange={palette.setOpen}
+            onShowShortcuts={onPaletteShortcuts}
           />
         )}
       </Suspense>

--- a/packages/workout-spa-editor/src/components/templates/MainLayout/use-header-overlays.ts
+++ b/packages/workout-spa-editor/src/components/templates/MainLayout/use-header-overlays.ts
@@ -1,0 +1,38 @@
+import { useCallback } from "react";
+
+import { useKeyboardShortcuts } from "../../../hooks/use-keyboard-shortcuts";
+import { useLazyDialog } from "../../../hooks/use-lazy-dialog";
+
+/**
+ * The header's three lazy overlays and the global bindings that open them:
+ * `?` for the shortcut sheet and Ctrl+K/⌘K for the command palette.
+ */
+export function useHeaderOverlays() {
+  const help = useLazyDialog();
+  const shortcuts = useLazyDialog();
+  const palette = useLazyDialog();
+
+  const showShortcuts = shortcuts.show;
+  const showPalette = palette.show;
+  const setPaletteOpen = palette.setOpen;
+
+  const onShowShortcuts = useCallback(() => {
+    showShortcuts();
+    return true;
+  }, [showShortcuts]);
+
+  const onShowCommandPalette = useCallback(() => {
+    showPalette();
+    return true;
+  }, [showPalette]);
+
+  // The palette's "all shortcuts" footer hands over to the sheet.
+  const onPaletteShortcuts = useCallback(() => {
+    setPaletteOpen(false);
+    showShortcuts();
+  }, [setPaletteOpen, showShortcuts]);
+
+  useKeyboardShortcuts({ onShowShortcuts, onShowCommandPalette });
+
+  return { help, shortcuts, palette, onPaletteShortcuts };
+}

--- a/packages/workout-spa-editor/src/constants/shortcut-rows-global.ts
+++ b/packages/workout-spa-editor/src/constants/shortcut-rows-global.ts
@@ -32,4 +32,12 @@ export const GLOBAL_SHORTCUT_ROWS: ReadonlyArray<ShortcutDef> = [
     labelKey: "shortcuts.help.showShortcuts",
     handlerKey: "onShowShortcuts",
   },
+  {
+    id: "show-command-palette",
+    group: "help",
+    keys: ["Ctrl", "K"],
+    macKeys: ["⌘", "K"],
+    labelKey: "shortcuts.help.showCommandPalette",
+    handlerKey: "onShowCommandPalette",
+  },
 ];

--- a/packages/workout-spa-editor/src/hooks/build-do-commands.test.ts
+++ b/packages/workout-spa-editor/src/hooks/build-do-commands.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildDoCommands } from "./build-do-commands";
+import type { EditorCommandGuards } from "./editor-command.types";
+import type { KeyboardShortcutHandlers } from "./keyboard-shortcut-handlers";
+
+const CLOSED: EditorCommandGuards = {
+  canCut: false,
+  canCopy: false,
+  canPaste: false,
+  canDelete: false,
+  canSelectAll: false,
+  canGroup: false,
+  canUngroup: false,
+  canUndo: false,
+  canRedo: false,
+  canSave: false,
+  selectedCount: 0,
+};
+
+const OPEN: EditorCommandGuards = {
+  canCut: true,
+  canCopy: true,
+  canPaste: true,
+  canDelete: true,
+  canSelectAll: true,
+  canGroup: true,
+  canUngroup: true,
+  canUndo: true,
+  canRedo: true,
+  canSave: true,
+  selectedCount: 3,
+};
+
+const build = (guards: EditorCommandGuards, handlers = {}) =>
+  buildDoCommands({ handlers, guards });
+
+const at = (guards: EditorCommandGuards, id: string, handlers = {}) => {
+  const command = build(guards, handlers).find((c) => c.id === id);
+  if (!command) throw new Error(`no command ${id}`);
+  return command;
+};
+
+describe("buildDoCommands", () => {
+  describe("guards", () => {
+    it("should enable every command when all guards are open", () => {
+      // Arrange
+
+      // Act
+      const commands = build(OPEN);
+
+      // Assert
+      expect(commands.every((command) => command.enabled)).toBe(true);
+    });
+
+    it("should disable every command when all guards are closed", () => {
+      // Arrange
+
+      // Act
+      const commands = build(CLOSED);
+
+      // Assert
+      expect(commands.some((command) => command.enabled)).toBe(false);
+    });
+
+    it.each([
+      { id: "cut", guard: "canCut" },
+      { id: "copy", guard: "canCopy" },
+      { id: "paste", guard: "canPaste" },
+      { id: "delete", guard: "canDelete" },
+      { id: "select-all", guard: "canSelectAll" },
+      { id: "create-block", guard: "canGroup" },
+      { id: "ungroup-block", guard: "canUngroup" },
+      { id: "undo", guard: "canUndo" },
+      { id: "redo", guard: "canRedo" },
+      { id: "save", guard: "canSave" },
+    ])("should enable $id from the $guard guard alone", ({ id, guard }) => {
+      // Arrange
+      const guards = { ...CLOSED, [guard]: true };
+
+      // Act
+      const command = at(guards, id);
+
+      // Assert
+      expect(command.enabled).toBe(true);
+    });
+  });
+
+  describe("run delegation", () => {
+    it.each([
+      { id: "cut", handler: "onCut" },
+      { id: "copy", handler: "onCopy" },
+      { id: "paste", handler: "onPaste" },
+      { id: "delete", handler: "onDelete" },
+      { id: "select-all", handler: "onSelectAll" },
+      { id: "create-block", handler: "onCreateBlock" },
+      { id: "ungroup-block", handler: "onUngroupBlock" },
+      { id: "undo", handler: "onUndo" },
+      { id: "redo", handler: "onRedo" },
+      { id: "save", handler: "onSave" },
+    ])("should run $id through the $handler thunk", ({ id, handler }) => {
+      // Arrange
+      const spy = vi.fn().mockReturnValue(true);
+      const handlers: KeyboardShortcutHandlers = { [handler]: spy };
+
+      // Act
+      at(OPEN, id, handlers).run();
+
+      // Assert
+      expect(spy).toHaveBeenCalledOnce();
+    });
+
+    it("should not throw when the thunk is absent", () => {
+      // Arrange
+      const command = at(OPEN, "undo");
+
+      // Act
+      const run = () => command.run();
+
+      // Assert
+      expect(run).not.toThrow();
+    });
+  });
+
+  describe("copy honesty", () => {
+    it("should point create-block at the dialog rather than a direct run", () => {
+      // Arrange
+
+      // Act
+      const command = at(OPEN, "create-block");
+
+      // Assert
+      expect(command.subtitleKey).toBe("commands.create-block.subtitle");
+    });
+
+    it("should explain the closed guard in the subtitle", () => {
+      // Arrange
+
+      // Act
+      const command = at(CLOSED, "create-block");
+
+      // Assert
+      expect(command.subtitleKey).toBe("commands.create-block.requires");
+    });
+
+    it("should title create-block with the selected count when groupable", () => {
+      // Arrange
+
+      // Act
+      const command = at(OPEN, "create-block");
+
+      // Assert
+      expect(command).toMatchObject({
+        titleKey: "commands.create-block.titleCount",
+        titleParams: { count: 3 },
+      });
+    });
+
+    it("should drop the count from the title when not groupable", () => {
+      // Arrange
+
+      // Act
+      const command = at(CLOSED, "create-block");
+
+      // Assert
+      expect(command.titleKey).toBe("commands.create-block.title");
+    });
+  });
+
+  describe("catalog pairing", () => {
+    it("should carry a shortcutId equal to the command id", () => {
+      // Arrange
+
+      // Act
+      const commands = build(OPEN);
+
+      // Assert
+      expect(commands.every((c) => c.shortcutId === c.id)).toBe(true);
+    });
+
+    it("should place every command in the do group", () => {
+      // Arrange
+
+      // Act
+      const commands = build(OPEN);
+
+      // Assert
+      expect(commands.every((command) => command.group === "do")).toBe(true);
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/build-do-commands.ts
+++ b/packages/workout-spa-editor/src/hooks/build-do-commands.ts
@@ -1,0 +1,44 @@
+import type { EditorCommand, EditorCommandInput } from "./editor-command.types";
+
+/**
+ * Command ids are also `SHORTCUT_CATALOG` row ids, so the key chips resolve
+ * without a second mapping. `subtitleKey` flips to `.requires` when the guard
+ * is closed, which is how a disabled row explains itself.
+ */
+const doCommand = (
+  id: string,
+  enabled: boolean,
+  run: () => void
+): EditorCommand => ({
+  id,
+  group: "do",
+  titleKey: `commands.${id}.title`,
+  subtitleKey: `commands.${id}.${enabled ? "subtitle" : "requires"}`,
+  shortcutId: id,
+  enabled,
+  run,
+});
+
+export const buildDoCommands = ({
+  handlers: h,
+  guards: g,
+}: EditorCommandInput): ReadonlyArray<EditorCommand> => [
+  doCommand("cut", g.canCut, () => void h.onCut?.()),
+  doCommand("copy", g.canCopy, () => void h.onCopy?.()),
+  doCommand("paste", g.canPaste, () => void h.onPaste?.()),
+  doCommand("delete", g.canDelete, () => void h.onDelete?.()),
+  doCommand("select-all", g.canSelectAll, () => void h.onSelectAll?.()),
+  {
+    ...doCommand("create-block", g.canGroup, () => void h.onCreateBlock?.()),
+    // The count-free title avoids "the 1 selected steps" while the guard is
+    // closed; `⌘G` opens the block dialog, so the subtitle never claims a run.
+    titleKey: g.canGroup
+      ? "commands.create-block.titleCount"
+      : "commands.create-block.title",
+    titleParams: { count: g.selectedCount },
+  },
+  doCommand("ungroup-block", g.canUngroup, () => void h.onUngroupBlock?.()),
+  doCommand("undo", g.canUndo, () => void h.onUndo?.()),
+  doCommand("redo", g.canRedo, () => void h.onRedo?.()),
+  doCommand("save", g.canSave, () => void h.onSave?.()),
+];

--- a/packages/workout-spa-editor/src/hooks/build-learn-commands.ts
+++ b/packages/workout-spa-editor/src/hooks/build-learn-commands.ts
@@ -1,0 +1,26 @@
+import type { EditorCommand } from "./editor-command.types";
+
+const DOCS_ORIGIN = "https://kaiord.com/docs";
+
+/** The docs site is the one copy of the long form — the palette only links. */
+export const DOCS_URL = `${DOCS_ORIGIN}/`;
+
+const LEARN_PAGES = [
+  { id: "quick-start", path: "/guide/quick-start" },
+  { id: "formats", path: "/formats/krd" },
+  { id: "convert", path: "/convert/" },
+] as const;
+
+export const openDocs = (path: string): void => {
+  window.open(`${DOCS_ORIGIN}${path}`, "_blank", "noopener,noreferrer");
+};
+
+export const buildLearnCommands = (): ReadonlyArray<EditorCommand> =>
+  LEARN_PAGES.map((page) => ({
+    id: `learn-${page.id}`,
+    group: "learn",
+    titleKey: `learn.${page.id}.title`,
+    subtitleKey: `learn.${page.id}.subtitle`,
+    enabled: true,
+    run: () => openDocs(page.path),
+  }));

--- a/packages/workout-spa-editor/src/hooks/editor-command-guards.test.ts
+++ b/packages/workout-spa-editor/src/hooks/editor-command-guards.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest";
+
+import type { KRD, Workout } from "../types/krd";
+import type { EditorCommandGuardInput } from "./editor-command-guards";
+import { buildEditorCommandGuards } from "./editor-command-guards";
+
+const step = (id: string, stepIndex: number) => ({
+  id,
+  stepIndex,
+  durationType: "time" as const,
+  durationValue: 60,
+  targetType: "open" as const,
+  intensity: "active" as const,
+});
+
+const NESTED = step("nested-uuid", 0);
+
+// Block ids are UUIDs from defaultIdProvider(), never the legacy `block-*`.
+const BLOCK = {
+  id: "0f3a9c1e-block-uuid",
+  repeatCount: 3,
+  steps: [NESTED],
+};
+
+const WORKOUT = {
+  steps: [step("step-uuid", 0), BLOCK],
+} as unknown as Workout;
+
+const BLOCKS_ONLY = { steps: [BLOCK] } as unknown as Workout;
+
+const build = (overrides: Partial<EditorCommandGuardInput> = {}) =>
+  buildEditorCommandGuards({
+    currentWorkout: {} as KRD,
+    workout: WORKOUT,
+    selectedStepId: null,
+    selectedStepIds: [],
+    hasClipboard: true,
+    canUndo: false,
+    canRedo: false,
+    ...overrides,
+  });
+
+describe("buildEditorCommandGuards", () => {
+  describe("a top-level step is selected", () => {
+    it("should allow cut, copy and delete", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ selectedStepId: "step-uuid" });
+
+      // Assert
+      expect(guards).toMatchObject({
+        canCut: true,
+        canCopy: true,
+        canDelete: true,
+      });
+    });
+
+    it("should not allow ungroup", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ selectedStepId: "step-uuid" });
+
+      // Assert
+      expect(guards.canUngroup).toBe(false);
+    });
+  });
+
+  describe("a repetition block is selected", () => {
+    it("should allow ungroup", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ selectedStepId: BLOCK.id });
+
+      // Assert
+      expect(guards.canUngroup).toBe(true);
+    });
+
+    it("should refuse cut, copy and delete, which would all no-op", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ selectedStepId: BLOCK.id });
+
+      // Assert
+      expect(guards).toMatchObject({
+        canCut: false,
+        canCopy: false,
+        canDelete: false,
+      });
+    });
+  });
+
+  describe("a step inside a block is selected", () => {
+    it("should refuse cut, copy, delete and ungroup", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ selectedStepId: NESTED.id });
+
+      // Assert
+      expect(guards).toMatchObject({
+        canCut: false,
+        canCopy: false,
+        canDelete: false,
+        canUngroup: false,
+      });
+    });
+  });
+
+  describe("nothing is selected", () => {
+    it("should refuse every selection-dependent command", () => {
+      // Arrange
+
+      // Act
+      const guards = build();
+
+      // Assert
+      expect(guards).toMatchObject({
+        canCut: false,
+        canCopy: false,
+        canDelete: false,
+        canUngroup: false,
+        canGroup: false,
+      });
+    });
+  });
+
+  describe("cut versus a multi-selection", () => {
+    it("should allow cut with one selected id", () => {
+      // Arrange
+
+      // Act
+      const guards = build({
+        selectedStepId: "step-uuid",
+        selectedStepIds: ["step-uuid"],
+      });
+
+      // Assert
+      expect(guards.canCut).toBe(true);
+    });
+
+    it("should refuse cut with two selected ids, as the thunk does", () => {
+      // Arrange
+
+      // Act
+      const guards = build({
+        selectedStepId: "step-uuid",
+        selectedStepIds: ["step-uuid", "other"],
+      });
+
+      // Assert
+      expect(guards).toMatchObject({ canCut: false, canCopy: true });
+    });
+  });
+
+  describe("select-all", () => {
+    it("should allow select-all when a step carries a stepIndex", () => {
+      // Arrange
+
+      // Act
+      const guards = build();
+
+      // Assert
+      expect(guards.canSelectAll).toBe(true);
+    });
+
+    it("should refuse select-all in a blocks-only workout", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ workout: BLOCKS_ONLY });
+
+      // Assert
+      expect(guards.canSelectAll).toBe(false);
+    });
+
+    it("should refuse select-all with no workout", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ workout: undefined });
+
+      // Assert
+      expect(guards.canSelectAll).toBe(false);
+    });
+  });
+
+  describe("paste", () => {
+    it("should allow paste with clipboard content and a workout", () => {
+      // Arrange
+
+      // Act
+      const guards = build();
+
+      // Assert
+      expect(guards.canPaste).toBe(true);
+    });
+
+    it("should refuse paste with an empty clipboard", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ hasClipboard: false });
+
+      // Assert
+      expect(guards.canPaste).toBe(false);
+    });
+
+    it("should refuse paste with no workout to paste into", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ workout: undefined });
+
+      // Assert
+      expect(guards.canPaste).toBe(false);
+    });
+  });
+
+  describe("group", () => {
+    it("should allow group from two selected ids", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ selectedStepIds: ["a", "b"] });
+
+      // Assert
+      expect(guards).toMatchObject({ canGroup: true, selectedCount: 2 });
+    });
+  });
+
+  describe("save", () => {
+    it("should refuse save with no loaded workout", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ currentWorkout: null });
+
+      // Assert
+      expect(guards.canSave).toBe(false);
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/editor-command-guards.ts
+++ b/packages/workout-spa-editor/src/hooks/editor-command-guards.ts
@@ -1,0 +1,50 @@
+import type { FindByIdResult } from "../store/find-by-id";
+import { findById } from "../store/find-by-id";
+import type { KRD, Workout } from "../types/krd";
+import type { EditorCommandGuards } from "./editor-command.types";
+
+export type EditorCommandGuardInput = {
+  currentWorkout: KRD | null;
+  workout: Workout | undefined;
+  selectedStepId: string | null;
+  selectedStepIds: Array<string>;
+  hasClipboard: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+};
+
+/**
+ * The clipboard thunks index by the positional `stepIndex`, and
+ * `getSelectedStepIndex` only resolves top-level steps — a block or a
+ * step-inside-block yields `null` and every one of them returns `false`.
+ */
+const isTopLevelStep = (found: FindByIdResult | null): boolean =>
+  found?.kind === "step" && "stepIndex" in found.step;
+
+/**
+ * Mirror of the guard each `buildKeyboardHandlers` thunk applies internally.
+ * Selection ids are UUIDs, so identity is resolved with `findById`, never by
+ * prefix-matching the legacy `block-*` format.
+ */
+export const buildEditorCommandGuards = (
+  input: EditorCommandGuardInput
+): EditorCommandGuards => {
+  const found = findById(input.workout, input.selectedStepId);
+  const onStep = isTopLevelStep(found);
+  const steps = input.workout?.steps ?? [];
+
+  return {
+    // onCut additionally bails out on a multi-selection.
+    canCut: onStep && input.selectedStepIds.length <= 1,
+    canCopy: onStep,
+    canPaste: input.hasClipboard && !!input.workout,
+    canDelete: onStep,
+    canSelectAll: steps.some((step) => "stepIndex" in step),
+    canGroup: input.selectedStepIds.length >= 2,
+    canUngroup: found?.kind === "block",
+    canUndo: input.canUndo,
+    canRedo: input.canRedo,
+    canSave: !!input.currentWorkout,
+    selectedCount: input.selectedStepIds.length,
+  };
+};

--- a/packages/workout-spa-editor/src/hooks/editor-command.types.ts
+++ b/packages/workout-spa-editor/src/hooks/editor-command.types.ts
@@ -1,0 +1,42 @@
+import type { KeyboardShortcutHandlers } from "./keyboard-shortcut-handlers";
+
+export type EditorCommandGroup = "do" | "learn";
+
+/** One enumerable editor action, rendered by the palette and the context menu. */
+export type EditorCommand = {
+  id: string;
+  group: EditorCommandGroup;
+  /** Dotted key into the `palette` i18n namespace. */
+  titleKey: string;
+  titleParams?: Record<string, string | number>;
+  subtitleKey?: string;
+  /** `SHORTCUT_CATALOG` row id whose chips document this command. */
+  shortcutId?: string;
+  enabled: boolean;
+  run: () => void;
+};
+
+/**
+ * Live availability, one field per command. Each mirrors the guard its own
+ * handler thunk applies, so a row is never offered for an action that would
+ * no-op — sharing a coarser flag across two commands is what let the
+ * right-click menu offer Delete on a repetition block.
+ */
+export type EditorCommandGuards = {
+  canCut: boolean;
+  canCopy: boolean;
+  canPaste: boolean;
+  canDelete: boolean;
+  canSelectAll: boolean;
+  canGroup: boolean;
+  canUngroup: boolean;
+  canUndo: boolean;
+  canRedo: boolean;
+  canSave: boolean;
+  selectedCount: number;
+};
+
+export type EditorCommandInput = {
+  handlers: KeyboardShortcutHandlers;
+  guards: EditorCommandGuards;
+};

--- a/packages/workout-spa-editor/src/hooks/keyboard-shortcut-handlers.ts
+++ b/packages/workout-spa-editor/src/hooks/keyboard-shortcut-handlers.ts
@@ -2,6 +2,7 @@ import { isAltGraphEvent } from "../utils/is-alt-graph-event";
 import { isFormElement } from "../utils/is-form-element";
 import {
   handleAltShortcuts,
+  handleCommandPaletteKey,
   handleModifierShortcuts,
   handlePlainKeys,
 } from "./modifier-shortcut-handlers";
@@ -21,6 +22,7 @@ export type KeyboardShortcutHandlers = {
   onSelectAll?: () => boolean;
   onClearSelection?: () => boolean;
   onShowShortcuts?: () => boolean;
+  onShowCommandPalette?: () => boolean;
 };
 
 // `Record<keyof …, true>` is exhaustive in both directions at compile time:
@@ -42,6 +44,7 @@ const HANDLER_KEY_MAP: Record<keyof KeyboardShortcutHandlers, true> = {
   onSelectAll: true,
   onClearSelection: true,
   onShowShortcuts: true,
+  onShowCommandPalette: true,
 };
 
 export const HANDLER_KEYS = Object.keys(HANDLER_KEY_MAP) as ReadonlyArray<
@@ -53,6 +56,9 @@ export function createKeyDownHandler(
   handlers: KeyboardShortcutHandlers
 ): (event: KeyboardEvent) => void {
   return (event: KeyboardEvent) => {
+    // Ctrl+K/⌘K sits IN FRONT of the form-field guard on purpose: the command
+    // palette is the one binding that must answer while the user is typing.
+    if (handleCommandPaletteKey(event, handlers)) return;
     if (isFormElement(event.target)) return;
     // AltGr characters (e.g. "?" on layouts that produce it that way)
     // dispatch as plain keys ONLY — see isAltGraphEvent.

--- a/packages/workout-spa-editor/src/hooks/modifier-shortcut-handlers.ts
+++ b/packages/workout-spa-editor/src/hooks/modifier-shortcut-handlers.ts
@@ -1,5 +1,22 @@
 import type { KeyboardShortcutHandlers } from "./keyboard-shortcut-handlers";
 
+/**
+ * Ctrl+K/⌘K — the only binding dispatched before the form-field guard, so it
+ * opens the palette from inside an input too. Returns `true` for any matched
+ * chord (handled or not) so the caller stops: the combination has no other
+ * meaning in the app. `Shift` and `Alt` variants fall through untouched.
+ */
+export function handleCommandPaletteKey(
+  event: KeyboardEvent,
+  handlers: KeyboardShortcutHandlers
+): boolean {
+  if (event.altKey || event.shiftKey) return false;
+  if (!event.ctrlKey && !event.metaKey) return false;
+  if (event.key.toLowerCase() !== "k") return false;
+  if (handlers.onShowCommandPalette?.() ?? false) event.preventDefault();
+  return true;
+}
+
 export function handleAltShortcuts(
   event: KeyboardEvent,
   handlers: KeyboardShortcutHandlers

--- a/packages/workout-spa-editor/src/hooks/use-editor-commands.test.ts
+++ b/packages/workout-spa-editor/src/hooks/use-editor-commands.test.ts
@@ -1,0 +1,254 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SHORTCUT_CATALOG } from "../constants/shortcut-catalog";
+import enPalette from "../i18n/locales/en/palette.json";
+import { useEditorCommands } from "./use-editor-commands";
+
+const hoisted = vi.hoisted(() => ({
+  store: {} as Record<string, unknown>,
+  clipboard: false,
+}));
+
+vi.mock("../store/selectors", () => ({
+  useContextMenuStore: () => hoisted.store,
+}));
+
+vi.mock("../store/clipboard-store", () => ({
+  hasClipboardContent: () => hoisted.clipboard,
+}));
+
+const WORKOUT = { steps: [] };
+
+const setStore = (overrides: Record<string, unknown>): void => {
+  hoisted.store = {
+    currentWorkout: { extensions: { structured_workout: WORKOUT } },
+    selectedStepId: null,
+    selectedStepIds: [],
+    selectStep: vi.fn(),
+    clearStepSelection: vi.fn(),
+    deleteStep: vi.fn(),
+    copyStep: vi.fn(),
+    pasteStep: vi.fn(),
+    openCreateBlockDialog: vi.fn(),
+    ungroupRepetitionBlock: vi.fn(),
+    selectAllSteps: vi.fn(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    reorderStep: vi.fn(),
+    ...overrides,
+  };
+};
+
+const resolve = (key: string): unknown =>
+  key
+    .split(".")
+    .reduce<unknown>(
+      (acc, segment) =>
+        acc && typeof acc === "object"
+          ? (acc as Record<string, unknown>)[segment]
+          : undefined,
+      enPalette
+    );
+
+const commands = () =>
+  renderHook(() => useEditorCommands()).result.current.commands;
+
+const byId = (id: string) => commands().find((command) => command.id === id);
+
+describe("useEditorCommands", () => {
+  beforeEach(() => {
+    hoisted.clipboard = false;
+    setStore({});
+  });
+
+  describe("selection-aware guards", () => {
+    it("should disable create-block with a single step selected", () => {
+      // Arrange
+      setStore({ selectedStepId: "step-1", selectedStepIds: ["step-1"] });
+
+      // Act
+      const command = byId("create-block");
+
+      // Assert
+      expect(command?.enabled).toBe(false);
+    });
+
+    it("should enable create-block with two steps selected", () => {
+      // Arrange
+      setStore({ selectedStepIds: ["step-1", "step-2"] });
+
+      // Act
+      const command = byId("create-block");
+
+      // Assert
+      expect(command?.enabled).toBe(true);
+    });
+
+    it("should take the create-block title count from the selection", () => {
+      // Arrange
+      setStore({ selectedStepIds: ["a", "b", "c"] });
+
+      // Act
+      const command = byId("create-block");
+
+      // Assert
+      expect(command?.titleParams).toEqual({ count: 3 });
+    });
+
+    it("should enable undo only when the store can undo", () => {
+      // Arrange
+      setStore({ canUndo: true });
+
+      // Act
+      const enabled = byId("undo")?.enabled;
+
+      // Assert
+      expect(enabled).toBe(true);
+    });
+
+    it("should disable paste while the clipboard is empty", () => {
+      // Arrange
+      hoisted.clipboard = false;
+
+      // Act
+      const enabled = byId("paste")?.enabled;
+
+      // Assert
+      expect(enabled).toBe(false);
+    });
+
+    it("should enable paste once the clipboard holds a step", () => {
+      // Arrange
+      hoisted.clipboard = true;
+
+      // Act
+      const enabled = byId("paste")?.enabled;
+
+      // Assert
+      expect(enabled).toBe(true);
+    });
+
+    it("should disable paste when there is no workout to paste into", () => {
+      // Arrange
+      hoisted.clipboard = true;
+      setStore({ currentWorkout: null });
+
+      // Act
+      const enabled = byId("paste")?.enabled;
+
+      // Assert
+      expect(enabled).toBe(false);
+    });
+  });
+
+  describe("run delegation", () => {
+    it("should open the block dialog rather than grouping directly", () => {
+      // Arrange
+      const openCreateBlockDialog = vi.fn();
+      setStore({ selectedStepIds: ["a", "b"], openCreateBlockDialog });
+
+      // Act
+      byId("create-block")?.run();
+
+      // Assert
+      expect(openCreateBlockDialog).toHaveBeenCalledOnce();
+    });
+
+    it("should delegate undo to the store action", () => {
+      // Arrange
+      const undo = vi.fn();
+      setStore({ canUndo: true, undo });
+
+      // Act
+      byId("undo")?.run();
+
+      // Assert
+      expect(undo).toHaveBeenCalledOnce();
+    });
+
+    it("should not run a store action while the guard is closed", () => {
+      // Arrange
+      const openCreateBlockDialog = vi.fn();
+      setStore({ selectedStepIds: ["a"], openCreateBlockDialog });
+
+      // Act
+      byId("create-block")?.run();
+
+      // Assert
+      expect(openCreateBlockDialog).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("learn entries", () => {
+    it("should open the docs site in a new tab", () => {
+      // Arrange
+      const open = vi.spyOn(window, "open").mockReturnValue(null);
+
+      // Act
+      byId("learn-quick-start")?.run();
+
+      // Assert
+      expect(open).toHaveBeenCalledWith(
+        "https://kaiord.com/docs/guide/quick-start",
+        "_blank",
+        "noopener,noreferrer"
+      );
+    });
+
+    it("should mark every learn entry runnable", () => {
+      // Arrange
+
+      // Act
+      const learn = commands().filter((command) => command.group === "learn");
+
+      // Assert
+      expect(learn.length).toBeGreaterThanOrEqual(2);
+      expect(learn.every((command) => command.enabled)).toBe(true);
+    });
+  });
+
+  describe("catalog and i18n pairing", () => {
+    it("should resolve every shortcutId to a catalog row", () => {
+      // Arrange
+      const ids = new Set(SHORTCUT_CATALOG.map((def) => def.id));
+
+      // Act
+      const strays = commands()
+        .map((command) => command.shortcutId)
+        .filter((id): id is string => id !== undefined)
+        .filter((id) => !ids.has(id));
+
+      // Assert
+      expect(strays).toEqual([]);
+    });
+
+    it("should resolve every title and subtitle in the palette namespace", () => {
+      // Arrange
+      const keys = commands().flatMap((command) =>
+        [command.titleKey, command.subtitleKey].filter(
+          (key): key is string => key !== undefined
+        )
+      );
+
+      // Act
+      const unresolved = keys.filter((key) => typeof resolve(key) !== "string");
+
+      // Assert
+      expect(unresolved).toEqual([]);
+    });
+
+    it("should keep every command id unique", () => {
+      // Arrange
+      const ids = commands().map((command) => command.id);
+
+      // Act
+      const unique = new Set(ids);
+
+      // Assert
+      expect(unique.size).toBe(ids.length);
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/use-editor-commands.ts
+++ b/packages/workout-spa-editor/src/hooks/use-editor-commands.ts
@@ -1,0 +1,54 @@
+import { useCallback } from "react";
+
+import { hasClipboardContent } from "../store/clipboard-store";
+import { useContextMenuStore } from "../store/selectors";
+import type { Workout } from "../types/krd";
+import { buildKeyboardHandlers } from "../utils/build-keyboard-handlers";
+import { getSelectedStepIndex } from "../utils/get-selected-step-index";
+import { buildDoCommands } from "./build-do-commands";
+import { buildLearnCommands } from "./build-learn-commands";
+import type { EditorCommand } from "./editor-command.types";
+import { buildEditorCommandGuards } from "./editor-command-guards";
+
+export type { EditorCommand } from "./editor-command.types";
+
+/**
+ * The one enumerable source of editor commands. `run` always delegates to a
+ * `buildKeyboardHandlers` thunk, so no surface re-implements a store action,
+ * and `enabled` mirrors that thunk's own guard.
+ */
+export function useEditorCommands() {
+  const store = useContextMenuStore();
+  const workout = store.currentWorkout?.extensions?.structured_workout as
+    Workout | undefined;
+
+  const stepIndex = useCallback(
+    () => getSelectedStepIndex(store.selectedStepId, workout),
+    [store.selectedStepId, workout]
+  );
+
+  const handlers = buildKeyboardHandlers({ ...store, workout, stepIndex });
+  const commands: ReadonlyArray<EditorCommand> = [
+    ...buildDoCommands({
+      handlers,
+      guards: buildEditorCommandGuards({
+        currentWorkout: store.currentWorkout,
+        workout,
+        selectedStepId: store.selectedStepId,
+        selectedStepIds: store.selectedStepIds,
+        hasClipboard: hasClipboardContent(),
+        canUndo: store.canUndo,
+        canRedo: store.canRedo,
+      }),
+    }),
+    ...buildLearnCommands(),
+  ];
+
+  return {
+    commands,
+    selectedStepId: store.selectedStepId,
+    selectedStepIds: store.selectedStepIds,
+    selectStep: store.selectStep,
+    clearStepSelection: store.clearStepSelection,
+  };
+}

--- a/packages/workout-spa-editor/src/hooks/use-editor-context-menu.test.ts
+++ b/packages/workout-spa-editor/src/hooks/use-editor-context-menu.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Composite coverage for store -> guards -> context-menu props.
+ *
+ * `EditorContextMenuContent.test.tsx` is presentational: it feeds `show*` in by
+ * hand, so a botched guard leaves it green. This pins the whole chain, and in
+ * particular that block identity is resolved by `findById` rather than by
+ * prefix-matching the legacy `block-*` id format.
+ */
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Workout } from "../types/krd";
+import { useEditorContextMenu } from "./use-editor-context-menu";
+
+const hoisted = vi.hoisted(() => ({
+  store: {} as Record<string, unknown>,
+  clipboard: false,
+}));
+
+vi.mock("../store/selectors", () => ({
+  useContextMenuStore: () => hoisted.store,
+}));
+
+vi.mock("../store/clipboard-store", () => ({
+  hasClipboardContent: () => hoisted.clipboard,
+}));
+
+const step = (id: string, stepIndex: number) => ({
+  id,
+  stepIndex,
+  durationType: "time" as const,
+  durationValue: 60,
+  targetType: "open" as const,
+  intensity: "active" as const,
+});
+
+const NESTED = step("nested-uuid", 0);
+const BLOCK = { id: "9b1c-uuid-block", repeatCount: 3, steps: [NESTED] };
+const STEP = step("step-uuid", 0);
+
+const workoutOf = (steps: Array<unknown>) => ({ steps }) as unknown as Workout;
+
+const setStore = (overrides: Record<string, unknown> = {}): void => {
+  const workout = (overrides.workout as Workout) ?? workoutOf([STEP, BLOCK]);
+  hoisted.store = {
+    currentWorkout: { extensions: { structured_workout: workout } },
+    selectedStepId: null,
+    selectedStepIds: [],
+    selectStep: vi.fn(),
+    clearStepSelection: vi.fn(),
+    deleteStep: vi.fn(),
+    copyStep: vi.fn(),
+    pasteStep: vi.fn(),
+    openCreateBlockDialog: vi.fn(),
+    ungroupRepetitionBlock: vi.fn(),
+    selectAllSteps: vi.fn(),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    reorderStep: vi.fn(),
+    ...overrides,
+  };
+};
+
+const menuOf = () => renderHook(() => useEditorContextMenu()).result.current;
+
+describe("useEditorContextMenu", () => {
+  beforeEach(() => {
+    hoisted.clipboard = false;
+    setStore();
+  });
+
+  describe("a repetition block is selected", () => {
+    it("should offer ungroup", () => {
+      // Arrange
+      setStore({ selectedStepId: BLOCK.id });
+
+      // Act
+      const menu = menuOf().menu;
+
+      // Assert
+      expect(menu.showUngroup).toBe(true);
+    });
+
+    it("should not offer cut, copy or delete on a UUID block id", () => {
+      // Arrange
+      setStore({ selectedStepId: BLOCK.id });
+
+      // Act
+      const menu = menuOf().menu;
+
+      // Assert
+      expect(menu).toMatchObject({
+        showCut: false,
+        showCopy: false,
+        showDelete: false,
+      });
+    });
+  });
+
+  describe("a step inside a block is selected", () => {
+    it("should offer neither the clipboard items nor ungroup", () => {
+      // Arrange
+      setStore({ selectedStepId: NESTED.id });
+
+      // Act
+      const menu = menuOf().menu;
+
+      // Assert
+      expect(menu).toMatchObject({
+        showCut: false,
+        showCopy: false,
+        showDelete: false,
+        showUngroup: false,
+      });
+    });
+  });
+
+  describe("a top-level step is selected", () => {
+    it("should offer cut, copy and delete but not ungroup", () => {
+      // Arrange
+      setStore({ selectedStepId: STEP.id });
+
+      // Act
+      const menu = menuOf().menu;
+
+      // Assert
+      expect(menu).toMatchObject({
+        showCut: true,
+        showCopy: true,
+        showDelete: true,
+        showUngroup: false,
+      });
+    });
+  });
+
+  describe("a blocks-only workout", () => {
+    it("should not offer select-all", () => {
+      // Arrange
+      setStore({ workout: workoutOf([BLOCK]) });
+
+      // Act
+      const menu = menuOf().menu;
+
+      // Assert
+      expect(menu.showSelectAll).toBe(false);
+    });
+
+    it("should still offer ungroup for the selected block", () => {
+      // Arrange
+      setStore({ workout: workoutOf([BLOCK]), selectedStepId: BLOCK.id });
+
+      // Act
+      const menu = menuOf().menu;
+
+      // Assert
+      expect(menu.showUngroup).toBe(true);
+    });
+  });
+
+  // The one visible change this fix makes to the shipped menu. Delete has
+  // never worked on a multi-selection: both `toggleStepSelection` and
+  // `selectAllSteps` leave `selectedStepId` null, so `onDelete` had no step to
+  // act on and returned false. The menu offered it anyway; now it says so.
+  describe("a multi-selection with no focused step", () => {
+    it("should not offer delete, which has always been a no-op here", () => {
+      // Arrange
+      setStore({ selectedStepId: null, selectedStepIds: [STEP.id, "other"] });
+
+      // Act
+      const menu = menuOf().menu;
+
+      // Assert
+      expect(menu.showDelete).toBe(false);
+    });
+
+    it("should still offer group, which is what a multi-selection is for", () => {
+      // Arrange
+      setStore({ selectedStepId: null, selectedStepIds: [STEP.id, "other"] });
+
+      // Act
+      const menu = menuOf().menu;
+
+      // Assert
+      expect(menu.showGroup).toBe(true);
+    });
+
+    it("should keep the menu open rather than suppressing it entirely", () => {
+      // Arrange
+      setStore({ selectedStepId: null, selectedStepIds: [STEP.id, "other"] });
+
+      // Act
+      const ctx = menuOf();
+
+      // Assert
+      expect(ctx.hasAnyAction).toBe(true);
+    });
+  });
+
+  describe("suppression", () => {
+    it("should report no action for an empty workout and empty clipboard", () => {
+      // Arrange
+      setStore({ workout: workoutOf([]) });
+
+      // Act
+      const ctx = menuOf();
+
+      // Assert
+      expect(ctx.hasAnyAction).toBe(false);
+    });
+
+    it("should report an action once the clipboard holds a step", () => {
+      // Arrange
+      hoisted.clipboard = true;
+      setStore({ workout: workoutOf([]) });
+
+      // Act
+      const ctx = menuOf();
+
+      // Assert
+      expect(ctx.hasAnyAction).toBe(true);
+    });
+  });
+
+  describe("action wiring", () => {
+    it("should ungroup the selected block through the store action", () => {
+      // Arrange
+      const ungroupRepetitionBlock = vi.fn();
+      setStore({ selectedStepId: BLOCK.id, ungroupRepetitionBlock });
+
+      // Act
+      menuOf().menu.onUngroup();
+
+      // Assert
+      expect(ungroupRepetitionBlock).toHaveBeenCalledWith(BLOCK.id);
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/use-editor-context-menu.ts
+++ b/packages/workout-spa-editor/src/hooks/use-editor-context-menu.ts
@@ -1,41 +1,20 @@
-import { useCallback } from "react";
+import {
+  contextMenuPropsFrom,
+  hasAnyContextMenuAction,
+} from "../components/organisms/EditorContextMenu/context-menu-props-from-commands";
+import { useEditorCommands } from "./use-editor-commands";
 
-import { hasClipboardContent } from "../store/clipboard-store";
-import { useContextMenuStore } from "../store/selectors";
-import type { Workout } from "../types/krd";
-import { buildKeyboardHandlers } from "../utils/build-keyboard-handlers";
-import { getSelectedStepIndex } from "../utils/get-selected-step-index";
-
+/**
+ * Context-menu view of `useEditorCommands`. The menu is a projection of the
+ * shared command list, never a second copy of the action set.
+ */
 export function useEditorContextMenu() {
-  const store = useContextMenuStore();
-  const workout = store.currentWorkout?.extensions?.structured_workout as
-    Workout | undefined;
-
-  const stepIndex = useCallback(
-    () => getSelectedStepIndex(store.selectedStepId, workout),
-    [store.selectedStepId, workout]
-  );
-
-  const handlers = buildKeyboardHandlers({ ...store, workout, stepIndex });
-  const sid = store.selectedStepId;
-  const hasSingle = !!sid && !sid.startsWith("block-");
-  const hasSelection = !!sid || store.selectedStepIds.length > 0;
-  const hasSteps = !!workout && workout.steps.length > 0;
-  const hasClipboard = hasClipboardContent();
+  const { commands, ...selection } = useEditorCommands();
+  const menu = contextMenuPropsFrom(commands);
 
   return {
-    handlers,
-    hasAnyAction: hasSelection || hasClipboard || hasSteps,
-    showCut: hasSingle,
-    showCopy: hasSingle,
-    showPaste: hasClipboard,
-    showDelete: hasSelection,
-    showSelectAll: hasSteps,
-    showGroup: store.selectedStepIds.length >= 2,
-    showUngroup: !!sid?.startsWith("block-"),
-    selectedStepId: sid,
-    selectedStepIds: store.selectedStepIds,
-    selectStep: store.selectStep,
-    clearStepSelection: store.clearStepSelection,
+    menu,
+    hasAnyAction: hasAnyContextMenuAction(menu),
+    ...selection,
   };
 }

--- a/packages/workout-spa-editor/src/hooks/use-keyboard-shortcuts.test.ts
+++ b/packages/workout-spa-editor/src/hooks/use-keyboard-shortcuts.test.ts
@@ -981,6 +981,172 @@ describe("useKeyboardShortcuts", () => {
     });
   });
 
+  describe("command palette shortcut", () => {
+    it.each([
+      { label: "Ctrl+K", init: { key: "k", ctrlKey: true } },
+      { label: "Cmd+K", init: { key: "k", metaKey: true } },
+      { label: "uppercase Ctrl+K", init: { key: "K", ctrlKey: true } },
+    ])("should call onShowCommandPalette on $label", ({ init }) => {
+      // Arrange
+      const onShowCommandPalette = vi.fn().mockReturnValue(true);
+      renderHook(() => useKeyboardShortcuts({ onShowCommandPalette }));
+      const event = new KeyboardEvent("keydown", {
+        ...init,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      // Act
+      window.dispatchEvent(event);
+
+      // Assert
+      expect(onShowCommandPalette).toHaveBeenCalledOnce();
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    // The differentiator vs `?`: the palette must answer mid-typing.
+    it.each([{ tag: "input" as const }, { tag: "textarea" as const }])(
+      "should still fire while typing in a $tag",
+      ({ tag }) => {
+        // Arrange
+        const onShowCommandPalette = vi.fn().mockReturnValue(true);
+        renderHook(() => useKeyboardShortcuts({ onShowCommandPalette }));
+        const el = document.createElement(tag);
+        document.body.appendChild(el);
+        const event = new KeyboardEvent("keydown", {
+          key: "k",
+          metaKey: true,
+          bubbles: true,
+        });
+
+        // Act
+        el.dispatchEvent(event);
+        el.remove();
+
+        // Assert
+        expect(onShowCommandPalette).toHaveBeenCalledOnce();
+      }
+    );
+
+    it("should still fire while typing in a contentEditable region", () => {
+      // Arrange
+      const onShowCommandPalette = vi.fn().mockReturnValue(true);
+      renderHook(() => useKeyboardShortcuts({ onShowCommandPalette }));
+      const el = document.createElement("div");
+      el.contentEditable = "true";
+      document.body.appendChild(el);
+      const event = new KeyboardEvent("keydown", {
+        key: "k",
+        ctrlKey: true,
+        bubbles: true,
+      });
+
+      // Act
+      el.dispatchEvent(event);
+      el.remove();
+
+      // Assert
+      expect(onShowCommandPalette).toHaveBeenCalledOnce();
+    });
+
+    it("should not fire on an unmodified k", () => {
+      // Arrange
+      const onShowCommandPalette = vi.fn().mockReturnValue(true);
+      renderHook(() => useKeyboardShortcuts({ onShowCommandPalette }));
+      const event = new KeyboardEvent("keydown", { key: "k", bubbles: true });
+
+      // Act
+      window.dispatchEvent(event);
+
+      // Assert
+      expect(onShowCommandPalette).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      {
+        label: "Ctrl+Shift+K",
+        init: { key: "k", ctrlKey: true, shiftKey: true },
+      },
+      { label: "Ctrl+Alt+K", init: { key: "k", ctrlKey: true, altKey: true } },
+    ])("should not fire on $label", ({ init }) => {
+      // Arrange
+      const onShowCommandPalette = vi.fn().mockReturnValue(true);
+      renderHook(() => useKeyboardShortcuts({ onShowCommandPalette }));
+      const event = new KeyboardEvent("keydown", { ...init, bubbles: true });
+
+      // Act
+      window.dispatchEvent(event);
+
+      // Assert
+      expect(onShowCommandPalette).not.toHaveBeenCalled();
+    });
+
+    it("should not preventDefault when the handler returns false", () => {
+      // Arrange
+      const onShowCommandPalette = vi.fn().mockReturnValue(false);
+      renderHook(() => useKeyboardShortcuts({ onShowCommandPalette }));
+      const event = new KeyboardEvent("keydown", {
+        key: "k",
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true,
+      });
+
+      // Act
+      window.dispatchEvent(event);
+
+      // Assert
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it.each([
+      { label: "Ctrl+S", init: { key: "s", ctrlKey: true }, handler: "onSave" },
+      { label: "Ctrl+C", init: { key: "c", ctrlKey: true }, handler: "onCopy" },
+      {
+        label: "Ctrl+G",
+        init: { key: "g", ctrlKey: true },
+        handler: "onCreateBlock",
+      },
+    ])(
+      "should leave $label untouched while ⌘K is bound",
+      ({ init, handler }) => {
+        // Arrange
+        const other = vi.fn().mockReturnValue(true);
+        const onShowCommandPalette = vi.fn().mockReturnValue(true);
+        renderHook(() =>
+          useKeyboardShortcuts({ [handler]: other, onShowCommandPalette })
+        );
+        const event = new KeyboardEvent("keydown", { ...init, bubbles: true });
+
+        // Act
+        window.dispatchEvent(event);
+
+        // Assert
+        expect(other).toHaveBeenCalledOnce();
+        expect(onShowCommandPalette).not.toHaveBeenCalled();
+      }
+    );
+
+    it("should keep ? behind the form-field guard while ⌘K is bound", () => {
+      // Arrange
+      const onShowShortcuts = vi.fn().mockReturnValue(true);
+      const onShowCommandPalette = vi.fn().mockReturnValue(true);
+      renderHook(() =>
+        useKeyboardShortcuts({ onShowShortcuts, onShowCommandPalette })
+      );
+      const el = document.createElement("input");
+      document.body.appendChild(el);
+      const event = new KeyboardEvent("keydown", { key: "?", bubbles: true });
+
+      // Act
+      el.dispatchEvent(event);
+      el.remove();
+
+      // Assert
+      expect(onShowShortcuts).not.toHaveBeenCalled();
+    });
+  });
+
   describe("contentEditable passthrough", () => {
     it("should not intercept Ctrl+C when target is contentEditable", () => {
       // Arrange

--- a/packages/workout-spa-editor/src/i18n/locales/en/help.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/help.json
@@ -60,7 +60,8 @@
     },
     "help": {
       "heading": "Help",
-      "showShortcuts": "Show keyboard shortcuts"
+      "showShortcuts": "Show keyboard shortcuts",
+      "showCommandPalette": "Open the command palette"
     }
   },
   "examples": {

--- a/packages/workout-spa-editor/src/i18n/locales/en/palette.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/palette.json
@@ -1,0 +1,83 @@
+{
+  "title": "Command palette",
+  "searchLabel": "Search commands",
+  "searchPlaceholder": "Search commands…",
+  "listLabel": "Commands",
+  "empty": "Nothing matches that search.",
+  "groups": {
+    "do": "Do it",
+    "learn": "Learn"
+  },
+  "footer": {
+    "run": "↵ run",
+    "shortcuts": "? all shortcuts",
+    "docs": "Full documentation ↗"
+  },
+  "commands": {
+    "cut": {
+      "title": "Cut the selected step",
+      "subtitle": "Removes it and puts it on the clipboard",
+      "requires": "Select a single step in the main list"
+    },
+    "copy": {
+      "title": "Copy the selected step",
+      "subtitle": "Puts it on the clipboard",
+      "requires": "Select a step in the main list"
+    },
+    "paste": {
+      "title": "Paste the copied step",
+      "subtitle": "Inserts it after the current selection",
+      "requires": "Copy or cut a step first"
+    },
+    "delete": {
+      "title": "Delete the selected step",
+      "subtitle": "Removes it from the workout",
+      "requires": "Select a step in the main list"
+    },
+    "select-all": {
+      "title": "Select every step",
+      "subtitle": "Selects all steps in the workout",
+      "requires": "Add a step first"
+    },
+    "create-block": {
+      "title": "Group the selected steps into a block",
+      "titleCount": "Group the {{count}} selected steps into a block",
+      "subtitle": "Opens the repetition-block dialog",
+      "requires": "Select 2 or more steps"
+    },
+    "ungroup-block": {
+      "title": "Ungroup the selected block",
+      "subtitle": "Replaces the block with its steps",
+      "requires": "Select a repetition block"
+    },
+    "undo": {
+      "title": "Undo the last change",
+      "subtitle": "Steps back through the edit history",
+      "requires": "Nothing to undo"
+    },
+    "redo": {
+      "title": "Redo the last undone change",
+      "subtitle": "Steps forward through the edit history",
+      "requires": "Nothing to redo"
+    },
+    "save": {
+      "title": "Save the workout",
+      "subtitle": "Downloads it as a .krd file",
+      "requires": "Open a workout first"
+    }
+  },
+  "learn": {
+    "quick-start": {
+      "title": "Quick start guide",
+      "subtitle": "Opens the documentation in a new tab"
+    },
+    "formats": {
+      "title": "How workouts are stored (KRD)",
+      "subtitle": "Opens the documentation in a new tab"
+    },
+    "convert": {
+      "title": "Convert between file formats",
+      "subtitle": "Opens the documentation in a new tab"
+    }
+  }
+}

--- a/packages/workout-spa-editor/src/i18n/locales/es/help.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/help.json
@@ -60,7 +60,8 @@
     },
     "help": {
       "heading": "Ayuda",
-      "showShortcuts": "Mostrar atajos de teclado"
+      "showShortcuts": "Mostrar atajos de teclado",
+      "showCommandPalette": "Abrir la paleta de comandos"
     }
   },
   "examples": {

--- a/packages/workout-spa-editor/src/i18n/locales/es/palette.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/palette.json
@@ -1,0 +1,83 @@
+{
+  "title": "Paleta de comandos",
+  "searchLabel": "Buscar comandos",
+  "searchPlaceholder": "Buscar comandos…",
+  "listLabel": "Comandos",
+  "empty": "No hay coincidencias para esa búsqueda.",
+  "groups": {
+    "do": "Hazlo",
+    "learn": "Aprende"
+  },
+  "footer": {
+    "run": "↵ ejecutar",
+    "shortcuts": "? todos los atajos",
+    "docs": "Documentación completa ↗"
+  },
+  "commands": {
+    "cut": {
+      "title": "Cortar el paso seleccionado",
+      "subtitle": "Lo elimina y lo deja en el portapapeles",
+      "requires": "Selecciona un único paso de la lista principal"
+    },
+    "copy": {
+      "title": "Copiar el paso seleccionado",
+      "subtitle": "Lo deja en el portapapeles",
+      "requires": "Selecciona un paso de la lista principal"
+    },
+    "paste": {
+      "title": "Pegar el paso copiado",
+      "subtitle": "Lo inserta tras la selección actual",
+      "requires": "Copia o corta antes un paso"
+    },
+    "delete": {
+      "title": "Eliminar el paso seleccionado",
+      "subtitle": "Lo quita del entrenamiento",
+      "requires": "Selecciona un paso de la lista principal"
+    },
+    "select-all": {
+      "title": "Seleccionar todos los pasos",
+      "subtitle": "Selecciona todos los pasos del entrenamiento",
+      "requires": "Añade antes un paso"
+    },
+    "create-block": {
+      "title": "Agrupar los pasos seleccionados en un bloque",
+      "titleCount": "Agrupar los {{count}} pasos seleccionados en un bloque",
+      "subtitle": "Abre el diálogo de bloque de repeticiones",
+      "requires": "Selecciona 2 pasos o más"
+    },
+    "ungroup-block": {
+      "title": "Desagrupar el bloque seleccionado",
+      "subtitle": "Sustituye el bloque por sus pasos",
+      "requires": "Selecciona un bloque de repeticiones"
+    },
+    "undo": {
+      "title": "Deshacer el último cambio",
+      "subtitle": "Retrocede en el historial de edición",
+      "requires": "No hay nada que deshacer"
+    },
+    "redo": {
+      "title": "Rehacer el último cambio deshecho",
+      "subtitle": "Avanza en el historial de edición",
+      "requires": "No hay nada que rehacer"
+    },
+    "save": {
+      "title": "Guardar el entrenamiento",
+      "subtitle": "Lo descarga como archivo .krd",
+      "requires": "Abre antes un entrenamiento"
+    }
+  },
+  "learn": {
+    "quick-start": {
+      "title": "Guía de inicio rápido",
+      "subtitle": "Abre la documentación en una pestaña nueva"
+    },
+    "formats": {
+      "title": "Cómo se guardan los entrenamientos (KRD)",
+      "subtitle": "Abre la documentación en una pestaña nueva"
+    },
+    "convert": {
+      "title": "Convertir entre formatos de archivo",
+      "subtitle": "Abre la documentación en una pestaña nueva"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Wave K2 of the Help redesign (`add-command-palette` OpenSpec change included). The palette answers *"how do I…"* and *"do this for me"* in the same list and teaches the shortcut on the way past. **⌘K opens it ahead of the form-field guard**, so it's reachable while typing — unlike the `?` sheet from K1.

The larger change is underneath: the editor's actions become **one enumerable command list**, and the right-click menu is now a projection over it, so palette and menu cannot drift.

## Building that list exposed a live bug it then had to fix

Both menus decided *"is a block selected?"* with `id.startsWith("block-")` — but **block ids are UUIDs**. Only blocks migrated from legacy data carry that prefix, and `build-step-handlers.ts` already carried a comment saying the check was unreliable.

With a block selected, the menu offered **Cut, Copy and Delete — all no-ops** — and **hid Ungroup, the one that worked**. Guards now derive from the same `findById` predicate the thunks use, with **one field per command** instead of shared coarse flags, so tightening one can never silently change another. That structure immediately surfaced a fourth case: cut also refuses a multi-selection.

**Delete therefore disappears from the menu** when a block or a multi-selection is active. It was already dead in both — selecting several steps leaves `selectedStepId` null, so `onDelete` never had a step to act on. The menu now says so instead of offering it.

> Product note, not a regression: **multi-select → Delete has never worked**, by menu or keyboard — there is no multi-delete path. This makes the gap visible; the capability itself is missing and worth its own ticket.

## Copy honesty
The create-block row states it **opens the dialog** (⌘G opens a dialog); delete is **singular** because it acts on one step; move-up/move-down are **absent** because their guard is positional and only the thunk can evaluate it — a row would render runnable and no-op at the list ends.

## Review trail
Two adversarial passes. The reviewer rebuilt the guard truth table from the thunks independently, proved every withdrawn menu case was already dead (the load-bearing one: both `toggleStepSelection` and `selectAllSteps` null out `selectedStepId`), verified the new tests would have caught the original defect, and checked the no-exit-animation claim **against the built stylesheet** rather than the source.

## Verification
845 files / **5992 tests** green (+139 vs main) · `tsc -b` clean · lint clean end-to-end · palette in its own **5.5 kB** lazy chunk · EN/ES parity · `openspec validate` valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an editor command palette accessible with **Ctrl+K** or **⌘K**, including search, grouped actions, keyboard navigation, shortcuts, and documentation links.
  * Commands now display availability explanations and localized English and Spanish text.
  * Context-menu actions are synchronized with the command palette and accurately reflect available editor actions.

* **Bug Fixes**
  * Prevented unavailable context-menu actions from appearing or performing no-ops.
  * Ensured the command palette shortcut works while typing in form fields.

* **Tests**
  * Added comprehensive coverage for palette behavior, accessibility, shortcuts, command availability, and context-menu integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->