### PR TITLE
fix(spa-editor): stop block-actions menu clicks from also selecting the block

### DIFF
--- a/packages/workout-spa-editor/src/components/molecules/RepetitionBlockCard/RepetitionBlockCard.test.tsx
+++ b/packages/workout-spa-editor/src/components/molecules/RepetitionBlockCard/RepetitionBlockCard.test.tsx
@@ -404,6 +404,32 @@ describe("RepetitionBlockCard", () => {
       // Assert
       expect(onEditRepeatCount).not.toHaveBeenCalled();
     });
+
+    it("should open inline editor via the block-actions menu without also selecting the block", async () => {
+      // Arrange
+      // Radix menu items render through a Portal to document.body, outside
+      // the card's DOM subtree, so a regression here would let the click
+      // bubble (via React's synthetic event tree) up to the card's own
+      // onClick and misfire onBlockSelect.
+      const onBlockSelect = vi.fn();
+      const user = userEvent.setup();
+      render(
+        <RepetitionBlockCard
+          block={mockBlock}
+          blockIndex={0}
+          onBlockSelect={onBlockSelect}
+          onDelete={vi.fn()}
+        />
+      );
+
+      // Act
+      await user.click(screen.getByTestId("block-actions-trigger"));
+      await user.click(screen.getByRole("menuitem", { name: /edit count/i }));
+
+      // Assert
+      expect(screen.getByTestId("repeat-count-input")).toBeInTheDocument();
+      expect(onBlockSelect).not.toHaveBeenCalled();
+    });
   });
 
   describe("step management", () => {

--- a/packages/workout-spa-editor/src/components/molecules/RepetitionBlockCard/repetition-block-card.helpers.ts
+++ b/packages/workout-spa-editor/src/components/molecules/RepetitionBlockCard/repetition-block-card.helpers.ts
@@ -24,9 +24,18 @@ export function buildBlockClasses(
 
 /**
  * Determine if a click event originated from a control element.
+ *
+ * Radix dropdown menu items render through a Portal to `document.body`,
+ * so `target` sits outside the block card's DOM subtree even though React's
+ * synthetic event still bubbles the click up to the card's onClick. Without
+ * the `[role="menuitem"]` check, selecting any block-actions-menu item (Edit
+ * Count, Add Step, Ungroup, Delete) also fires the card's own block-select
+ * handler.
  */
 export function isControlClick(target: HTMLElement): boolean {
-  return !!target.closest("button, input, [data-testid='step-card']");
+  return !!target.closest(
+    "button, input, [role='menuitem'], [data-testid='step-card']"
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- Radix dropdown menu items render through a Portal to `document.body`, so `isControlClick`'s `target.closest("button, input, ...")` never finds a matching ancestor for a menu-item click, even though the click's synthetic event still bubbles to the block card's own `onClick` via React's portal event handling.
- Result: clicking any block-actions-menu item (Edit Count, Add Step, Ungroup, Delete) also fires `onBlockSelect` as an unintended side effect.
- Fix: recognize `[role='menuitem']` as a control element too.

## Context
Investigated while triaging why `main`'s `e2e-frontend` shard 4 job has been consistently red today (`repetition-blocks.spec.ts › should open inline editor via Edit Count menu item`, unrelated to any of today's dependency bumps — component/test code unchanged for months, and today's CI history shows the failure appears on every run where e2e-frontend actually executes).

This is a real, independently-verified bug in `isControlClick` regardless of whether it's the root cause of that specific e2e failure. I could **not** reproduce the e2e failure locally in jsdom/RTL (added a regression test — `should open inline editor via the block-actions menu without also selecting the block` — which passes both with and without the fix, so Radix likely handles event propagation differently there than in a real browser). Opening this as its own PR so the real `e2e-frontend` CI job can verify empirically whether this resolves shard 4.

## Test plan
- [x] `RepetitionBlockCard.test.tsx` — added regression test asserting `onBlockSelect` is not called when using the context-menu Edit Count path
- [x] Full `RepetitionBlockCard` suite (94 tests) passes
- [ ] Watch `e2e-frontend (4)` on this PR's CI run to see if `repetition-blocks.spec.ts` now passes

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed block selection being triggered when choosing an action from the block menu.
  * Selecting “Edit count” now opens the repeat-count editor without selecting the block.

* **Tests**
  * Added regression coverage for the block menu’s “Edit count” interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->