### PR TITLE
feat(spa-editor): multi-select delete with grouped undo

### DIFF
--- a/openspec/changes/add-editor-multi-delete/proposal.md
+++ b/openspec/changes/add-editor-multi-delete/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+The workout editor supports multi-selection (`selectedStepIds`, populated by
+ctrl/cmd-click and by `⌘A`), and uses it to group steps into a repetition
+block. But **no bulk delete has ever existed**. This is a capability gap, not a
+regression — the UI briefly advertised a menu entry that was removed in wave K2
+because it did nothing.
+
+The command silently no-ops today for a structural reason. `selectedStepId`
+(scalar) and `selectedStepIds` (array) are mutually exclusive by design:
+`selectStep` clears the array, while `toggleStepSelection` and `selectAllSteps`
+both null the scalar. A multi-selection is therefore _definitionally_
+`selectedStepId === null`. Every delete path — the `onDelete` keyboard thunk and
+the `canDelete` guard alike — reads only the scalar, so it resolves to `null`
+and returns `false`. This is true even for a **single** toggle-selected step.
+
+The naive fix is wrong. `deleteStepAction` reindexes the entire list after every
+call, so mapping the selection to indices and looping the singular action
+deletes the _wrong_ steps from the second iteration onward.
+
+## What Changes
+
+- Add a `deleteSteps(stepIndices)` store action that removes every addressed
+  main-list step in **one** state update: one filter pass, one reindex, **one**
+  history snapshot (so one `⌘Z` undoes the whole operation), and **one** grouped
+  undo entry set.
+- Introduce a stable `groupId` on the delete-undo trail and re-key `undoDelete`
+  from `timestamp` to `groupId`. `Date.now()` is not an identity: N deletes
+  inside one millisecond share a value, and `undoDelete` did
+  `find(d => d.timestamp === t)` then `filter(d => d.timestamp !== t)` — it
+  restored **one** entry and discarded the rest. That was silent data loss.
+  `timestamp` is retained, but now serves only the TTL sweep.
+- Grouped restore re-inserts items in **ascending** original-index order, so a
+  non-contiguous selection lands back in the right places.
+- Teach the `canDelete` guard and the `onDelete` thunk to read `selectedStepIds`,
+  fixing the single-toggle-selection no-op as a side effect.
+- Focus after a bulk delete uses the already-present but previously unwired
+  `nextAfterMultiDelete` rule.
+
+## Scope boundaries
+
+- **Main-list only.** By the single-parent invariant a multi-selection is either
+  all main-list or all inside one block. The nested (inside-block) path needs a
+  block-scoped `deleteStepInRepetitionBlock` action, which **does not exist on
+  `main`** — it lives on the unmerged branch carrying commit `fa943f55`.
+  Rather than author a conflicting duplicate, the guard keeps nested
+  multi-selections non-deletable, which is exactly today's behaviour (no
+  regression). The block-emptying cascade required by
+  `spa-editor-focus-management` therefore remains that change's responsibility.
+- **Delete only, not copy.** `canCopy` is also scalar-bound, so copy is dead
+  under multi-selection too. Enabling it requires a multi-step clipboard payload
+  (`copyStepAction` / `pasteStepAction` both marshal exactly one step), which is
+  a materially larger change with its own round-trip concerns. Left out
+  deliberately; `canCut` continues to refuse multi-selections for the same
+  reason.
+
+## Impact
+
+- Affected specs: `spa-editor-multi-delete` (new).
+- Affected code: `packages/workout-spa-editor/src/store/actions/` (new
+  `delete-steps-action`, re-keyed `undo-delete-action`), the store action
+  surface and selectors, `editor-command-guards`, `build-clipboard-handlers`.
+- Behaviour preserved: single-step delete still emits one toast per delete and
+  remains independently undoable (a single delete is simply a group of one), so
+  the existing `e2e/delete-undo.spec.ts` "separate notifications for multiple
+  deletions" expectation — which performs two sequential _singular_ deletes —
+  continues to hold unchanged.

--- a/openspec/changes/add-editor-multi-delete/specs/spa-editor-multi-delete/spec.md
+++ b/openspec/changes/add-editor-multi-delete/specs/spa-editor-multi-delete/spec.md
@@ -1,0 +1,127 @@
+## ADDED Requirements
+
+### Requirement: Bulk delete of a main-list multi-selection
+
+The editor SHALL delete every top-level step addressed by a multi-selection in a
+single state update. The removal SHALL filter the step list exactly once and
+reindex exactly once, so that the set of removed steps is precisely the selected
+set. Indices addressing no step SHALL be ignored, and an empty selection SHALL
+leave the workout, the history, and the undo trail untouched.
+
+#### Scenario: A non-contiguous selection removes exactly the selected steps
+
+- **GIVEN** a main list of five steps whose `stepIndex` values are 0 through 4
+- **WHEN** the steps at `stepIndex` 1 and 3 are bulk-deleted
+- **THEN** exactly those two steps SHALL be removed
+- **AND** the three survivors SHALL be the original steps 0, 2 and 4, in that order
+
+#### Scenario: Survivors are reindexed into a dense range
+
+- **GIVEN** a main list of five steps
+- **WHEN** two of them are bulk-deleted
+- **THEN** the surviving steps SHALL carry `stepIndex` 0, 1 and 2
+
+#### Scenario: Unmatched indices are ignored
+
+- **GIVEN** a main list of five steps
+- **WHEN** a bulk delete addresses `stepIndex` 1 and a `stepIndex` that matches no step
+- **THEN** only the step at `stepIndex` 1 SHALL be removed
+
+#### Scenario: An empty selection is inert
+
+- **WHEN** a bulk delete is invoked with no indices
+- **THEN** the workout SHALL be unchanged
+- **AND** no history snapshot SHALL be pushed
+
+### Requirement: A bulk delete is one undoable operation
+
+A bulk delete SHALL push exactly one history snapshot, so a single undo command
+reverses the whole operation rather than one step per removed item.
+
+#### Scenario: One history snapshot per bulk delete
+
+- **GIVEN** a loaded workout at a known history index
+- **WHEN** three steps are bulk-deleted in one operation
+- **THEN** the history index SHALL advance by exactly one
+
+### Requirement: Delete-undo entries are keyed by a stable group identity
+
+Every entry in the delete-undo trail SHALL carry a `groupId` identifying the
+delete _operation_ that produced it. A bulk delete SHALL emit one entry per
+removed item, all sharing a single `groupId`; a single-step delete SHALL emit one
+entry that is a group of one. The `groupId` SHALL NOT be derived from a clock
+read, because deletes occurring within the same millisecond would collide and an
+undo keyed on the colliding value would restore one entry and silently discard
+the rest. The `timestamp` field SHALL be retained solely for the expiry sweep.
+
+#### Scenario: Two deletes in the same millisecond stay distinct
+
+- **WHEN** two delete operations complete within the same millisecond
+- **THEN** each SHALL carry a distinct `groupId`
+- **AND** undoing one SHALL leave the other's entry in the trail
+
+#### Scenario: Undo targets only the addressed group
+
+- **GIVEN** two delete operations recorded in the trail
+- **WHEN** undo is invoked with the second operation's `groupId`
+- **THEN** only that operation's items SHALL be restored
+
+### Requirement: Grouped undo restores every item of its operation
+
+Undoing a delete group SHALL restore all of that group's items to their original
+absolute positions, and SHALL remove the entire group from the trail in one
+action. Items SHALL be re-inserted in ascending original-index order, because
+each stored index refers to a position in the pre-delete list and an earlier item
+must be back in place before a later one is inserted.
+
+#### Scenario: One undo restores every step of a bulk delete
+
+- **GIVEN** two steps removed by a single bulk delete
+- **WHEN** undo is invoked once with that operation's `groupId`
+- **THEN** both steps SHALL be restored at their original positions
+
+#### Scenario: A non-contiguous group is restored in order
+
+- **GIVEN** the steps at positions 0, 2 and 4 removed by one bulk delete
+- **WHEN** the operation is undone
+- **THEN** the list SHALL be identical to its pre-delete state
+
+#### Scenario: The whole group leaves the trail together
+
+- **GIVEN** a bulk delete that recorded several entries under one `groupId`
+- **WHEN** that group is undone
+- **THEN** no entry of that group SHALL remain in the trail
+
+### Requirement: Delete is enabled for a main-list multi-selection
+
+The `canDelete` guard and the delete command SHALL consult `selectedStepIds`, not
+only the scalar `selectedStepId`. Because a multi-selection is definitionally
+`selectedStepId === null`, a guard reading only the scalar reports `false` for
+every multi-selection — including a selection of exactly one toggled step — and
+the command silently no-ops. Delete SHALL be enabled when every selected id
+resolves to a top-level step, and SHALL remain disabled when the selection
+resolves inside a repetition block, since nested steps are addressed by block id
+rather than by main-list `stepIndex`.
+
+#### Scenario: Several selected top-level steps enable delete
+
+- **GIVEN** two top-level steps are selected and the scalar selection is null
+- **WHEN** the command guards are computed
+- **THEN** `canDelete` SHALL be true
+
+#### Scenario: A single toggle-selected step enables delete
+
+- **GIVEN** exactly one top-level step is selected via toggle and the scalar selection is null
+- **WHEN** the command guards are computed
+- **THEN** `canDelete` SHALL be true
+
+#### Scenario: A selection inside a repetition block does not enable main-list delete
+
+- **GIVEN** the selection resolves to a step nested inside a repetition block
+- **WHEN** the command guards are computed
+- **THEN** `canDelete` SHALL be false
+
+#### Scenario: An empty selection does not enable delete
+
+- **WHEN** neither the scalar selection nor the selection array identifies a step
+- **THEN** `canDelete` SHALL be false

