### PR TITLE
fix(spa-editor): tolerate minor pixel diffs in visual regression screenshots

### DIFF
--- a/packages/workout-spa-editor/playwright.config.ts
+++ b/packages/workout-spa-editor/playwright.config.ts
@@ -27,6 +27,12 @@ export default defineConfig({
 
   expect: {
     timeout: 10_000, // 10s for assertions (Dexie clear + reload is slow on Mobile Safari)
+    toHaveScreenshot: {
+      // Absorb CI font-hinting/anti-aliasing jitter between runs (observed:
+      // ~0.01% of pixels on coaching-sidebar.visual.spec.ts) without masking
+      // real visual regressions.
+      maxDiffPixelRatio: 0.01,
+    },
   },
 
   // Global timeout for tests


### PR DESCRIPTION
## Summary
- \`toHaveScreenshot\` had no \`maxDiffPixelRatio\` configured, so any sub-pixel anti-aliasing/font-hinting jitter between CI runs fails the whole assertion.
- \`coaching-sidebar.visual.spec.ts\` has been intermittently red on \`main\` today with no related code change (observed: 27 pixels / 0.01% diff on the mobile screenshot).
- Allow up to 1% pixel drift globally — comfortably above observed noise, well under what an actual visual regression would produce.

## Context
Last remaining red job on \`main\`'s \`e2e-frontend\` matrix after #1066 fixed the other (deterministic) failure in that same job group today.

Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>