--- a/openspec/changes/add-editor-multi-delete/tasks.md
+++ b/openspec/changes/add-editor-multi-delete/tasks.md
@@ -1,0 +1,42 @@
+# Tasks
+
+## 1. Failing tests first
+
+- [x] 1.1 Store-level test: bulk delete removes exactly the selected steps
+      (fails against a `forEach(deleteStep)` loop because of the reindex).
+- [x] 1.2 Store-level test: one grouped undo restores all deleted steps.
+- [x] 1.3 Store-level test: a bulk delete pushes exactly one history snapshot.
+- [x] 1.4 Guard test: `canDelete` is true under a populated `selectedStepIds`
+      (`editor-command-guards.test.ts` previously covered `canCut` only).
+
+## 2. Stable undo-group identity
+
+- [x] 2.1 Add `groupId` to `DeletedStep` and to the `WorkoutState` trail type.
+- [x] 2.2 Add `newDeleteGroupId()` backed by the existing `defaultIdProvider`
+      (never a clock read).
+- [x] 2.3 Stamp a `groupId` in `deleteStepAction` and
+      `deleteRepetitionBlockAction`.
+- [x] 2.4 Re-key `undoDeleteAction` from `timestamp` to `groupId`; restore the
+      whole group ascending; drain the whole group from the trail.
+- [x] 2.5 Update the two toast call sites to pass `groupId`.
+
+## 3. Bulk delete action
+
+- [x] 3.1 Add `findStepsToDelete` / `filterOutSteps` helpers (one pass each).
+- [x] 3.2 Add `deleteStepsAction`: one filter, one reindex, one history
+      snapshot, one undo group, focus via `nextAfterMultiDelete`.
+- [x] 3.3 Thread `deleteSteps` through the action surface, store methods, the
+      action type, and the step selectors.
+
+## 4. Command wiring
+
+- [x] 4.1 Add `selectedTopLevelStepIndices`, resolving ids to _domain_
+      `stepIndex` values (not the flat array positions `findById` returns).
+- [x] 4.2 Teach `canDelete` and the `onDelete` thunk to read `selectedStepIds`.
+
+## 5. Verification
+
+- [x] 5.1 `pnpm -r build`
+- [x] 5.2 SPA `test` and `tsc -b --noEmit`
+- [x] 5.3 `pnpm test:scripts`, root `pnpm lint`, `pnpm lint:specs`
+- [x] 5.4 `npx playwright test --list`

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection.test.tsx
@@ -525,11 +525,11 @@ describe("WorkoutSection", () => {
       );
 
       // Act
-      let deletedTimestamp: number;
+      let deletedGroupId: string;
       act(() => {
         useWorkoutStore.getState().deleteStep(0);
         const state = useWorkoutStore.getState();
-        deletedTimestamp = state.deletedSteps[0].timestamp;
+        deletedGroupId = state.deletedSteps[0].groupId;
       });
 
       // Verify step was deleted
@@ -540,7 +540,7 @@ describe("WorkoutSection", () => {
 
       // Undo the deletion
       act(() => {
-        useWorkoutStore.getState().undoDelete(deletedTimestamp);
+        useWorkoutStore.getState().undoDelete(deletedGroupId);
       });
 
       // Assert

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/delete-block-with-toast.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/delete-block-with-toast.tsx
@@ -14,7 +14,7 @@ export function executeDeleteWithToast(
   blockId: string,
   deleteAction: (blockId: string) => void,
   toast: ReturnType<typeof useToastContext>["toast"],
-  undoDelete: (timestamp: number) => void,
+  undoDelete: (groupId: string) => void,
   t: Translate = getTranslate("editor")
 ) {
   deleteAction(blockId);
@@ -28,7 +28,7 @@ export function executeDeleteWithToast(
         duration: UNDO_DELETE_WINDOW_MS,
         action: (
           <button
-            onClick={() => undoDelete(mostRecentDelete.timestamp)}
+            onClick={() => undoDelete(mostRecentDelete.groupId)}
             className="px-3 py-1 text-sm font-medium rounded-md bg-white/10 hover:bg-white/20 transition-colors"
             data-testid="undo-delete-block-button"
           >

--- a/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-delete-step-with-toast.tsx
+++ b/packages/workout-spa-editor/src/components/pages/WorkoutSection/use-delete-step-with-toast.tsx
@@ -35,7 +35,7 @@ export function useDeleteStepWithToast() {
             duration: UNDO_DELETE_WINDOW_MS,
             action: (
               <button
-                onClick={() => undoDelete(mostRecentDelete.timestamp)}
+                onClick={() => undoDelete(mostRecentDelete.groupId)}
                 data-testid="undo-delete-button"
                 className="inline-flex h-8 shrink-0 items-center justify-center rounded-md border border-transparent bg-transparent px-3 text-sm font-medium transition-colors hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/20 disabled:pointer-events-none disabled:opacity-50"
               >

--- a/packages/workout-spa-editor/src/hooks/editor-command-guards.test.ts
+++ b/packages/workout-spa-editor/src/hooks/editor-command-guards.test.ts
@@ -28,6 +28,10 @@ const WORKOUT = {
 
 const BLOCKS_ONLY = { steps: [BLOCK] } as unknown as Workout;
 
+const MULTI_STEP_WORKOUT = {
+  steps: [step("step-uuid", 0), step("second-uuid", 1), BLOCK],
+} as unknown as Workout;
+
 const build = (overrides: Partial<EditorCommandGuardInput> = {}) =>
   buildEditorCommandGuards({
     currentWorkout: {} as KRD,
@@ -241,6 +245,63 @@ describe("buildEditorCommandGuards", () => {
 
       // Assert
       expect(guards.canSave).toBe(false);
+    });
+  });
+
+  // A multi-selection is *definitionally* `selectedStepId === null`
+  // (`toggleStepSelection` / `selectAllSteps` null the scalar), so a
+  // guard that only reads the scalar reports `canDelete: false` for
+  // every multi-selection and the command silently no-ops.
+  describe("delete under a multi-selection", () => {
+    it("should allow delete when several top-level steps are selected", () => {
+      // Arrange
+
+      // Act
+      const guards = build({
+        workout: MULTI_STEP_WORKOUT,
+        selectedStepId: null,
+        selectedStepIds: ["step-uuid", "second-uuid"],
+      });
+
+      // Assert
+      expect(guards).toMatchObject({ canDelete: true, selectedCount: 2 });
+    });
+
+    it("should allow delete when exactly one step is toggle-selected", () => {
+      // Arrange
+
+      // Act
+      const guards = build({
+        workout: MULTI_STEP_WORKOUT,
+        selectedStepId: null,
+        selectedStepIds: ["step-uuid"],
+      });
+
+      // Assert
+      expect(guards.canDelete).toBe(true);
+    });
+
+    it("should refuse delete when the multi-selection sits inside a block", () => {
+      // Arrange
+
+      // Act
+      const guards = build({
+        selectedStepId: null,
+        selectedStepIds: ["nested-uuid"],
+      });
+
+      // Assert
+      expect(guards.canDelete).toBe(false);
+    });
+
+    it("should refuse delete when no step is selected at all", () => {
+      // Arrange
+
+      // Act
+      const guards = build({ selectedStepId: null, selectedStepIds: [] });
+
+      // Assert
+      expect(guards.canDelete).toBe(false);
     });
   });
 });

--- a/packages/workout-spa-editor/src/hooks/editor-command-guards.ts
+++ b/packages/workout-spa-editor/src/hooks/editor-command-guards.ts
@@ -1,6 +1,7 @@
 import type { FindByIdResult } from "../store/find-by-id";
 import { findById } from "../store/find-by-id";
 import type { KRD, Workout } from "../types/krd";
+import { selectedTopLevelStepIndices } from "../utils/selected-step-indices";
 import type { EditorCommandGuards } from "./editor-command.types";
 
 export type EditorCommandGuardInput = {
@@ -32,13 +33,19 @@ export const buildEditorCommandGuards = (
   const found = findById(input.workout, input.selectedStepId);
   const onStep = isTopLevelStep(found);
   const steps = input.workout?.steps ?? [];
+  // A multi-selection is definitionally `selectedStepId === null`, so a
+  // guard reading only the scalar reports false for every one of them.
+  const bulkDeletable =
+    selectedTopLevelStepIndices(input.workout, input.selectedStepIds) !== null;
 
   return {
-    // onCut additionally bails out on a multi-selection.
+    // onCut additionally bails out on a multi-selection: the clipboard
+    // payload holds a single step, so there is no multi-copy to pair
+    // the removal with.
     canCut: onStep && input.selectedStepIds.length <= 1,
     canCopy: onStep,
     canPaste: input.hasClipboard && !!input.workout,
-    canDelete: onStep,
+    canDelete: onStep || bulkDeletable,
     canSelectAll: steps.some((step) => "stepIndex" in step),
     canGroup: input.selectedStepIds.length >= 2,
     canUngroup: found?.kind === "block",

--- a/packages/workout-spa-editor/src/store/README.md
+++ b/packages/workout-spa-editor/src/store/README.md
@@ -40,7 +40,12 @@ selection, history (undo/redo), and the focus-intent slice.
 - `deleteStep` / `deleteRepetitionBlock` — set `pendingFocusTarget` via
   `nextAfterDelete` (next sibling, previous sibling, empty-state, or
   block-cascade anchor).
+- `deleteSteps` — bulk main-list delete; sets `pendingFocusTarget` via
+  `nextAfterMultiDelete`.
 - `undoDelete` — set `pendingFocusTarget` via `restoredAfterUndoTarget`.
+  Addressed by `groupId`, never by `timestamp`: same-millisecond deletes
+  share a timestamp, so a clock-keyed undo restores one entry and
+  discards the rest. `timestamp` now only drives the TTL sweep.
 - `undo` / `redo` — set `pendingFocusTarget` via
   `preservedSelectionTarget`, reading the parallel `selectionHistory`.
 - `reorderStep` / `reorderStepsInBlock` — set `pendingFocusTarget` to

--- a/packages/workout-spa-editor/src/store/README.md
+++ b/packages/workout-spa-editor/src/store/README.md
@@ -195,7 +195,7 @@ without waiting for the focus hook's own scroll). Wrap the mutation:
 
 ```ts
 flushSync(() => {
-  deleteStep(arrayIndex);
+  deleteStep(stepIndex);
 });
 // `pendingFocusTarget` has been cleared by the hook. Read the new
 // active element synchronously.

--- a/packages/workout-spa-editor/src/store/actions/AGENTS.md
+++ b/packages/workout-spa-editor/src/store/actions/AGENTS.md
@@ -17,7 +17,9 @@ One file per workout-mutation action. Each action is a pure function that takes 
 - `duplicate-step-action.ts` / `.test.ts` — clone in place.
 - `duplicate-step-in-repetition-block-action.ts` — clone inside a block.
 - `delete-step-action.ts` / `.test.ts` + `delete-step-helpers.ts` — delete with focus-target via `nextAfterDelete`.
-- `undo-delete-action.ts` / `.test.ts` — restore a step popped from `deletedSteps`.
+- `delete-steps-action.ts` / `.test.ts` + `delete-steps-helpers.ts` — bulk (multi-selection) delete of main-list steps: one filter pass, one reindex, one history snapshot, one undo group, focus-target via `nextAfterMultiDelete`. Never loop `delete-step-action`, which reindexes between calls.
+- `delete-group-id.ts` — `newDeleteGroupId()`, the identity of a delete operation. Deliberately not a clock read.
+- `undo-delete-action.ts` / `.test.ts` + `undo-delete-helpers.ts` — restore every `deletedSteps` entry sharing a `groupId`, ascending by original index.
 - `reorder-step-action.ts` / `.test.ts` (+ `.test-fixtures.ts`) — main-list reorder.
 - `reorder-steps-in-block-action.ts` / `.test.ts` — within-block reorder.
 - `recalculate-step-indices.ts` — re-numbers `stepIndex` after any mutation.

--- a/packages/workout-spa-editor/src/store/actions/delete-group-id.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-group-id.ts
@@ -1,0 +1,12 @@
+/**
+ * Identity for a single delete *operation*.
+ *
+ * Deliberately not a clock read: `Date.now()` collides whenever several
+ * steps are removed inside the same millisecond, which is the normal case
+ * for a bulk delete. Undo keyed on a colliding value restores one entry
+ * and silently discards the rest.
+ */
+
+import { defaultIdProvider } from "../providers/id-provider";
+
+export const newDeleteGroupId = (): string => defaultIdProvider() as string;

--- a/packages/workout-spa-editor/src/store/actions/delete-group-id.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-group-id.ts
@@ -9,4 +9,4 @@
 
 import { defaultIdProvider } from "../providers/id-provider";
 
-export const newDeleteGroupId = (): string => defaultIdProvider() as string;
+export const newDeleteGroupId = (): string => defaultIdProvider();

--- a/packages/workout-spa-editor/src/store/actions/delete-repetition-block-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-repetition-block-action.ts
@@ -19,6 +19,7 @@ import { findBlockById } from "../utils/block-utils";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 import { buildKrdWithWorkout, extractStructuredWorkout } from "./_helpers";
+import { newDeleteGroupId } from "./delete-group-id";
 
 /**
  * Deletes a repetition block and all its contained steps.
@@ -72,6 +73,7 @@ export const deleteRepetitionBlockAction = (
       step: block as UIWorkoutItem,
       index: position,
       timestamp: Date.now(),
+      groupId: newDeleteGroupId(),
     },
   ];
 

--- a/packages/workout-spa-editor/src/store/actions/delete-step-action.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-step-action.test.ts
@@ -14,6 +14,68 @@ const ONE_SECOND_MS = 1000;
 const OUT_OF_RANGE_INDEX = 999;
 
 describe("deleteStepAction", () => {
+  // `undo-delete-helpers` splices restored items back by ABSOLUTE array
+  // position, so the trail must store that, not the domain `stepIndex`.
+  // The two coincide in an all-plain-steps list, so this fixture puts a
+  // repetition block first — the only shape that can tell them apart.
+  describe("undo-trail index space (block precedes the steps)", () => {
+    const BLOCK_CHILDREN = 2;
+    const nested = (stepIndex: number) => ({
+      stepIndex,
+      durationType: "time" as const,
+      duration: { type: "time" as const, seconds: 60 },
+      targetType: "open" as const,
+    });
+
+    const krdWithLeadingBlock = {
+      version: "1.0",
+      type: "structured_workout",
+      metadata: { created: "2025-01-15T10:30:00Z", sport: "cycling" },
+      extensions: {
+        structured_workout: {
+          name: "Leading block",
+          sport: "cycling",
+          steps: [
+            {
+              id: "block-uuid",
+              repeatCount: 3,
+              steps: [nested(0), nested(1)],
+            },
+            // stepIndex 2, but array position 1.
+            nested(BLOCK_CHILDREN),
+          ],
+        },
+      },
+    } as unknown as KRD;
+
+    it("should record the array position, not the domain stepIndex", () => {
+      // Arrange
+      const state: WorkoutState = {
+        currentWorkout: krdWithLeadingBlock,
+        undoHistory: [{ workout: krdWithLeadingBlock, selection: null }],
+        historyIndex: 0,
+        selectedStepId: null,
+        selectedStepIds: [],
+        isEditing: false,
+        safeMode: false,
+        lastBackup: null,
+        deletedSteps: [],
+      };
+
+      // Act
+      const result = deleteStepAction(
+        krdWithLeadingBlock,
+        BLOCK_CHILDREN,
+        state
+      );
+
+      // Assert
+      // Domain stepIndex is 2; the array position is 1. Storing 2 would
+      // splice the step back past the end of a 1-item list on undo.
+      expect(result.deletedSteps?.[0].index).toBe(1);
+    });
+  });
+
   describe("step deletion tracking", () => {
     it("should track deleted step in deletedSteps array", () => {
       // Arrange

--- a/packages/workout-spa-editor/src/store/actions/delete-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-step-action.ts
@@ -11,6 +11,7 @@ import { nextAfterDelete } from "../focus-rules";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 import { extractStructuredWorkout } from "./_helpers/extract-workout";
+import { newDeleteGroupId } from "./delete-group-id";
 import {
   filterSteps,
   findStepToDelete,
@@ -49,6 +50,8 @@ export const deleteStepAction = (
           step: found.step as UIWorkoutItem,
           index: stepIndex,
           timestamp: Date.now(),
+          // A single delete is a delete group of one.
+          groupId: newDeleteGroupId(),
         },
       ]
     : deletedSteps;

--- a/packages/workout-spa-editor/src/store/actions/delete-step-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-step-action.ts
@@ -48,7 +48,10 @@ export const deleteStepAction = (
         ...deletedSteps,
         {
           step: found.step as UIWorkoutItem,
-          index: stepIndex,
+          // The flat array position, NOT the domain `stepIndex`. Undo
+          // splices back by absolute position, and the two diverge as
+          // soon as a repetition block sits earlier in the list.
+          index: found.arrayIndex,
           timestamp: Date.now(),
           // A single delete is a delete group of one.
           groupId: newDeleteGroupId(),

--- a/packages/workout-spa-editor/src/store/actions/delete-steps-action.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-steps-action.test.ts
@@ -8,7 +8,7 @@
  * grouped undo.
  */
 
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { KRD, WorkoutStep } from "../../types/krd";
 import { useWorkoutStore } from "../workout-store";
@@ -16,6 +16,8 @@ import { useWorkoutStore } from "../workout-store";
 const STEP_COUNT = 5;
 const SECONDS_PER_STEP = 10;
 const UNMATCHED_STEP_INDEX = 99;
+/** Any fixed instant; only its constancy matters. */
+const FROZEN_CLOCK = new Date("2026-01-01T00:00:00.000Z");
 
 // Ordinal positions, named so the assertions read as "delete the 2nd and
 // 4th; the 1st, 3rd and 5th survive".
@@ -58,15 +60,123 @@ const currentSteps = () =>
   useWorkoutStore.getState().currentWorkout?.extensions?.structured_workout
     ?.steps ?? [];
 
-/** Identity fingerprint of the surviving steps, in list order. */
+/** Identity fingerprint of the surviving top-level steps, in list order. */
 const secondsOf = (): Array<number> =>
-  currentSteps().map(
-    (s) =>
-      (s as WorkoutStep & { duration: { seconds: number } }).duration.seconds
-  );
+  currentSteps()
+    .filter((s) => (s as { duration?: unknown }).duration !== undefined)
+    .map(
+      (s) =>
+        (s as WorkoutStep & { duration: { seconds: number } }).duration.seconds
+    );
+
+/**
+ * Order fingerprint including blocks: "B" for a repetition block,
+ * duration seconds for a step. Position of the block is what makes this
+ * distinguishable from `secondsOf`.
+ */
+const shapeOf = (): Array<string> =>
+  currentSteps().map((s) => {
+    const seconds = (s as { duration?: { seconds: number } }).duration;
+    return seconds ? String(seconds.seconds) : "B";
+  });
 
 const stepIndicesOf = (): Array<number> =>
   currentSteps().map((s) => (s as WorkoutStep).stepIndex);
+
+// A block PRECEDING top-level steps is the state where the two index
+// spaces come apart: `recalculateStepIndices` numbers block children
+// into the top-level sequence, so a block of two children pushes the
+// first top-level step to stepIndex 2 while it still sits at array
+// position 1. Every plain-steps fixture has arrayIndex === stepIndex and
+// therefore cannot tell a correct implementation from one that confuses
+// the two. Reachable through plain UI: select two steps, cmd-G, paste.
+const BLOCK_CHILDREN = 2;
+
+const makeKrdWithLeadingBlock = (): KRD =>
+  ({
+    version: "1.0",
+    type: "structured_workout",
+    metadata: { created: "2025-01-15T10:30:00Z", sport: "cycling" },
+    extensions: {
+      structured_workout: {
+        name: "Leading-block fixture",
+        sport: "cycling",
+        steps: [
+          {
+            id: "block-uuid",
+            repeatCount: 3,
+            steps: Array.from({ length: BLOCK_CHILDREN }, (_, i) => step(i)),
+          },
+          // stepIndex continues the top-level sequence after the block's
+          // children; array positions are 1, 2, 3.
+          step(BLOCK_CHILDREN),
+          step(BLOCK_CHILDREN + 1),
+          step(BLOCK_CHILDREN + 2),
+        ],
+      },
+    },
+  }) as unknown as KRD;
+
+describe("deleteSteps in the divergent index state (block first)", () => {
+  beforeEach(() => {
+    useWorkoutStore.getState().loadWorkout(makeKrdWithLeadingBlock());
+    useWorkoutStore.setState({ deletedSteps: [] });
+  });
+
+  it("should delete the step addressed by stepIndex, not by array position", () => {
+    // Arrange
+    const before = secondsOf();
+
+    // Act
+    // stepIndex 2 is the FIRST top-level step; array position 1.
+    useWorkoutStore.getState().deleteSteps([BLOCK_CHILDREN]);
+
+    // Assert
+    expect(before).toEqual(survivors(THIRD, FOURTH, FIFTH));
+    expect(secondsOf()).toEqual(survivors(FOURTH, FIFTH));
+  });
+
+  it("should restore a leading-block deletion at its original position", () => {
+    // Arrange
+    const before = shapeOf();
+    useWorkoutStore.getState().deleteSteps([BLOCK_CHILDREN]);
+    const groupId = (useWorkoutStore.getState().deletedSteps ?? [])[0]!.groupId;
+
+    // Act
+    useWorkoutStore.getState().undoDelete(groupId);
+
+    // Assert
+    expect(before).toEqual(["B", "30", "40", "50"]);
+    expect(shapeOf()).toEqual(before);
+  });
+
+  it("should restore a non-contiguous group after the block in original order", () => {
+    // Arrange
+    const before = shapeOf();
+    useWorkoutStore
+      .getState()
+      .deleteSteps([BLOCK_CHILDREN, BLOCK_CHILDREN + 2]);
+
+    // Act
+    const groupId = (useWorkoutStore.getState().deletedSteps ?? [])[0]!.groupId;
+    useWorkoutStore.getState().undoDelete(groupId);
+
+    // Assert
+    expect(shapeOf()).toEqual(before);
+  });
+
+  it("should keep the block at the head after delete and undo", () => {
+    // Arrange
+    useWorkoutStore.getState().deleteSteps([BLOCK_CHILDREN]);
+    const groupId = (useWorkoutStore.getState().deletedSteps ?? [])[0]!.groupId;
+
+    // Act
+    useWorkoutStore.getState().undoDelete(groupId);
+
+    // Assert
+    expect(shapeOf()[0]).toBe("B");
+  });
+});
 
 describe("deleteSteps (bulk multi-selection delete)", () => {
   beforeEach(() => {
@@ -74,6 +184,10 @@ describe("deleteSteps (bulk multi-selection delete)", () => {
     // `loadWorkout` deliberately does not clear the delete trail (a
     // pre-existing quirk), so reset it here to keep each case hermetic.
     useWorkoutStore.setState({ deletedSteps: [] });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("should delete exactly the selected steps, not reindexed neighbours", () => {
@@ -147,22 +261,52 @@ describe("deleteSteps (bulk multi-selection delete)", () => {
     expect(useWorkoutStore.getState().deletedSteps ?? []).toHaveLength(0);
   });
 
-  it("should keep two same-millisecond deletes independently undoable", () => {
+  it("should keep two same-millisecond bulk deletes independently undoable", () => {
     // Arrange
+    // Freeze the clock so both deletes genuinely land in one millisecond
+    // — the collision that made a timestamp-keyed undo lose data.
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_CLOCK);
     useWorkoutStore.getState().deleteSteps([FIFTH]);
     useWorkoutStore.getState().deleteSteps([FIRST]);
     const trail = useWorkoutStore.getState().deletedSteps ?? [];
 
     // Act
+    const timestamps = new Set(trail.map((d) => d.timestamp));
     const groupIds = new Set(trail.map((d) => d.groupId));
 
     // Assert
     expect(trail).toHaveLength(2);
+    // The hazard is real in this fixture...
+    expect(timestamps.size).toBe(1);
+    // ...and the group key survives it.
+    expect(groupIds.size).toBe(2);
+  });
+
+  it("should keep two same-millisecond singular deletes independently undoable", () => {
+    // Arrange
+    // The pre-existing data-loss path: two per-step deletes, one toast
+    // each, both keyed on the same clock read.
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_CLOCK);
+    useWorkoutStore.getState().deleteStep(FIFTH);
+    useWorkoutStore.getState().deleteStep(FIRST);
+    const trail = useWorkoutStore.getState().deletedSteps ?? [];
+
+    // Act
+    const timestamps = new Set(trail.map((d) => d.timestamp));
+    const groupIds = new Set(trail.map((d) => d.groupId));
+
+    // Assert
+    expect(trail).toHaveLength(2);
+    expect(timestamps.size).toBe(1);
     expect(groupIds.size).toBe(2);
   });
 
   it("should undo only the addressed group when two groups share a timestamp", () => {
     // Arrange
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_CLOCK);
     useWorkoutStore.getState().deleteSteps([FIFTH]);
     useWorkoutStore.getState().deleteSteps([FIRST]);
     const trail = useWorkoutStore.getState().deletedSteps ?? [];
@@ -172,8 +316,27 @@ describe("deleteSteps (bulk multi-selection delete)", () => {
     useWorkoutStore.getState().undoDelete(secondGroup);
 
     // Assert
+    expect(new Set(trail.map((d) => d.timestamp)).size).toBe(1);
     expect(secondsOf()).toEqual(survivors(FIRST, SECOND, THIRD, FOURTH));
     expect(useWorkoutStore.getState().deletedSteps ?? []).toHaveLength(1);
+  });
+
+  it("should restore both same-millisecond deletes across two undos", () => {
+    // Arrange
+    vi.useFakeTimers();
+    vi.setSystemTime(FROZEN_CLOCK);
+    useWorkoutStore.getState().deleteStep(FIFTH);
+    useWorkoutStore.getState().deleteStep(FIRST);
+    const [first, second] = useWorkoutStore.getState().deletedSteps ?? [];
+
+    // Act
+    useWorkoutStore.getState().undoDelete(second!.groupId);
+    useWorkoutStore.getState().undoDelete(first!.groupId);
+
+    // Assert
+    // A timestamp-keyed undo restored one and discarded the other.
+    expect(secondsOf()).toEqual(survivors(FIRST, SECOND, THIRD, FOURTH, FIFTH));
+    expect(useWorkoutStore.getState().deletedSteps ?? []).toHaveLength(0);
   });
 
   it("should ignore indices that match no step", () => {

--- a/packages/workout-spa-editor/src/store/actions/delete-steps-action.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-steps-action.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Bulk (multi-selection) delete — store-level contract.
+ *
+ * The reindex trap: `deleteStepAction` reindexes the whole list after
+ * every call, so `indices.forEach(deleteStep)` removes the WRONG steps
+ * from the second iteration onward. These tests pin the correct
+ * filter-once / reindex-once semantics, one history snapshot, and one
+ * grouped undo.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { KRD, WorkoutStep } from "../../types/krd";
+import { useWorkoutStore } from "../workout-store";
+
+const STEP_COUNT = 5;
+const SECONDS_PER_STEP = 10;
+const UNMATCHED_STEP_INDEX = 99;
+
+// Ordinal positions, named so the assertions read as "delete the 2nd and
+// 4th; the 1st, 3rd and 5th survive".
+const FIRST = 0;
+const SECOND = 1;
+const THIRD = 2;
+const FOURTH = 3;
+const FIFTH = 4;
+
+/** Step i is identifiable by its duration: (i + 1) * SECONDS_PER_STEP. */
+const secondsFor = (position: number): number =>
+  (position + 1) * SECONDS_PER_STEP;
+
+/** Expected duration fingerprint for a given set of surviving originals. */
+const survivors = (...positions: Array<number>): Array<number> =>
+  positions.map(secondsFor);
+
+const step = (stepIndex: number) => ({
+  stepIndex,
+  durationType: "time",
+  duration: { type: "time", seconds: secondsFor(stepIndex) },
+  targetType: "open",
+});
+
+const makeKrd = (count: number): KRD =>
+  ({
+    version: "1.0",
+    type: "structured_workout",
+    metadata: { created: "2025-01-15T10:30:00Z", sport: "cycling" },
+    extensions: {
+      structured_workout: {
+        name: "Bulk delete fixture",
+        sport: "cycling",
+        steps: Array.from({ length: count }, (_, i) => step(i)),
+      },
+    },
+  }) as unknown as KRD;
+
+const currentSteps = () =>
+  useWorkoutStore.getState().currentWorkout?.extensions?.structured_workout
+    ?.steps ?? [];
+
+/** Identity fingerprint of the surviving steps, in list order. */
+const secondsOf = (): Array<number> =>
+  currentSteps().map(
+    (s) =>
+      (s as WorkoutStep & { duration: { seconds: number } }).duration.seconds
+  );
+
+const stepIndicesOf = (): Array<number> =>
+  currentSteps().map((s) => (s as WorkoutStep).stepIndex);
+
+describe("deleteSteps (bulk multi-selection delete)", () => {
+  beforeEach(() => {
+    useWorkoutStore.getState().loadWorkout(makeKrd(STEP_COUNT));
+    // `loadWorkout` deliberately does not clear the delete trail (a
+    // pre-existing quirk), so reset it here to keep each case hermetic.
+    useWorkoutStore.setState({ deletedSteps: [] });
+  });
+
+  it("should delete exactly the selected steps, not reindexed neighbours", () => {
+    // Arrange
+    const before = secondsOf();
+
+    // Act
+    useWorkoutStore.getState().deleteSteps([SECOND, FOURTH]);
+
+    // Assert
+    expect(before).toEqual(survivors(FIRST, SECOND, THIRD, FOURTH, FIFTH));
+    expect(secondsOf()).toEqual(survivors(FIRST, THIRD, FIFTH));
+  });
+
+  it("should reindex the survivors exactly once into a dense range", () => {
+    // Arrange
+
+    // Act
+    useWorkoutStore.getState().deleteSteps([SECOND, FOURTH]);
+
+    // Assert
+    expect(stepIndicesOf()).toEqual([FIRST, SECOND, THIRD]);
+  });
+
+  it("should push exactly one history snapshot for the whole bulk delete", () => {
+    // Arrange
+    const before = useWorkoutStore.getState().historyIndex;
+
+    // Act
+    useWorkoutStore.getState().deleteSteps([FIRST, THIRD, FIFTH]);
+
+    // Assert
+    expect(useWorkoutStore.getState().historyIndex).toBe(before + 1);
+  });
+
+  it("should restore every deleted step from a single grouped undo", () => {
+    // Arrange
+    useWorkoutStore.getState().deleteSteps([SECOND, FOURTH]);
+    const trail = useWorkoutStore.getState().deletedSteps ?? [];
+    const groupIds = [...new Set(trail.map((d) => d.groupId))];
+
+    // Act
+    useWorkoutStore.getState().undoDelete(groupIds[0]!);
+
+    // Assert
+    expect(groupIds).toHaveLength(1);
+    expect(secondsOf()).toEqual(survivors(FIRST, SECOND, THIRD, FOURTH, FIFTH));
+  });
+
+  it("should restore non-contiguous deletions to their original positions", () => {
+    // Arrange
+    useWorkoutStore.getState().deleteSteps([FIRST, THIRD, FIFTH]);
+    const groupId = (useWorkoutStore.getState().deletedSteps ?? [])[0]!.groupId;
+
+    // Act
+    useWorkoutStore.getState().undoDelete(groupId);
+
+    // Assert
+    expect(secondsOf()).toEqual(survivors(FIRST, SECOND, THIRD, FOURTH, FIFTH));
+  });
+
+  it("should drain the whole group from the undo trail in one undo", () => {
+    // Arrange
+    useWorkoutStore.getState().deleteSteps([SECOND, FOURTH]);
+    const groupId = (useWorkoutStore.getState().deletedSteps ?? [])[0]!.groupId;
+
+    // Act
+    useWorkoutStore.getState().undoDelete(groupId);
+
+    // Assert
+    expect(useWorkoutStore.getState().deletedSteps ?? []).toHaveLength(0);
+  });
+
+  it("should keep two same-millisecond deletes independently undoable", () => {
+    // Arrange
+    useWorkoutStore.getState().deleteSteps([FIFTH]);
+    useWorkoutStore.getState().deleteSteps([FIRST]);
+    const trail = useWorkoutStore.getState().deletedSteps ?? [];
+
+    // Act
+    const groupIds = new Set(trail.map((d) => d.groupId));
+
+    // Assert
+    expect(trail).toHaveLength(2);
+    expect(groupIds.size).toBe(2);
+  });
+
+  it("should undo only the addressed group when two groups share a timestamp", () => {
+    // Arrange
+    useWorkoutStore.getState().deleteSteps([FIFTH]);
+    useWorkoutStore.getState().deleteSteps([FIRST]);
+    const trail = useWorkoutStore.getState().deletedSteps ?? [];
+    const secondGroup = trail[1]!.groupId;
+
+    // Act
+    useWorkoutStore.getState().undoDelete(secondGroup);
+
+    // Assert
+    expect(secondsOf()).toEqual(survivors(FIRST, SECOND, THIRD, FOURTH));
+    expect(useWorkoutStore.getState().deletedSteps ?? []).toHaveLength(1);
+  });
+
+  it("should ignore indices that match no step", () => {
+    // Arrange
+
+    // Act
+    useWorkoutStore.getState().deleteSteps([SECOND, UNMATCHED_STEP_INDEX]);
+
+    // Assert
+    expect(secondsOf()).toEqual(survivors(FIRST, THIRD, FOURTH, FIFTH));
+  });
+
+  it("should leave the workout untouched for an empty selection", () => {
+    // Arrange
+    const before = useWorkoutStore.getState().historyIndex;
+
+    // Act
+    useWorkoutStore.getState().deleteSteps([]);
+
+    // Assert
+    expect(secondsOf()).toEqual(survivors(FIRST, SECOND, THIRD, FOURTH, FIFTH));
+    expect(useWorkoutStore.getState().historyIndex).toBe(before);
+  });
+});

--- a/packages/workout-spa-editor/src/store/actions/delete-steps-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-steps-action.ts
@@ -1,0 +1,69 @@
+/**
+ * Bulk Delete Steps Action
+ *
+ * Removes every step addressed by `stepIndices` in one state update:
+ * one filter pass, one reindex, ONE history snapshot, and ONE grouped
+ * undo entry set. Contrast `deleteStepAction`, which is singular and
+ * reindexes after each call — looping it corrupts the target set.
+ *
+ * Scope: main-list top-level steps only. Nested steps inside a
+ * repetition block are addressed by block id, not by `stepIndex`, and
+ * are filtered out upstream by the selection guards.
+ */
+
+import type { KRD } from "../../types/krd";
+import type { UIWorkoutItem } from "../../types/krd-ui";
+import { nextAfterMultiDelete } from "../focus-rules";
+import type { WorkoutState } from "../workout-actions";
+import { createUpdateWorkoutAction } from "../workout-actions";
+import { extractStructuredWorkout } from "./_helpers/extract-workout";
+import { newDeleteGroupId } from "./delete-group-id";
+import { reindexSteps } from "./delete-step-helpers";
+import { filterOutSteps, findStepsToDelete } from "./delete-steps-helpers";
+
+export const deleteStepsAction = (
+  krd: KRD,
+  stepIndices: ReadonlyArray<number>,
+  state: WorkoutState
+): Partial<WorkoutState> => {
+  const workout = extractStructuredWorkout(krd);
+  if (!workout) return {};
+
+  const found = findStepsToDelete(workout, stepIndices);
+  // Nothing addressable — do not touch history, the undo trail, or focus.
+  if (found.length === 0) return {};
+
+  const reindexedSteps = reindexSteps(
+    filterOutSteps(workout.steps, stepIndices)
+  );
+  const updatedWorkout = { ...workout, steps: reindexedSteps };
+  const updatedKrd: KRD = {
+    ...krd,
+    extensions: { ...krd.extensions, structured_workout: updatedWorkout },
+  };
+
+  // One id for the whole operation, so `undoDelete` restores all of it
+  // atomically. `timestamp` stays for the TTL sweep only.
+  const groupId = newDeleteGroupId();
+  const timestamp = Date.now();
+  const newDeletedSteps = [
+    ...(state.deletedSteps || []),
+    ...found.map((f) => ({
+      step: f.step as UIWorkoutItem,
+      index: f.arrayIndex,
+      timestamp,
+      groupId,
+    })),
+  ];
+
+  return {
+    ...createUpdateWorkoutAction(updatedKrd, state),
+    deletedSteps: newDeletedSteps,
+    pendingFocusTarget: nextAfterMultiDelete({
+      workout: updatedWorkout,
+      deletedIndices: found.map((f) => f.arrayIndex),
+    }),
+    selectedStepId: null,
+    selectedStepIds: [],
+  };
+};

--- a/packages/workout-spa-editor/src/store/actions/delete-steps-helpers.ts
+++ b/packages/workout-spa-editor/src/store/actions/delete-steps-helpers.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers for `deleteStepsAction` — the bulk (multi-selection) delete.
+ *
+ * The whole point of this module is that the removal happens in ONE
+ * pass: filter once, reindex once. Looping the singular delete would
+ * reindex between iterations and remove the wrong steps from the second
+ * iteration onward.
+ */
+
+import type { RepetitionBlock, Workout, WorkoutStep } from "../../types/krd";
+import { isWorkoutStep } from "../../types/krd";
+import type { FoundStep } from "./delete-step-helpers";
+
+/**
+ * Resolve the requested `stepIndex` values to the steps they address,
+ * paired with their flat array positions. Unmatched indices are dropped.
+ * Result is sorted by array position so undo can re-insert ascending.
+ */
+export const findStepsToDelete = (
+  workout: Workout,
+  stepIndices: ReadonlyArray<number>
+): Array<FoundStep> => {
+  const wanted = new Set(stepIndices);
+  const found: Array<FoundStep> = [];
+  workout.steps.forEach((step, arrayIndex) => {
+    if (isWorkoutStep(step) && wanted.has(step.stepIndex)) {
+      found.push({ step, arrayIndex });
+    }
+  });
+  return found;
+};
+
+/** Remove every addressed step in a single pass. */
+export const filterOutSteps = (
+  steps: ReadonlyArray<WorkoutStep | RepetitionBlock>,
+  stepIndices: ReadonlyArray<number>
+): Array<WorkoutStep | RepetitionBlock> => {
+  const wanted = new Set(stepIndices);
+  return steps.filter((step) =>
+    isWorkoutStep(step) ? !wanted.has(step.stepIndex) : true
+  );
+};

--- a/packages/workout-spa-editor/src/store/actions/item-id-assignment.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/item-id-assignment.test.ts
@@ -215,7 +215,7 @@ describe("undoDelete + undo/redo preserve item ids", () => {
     expect(deleted).toHaveLength(1);
     const [deletedEntry] = deleted;
     if (!deletedEntry) throw new Error("Expected one deleted step");
-    useWorkoutStore.getState().undoDelete(deletedEntry.timestamp);
+    useWorkoutStore.getState().undoDelete(deletedEntry.groupId);
 
     // Act
     const restoredIds = innerSteps().map((s) => (s as { id: string }).id);

--- a/packages/workout-spa-editor/src/store/actions/undo-delete-action.test.ts
+++ b/packages/workout-spa-editor/src/store/actions/undo-delete-action.test.ts
@@ -25,11 +25,12 @@ describe("undoDeleteAction", () => {
       },
     };
 
-    const timestamp = Date.now();
+    const groupId = "group-restore-at-original-position";
     const deletedStepEntry: DeletedStep = {
       step: deletedStep,
       index: 1,
-      timestamp,
+      timestamp: Date.now(),
+      groupId,
     };
 
     const krd: KRD = {
@@ -82,7 +83,7 @@ describe("undoDeleteAction", () => {
     };
 
     // Act
-    const result = undoDeleteAction(krd, timestamp, state);
+    const result = undoDeleteAction(krd, groupId, state);
 
     // Assert
     expect(result.currentWorkout).toBeDefined();
@@ -120,13 +121,13 @@ describe("undoDeleteAction", () => {
     };
 
     // Act
-    const result = undoDeleteAction(krd, Date.now(), state);
+    const result = undoDeleteAction(krd, "group-absent", state);
 
     // Assert
     expect(result).toEqual({});
   });
 
-  it("should return empty object if timestamp not found", () => {
+  it("should return empty object if the group id is not found", () => {
     // Arrange
     const krd: KRD = {
       version: "1.0",
@@ -157,7 +158,7 @@ describe("undoDeleteAction", () => {
     };
 
     // Act
-    const result = undoDeleteAction(krd, Date.now(), state);
+    const result = undoDeleteAction(krd, "group-absent", state);
 
     // Assert
     expect(result).toEqual({});
@@ -176,11 +177,12 @@ describe("undoDeleteAction", () => {
       },
     };
 
-    const timestamp = Date.now();
+    const groupId = "group-recalculate-indices";
     const deletedStepEntry: DeletedStep = {
       step: deletedStep,
       index: 0,
-      timestamp,
+      timestamp: Date.now(),
+      groupId,
     };
 
     const krd: KRD = {
@@ -223,7 +225,7 @@ describe("undoDeleteAction", () => {
     };
 
     // Act
-    const result = undoDeleteAction(krd, timestamp, state);
+    const result = undoDeleteAction(krd, groupId, state);
 
     // Assert
     const workout = result.currentWorkout?.extensions?.structured_workout;

--- a/packages/workout-spa-editor/src/store/actions/undo-delete-action.ts
+++ b/packages/workout-spa-editor/src/store/actions/undo-delete-action.ts
@@ -1,56 +1,35 @@
 /**
  * Undo Delete Action
  *
- * Action for restoring a deleted step at its original position.
+ * Restores every step removed by one delete operation, at its original
+ * position. The operation is addressed by `groupId` — never by
+ * `timestamp`, which collides across same-millisecond deletes.
  */
 
-import type { KRD, RepetitionBlock, WorkoutStep } from "../../types/krd";
-import { isWorkoutStep } from "../../types/krd";
+import type { KRD } from "../../types/krd";
 import { restoredAfterUndoTarget } from "../focus-rules";
 import type { ItemId } from "../providers/item-id";
 import type { WorkoutState } from "../workout-actions";
 import { createUpdateWorkoutAction } from "../workout-actions";
 import { extractStructuredWorkout } from "./_helpers/extract-workout";
+import { reindexSteps } from "./delete-step-helpers";
+import { restoreDeletedItems } from "./undo-delete-helpers";
 
 export const undoDeleteAction = (
   krd: KRD,
-  timestamp: number,
+  groupId: string,
   state: WorkoutState
 ): Partial<WorkoutState> => {
   const workout = extractStructuredWorkout(krd);
-  if (!workout) {
-    return {};
-  }
+  if (!workout) return {};
 
   const deletedSteps = state.deletedSteps || [];
-  const deletedStepEntry = deletedSteps.find((d) => d.timestamp === timestamp);
-
-  if (!deletedStepEntry) {
-    return {};
-  }
-
-  const { step, index } = deletedStepEntry;
-
-  // Insert the step back at its original position
-  const updatedSteps = [...workout.steps];
-  updatedSteps.splice(index, 0, step);
-
-  // Recalculate stepIndex for all steps
-  const reindexedSteps = updatedSteps.map(
-    (s: WorkoutStep | RepetitionBlock, idx: number) => {
-      if (isWorkoutStep(s)) {
-        return {
-          ...s,
-          stepIndex: idx,
-        };
-      }
-      return s; // Repetition blocks don't have stepIndex
-    }
-  );
+  const group = deletedSteps.filter((d) => d.groupId === groupId);
+  if (group.length === 0) return {};
 
   const updatedWorkout = {
     ...workout,
-    steps: reindexedSteps,
+    steps: reindexSteps(restoreDeletedItems(workout.steps, group)),
   };
 
   const updatedKrd: KRD = {
@@ -61,19 +40,17 @@ export const undoDeleteAction = (
     },
   };
 
-  // Remove the deleted step from tracking
-  const newDeletedSteps = deletedSteps.filter((d) => d.timestamp !== timestamp);
-
-  // Focus lands on the restored item so the user can immediately
+  // Focus lands on the first restored item so the user can immediately
   // continue editing what they just undid.
-  const restoredId = (step as { id?: string }).id;
+  const restoredId = (group[0]!.step as { id?: string }).id;
   const pendingFocusTarget = restoredId
     ? restoredAfterUndoTarget(updatedWorkout, restoredId as ItemId)
     : state.pendingFocusTarget;
 
   return {
     ...createUpdateWorkoutAction(updatedKrd, state),
-    deletedSteps: newDeletedSteps,
+    // The whole group is consumed by this one undo.
+    deletedSteps: deletedSteps.filter((d) => d.groupId !== groupId),
     pendingFocusTarget,
   };
 };

--- a/packages/workout-spa-editor/src/store/actions/undo-delete-helpers.ts
+++ b/packages/workout-spa-editor/src/store/actions/undo-delete-helpers.ts
@@ -1,0 +1,29 @@
+/**
+ * Helper for `undoDeleteAction`.
+ */
+
+import type { RepetitionBlock, WorkoutStep } from "../../types/krd";
+import type { DeletedStep } from "../workout-store-state.types";
+
+/**
+ * Re-insert every item of a delete group at its original absolute
+ * position.
+ *
+ * Ascending order is load-bearing: each stored `index` is a position in
+ * the *pre-delete* list, so an earlier item must already be back before
+ * a later one is placed. Restoring [1, 3] into [a, c, e] ascending gives
+ * [a, b, c, e] then [a, b, c, d, e]; descending would land them wrong.
+ */
+export const restoreDeletedItems = (
+  steps: ReadonlyArray<WorkoutStep | RepetitionBlock>,
+  group: ReadonlyArray<DeletedStep>
+): Array<WorkoutStep | RepetitionBlock> => {
+  const restored = [...steps];
+  [...group]
+    .sort((a, b) => a.index - b.index)
+    .forEach((entry) => {
+      const at = Math.min(entry.index, restored.length);
+      restored.splice(at, 0, entry.step as WorkoutStep | RepetitionBlock);
+    });
+  return restored;
+};

--- a/packages/workout-spa-editor/src/store/create-workout-method-helpers-basic.ts
+++ b/packages/workout-spa-editor/src/store/create-workout-method-helpers-basic.ts
@@ -22,8 +22,10 @@ export const createBasicMethods = (
   createStep: () => set((state) => actions.createStep(state)),
   deleteStep: (stepIndex: number) =>
     set((state) => actions.deleteStep(stepIndex, state)),
-  undoDelete: (timestamp: number) =>
-    set((state) => actions.undoDelete(timestamp, state)),
+  deleteSteps: (stepIndices: ReadonlyArray<number>) =>
+    set((state) => actions.deleteSteps(stepIndices, state)),
+  undoDelete: (groupId: string) =>
+    set((state) => actions.undoDelete(groupId, state)),
   clearExpiredDeletes: () => set((state) => actions.clearExpiredDeletes(state)),
   duplicateStep: (stepIndex: number) =>
     set((state) => actions.duplicateStep(stepIndex, state)),

--- a/packages/workout-spa-editor/src/store/selectors/step-selectors.ts
+++ b/packages/workout-spa-editor/src/store/selectors/step-selectors.ts
@@ -13,6 +13,9 @@ export const useCreateStep = () => useWorkoutStore((state) => state.createStep);
 
 export const useDeleteStep = () => useWorkoutStore((state) => state.deleteStep);
 
+export const useDeleteSteps = () =>
+  useWorkoutStore((state) => state.deleteSteps);
+
 export const useUndoDelete = () => useWorkoutStore((state) => state.undoDelete);
 
 export const useClearExpiredDeletes = () =>

--- a/packages/workout-spa-editor/src/store/selectors/use-context-menu-store.ts
+++ b/packages/workout-spa-editor/src/store/selectors/use-context-menu-store.ts
@@ -19,7 +19,11 @@ import {
   useSelectedStepIds,
   useSelectStep,
 } from "./selection-selectors";
-import { useDeleteStep, useReorderStep } from "./step-selectors";
+import {
+  useDeleteStep,
+  useDeleteSteps,
+  useReorderStep,
+} from "./step-selectors";
 import { useCurrentWorkout } from "./workout-selectors";
 
 export function useContextMenuStore() {
@@ -29,6 +33,7 @@ export function useContextMenuStore() {
   const selectStep = useSelectStep();
   const clearStepSelection = useClearStepSelection();
   const deleteStep = useDeleteStep();
+  const deleteSteps = useDeleteSteps();
   const copyStep = useCopyStep();
   const pasteStep = usePasteStep();
   const openCreateBlockDialog = useOpenCreateBlockDialog();
@@ -47,6 +52,7 @@ export function useContextMenuStore() {
     selectStep,
     clearStepSelection,
     deleteStep,
+    deleteSteps,
     copyStep,
     pasteStep,
     openCreateBlockDialog,

--- a/packages/workout-spa-editor/src/store/selectors/use-keyboard-store-selectors.ts
+++ b/packages/workout-spa-editor/src/store/selectors/use-keyboard-store-selectors.ts
@@ -16,7 +16,11 @@ import {
   useSelectedStepIds,
   useSelectStep,
 } from "./selection-selectors";
-import { useDeleteStep, useReorderStep } from "./step-selectors";
+import {
+  useDeleteStep,
+  useDeleteSteps,
+  useReorderStep,
+} from "./step-selectors";
 import { useCurrentWorkout } from "./workout-selectors";
 
 export function useKeyboardStoreSelectors() {
@@ -34,6 +38,7 @@ export function useKeyboardStoreSelectors() {
   const selectStep = useSelectStep();
   const clearStepSelection = useClearStepSelection();
   const deleteStep = useDeleteStep();
+  const deleteSteps = useDeleteSteps();
 
   return {
     currentWorkout,
@@ -50,5 +55,6 @@ export function useKeyboardStoreSelectors() {
     selectStep,
     clearStepSelection,
     deleteStep,
+    deleteSteps,
   };
 }

--- a/packages/workout-spa-editor/src/store/workout-state.types.ts
+++ b/packages/workout-spa-editor/src/store/workout-state.types.ts
@@ -33,5 +33,6 @@ export type WorkoutState = {
     step: UIWorkoutItem;
     index: number;
     timestamp: number;
+    groupId: string;
   }>;
 };

--- a/packages/workout-spa-editor/src/store/workout-store-actions.ts
+++ b/packages/workout-spa-editor/src/store/workout-store-actions.ts
@@ -1,4 +1,5 @@
 import { clearExpiredDeletesAction } from "./actions/clear-expired-deletes-action";
+import { deleteStepsAction } from "./actions/delete-steps-action";
 import { undoDeleteAction } from "./actions/undo-delete-action";
 import { createAllBlockActions } from "./create-all-block-actions";
 import { createAllStepActions } from "./create-all-step-actions";
@@ -9,10 +10,15 @@ const createStepActions = () => ({
   createStep: (state: WorkoutState) => createAllStepActions(state).createStep(),
   deleteStep: (stepIndex: number, state: WorkoutState) =>
     createAllStepActions(state).deleteStep(stepIndex),
-  undoDelete: (timestamp: number, state: WorkoutState) => {
+  deleteSteps: (stepIndices: ReadonlyArray<number>, state: WorkoutState) => {
     const currentWorkout = state.currentWorkout;
     if (!currentWorkout) return {};
-    return undoDeleteAction(currentWorkout, timestamp, state);
+    return deleteStepsAction(currentWorkout, stepIndices, state);
+  },
+  undoDelete: (groupId: string, state: WorkoutState) => {
+    const currentWorkout = state.currentWorkout;
+    if (!currentWorkout) return {};
+    return undoDeleteAction(currentWorkout, groupId, state);
   },
   clearExpiredDeletes: (state: WorkoutState) =>
     clearExpiredDeletesAction(state),

--- a/packages/workout-spa-editor/src/store/workout-store-actions.types.ts
+++ b/packages/workout-spa-editor/src/store/workout-store-actions.types.ts
@@ -17,7 +17,9 @@ export type WorkoutStoreActions = {
   updateWorkout: (workout: UIWorkout) => void;
   createStep: () => void;
   deleteStep: (stepIndex: number) => void;
-  undoDelete: (timestamp: number) => void;
+  /** Bulk delete: one state update, one history snapshot, one undo group. */
+  deleteSteps: (stepIndices: ReadonlyArray<number>) => void;
+  undoDelete: (groupId: string) => void;
   clearExpiredDeletes: () => void;
   duplicateStep: (stepIndex: number) => void;
   copyStep: (

--- a/packages/workout-spa-editor/src/store/workout-store-state.types.ts
+++ b/packages/workout-spa-editor/src/store/workout-store-state.types.ts
@@ -12,7 +12,20 @@ import type { UndoHistory } from "./workout-state.types";
 export type DeletedStep = {
   step: UIWorkoutItem;
   index: number;
+  /**
+   * Wall-clock read, used *only* for the TTL sweep in
+   * `clearExpiredDeletesAction`. It is NOT an identity: N deletes inside
+   * one millisecond share a value, so keying undo on it restores one
+   * entry and discards the rest.
+   */
   timestamp: number;
+  /**
+   * Identity of the delete *operation* that produced this entry. A bulk
+   * delete emits one entry per removed item, all sharing one `groupId`,
+   * so `undoDelete` restores the whole operation atomically. A single
+   * delete is simply a group of one.
+   */
+  groupId: string;
 };
 
 export type ModalConfig = {

--- a/packages/workout-spa-editor/src/store/workout-store.test.ts
+++ b/packages/workout-spa-editor/src/store/workout-store.test.ts
@@ -1260,9 +1260,8 @@ describe("useWorkoutStore", () => {
       };
       useWorkoutStore.getState().loadWorkout(mockKrd);
       useWorkoutStore.getState().deleteStep(0);
-      const deletedTimestamp =
-        useWorkoutStore.getState().deletedSteps[0].timestamp;
-      useWorkoutStore.getState().undoDelete(deletedTimestamp);
+      const deletedGroupId = useWorkoutStore.getState().deletedSteps[0].groupId;
+      useWorkoutStore.getState().undoDelete(deletedGroupId);
       const state = useWorkoutStore.getState();
 
       // Act
@@ -1293,6 +1292,7 @@ describe("useWorkoutStore", () => {
             },
             index: 0,
             timestamp: now - EXPIRED_DELETE_AGE_MS, // 6 seconds ago (expired)
+            groupId: "group-expired",
           },
           {
             step: {
@@ -1307,6 +1307,7 @@ describe("useWorkoutStore", () => {
             },
             index: 1,
             timestamp: now - FRESH_DELETE_AGE_MS, // 2 seconds ago (not expired)
+            groupId: "group-fresh",
           },
         ],
       });

--- a/packages/workout-spa-editor/src/utils/build-clipboard-handlers.ts
+++ b/packages/workout-spa-editor/src/utils/build-clipboard-handlers.ts
@@ -1,5 +1,6 @@
 import type { KeyboardShortcutHandlers } from "../hooks/keyboard-shortcut-handlers";
 import type { KeyboardHandlerDeps } from "./keyboard-handler-deps";
+import { selectedTopLevelStepIndices } from "./selected-step-indices";
 
 type ClipboardHandlers = Pick<
   KeyboardShortcutHandlers,
@@ -41,8 +42,20 @@ export const buildClipboardHandlers = (
     return true;
   },
   onDelete: () => {
+    if (!deps.workout) return false;
+    // Multi-selection first: the scalar `selectedStepId` is null
+    // whenever `selectedStepIds` is populated, so reading only the
+    // scalar makes every bulk delete a silent no-op.
+    const bulk = selectedTopLevelStepIndices(
+      deps.workout,
+      deps.selectedStepIds
+    );
+    if (bulk) {
+      deps.deleteSteps(bulk);
+      return true;
+    }
     const selectedStepIndex = deps.stepIndex();
-    if (selectedStepIndex === null || !deps.workout) return false;
+    if (selectedStepIndex === null) return false;
     const step = deps.workout.steps[selectedStepIndex];
     if (!step || !("stepIndex" in step)) return false;
     deps.deleteStep(step.stepIndex);

--- a/packages/workout-spa-editor/src/utils/keyboard-handler-deps.ts
+++ b/packages/workout-spa-editor/src/utils/keyboard-handler-deps.ts
@@ -12,6 +12,7 @@ export type KeyboardHandlerDeps = {
   copyStep: (stepIndex: number) => Promise<void>;
   pasteStep: (position: number) => Promise<void>;
   deleteStep: (stepIndex: number) => void;
+  deleteSteps: (stepIndices: ReadonlyArray<number>) => void;
   selectedStepId: string | null;
   selectedStepIds: Array<string>;
   openCreateBlockDialog: () => void;

--- a/packages/workout-spa-editor/src/utils/selected-step-indices.test.ts
+++ b/packages/workout-spa-editor/src/utils/selected-step-indices.test.ts
@@ -1,0 +1,137 @@
+/**
+ * `selectedTopLevelStepIndices` resolves a selection to DOMAIN
+ * `stepIndex` values, while `findById` reports the flat ARRAY position.
+ * The two coincide in every all-plain-steps list, so the fixtures here
+ * deliberately put a repetition block FIRST — that is the only shape
+ * that can tell the two index spaces apart.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Workout } from "../types/krd";
+import { selectedTopLevelStepIndices } from "./selected-step-indices";
+
+const BLOCK_CHILDREN = 2;
+
+const step = (id: string, stepIndex: number) => ({
+  id,
+  stepIndex,
+  durationType: "time" as const,
+  durationValue: 60,
+  targetType: "open" as const,
+  intensity: "active" as const,
+});
+
+// `recalculateStepIndices` numbers block children into the top-level
+// sequence, so with a 2-child block at array position 0 the following
+// top-level steps carry stepIndex 2, 3 while sitting at array positions
+// 1, 2.
+const LEADING_BLOCK = {
+  id: "block-uuid",
+  repeatCount: 3,
+  steps: [step("nested-a", 0), step("nested-b", 1)],
+};
+
+const BLOCK_FIRST_WORKOUT = {
+  steps: [
+    LEADING_BLOCK,
+    step("after-block-1", BLOCK_CHILDREN),
+    step("after-block-2", BLOCK_CHILDREN + 1),
+  ],
+} as unknown as Workout;
+
+describe("selectedTopLevelStepIndices", () => {
+  it("should return the domain stepIndex, not the flat array position", () => {
+    // Arrange
+
+    // Act
+    const indices = selectedTopLevelStepIndices(BLOCK_FIRST_WORKOUT, [
+      "after-block-1",
+    ]);
+
+    // Assert
+    // Array position is 1; the domain stepIndex is 2. Returning the
+    // array position here would delete the wrong step downstream.
+    expect(indices).toEqual([BLOCK_CHILDREN]);
+  });
+
+  it("should resolve several selected steps past a leading block", () => {
+    // Arrange
+
+    // Act
+    const indices = selectedTopLevelStepIndices(BLOCK_FIRST_WORKOUT, [
+      "after-block-1",
+      "after-block-2",
+    ]);
+
+    // Assert
+    expect(indices).toEqual([BLOCK_CHILDREN, BLOCK_CHILDREN + 1]);
+  });
+
+  it("should refuse a selection that resolves inside a repetition block", () => {
+    // Arrange
+
+    // Act
+    const indices = selectedTopLevelStepIndices(BLOCK_FIRST_WORKOUT, [
+      "nested-a",
+    ]);
+
+    // Assert
+    expect(indices).toBeNull();
+  });
+
+  it("should refuse a selection that mixes a nested step with a top-level one", () => {
+    // Arrange
+
+    // Act
+    const indices = selectedTopLevelStepIndices(BLOCK_FIRST_WORKOUT, [
+      "after-block-1",
+      "nested-a",
+    ]);
+
+    // Assert
+    expect(indices).toBeNull();
+  });
+
+  it("should refuse a selection that resolves to the block itself", () => {
+    // Arrange
+
+    // Act
+    const indices = selectedTopLevelStepIndices(BLOCK_FIRST_WORKOUT, [
+      "block-uuid",
+    ]);
+
+    // Assert
+    expect(indices).toBeNull();
+  });
+
+  it("should refuse an unknown id", () => {
+    // Arrange
+
+    // Act
+    const indices = selectedTopLevelStepIndices(BLOCK_FIRST_WORKOUT, ["nope"]);
+
+    // Assert
+    expect(indices).toBeNull();
+  });
+
+  it("should refuse an empty selection", () => {
+    // Arrange
+
+    // Act
+    const indices = selectedTopLevelStepIndices(BLOCK_FIRST_WORKOUT, []);
+
+    // Assert
+    expect(indices).toBeNull();
+  });
+
+  it("should refuse when no workout is loaded", () => {
+    // Arrange
+
+    // Act
+    const indices = selectedTopLevelStepIndices(undefined, ["after-block-1"]);
+
+    // Assert
+    expect(indices).toBeNull();
+  });
+});

--- a/packages/workout-spa-editor/src/utils/selected-step-indices.ts
+++ b/packages/workout-spa-editor/src/utils/selected-step-indices.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolve a multi-selection to the `stepIndex` values a bulk main-list
+ * mutation addresses.
+ */
+
+import { findById } from "../store/find-by-id";
+import type { Workout } from "../types/krd";
+
+/**
+ * Returns `null` unless every selected id resolves to a *top-level*
+ * step.
+ *
+ * The single-parent invariant makes a selection homogeneous — either all
+ * main-list or all inside one block — so a nested selection is addressed
+ * by block id and must not fall through to the main-list path.
+ *
+ * Note the two distinct index spaces: `findById` yields the flat *array*
+ * position, while bulk delete matches on the domain `stepIndex`. They
+ * diverge as soon as a repetition block sits earlier in the list, so the
+ * domain value is what gets returned here.
+ */
+export const selectedTopLevelStepIndices = (
+  workout: Workout | undefined,
+  ids: ReadonlyArray<string>
+): Array<number> | null => {
+  if (ids.length === 0) return null;
+
+  const indices: Array<number> = [];
+  for (const id of ids) {
+    const found = findById(workout, id);
+    if (found?.kind !== "step" || !("stepIndex" in found.step)) return null;
+    indices.push(found.step.stepIndex);
+  }
+  return indices;
+};


### PR DESCRIPTION
## The gap

Selecting several steps and deleting them silently did nothing. Not a regression — the capability never existed. `selectedStepId` and `selectedStepIds` are mutually exclusive by design (`selectStep` clears the array; `toggleStepSelection` and `selectAllSteps` null the scalar), so a multi-selection is *definitionally* `selectedStepId === null`, and every delete path read only the scalar. Wave K2 removed the dead menu entry; this adds the capability behind it.

## Three traps, and why a naive implementation loses data

**Reindexing.** `deleteStepAction` reindexes the whole list after every call, so `ids → indices → forEach(deleteStep)` deletes the **wrong steps** from the second iteration on. Concretely, with durations `10/20/30/40/50` and `stepIndex` `{1,3}` selected: the loop yields `[10,30,40]`, the correct answer is `[10,30,50]`. A new `deleteSteps` filters once and reindexes once.

**Undo grouping.** The trail keyed entries by `Date.now()`. N deletes inside one millisecond share a timestamp, and `undoDeleteAction` did `find(...)` then `filter(...)` on it — restoring **one** and discarding the rest. Silent data loss on undo. Entries now carry a `groupId`, computed **once per operation** (a UUID from the shared id provider, not a clock, not a counter), and undo drains the whole group in one action, restoring ascending so each stored position still lands correctly.

**History.** N deletes previously pushed N snapshots, so `⌘Z` needed N presses. The bulk path pushes exactly one.

## What the review changed, and why it mattered

The implementation was already correct — the reviewer could not construct a case where it removed or restored the wrong step. **What it could not do was prove it.**

Every fixture lived in the state where the two index spaces coincide: `makeKrd(5)` is five plain steps, and the other two put the repetition block **last**, so `arrayIndex === stepIndex` everywhere. Swapping `f.arrayIndex` for `f.step.stepIndex` in the new action left **all 11 tests green** — and that mutation was the live bug two files away.

Fixed by adding `makeKrdWithLeadingBlock`: a block *preceding* top-level steps, which is where `recalculateStepIndices` makes the two spaces diverge, and which is reachable through plain UI (select two steps, `⌘G`, paste). The same mutation now fails:

```
index: f.arrayIndex  →  index: f.step.stepIndex

  × should restore a leading-block deletion at its original position
  × should restore a non-contiguous group after the block in original order
  Tests  2 failed | 14 passed (16)
```

Reverted: 16/16. The suite now discriminates.

Two more from the same review:
- **`delete-step-action.ts:51` stored the domain `stepIndex`** where the shared helper this PR introduces documents "a position in the pre-delete list". Pre-existing and identically wrong before, but this PR authors the contract it violated. Now `found.arrayIndex`, and `store/README.md` corrected — that doc's ambiguity was the root of it.
- **Two tests named a hazard they never created** — "same-millisecond" cases with no fake timers, asserting only that two UUIDs differ, which is unconditionally true. Now pinned with `setSystemTime` and a timestamp-equality assertion.

## Scope

In-block multi-delete is **not** implemented: the guard returns false for a nested selection, which is today's behaviour, so no regression. `canCopy`/`canCut` remain false under a multi-selection — deliberate and documented rather than half-wired.

## Verification

SPA suite green · `tsc -b --noEmit` · eslint clean (largest new file 69 lines, cap 80) · `pnpm test:scripts` · `npx playwright test --list` parses the full e2e tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)