### PR TITLE
feat(spa-editor): show where each data type comes from (Wave 2a)

### DIFF
--- a/openspec/changes/add-connections-data-type-rows/design.md
+++ b/openspec/changes/add-connections-data-type-rows/design.md
@@ -29,6 +29,31 @@ bridge ids into it) deciding the head.
 silently changes read semantics for the type — a Wave 2b decision to state
 explicitly, not one to slip in under a read-only surface.
 
+### D1a. `priority` with nothing ranked is unranked, not primary
+
+The head is the first entry of the saved order that is still an available
+source — the same element `resolveEffectiveSource` picks. When the saved order
+pins none of them there is no head, and the row reports a count.
+
+This is not defensive coding; both doors are open today. The chat
+`set_data_route` tool's refinement counts the RAW `sourceOrder`, so `["strava"]`
+(a real registry entry with no bridge id) passes the length check and then
+resolves to nothing — review believed the ABSENT-order door was also open, but
+`setDataRouteSchema.superRefine` does close that one. Independently, ranking
+Garmin and then switching Garmin's import off and WHOOP's on leaves a saved
+order pinning nothing available, through the Data Hub alone. In both states the
+pre-fix code named `sources[0]` — policy-table insertion order — which is the
+same overclaim union avoids, arriving through a different door.
+
+### D1b. The writer refuses what it cannot honour
+
+`applySourcePolicy` is where that state is minted, so it is fixed here rather
+than deferred: a ranked mode whose order resolves to nothing is refused and
+reported, following `applyRouteToggle`'s existing shape (return an `error`
+object, write nothing) rather than throwing. A partially-resolvable order is
+still stored — one usable source ranks something. Deferring this to Wave 2b
+would have meant its "Change" control inheriting a corrupt state class.
+
 ## D2. `buildSourcePolicyRows` is not widened
 
 `source-policy-rows.ts` skips any type with fewer than two enabled import

--- a/openspec/changes/add-connections-data-type-rows/design.md
+++ b/openspec/changes/add-connections-data-type-rows/design.md
@@ -45,14 +45,49 @@ order pinning nothing available, through the Data Hub alone. In both states the
 pre-fix code named `sources[0]` — policy-table insertion order — which is the
 same overclaim union avoids, arriving through a different door.
 
-### D1b. The writer refuses what it cannot honour
+### D1b. The writer refuses what it cannot honour — including partially
 
 `applySourcePolicy` is where that state is minted, so it is fixed here rather
-than deferred: a ranked mode whose order resolves to nothing is refused and
-reported, following `applyRouteToggle`'s existing shape (return an `error`
-object, write nothing) rather than throwing. A partially-resolvable order is
-still stored — one usable source ranks something. Deferring this to Wave 2b
-would have meant its "Change" control inheriting a corrupt state class.
+than deferred: a ranked order is stored only when EVERY name resolves,
+following `applyRouteToggle`'s existing shape (return an `error` object, write
+nothing) rather than throwing.
+
+Refusing only TOTAL failure was the first attempt and was wrong. `.filter(id =>
+id !== undefined)` keeps the survivors, so `["whoop-bridge", "tanita"]` — where
+`whoop-bridge` is the storage key rather than the chat-facing id — drops WHOOP
+and durably ranks Tanita first. The resolver honours it and the pill names it.
+Partial failure is worse than total failure precisely because it looks like
+success, so it is refused on the same terms, with the unresolvable names
+reported back so the assistant can say which ones.
+
+### D1c. Mode is consulted for one source too
+
+`originOf` does not short-circuit on `length === 1`. A ranked order that
+excludes the lone available source leaves the resolver's effective order empty,
+so it returns nothing — and naming that source would attribute the type to
+records that never surface. Reachable without any legacy data: chat
+`set_source_policy stress priority ["garmin"]` resolves cleanly, so no writer
+guard stops it, but Garmin announces only `write:workouts`, `read:activities`
+and `write:body` — a Garmin stress import can never be enabled. Manual entry is
+then the only source, and the pre-fix code named it while the user's typed
+stress failed to reach Daily.
+
+### D1d. "Ranked but unavailable" is its own state, not unranked
+
+Folding it into `unranked` traded a false name for a false reassurance: the
+unranked note says the sources are kept side by side with none ranked first,
+which is the opposite of a row that is ranked and reading nothing.
+`rankedUnavailable` therefore has its own label ("No usable source"), its own
+note, and an amber ring — the one row on this read-only surface that presents
+itself as a problem. No CTA: acting on it needs Wave 2b's picker.
+
+### D1e. The explanatory copy is visible text, not a `title`
+
+The first version put the "N sources" explanation in a native `title` on a
+`<span>`, which no keyboard user can reach and which screen readers announce
+inconsistently. Both explained states now render their note as visible muted
+text in the slot the freshness line would occupy — which is free precisely
+because neither state has a single owning source to date the row by.
 
 ## D2. `buildSourcePolicyRows` is not widened
 
@@ -87,6 +122,23 @@ other eleven **by construction**, not because the user switched something off.
 Rendering "Nowhere" there would describe the absence of a route that cannot be
 created; the affordance is omitted instead. `workout` with no enabled export
 route does say "Nowhere", because there the sentence is true.
+
+## D4a. Test fixtures name the writer that can actually create them
+
+Four fixtures originally described routes the capability gate forbids — Garmin
+importing sleep or weight. Garmin announces `write:workouts`,
+`read:activities`, `write:body` and nothing else, so the Data Hub renders those
+cells `na` and its priority editor never lists the type. The assertions were
+right and the tests passed; the provenance comments were fiction, which is this
+programme's usual failure mode inverted, and it is what sent an earlier review
+down the wrong door.
+
+Fixtures now use capability-legal pairs — WHOOP for sleep (the only bridge
+announcing `read:sleep`), WHOOP + Tanita for weight (both announce `read:body`,
+both serve weight) — and each comment names the writer that creates the state:
+the Data Hub cell toggle, its priority editor, chat `set_source_policy`, or
+chat `enable_route`, which is the one writer with **no capability check at
+all**.
 
 ## D5. The grouping is new code, so it gets an invariant
 

--- a/openspec/changes/add-connections-data-type-rows/design.md
+++ b/openspec/changes/add-connections-data-type-rows/design.md
@@ -1,0 +1,75 @@
+# Design — Connections data-type routing rows
+
+## D1. The pill reports the mode, not a preferred brand
+
+The reference design's organising line is "one source of truth per type · others
+stay as backup". `DEFAULT_DATA_TYPE_SOURCE_MODE` is `union`, and union keeps
+every source's record for a day with nothing ranking them
+(`resolve-effective-source.use-case.ts`); `pick-effective-health-record.ts` takes
+`records.at(-1)` when one value is needed, and its own comment says union "has no
+ranked winner". `use-source-policy-editor.ts` even erases `sourceOrder` when the
+user selects union.
+
+So the pill is derived from the mode:
+
+| sources | mode       | pill                      |
+| ------- | ---------- | ------------------------- |
+| 0       | —          | "No source"               |
+| 1       | —          | that source's name        |
+| ≥2      | `priority` | head of `orderSources(…)` |
+| ≥2      | `union`    | "N sources"               |
+
+The `priority` head is the same element `resolveEffectiveSource` consults first,
+so the pill and the resolver cannot disagree. `manual` is appended last to the
+available list, which keeps a saved order (the Data Hub editor only ever writes
+bridge ids into it) deciding the head.
+
+**Alternative rejected**: making the row's "Change" control write
+`mode: "priority"` on first use so the pill becomes true going forward. That
+silently changes read semantics for the type — a Wave 2b decision to state
+explicitly, not one to slip in under a read-only surface.
+
+## D2. `buildSourcePolicyRows` is not widened
+
+`source-policy-rows.ts` skips any type with fewer than two enabled import
+sources. That skip is correct for what it does — it gates a reorder control, and
+a single-source type has nothing to reorder — and its test pins it. Reusing it
+here would drop eleven of the thirteen rows on a typical profile. This change
+adds `buildDataTypeRoutingRows`, which covers all thirteen, and reuses only the
+pure `orderSources` helper so both agree on what "first" means.
+
+## D3. Freshness bypasses the Data Hub matrix
+
+`build-data-hub-matrix.ts` computes a per-cell `lastSyncedAt` (and only when the
+cell is active). These rows are per-TYPE and each already resolves at most one
+source, so they read `useBridgeSyncStates(...).get(sourceId)` directly: one
+`useLiveQuery`, no change to shared code, no test churn, and nothing stranded
+when Wave 4 deletes the matrix UI.
+
+The constraint this creates is a copy constraint. `coachingSyncState` is keyed by
+`[source+profileId]` and holds no data type, so "Sleep arrived 2 minutes ago" is
+not a sentence the state can support. The row names the source
+("Garmin last sent data 2 minutes ago") and the section header says once that
+these times are per source. A row with no single owning source shows no time at
+all rather than picking one of several arbitrarily, and manual entry — which
+never writes a sync row — shows none either.
+
+## D4. "Also sent to" is absent, not empty, where no export can exist
+
+`MANAGED_DATA_REGISTRY` gives an export capability to `workout` and
+`body-composition` only. `useDataFlows` therefore returns `export: []` for the
+other eleven **by construction**, not because the user switched something off.
+Rendering "Nowhere" there would describe the absence of a route that cannot be
+created; the affordance is omitted instead. `workout` with no enabled export
+route does say "Nowhere", because there the sentence is true.
+
+## D5. The grouping is new code, so it gets an invariant
+
+Training / Recovery / Body exists nowhere in `@kaiord/core`; `managedDataTypes`
+is flat. A fourteenth type added there would belong to no group and disappear
+from the page with nothing failing — and three types (`strain`, `vitals`,
+`heart-rate-series`) were already appended to that list in exactly one PR.
+`data-type-groups.test.ts` asserts the partition in both directions: every
+managed type is grouped exactly once, and no group holds a type the domain no
+longer manages. The same drift one row lower is covered by extending
+`connections-data-types.test.ts` to the new hint catalog.

--- a/openspec/changes/add-connections-data-type-rows/proposal.md
+++ b/openspec/changes/add-connections-data-type-rows/proposal.md
@@ -1,0 +1,94 @@
+## Why
+
+The Connections section answers "which sources are linked". It does not answer
+the question a user actually arrives with: _where does my sleep data come from_.
+That answer exists in state today — enabled `IntegrationPolicy` import routes,
+the per-type `DataTypeSourcePolicy` mode, the manual-entry path — but it is only
+readable by cross-referencing a 13×9 matrix on a different page.
+
+The reference design answers it with "one source of truth per type · others stay
+as backup". **The product does not work that way.**
+`DEFAULT_DATA_TYPE_SOURCE_MODE` is `union`, documented as keeping every source's
+record for a day, each tagged with its own `sourceBridgeId`; when a consumer
+needs a single value it takes the last one written. A confident "From: Garmin"
+pill on a union-mode type would be reporting **write order** as if it were a
+choice the user made. This change ships the question, and answers it only as far
+as the state allows.
+
+## What Changes
+
+- **A read-only routing section** under the source cards: all thirteen managed
+  data types, grouped Training / Recovery / Body, each row naming where the type
+  comes from and, where such a route can exist, where Kaiord sends it on.
+- **An origin derivation that reports mode honestly**:
+  `sources = enabled import routes ∪ manual (where a manual path exists)`, then
+  none → "No source"; one → that source; two or more under `priority` → the
+  ranked head, the same one `resolveEffectiveSource` consults; two or more under
+  `union` (the default) → **a count, never a name**.
+- **Per-source freshness on each row**, read straight from `coachingSyncState`
+  by source rather than through the Data Hub matrix. `coachingSyncState` is
+  keyed by (source, profile) and carries no data type, so the copy names the
+  SOURCE as the subject and the section says so once, in a header hint.
+- **A Training / Recovery / Body grouping constant** with a parity test binding
+  it to `managedDataTypes` — the grouping exists nowhere in `@kaiord/core`, and
+  three types were already appended to that flat list in one PR.
+- **Row descriptions** for all thirteen types in `en` and `es`, derived from
+  what each schema actually carries.
+
+Deliberately NOT shipped, because no state backs them:
+
+- **"Also sent to" on eleven of thirteen rows.** Only `workout`
+  (`write:workouts`) and `body-composition` (`write:body`) have an export
+  capability at all; the design shows the affordance on Planned Session,
+  Training Zones and Weight, which are import-only. Those rows omit it rather
+  than saying "Nowhere" about a route that cannot be created.
+- **Fallback display** ("WHOOP ~~struck~~ → Garmin · backup since <date>").
+  `usedFallback` is priority-mode only, is per-(type, day), means "no record
+  that day" rather than "this source broke", and is undefined for `strain`,
+  `vitals` and `heart-rate-series` — including Strain, the row the design uses
+  to demonstrate it.
+- **"No source since <date>"**. "No source" is derivable; the date is not. No
+  transition timestamp exists anywhere in the product.
+- **"Baseline reset — 3 days of new data"** and **"Tanita would be more accurate
+  here"** — no state at all behind either.
+- **Per-type freshness.** "Sleep synced 2 minutes ago" is not expressible; the
+  same instant belongs to every row that source feeds.
+
+Out of scope: the inline "Change" control that picks a source of truth
+(Wave 2b), the stats row and consequence banner (Wave 3), and retiring the Data
+Hub matrix (Wave 4).
+
+## Capabilities
+
+### Modified Capabilities
+
+- `spa-connections-page`: gains the per-data-type routing section — the origin
+  derivation and what each origin is permitted to claim, the grouping
+  completeness invariant, the export-affordance rule, and the constraint that
+  binds freshness copy to the source rather than the data type. The capability
+  itself is introduced by `add-connections-page` (Wave 1) and lands in
+  `openspec/specs/` when that change archives; this change's delta is purely
+  additive to it and neither restates nor contradicts a Wave 1 requirement.
+
+## Impact
+
+- **Package**: `@kaiord/workout-spa-editor` (private SPA) only. No domain,
+  port or adapter-package change; no dependency added; no Dexie version bump.
+- **Shared code touched**: none of the routing logic is widened.
+  `buildSourcePolicyRows` keeps its `< 2 sources` skip — that skip is correct
+  for gating a reorder control and is pinned by its test — so this ships its own
+  derivation instead. The only shared change is extracting the
+  `dataTypeSourcePolicy` live query out of `useSourcePolicies` into
+  `useDataTypeSourcePolicies`, which both consumers now call; behaviour is
+  unchanged.
+- **Behaviour change**: none outside the new section. Nothing writes.
+- **i18n**: `connections.routing.*` and `connections.dataTypeHints.*` added to
+  both locales; covered by `resource-parity.test.ts` and by the extended
+  `connections-data-types.test.ts`.
+- **Tests**: `ConnectionsTab.test.tsx` now renders inside a
+  `PersistenceProvider`, because the tab reads the persistence port for
+  per-source freshness.
+- **e2e**: no test id and no URL changed; `data-flows-density.spec.ts` exercises
+  `/athlete`, not this section.
+- **No** changeset (the SPA is private and excluded from the changeset-bot
+  PUBLISHABLE set).

--- a/openspec/changes/add-connections-data-type-rows/specs/spa-connections-page/spec.md
+++ b/openspec/changes/add-connections-data-type-rows/specs/spa-connections-page/spec.md
@@ -1,0 +1,135 @@
+## ADDED Requirements
+
+### Requirement: The section names where every managed data type comes from
+
+The system SHALL present every managed data type as a row in one section beneath
+the source cards, and SHALL derive the set of rows from the domain's own list of
+managed types rather than from a hand-kept copy. Rows SHALL be presented in
+named groups, and every managed type SHALL belong to exactly one group, so a
+type added to the domain cannot render in no group at all.
+
+Each row SHALL be addressable by a stable identifier derived from its data type,
+and SHALL expose its derived origin as data rather than only as prose.
+
+#### Scenario: Every managed type is rendered
+
+- **WHEN** the section renders
+- **THEN** every data type the domain manages SHALL appear exactly once
+
+#### Scenario: A type the grouping does not cover fails loudly
+
+- **GIVEN** a data type present in the domain's managed list and absent from every group
+- **WHEN** the grouping is checked
+- **THEN** the check SHALL fail rather than the type being omitted from the page
+
+### Requirement: A source is named only when one source is real
+
+The system SHALL derive a row's origin from the profile's enabled import routes
+for that type, together with manual entry for the types that have a manual entry
+path. With no source it SHALL say so. With exactly one source it SHALL name that
+source.
+
+With two or more sources the system SHALL consult the type's stored multi-source
+mode. Under a ranked mode it SHALL name the first source in the effective order —
+the same one the read resolver consults — so the two cannot disagree. Under the
+default unranked mode every source keeps writing and nothing ranks them, so the
+system SHALL report HOW MANY sources there are and SHALL NOT name one; naming one
+would present the order records happened to be written in as a choice the user
+made.
+
+#### Scenario: A type with no manual path and no route has no source
+
+- **GIVEN** a data type with no enabled import route and no manual entry path
+- **WHEN** its origin is derived
+- **THEN** it SHALL report that it has no source
+
+#### Scenario: Manual entry counts as a source
+
+- **GIVEN** a data type with a manual entry path and no enabled import route
+- **WHEN** its origin is derived
+- **THEN** manual entry SHALL be named as its source
+
+#### Scenario: The default unranked mode reports a count
+
+- **GIVEN** a data type with two or more sources and no stored ranking
+- **WHEN** its origin is derived
+- **THEN** the row SHALL state how many sources it has
+- **AND** SHALL NOT name any one of them
+
+#### Scenario: A stored ranking is honoured
+
+- **GIVEN** a data type with two or more sources and a stored ranked order
+- **WHEN** its origin is derived
+- **THEN** the row SHALL name the first source of that order
+
+#### Scenario: A route the user switched off is not a source
+
+- **GIVEN** an import route that exists but is disabled
+- **WHEN** the origin is derived
+- **THEN** that route's source SHALL NOT be counted
+
+### Requirement: Freshness is attributed to the source, never to the data type
+
+Stored sync freshness is recorded per (source, profile) and carries no data type.
+The system SHALL therefore state freshness with the SOURCE as its subject, and
+SHALL make it plain that the time describes everything that source sends rather
+than the row it appears on. The system SHALL NOT claim that a particular data
+type arrived at a particular time.
+
+Where no single source owns a row, the system SHALL show no time rather than
+choosing one of several arbitrarily. Where a source has recorded no sync at all —
+including manual entry, which records none by design — the system SHALL show no
+time rather than inventing one.
+
+#### Scenario: The time names its source
+
+- **GIVEN** a row whose single source has a recorded sync time
+- **WHEN** the row renders
+- **THEN** the sentence SHALL name that source as the subject of the time
+
+#### Scenario: No owning source, no time
+
+- **GIVEN** a row reporting a count of sources rather than a name
+- **WHEN** the row renders
+- **THEN** no sync time SHALL be shown
+
+#### Scenario: A source that has never synced shows no time
+
+- **GIVEN** a row whose source has no recorded sync
+- **WHEN** the row renders
+- **THEN** no sync time SHALL be shown
+
+### Requirement: An export target is offered only where an export can exist
+
+The system SHALL offer a row's "sent onwards" affordance only for data types the
+registry gives an export capability. For a type with no export capability the
+affordance SHALL be absent, because reporting that the type goes nowhere would
+describe the absence of a route that cannot be created. For a type that can be
+exported but has no enabled export route, the system SHALL report that it goes
+nowhere, which there is true.
+
+#### Scenario: An import-only type offers nothing
+
+- **GIVEN** a data type with no export capability in the registry
+- **WHEN** its row renders
+- **THEN** no "sent onwards" affordance SHALL be present
+
+#### Scenario: An exportable type with no enabled route says so
+
+- **GIVEN** a data type with an export capability and no enabled export route
+- **WHEN** its row renders
+- **THEN** the row SHALL report that it is sent nowhere
+
+### Requirement: The section claims no fallback and no transition date
+
+No state records when a source stopped working or when another took over: the
+fallback signal that exists is ranked-mode only, is scoped to a single day,
+means "no record that day" rather than "this source broke", and does not cover
+every type. The system SHALL NOT present a struck-through source, a "backup
+since" date, a "stopped syncing" duration, or any other claim about a transition
+between sources.
+
+#### Scenario: No transition claim is rendered
+
+- **WHEN** a row renders for a type with several sources
+- **THEN** it SHALL NOT state that any source has been replaced, has fallen back, or has been a backup since some date

--- a/openspec/changes/add-connections-data-type-rows/specs/spa-connections-page/spec.md
+++ b/openspec/changes/add-connections-data-type-rows/specs/spa-connections-page/spec.md
@@ -1,5 +1,29 @@
 ## ADDED Requirements
 
+### Requirement: A ranked source policy is never stored without its ranking
+
+A ranked multi-source mode is meaningless without an order: the read resolver
+consults the stored order and, finding nothing in it, resolves no record at all,
+while every display surface is left to invent a winner. The system SHALL
+therefore refuse to persist a ranked policy whose order, AFTER resolving the
+names given to storage keys, contains no usable source, and SHALL report that
+refusal to the caller rather than writing a policy it cannot honour. A
+partially-resolvable order SHALL still be stored, because one usable source
+ranks something.
+
+#### Scenario: An order that resolves to nothing is refused
+
+- **GIVEN** a request to set a ranked source policy naming only sources that do not resolve to a storage key
+- **WHEN** the request is applied
+- **THEN** no policy SHALL be persisted
+- **AND** the caller SHALL be told the order could not be resolved
+
+#### Scenario: A partially resolvable order is kept
+
+- **GIVEN** a request to set a ranked source policy naming one source that resolves and one that does not
+- **WHEN** the request is applied
+- **THEN** the policy SHALL be persisted with the resolvable source alone
+
 ### Requirement: The section names where every managed data type comes from
 
 The system SHALL present every managed data type as a row in one section beneath
@@ -61,6 +85,13 @@ made.
 - **GIVEN** a data type with two or more sources and a stored ranked order
 - **WHEN** its origin is derived
 - **THEN** the row SHALL name the first source of that order
+
+#### Scenario: A ranked mode that ranks nothing names nothing
+
+- **GIVEN** a data type in a ranked mode whose stored order names none of its currently available sources
+- **WHEN** its origin is derived
+- **THEN** the row SHALL report a count rather than naming a source
+- **AND** SHALL NOT fall back to whichever source happens to be first
 
 #### Scenario: A route the user switched off is not a source
 

--- a/openspec/changes/add-connections-data-type-rows/specs/spa-connections-page/spec.md
+++ b/openspec/changes/add-connections-data-type-rows/specs/spa-connections-page/spec.md
@@ -3,13 +3,17 @@
 ### Requirement: A ranked source policy is never stored without its ranking
 
 A ranked multi-source mode is meaningless without an order: the read resolver
-consults the stored order and, finding nothing in it, resolves no record at all,
-while every display surface is left to invent a winner. The system SHALL
-therefore refuse to persist a ranked policy whose order, AFTER resolving the
-names given to storage keys, contains no usable source, and SHALL report that
-refusal to the caller rather than writing a policy it cannot honour. A
-partially-resolvable order SHALL still be stored, because one usable source
-ranks something.
+consults the stored order and, finding nothing usable in it, resolves no record
+at all, while every display surface is left to invent a winner. The system SHALL
+persist a ranked policy only when EVERY source named in the request resolves to
+a storage key, and SHALL otherwise report the refusal, naming the sources it
+could not resolve, without writing anything.
+
+Discarding the unresolvable names and storing the rest SHALL NOT be treated as
+success: dropping a leading name promotes a source the request ranked BELOW it,
+which the resolver then honours and every display surface then reports, so a
+partial failure would silently invert the user's stated preference while
+appearing to have worked.
 
 #### Scenario: An order that resolves to nothing is refused
 
@@ -18,11 +22,18 @@ ranks something.
 - **THEN** no policy SHALL be persisted
 - **AND** the caller SHALL be told the order could not be resolved
 
-#### Scenario: A partially resolvable order is kept
+#### Scenario: A partially resolvable order is refused too
 
-- **GIVEN** a request to set a ranked source policy naming one source that resolves and one that does not
+- **GIVEN** a request to set a ranked source policy whose first source does not resolve and whose second does
 - **WHEN** the request is applied
-- **THEN** the policy SHALL be persisted with the resolvable source alone
+- **THEN** no policy SHALL be persisted
+- **AND** the second source SHALL NOT become the ranked first
+
+#### Scenario: A fully resolvable order is stored
+
+- **GIVEN** a request to set a ranked source policy in which every named source resolves
+- **WHEN** the request is applied
+- **THEN** the policy SHALL be persisted in the order requested
 
 ### Requirement: The section names where every managed data type comes from
 
@@ -53,13 +64,15 @@ for that type, together with manual entry for the types that have a manual entry
 path. With no source it SHALL say so. With exactly one source it SHALL name that
 source.
 
-With two or more sources the system SHALL consult the type's stored multi-source
-mode. Under a ranked mode it SHALL name the first source in the effective order —
-the same one the read resolver consults — so the two cannot disagree. Under the
-default unranked mode every source keeps writing and nothing ranks them, so the
-system SHALL report HOW MANY sources there are and SHALL NOT name one; naming one
-would present the order records happened to be written in as a choice the user
-made.
+The stored multi-source mode SHALL be consulted whatever the number of sources,
+including one: a ranked order that excludes the lone available source makes the
+resolver read nothing, so naming that source would attribute the type to data
+that never surfaces. Under a ranked mode the system SHALL name the first source
+of the effective order — the same one the read resolver consults — so the two
+cannot disagree. Under the default unranked mode every source keeps writing and
+nothing ranks them, so with two or more sources the system SHALL report HOW MANY
+there are and SHALL NOT name one; naming one would present the order records
+happened to be written in as a choice the user made.
 
 #### Scenario: A type with no manual path and no route has no source
 
@@ -90,8 +103,30 @@ made.
 
 - **GIVEN** a data type in a ranked mode whose stored order names none of its currently available sources
 - **WHEN** its origin is derived
-- **THEN** the row SHALL report a count rather than naming a source
+- **THEN** the row SHALL report that it has no usable source
 - **AND** SHALL NOT fall back to whichever source happens to be first
+
+#### Scenario: A ranked order that excludes the only source
+
+- **GIVEN** a data type with exactly one available source and a stored ranked order that does not include it
+- **WHEN** its origin is derived
+- **THEN** the row SHALL report that it has no usable source rather than naming that source
+
+### Requirement: A row whose ranking cannot be honoured says so
+
+Where a ranked order names none of the currently available sources the resolver
+returns no record for that type at all — the data is not merely unranked, it is
+not being read. The system SHALL distinguish this from the unranked default in
+both its wording and its visual treatment, and SHALL NOT describe it with copy
+that implies the sources are being kept side by side. This is the one state on
+this read-only surface permitted to present itself as a problem.
+
+#### Scenario: The stalled state is not described as healthy redundancy
+
+- **GIVEN** a data type whose ranked order names no available source
+- **WHEN** its row renders
+- **THEN** the row SHALL state that nothing is being read for the type
+- **AND** SHALL NOT reuse the wording given to a type whose sources are all kept
 
 #### Scenario: A route the user switched off is not a source
 

--- a/openspec/changes/add-connections-data-type-rows/tasks.md
+++ b/openspec/changes/add-connections-data-type-rows/tasks.md
@@ -4,24 +4,40 @@
       `sources = enabled import routes ∪ manual (where MANUAL_ENTRY_TYPES has
 the type)`, appending `manual` last so a saved bridge order keeps deciding
       the head. See design.md D1.
-- [x] 1.2 Report `none` / `only` / `primary` / `unranked`, taking the ranked
-      head as the first saved entry still available — the element
-      `resolveEffectiveSource` picks — so the pill and the resolver cannot
-      disagree.
+- [x] 1.2 Report `none` / `only` / `primary` / `unranked` /
+      `rankedUnavailable`, taking the ranked head as the first saved entry
+      still available — the element `resolveEffectiveSource` picks — so the
+      pill and the resolver cannot disagree.
 - [x] 1.3 Carry `exportable` from `MANAGED_DATA_REGISTRY[...].capabilities
 .export`, and `sentTo` from enabled export routes only. See design.md D4.
 - [x] 1.4 Leave `buildSourcePolicyRows` untouched — its `< 2 sources` skip is
       correct for gating a reorder control and is pinned by its test. See
       design.md D2.
-- [x] 1.5 Report `unranked` when a `priority` policy's saved order pins none of
-      the available sources, instead of naming `sources[0]`. Reachable through
-      the chat tool (raw-length refinement, ids that fail to resolve) and
-      through the Data Hub (rank a bridge, then switch its import off). See
-      design.md D1a.
+- [x] 1.5 Stop naming `sources[0]` when a `priority` policy's saved order pins
+      none of the available sources. Reachable through the chat tool (ids that
+      pass its raw-length check and then fail to resolve) and through the Data
+      Hub (rank a bridge, then switch its import off). See design.md D1a.
 - [x] 1.6 Refuse the write that mints that state: `applySourcePolicy` returns
-      `unresolvable_source_order` and persists nothing when a `priority` order
-      resolves empty, following `applyRouteToggle`'s error shape. See
-      design.md D1b.
+      `unresolvable_source_order` and persists nothing unless EVERY named source
+      resolves — a partial drop silently promotes a source the request ranked
+      lower. See design.md D1b.
+- [x] 1.7 Consult the mode for a single source too, so a ranked order excluding
+      the lone source reports `rankedUnavailable` instead of naming it. See
+      design.md D1c.
+- [x] 1.8 Give `rankedUnavailable` its own label, note and amber ring rather
+      than folding it into `unranked`, whose note says the opposite. See
+      design.md D1d.
+- [x] 1.9 Render both explanatory notes as visible text; drop the native
+      `title`, which no keyboard user can reach. See design.md D1e.
+- [x] 1.10 Comment the manual-source asymmetry: this derivation gates `manual`
+      on `MANUAL_ENTRY_TYPES` while `resolveEffectiveSource` exempts it
+      unconditionally, so adding a manual path without updating that set makes
+      pill and resolver diverge silently.
+- [x] 1.11 Rebuild the test fixtures on capability-legal routes and name the
+      writer that creates each state; four described routes the capability gate
+      forbids. See design.md D4a.
+- [x] 1.12 Populate `syncedAt` in the freshness tests — the spec'd "no owning
+      source, no time" scenario ran against an empty map and could not fail.
 
 ## 2. Grouping
 

--- a/openspec/changes/add-connections-data-type-rows/tasks.md
+++ b/openspec/changes/add-connections-data-type-rows/tasks.md
@@ -1,0 +1,62 @@
+## 1. Origin derivation
+
+- [x] 1.1 `application/connections/data-type-routing.ts`: derive
+      `sources = enabled import routes ∪ manual (where MANUAL_ENTRY_TYPES has
+    the type)`, appending `manual` last so a saved bridge order keeps deciding
+      the head. See design.md D1.
+- [x] 1.2 Report `none` / `only` / `primary` / `unranked`, taking the ranked
+      head from the shared `orderSources` so the pill and
+      `resolveEffectiveSource` cannot disagree.
+- [x] 1.3 Carry `exportable` from `MANAGED_DATA_REGISTRY[...].capabilities
+    .export`, and `sentTo` from enabled export routes only. See design.md D4.
+- [x] 1.4 Leave `buildSourcePolicyRows` untouched — its `< 2 sources` skip is
+      correct for gating a reorder control and is pinned by its test. See
+      design.md D2.
+
+## 2. Grouping
+
+- [x] 2.1 `application/connections/data-type-groups.ts`: Training / Recovery /
+      Body as an SPA-side constant.
+- [x] 2.2 `data-type-groups.test.ts`: assert the partition in both directions —
+      every managed type grouped exactly once, and no group entry the domain no
+      longer manages. See design.md D5.
+
+## 3. Hooks
+
+- [x] 3.1 Extract the `dataTypeSourcePolicy` live query out of
+      `useSourcePolicies` into `hooks/data-hub/use-data-type-source-policies.ts`;
+      both consumers read the same query.
+- [x] 3.2 `hooks/connections/use-data-type-routing.ts`: take `byDataType` from
+      the page rather than opening a second `useDataFlows` subscription, and read
+      freshness with `useBridgeSyncStates` rather than through the Data Hub
+      matrix. See design.md D3.
+
+## 4. UI
+
+- [x] 4.1 `DataTypeRoutingSection` / `DataTypeRoutingGroup` /
+      `DataTypeRoutingRow`, each row addressable as `routing-row-<dataType>` and
+      exposing its origin kind as `data-origin`.
+- [x] 4.2 `RoutingFreshness`: name the source as the subject; render nothing
+      without a stored timestamp.
+- [x] 4.3 Omit the "Also sent to" affordance on the eleven types with no export
+      capability; say "Nowhere" only where an export route could exist.
+- [x] 4.4 Mount the section in `ConnectionsTab` under the source cards, reusing
+      the page's single `useDataFlows` result.
+- [x] 4.5 Theme tokens only (`bg-surface`, `border-edge`, `text-ink-*`) — the
+      design's palette would trip `check-theme-dialect`.
+
+## 5. Copy
+
+- [x] 5.1 `connections.routing.*` in `en` and `es`, including the header hint
+      that states freshness is per source.
+- [x] 5.2 `connections.dataTypeHints.*` for all thirteen types in both locales,
+      written from what each schema carries (`daily-wellness` is steps /
+      calories / intensity minutes, not "body battery", which nothing ingests).
+- [x] 5.3 Extend `connections-data-types.test.ts` to the hint catalog.
+
+## 6. Verification
+
+- [x] 6.1 `pnpm -r build`
+- [x] 6.2 SPA `pnpm test` and `pnpm lint` (`tsc -b --noEmit`)
+- [x] 6.3 `pnpm test:scripts`, root `pnpm lint`, `pnpm lint:specs`
+- [x] 6.4 `npx playwright test --list`

--- a/openspec/changes/add-connections-data-type-rows/tasks.md
+++ b/openspec/changes/add-connections-data-type-rows/tasks.md
@@ -2,16 +2,26 @@
 
 - [x] 1.1 `application/connections/data-type-routing.ts`: derive
       `sources = enabled import routes ∪ manual (where MANUAL_ENTRY_TYPES has
-    the type)`, appending `manual` last so a saved bridge order keeps deciding
+the type)`, appending `manual` last so a saved bridge order keeps deciding
       the head. See design.md D1.
 - [x] 1.2 Report `none` / `only` / `primary` / `unranked`, taking the ranked
-      head from the shared `orderSources` so the pill and
-      `resolveEffectiveSource` cannot disagree.
+      head as the first saved entry still available — the element
+      `resolveEffectiveSource` picks — so the pill and the resolver cannot
+      disagree.
 - [x] 1.3 Carry `exportable` from `MANAGED_DATA_REGISTRY[...].capabilities
-    .export`, and `sentTo` from enabled export routes only. See design.md D4.
+.export`, and `sentTo` from enabled export routes only. See design.md D4.
 - [x] 1.4 Leave `buildSourcePolicyRows` untouched — its `< 2 sources` skip is
       correct for gating a reorder control and is pinned by its test. See
       design.md D2.
+- [x] 1.5 Report `unranked` when a `priority` policy's saved order pins none of
+      the available sources, instead of naming `sources[0]`. Reachable through
+      the chat tool (raw-length refinement, ids that fail to resolve) and
+      through the Data Hub (rank a bridge, then switch its import off). See
+      design.md D1a.
+- [x] 1.6 Refuse the write that mints that state: `applySourcePolicy` returns
+      `unresolvable_source_order` and persists nothing when a `priority` order
+      resolves empty, following `applyRouteToggle`'s error shape. See
+      design.md D1b.
 
 ## 2. Grouping
 

--- a/packages/workout-spa-editor/src/application/connections/data-type-groups.test.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-groups.test.ts
@@ -1,0 +1,37 @@
+import { managedDataTypes } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import { DATA_TYPE_GROUPS } from "./data-type-groups";
+
+const grouped = DATA_TYPE_GROUPS.flatMap((group) => group.types);
+
+describe("data-type groups", () => {
+  it("should place every managed data type in exactly one group", () => {
+    // Arrange
+    // Training / Recovery / Body exists only here. `managedDataTypes` is a
+    // flat list in @kaiord/core, and three types (strain, vitals,
+    // heart-rate-series) were already appended to it in one PR — a fourth
+    // would otherwise render in no group and vanish from the page silently.
+    const expected = [...managedDataTypes].sort();
+
+    // Act
+    const actual = [...grouped].sort();
+
+    // Assert
+    expect(actual).toEqual(expected);
+  });
+
+  it("should not keep a type the domain no longer manages", () => {
+    // Arrange
+    // The other direction of the same drift: a type renamed or removed in
+    // core leaves a group entry that resolves to no row, so the group renders
+    // one item short with nothing failing.
+    const managed = new Set<string>(managedDataTypes);
+
+    // Act
+    const stale = grouped.filter((dataType) => !managed.has(dataType));
+
+    // Assert
+    expect(stale).toEqual([]);
+  });
+});

--- a/packages/workout-spa-editor/src/application/connections/data-type-groups.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-groups.ts
@@ -1,0 +1,37 @@
+/**
+ * Training / Recovery / Body — a presentation grouping that exists nowhere in
+ * `@kaiord/core`. `managedDataTypes` is a flat list, so a 14th type added
+ * there would belong to no group and silently render on no surface at all.
+ * `data-type-groups.test.ts` pins the partition instead of leaving that to
+ * whoever notices; three types (strain, vitals, heart-rate-series) were
+ * already added to the flat list exactly that way.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+export type DataTypeGroupId = "training" | "recovery" | "body";
+
+export type DataTypeGroup = {
+  readonly id: DataTypeGroupId;
+  readonly types: readonly ManagedDataType[];
+};
+
+export const DATA_TYPE_GROUPS: readonly DataTypeGroup[] = [
+  {
+    id: "training",
+    types: [
+      "workout",
+      "planned-session",
+      "activity",
+      "training-zones",
+      "heart-rate-series",
+    ],
+  },
+  {
+    id: "recovery",
+    types: ["sleep", "hrv", "daily-wellness", "stress", "strain"],
+  },
+  {
+    id: "body",
+    types: ["weight", "body-composition", "vitals"],
+  },
+];

--- a/packages/workout-spa-editor/src/application/connections/data-type-groups.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-groups.ts
@@ -1,10 +1,7 @@
 /**
- * Training / Recovery / Body — a presentation grouping that exists nowhere in
- * `@kaiord/core`. `managedDataTypes` is a flat list, so a 14th type added
- * there would belong to no group and silently render on no surface at all.
- * `data-type-groups.test.ts` pins the partition instead of leaving that to
- * whoever notices; three types (strain, vitals, heart-rate-series) were
- * already added to the flat list exactly that way.
+ * `managedDataTypes` is a flat list, so a type added there belongs to no group
+ * and renders on no surface until it is placed here. The partition is pinned
+ * by test in both directions rather than left to whoever notices.
  */
 import type { ManagedDataType } from "@kaiord/core";
 

--- a/packages/workout-spa-editor/src/application/connections/data-type-routing.test.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-routing.test.ts
@@ -1,0 +1,163 @@
+import type { ManagedDataType } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import type { DataFlowsByType } from "../../components/organisms/ProfileManager/components/useDataFlows";
+import type { DataTypeSourcePolicy } from "../../types/data-type-source-policy";
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import {
+  buildDataTypeRoutingRows,
+  type DataTypeRoutingRow,
+} from "./data-type-routing";
+
+const route = (bridgeId: string, enabled = true): IntegrationPolicy =>
+  ({ bridgeId, enabled }) as IntegrationPolicy;
+
+const flows = (
+  entries: Partial<
+    Record<
+      ManagedDataType,
+      { import?: IntegrationPolicy[]; export?: IntegrationPolicy[] }
+    >
+  >
+): DataFlowsByType =>
+  new Map(
+    Object.entries(entries).map(([dataType, value]) => [
+      dataType as ManagedDataType,
+      { import: value?.import ?? [], export: value?.export ?? [] },
+    ])
+  );
+
+const rowFor = (
+  rows: DataTypeRoutingRow[],
+  dataType: ManagedDataType
+): DataTypeRoutingRow => {
+  const row = rows.find((candidate) => candidate.dataType === dataType);
+  if (row === undefined) throw new Error(`no row for ${dataType}`);
+  return row;
+};
+
+const priority = (
+  dataType: ManagedDataType,
+  sourceOrder: string[]
+): DataTypeSourcePolicy =>
+  ({ dataType, mode: "priority", sourceOrder }) as DataTypeSourcePolicy;
+
+describe("buildDataTypeRoutingRows", () => {
+  it("should treat manual entry as a source where a manual path exists", () => {
+    // Arrange
+    // The state of a profile that has linked nothing yet — the first thing
+    // anyone opening the page sees. `sleep` has a manual entry path, so it is
+    // never sourceless even with no bridge at all.
+    const rows = buildDataTypeRoutingRows(flows({}), []);
+
+    // Act
+    const origin = rowFor(rows, "sleep").origin;
+
+    // Assert
+    expect(origin).toEqual({ kind: "only", sourceId: "manual" });
+  });
+
+  it("should report no source only for a type with no manual path", () => {
+    // Arrange
+    // Same empty profile. `planned-session` is deliberately absent from
+    // MANUAL_ENTRY_TYPES (there is no way to author a coach session by hand),
+    // so it is one of the four types where "No source" is reachable at all.
+    const rows = buildDataTypeRoutingRows(flows({}), []);
+
+    // Act
+    const origin = rowFor(rows, "planned-session").origin;
+
+    // Assert
+    expect(origin).toEqual({ kind: "none" });
+  });
+
+  it("should count sources rather than name one in the default union mode", () => {
+    // Arrange
+    // One enabled Garmin sleep route plus the always-present manual path is
+    // already two sources, and union — the DEFAULT with no policy row — keeps
+    // both records with nothing ranking them. Naming Garmin here would be
+    // reporting write order as a choice the user never made.
+    const rows = buildDataTypeRoutingRows(
+      flows({ sleep: { import: [route("garmin-bridge")] } }),
+      []
+    );
+
+    // Act
+    const origin = rowFor(rows, "sleep").origin;
+
+    // Assert
+    expect(origin).toEqual({ kind: "unranked", count: 2 });
+  });
+
+  it("should name the priority head once the user has ranked the sources", () => {
+    // Arrange
+    // The Data Hub's source-priority editor writes exactly this row, and the
+    // head it stores is the one resolveEffectiveSource consults first.
+    const rows = buildDataTypeRoutingRows(
+      flows({
+        weight: {
+          import: [route("garmin-bridge"), route("trainingpeaks-bridge")],
+        },
+      }),
+      [priority("weight", ["trainingpeaks-bridge", "garmin-bridge"])]
+    );
+
+    // Act
+    const origin = rowFor(rows, "weight").origin;
+
+    // Assert
+    expect(origin).toEqual({
+      kind: "primary",
+      sourceId: "trainingpeaks",
+      count: 3,
+    });
+  });
+
+  it("should drop an import route the user switched off", () => {
+    // Arrange
+    // Toggling a Data Hub cell off writes enabled:false rather than deleting
+    // the row, so a disabled route stays visible to this derivation.
+    const rows = buildDataTypeRoutingRows(
+      flows({ weight: { import: [route("garmin-bridge", false)] } }),
+      []
+    );
+
+    // Act
+    const origin = rowFor(rows, "weight").origin;
+
+    // Assert
+    expect(origin).toEqual({ kind: "only", sourceId: "manual" });
+  });
+
+  it("should list an export target only while its route is enabled", () => {
+    // Arrange
+    const enabled = flows({ workout: { export: [route("garmin-bridge")] } });
+    const off = flows({ workout: { export: [route("garmin-bridge", false)] } });
+
+    // Act
+    const on = rowFor(buildDataTypeRoutingRows(enabled, []), "workout");
+    const paused = rowFor(buildDataTypeRoutingRows(off, []), "workout");
+
+    // Assert
+    expect(on.sentTo).toEqual(["garmin"]);
+    expect(paused.sentTo).toEqual([]);
+  });
+
+  it("should mark only the two types that can be exported at all", () => {
+    // Arrange
+    // Eleven of thirteen have no export capability in MANAGED_DATA_REGISTRY,
+    // so the design's "Also sent to · Nowhere" on Planned Session, Training
+    // Zones and Weight describes a route that cannot be created. If a future
+    // registry entry gains an export token, this fails and that copy decision
+    // gets revisited rather than silently widening.
+    const rows = buildDataTypeRoutingRows(flows({}), []);
+
+    // Act
+    const exportable = rows
+      .filter((row) => row.exportable)
+      .map((row) => row.dataType);
+
+    // Assert
+    expect(exportable).toEqual(["workout", "body-composition"]);
+  });
+});

--- a/packages/workout-spa-editor/src/application/connections/data-type-routing.test.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-routing.test.ts
@@ -113,6 +113,41 @@ describe("buildDataTypeRoutingRows", () => {
     });
   });
 
+  it("should not name a head when a priority policy ranks nothing", () => {
+    // Arrange
+    // Reachable through chat: `set_data_route` counts the RAW sourceOrder, so
+    // ["strava"] passes its length check and then resolves to nothing, leaving
+    // a persisted priority policy with an empty order. Naming sources[0] here
+    // would attribute sleep to whichever import route was created first.
+    const rows = buildDataTypeRoutingRows(
+      flows({ sleep: { import: [route("garmin-bridge")] } }),
+      [priority("sleep", [])]
+    );
+
+    // Act
+    const origin = rowFor(rows, "sleep").origin;
+
+    // Assert
+    expect(origin).toEqual({ kind: "unranked", count: 2 });
+  });
+
+  it("should not name a head that is no longer an enabled source", () => {
+    // Arrange
+    // The same shape reached through the Data Hub alone: rank Garmin, then
+    // switch Garmin's import off and WHOOP's on. The saved order still exists
+    // but pins nothing available, and WHOOP was never ranked.
+    const rows = buildDataTypeRoutingRows(
+      flows({ sleep: { import: [route("whoop-bridge")] } }),
+      [priority("sleep", ["garmin-bridge"])]
+    );
+
+    // Act
+    const origin = rowFor(rows, "sleep").origin;
+
+    // Assert
+    expect(origin).toEqual({ kind: "unranked", count: 2 });
+  });
+
   it("should drop an import route the user switched off", () => {
     // Arrange
     // Toggling a Data Hub cell off writes enabled:false rather than deleting

--- a/packages/workout-spa-editor/src/application/connections/data-type-routing.test.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-routing.test.ts
@@ -73,12 +73,12 @@ describe("buildDataTypeRoutingRows", () => {
 
   it("should count sources rather than name one in the default union mode", () => {
     // Arrange
-    // One enabled Garmin sleep route plus the always-present manual path is
-    // already two sources, and union — the DEFAULT with no policy row — keeps
-    // both records with nothing ranking them. Naming Garmin here would be
-    // reporting write order as a choice the user never made.
+    // WHOOP is the ONLY bridge announcing `read:sleep`, so this is the whole
+    // reachable source set for sleep: one bridge plus the always-present manual
+    // path. Union — the DEFAULT with no policy row — keeps both records with
+    // nothing ranking them. Writer: the Data Hub sleep/WHOOP import toggle.
     const rows = buildDataTypeRoutingRows(
-      flows({ sleep: { import: [route("garmin-bridge")] } }),
+      flows({ sleep: { import: [route("whoop-bridge")] } }),
       []
     );
 
@@ -91,36 +91,33 @@ describe("buildDataTypeRoutingRows", () => {
 
   it("should name the priority head once the user has ranked the sources", () => {
     // Arrange
-    // The Data Hub's source-priority editor writes exactly this row, and the
-    // head it stores is the one resolveEffectiveSource consults first.
+    // WHOOP and Tanita both announce `read:body`, and Tanita's route filter
+    // allows weight, so weight genuinely reaches 2 enabled bridge imports —
+    // which is what makes the Data Hub's priority editor list it at all. That
+    // editor is the writer; the head it stores is the one
+    // resolveEffectiveSource consults first.
     const rows = buildDataTypeRoutingRows(
       flows({
-        weight: {
-          import: [route("garmin-bridge"), route("trainingpeaks-bridge")],
-        },
+        weight: { import: [route("whoop-bridge"), route("tanita-bridge")] },
       }),
-      [priority("weight", ["trainingpeaks-bridge", "garmin-bridge"])]
+      [priority("weight", ["tanita-bridge", "whoop-bridge"])]
     );
 
     // Act
     const origin = rowFor(rows, "weight").origin;
 
     // Assert
-    expect(origin).toEqual({
-      kind: "primary",
-      sourceId: "trainingpeaks",
-      count: 3,
-    });
+    expect(origin).toEqual({ kind: "primary", sourceId: "tanita", count: 3 });
   });
 
-  it("should not name a head when a priority policy ranks nothing", () => {
+  it("should not name a head when a stored priority order is empty", () => {
     // Arrange
-    // Reachable through chat: `set_data_route` counts the RAW sourceOrder, so
-    // ["strava"] passes its length check and then resolves to nothing, leaving
-    // a persisted priority policy with an empty order. Naming sources[0] here
-    // would attribute sleep to whichever import route was created first.
+    // `applySourcePolicy` now refuses to mint this, but rows persisted by
+    // earlier builds survive in IndexedDB with no migration, so the reader
+    // still meets it. Naming sources[0] would attribute sleep to whichever
+    // import route happened to be created first.
     const rows = buildDataTypeRoutingRows(
-      flows({ sleep: { import: [route("garmin-bridge")] } }),
+      flows({ sleep: { import: [route("whoop-bridge")] } }),
       [priority("sleep", [])]
     );
 
@@ -128,32 +125,59 @@ describe("buildDataTypeRoutingRows", () => {
     const origin = rowFor(rows, "sleep").origin;
 
     // Assert
-    expect(origin).toEqual({ kind: "unranked", count: 2 });
+    expect(origin).toEqual({ kind: "rankedUnavailable", count: 2 });
   });
 
   it("should not name a head that is no longer an enabled source", () => {
     // Arrange
-    // The same shape reached through the Data Hub alone: rank Garmin, then
-    // switch Garmin's import off and WHOOP's on. The saved order still exists
-    // but pins nothing available, and WHOOP was never ranked.
+    // Live, post-guard path: chat `set_source_policy weight priority ["whoop"]`
+    // resolves cleanly and is accepted, then the Data Hub switches WHOOP's
+    // weight import off and Tanita's + TrainingPeaks' on. The saved order
+    // survives pinning nothing available, and neither remaining bridge was
+    // ever ranked.
     const rows = buildDataTypeRoutingRows(
-      flows({ sleep: { import: [route("whoop-bridge")] } }),
-      [priority("sleep", ["garmin-bridge"])]
+      flows({
+        weight: {
+          import: [route("tanita-bridge"), route("trainingpeaks-bridge")],
+        },
+      }),
+      [priority("weight", ["whoop-bridge"])]
     );
 
     // Act
-    const origin = rowFor(rows, "sleep").origin;
+    const origin = rowFor(rows, "weight").origin;
 
     // Assert
-    expect(origin).toEqual({ kind: "unranked", count: 2 });
+    expect(origin).toEqual({ kind: "rankedUnavailable", count: 3 });
+  });
+
+  it("should not name a lone source a ranked order excludes", () => {
+    // Arrange
+    // Chat `set_source_policy stress priority ["garmin"]` resolves fine, so no
+    // writer guard stops it — but Garmin announces only write:workouts,
+    // read:activities and write:body, so a Garmin stress import can never be
+    // enabled. Manual entry is then the lone source while the resolver's
+    // effective order is empty and it returns NOTHING: the pill must not
+    // attribute the type to manual entry while the user's typed stress is
+    // failing to surface.
+    const rows = buildDataTypeRoutingRows(flows({}), [
+      priority("stress", ["garmin-bridge"]),
+    ]);
+
+    // Act
+    const origin = rowFor(rows, "stress").origin;
+
+    // Assert
+    expect(origin).toEqual({ kind: "rankedUnavailable", count: 1 });
   });
 
   it("should drop an import route the user switched off", () => {
     // Arrange
-    // Toggling a Data Hub cell off writes enabled:false rather than deleting
-    // the row, so a disabled route stays visible to this derivation.
+    // Toggling the Data Hub's weight/WHOOP cell off writes enabled:false rather
+    // than deleting the row, so a disabled route stays visible to this
+    // derivation.
     const rows = buildDataTypeRoutingRows(
-      flows({ weight: { import: [route("garmin-bridge", false)] } }),
+      flows({ weight: { import: [route("whoop-bridge", false)] } }),
       []
     );
 
@@ -166,6 +190,8 @@ describe("buildDataTypeRoutingRows", () => {
 
   it("should list an export target only while its route is enabled", () => {
     // Arrange
+    // Garmin announces `write:workouts` with no route restriction, so this is
+    // the one export the Data Hub can genuinely switch on.
     const enabled = flows({ workout: { export: [route("garmin-bridge")] } });
     const off = flows({ workout: { export: [route("garmin-bridge", false)] } });
 

--- a/packages/workout-spa-editor/src/application/connections/data-type-routing.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-routing.ts
@@ -20,7 +20,6 @@ import { integrationIdForBridge } from "../../integrations/integration-registry"
 import { MANUAL_ENTRY_TYPES } from "../../integrations/manual-entry-types";
 import type { DataTypeSourcePolicy } from "../../types/data-type-source-policy";
 import { DEFAULT_DATA_TYPE_SOURCE_MODE } from "../../types/data-type-source-policy";
-import { orderSources } from "../data-hub/source-policy-rows";
 
 export const MANUAL_SOURCE_ID = "manual";
 
@@ -56,6 +55,19 @@ const enabledSources = (
   ...new Set(rows.filter((row) => row.enabled).map((row) => row.bridgeId)),
 ];
 
+/**
+ * The saved order's first entry that is still an available source — exactly
+ * what `resolveEffectiveSource` consults, so the pill cannot name a source the
+ * resolver would not read from. Undefined when the saved order pins none of
+ * them, which is NOT a corner case: the chat `set_data_route` tool persists
+ * `priority` with an order emptied by unresolvable ids, and disabling every
+ * ranked route in the Data Hub leaves the same shape behind.
+ */
+const rankedHead = (
+  sources: readonly string[],
+  saved: readonly string[]
+): string | undefined => saved.find((sourceId) => sources.includes(sourceId));
+
 const originOf = (
   sources: readonly string[],
   policy: DataTypeSourcePolicy | undefined
@@ -64,11 +76,15 @@ const originOf = (
   if (first === undefined) return { kind: "none" };
   if (rest.length === 0)
     return { kind: "only", sourceId: toIntegrationId(first) };
+  const unranked = { kind: "unranked", count: sources.length } as const;
   const mode = policy?.mode ?? DEFAULT_DATA_TYPE_SOURCE_MODE;
-  if (mode !== "priority") return { kind: "unranked", count: sources.length };
-  // `= first` is a type default, not a reachable branch: `orderSources`
-  // returns a permutation of a list already known to be non-empty here.
-  const [head = first] = orderSources(sources, policy?.sourceOrder ?? []);
+  if (mode !== "priority") return unranked;
+  const head = rankedHead(sources, policy?.sourceOrder ?? []);
+  // "Priority selected, nothing ranked yet" is the honest reading. Naming
+  // `sources[0]` here would attribute the type to whichever import route
+  // happened to be created first — the same overclaim union avoids, arriving
+  // through a different door.
+  if (head === undefined) return unranked;
   return {
     kind: "primary",
     sourceId: toIntegrationId(head),

--- a/packages/workout-spa-editor/src/application/connections/data-type-routing.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-routing.ts
@@ -1,0 +1,98 @@
+/**
+ * Where one managed data type comes from, derived only from state that exists.
+ *
+ * `union` is the DEFAULT multi-source mode and has NO winner: it keeps every
+ * source's record for a day, and a consumer needing a single value takes the
+ * last one written. So with 2+ sources in union mode this reports a COUNT and
+ * never a name — naming one would present write order as if it were a choice.
+ * A name is only claimed when exactly one source exists, or when the user has
+ * actually switched the type to `priority`, whose head is the same one
+ * `resolveEffectiveSource` consults.
+ *
+ * `manual` counts as a source for the types that have a real manual-entry path;
+ * the resolver exempts it from the enabled-policy filter for the same reason.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+import { MANAGED_DATA_REGISTRY, managedDataTypes } from "@kaiord/core";
+
+import type { DataFlowsByType } from "../../components/organisms/ProfileManager/components/useDataFlows";
+import { integrationIdForBridge } from "../../integrations/integration-registry";
+import { MANUAL_ENTRY_TYPES } from "../../integrations/manual-entry-types";
+import type { DataTypeSourcePolicy } from "../../types/data-type-source-policy";
+import { DEFAULT_DATA_TYPE_SOURCE_MODE } from "../../types/data-type-source-policy";
+import { orderSources } from "../data-hub/source-policy-rows";
+
+export const MANUAL_SOURCE_ID = "manual";
+
+export type RoutingOrigin =
+  | { readonly kind: "none" }
+  | { readonly kind: "only"; readonly sourceId: string }
+  | {
+      readonly kind: "primary";
+      readonly sourceId: string;
+      readonly count: number;
+    }
+  | { readonly kind: "unranked"; readonly count: number };
+
+export type DataTypeRoutingRow = {
+  readonly dataType: ManagedDataType;
+  readonly origin: RoutingOrigin;
+  /** Integration ids with an ENABLED export route for this type. */
+  readonly sentTo: readonly string[];
+  /** False when no bridge could ever export this type — 11 of 13 have no
+      export capability, so even "Nowhere" would imply a route that cannot
+      be created. */
+  readonly exportable: boolean;
+};
+
+const toIntegrationId = (sourceId: string): string =>
+  sourceId === MANUAL_SOURCE_ID
+    ? MANUAL_SOURCE_ID
+    : (integrationIdForBridge(sourceId) ?? sourceId);
+
+const enabledSources = (
+  rows: readonly { bridgeId: string; enabled: boolean }[]
+): string[] => [
+  ...new Set(rows.filter((row) => row.enabled).map((row) => row.bridgeId)),
+];
+
+const originOf = (
+  sources: readonly string[],
+  policy: DataTypeSourcePolicy | undefined
+): RoutingOrigin => {
+  const [first, ...rest] = sources;
+  if (first === undefined) return { kind: "none" };
+  if (rest.length === 0)
+    return { kind: "only", sourceId: toIntegrationId(first) };
+  const mode = policy?.mode ?? DEFAULT_DATA_TYPE_SOURCE_MODE;
+  if (mode !== "priority") return { kind: "unranked", count: sources.length };
+  // `= first` is a type default, not a reachable branch: `orderSources`
+  // returns a permutation of a list already known to be non-empty here.
+  const [head = first] = orderSources(sources, policy?.sourceOrder ?? []);
+  return {
+    kind: "primary",
+    sourceId: toIntegrationId(head),
+    count: sources.length,
+  };
+};
+
+export const buildDataTypeRoutingRows = (
+  byDataType: DataFlowsByType,
+  policies: readonly DataTypeSourcePolicy[]
+): DataTypeRoutingRow[] => {
+  const byType = new Map(policies.map((policy) => [policy.dataType, policy]));
+  return managedDataTypes.map((dataType) => {
+    const flows = byDataType.get(dataType);
+    const sources = enabledSources(flows?.import ?? []);
+    // Appended last so a saved priority order (which the Data Hub editor only
+    // ever fills with bridges) keeps deciding the head.
+    if (MANUAL_ENTRY_TYPES.has(dataType)) sources.push(MANUAL_SOURCE_ID);
+    return {
+      dataType,
+      origin: originOf(sources, byType.get(dataType)),
+      sentTo: enabledSources(flows?.export ?? []).map(toIntegrationId),
+      exportable:
+        MANAGED_DATA_REGISTRY[dataType].capabilities.export !== undefined,
+    };
+  });
+};

--- a/packages/workout-spa-editor/src/application/connections/data-type-routing.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-routing.ts
@@ -31,7 +31,10 @@ export type RoutingOrigin =
       readonly sourceId: string;
       readonly count: number;
     }
-  | { readonly kind: "unranked"; readonly count: number };
+  | { readonly kind: "unranked"; readonly count: number }
+  /** Ranked mode whose order pins nothing available — the resolver reads NO
+      record at all here, so this is the one origin that reports a problem. */
+  | { readonly kind: "rankedUnavailable"; readonly count: number };
 
 export type DataTypeRoutingRow = {
   readonly dataType: ManagedDataType;
@@ -58,38 +61,39 @@ const enabledSources = (
 /**
  * The saved order's first entry that is still an available source — exactly
  * what `resolveEffectiveSource` consults, so the pill cannot name a source the
- * resolver would not read from. Undefined when the saved order pins none of
- * them, which is NOT a corner case: the chat `set_data_route` tool persists
- * `priority` with an order emptied by unresolvable ids, and disabling every
- * ranked route in the Data Hub leaves the same shape behind.
+ * resolver would not read from.
  */
 const rankedHead = (
   sources: readonly string[],
   saved: readonly string[]
 ): string | undefined => saved.find((sourceId) => sources.includes(sourceId));
 
+/**
+ * The mode is consulted for ONE source too, not just for several. A ranked
+ * order that excludes the lone available source makes the resolver read
+ * nothing, so short-circuiting on `length === 1` would name a source whose
+ * records never surface — e.g. stress ranked to garmin (which announces no
+ * `read:body`, so that route can never be enabled) leaves manual entry as the
+ * only source while the user's hand-typed stress resolves to nothing.
+ */
 const originOf = (
   sources: readonly string[],
   policy: DataTypeSourcePolicy | undefined
 ): RoutingOrigin => {
-  const [first, ...rest] = sources;
+  const count = sources.length;
+  const [first] = sources;
   if (first === undefined) return { kind: "none" };
-  if (rest.length === 0)
-    return { kind: "only", sourceId: toIntegrationId(first) };
-  const unranked = { kind: "unranked", count: sources.length } as const;
+  const only = (sourceId: string) =>
+    ({ kind: "only", sourceId: toIntegrationId(sourceId) }) as const;
   const mode = policy?.mode ?? DEFAULT_DATA_TYPE_SOURCE_MODE;
-  if (mode !== "priority") return unranked;
+  if (mode !== "priority") {
+    return count === 1 ? only(first) : { kind: "unranked", count };
+  }
   const head = rankedHead(sources, policy?.sourceOrder ?? []);
-  // "Priority selected, nothing ranked yet" is the honest reading. Naming
-  // `sources[0]` here would attribute the type to whichever import route
-  // happened to be created first — the same overclaim union avoids, arriving
-  // through a different door.
-  if (head === undefined) return unranked;
-  return {
-    kind: "primary",
-    sourceId: toIntegrationId(head),
-    count: sources.length,
-  };
+  if (head === undefined) return { kind: "rankedUnavailable", count };
+  return count === 1
+    ? only(head)
+    : { kind: "primary", sourceId: toIntegrationId(head), count };
 };
 
 export const buildDataTypeRoutingRows = (
@@ -102,6 +106,13 @@ export const buildDataTypeRoutingRows = (
     const sources = enabledSources(flows?.import ?? []);
     // Appended last so a saved priority order (which the Data Hub editor only
     // ever fills with bridges) keeps deciding the head.
+    //
+    // ⚠ ASYMMETRY: this gate is MANUAL_ENTRY_TYPES, while
+    // `resolveEffectiveSource` exempts "manual" from its enabled filter
+    // UNCONDITIONALLY. Giving a type a manual entry path without adding it here
+    // makes the pill and the resolver disagree silently. Widening this to every
+    // type is not the fix — it would claim a source for types with no way to
+    // enter one (`planned-session` has no manual authoring path at all).
     if (MANUAL_ENTRY_TYPES.has(dataType)) sources.push(MANUAL_SOURCE_ID);
     return {
       dataType,

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionRouteList.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionRouteList.tsx
@@ -1,7 +1,8 @@
 import type { ManagedDataType } from "@kaiord/core";
 
 import type { ConnectionSource } from "../../../application/connections/connection-source";
-import { type Translate, useTranslate } from "../../../i18n/use-translate";
+import type { Translate } from "../../../i18n/use-translate";
+import { useTranslate } from "../../../i18n/use-translate";
 
 type RowProps = {
   labelKey: string;

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsTab.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsTab.test.tsx
@@ -1,12 +1,24 @@
-import { render, screen } from "@testing-library/react";
+import { render as rtlRender, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ConnectionSource } from "../../../application/connections/connection-source";
+import { PersistenceProvider } from "../../../contexts/persistence-context";
 import { useConnectionSources } from "../../../hooks/connections/use-connection-sources";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { createInMemoryPersistence } from "../../../test-utils/in-memory-persistence";
 import { useDataFlows } from "../ProfileManager/components/useDataFlows";
 import { ConnectionsTab } from "./ConnectionsTab";
+
+// The routing rows read per-source sync freshness through the persistence
+// port, so the tab no longer renders outside a provider.
+const render = (ui: ReactElement) =>
+  rtlRender(
+    <PersistenceProvider persistence={createInMemoryPersistence()}>
+      {ui}
+    </PersistenceProvider>
+  );
 
 vi.mock("../../../hooks/connections/use-connection-sources", () => ({
   useConnectionSources: vi.fn(),

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsTab.tsx
@@ -5,6 +5,7 @@ import { useTranslate } from "../../../i18n/use-translate";
 import { useDataFlows } from "../ProfileManager/components/useDataFlows";
 import { ConnectionSourceCard } from "./ConnectionSourceCard";
 import { ConnectionsUnsupported } from "./ConnectionsUnsupported";
+import { DataTypeRoutingSection } from "./DataTypeRoutingSection";
 
 const isUnsupported = (source: ConnectionSource): boolean =>
   source.status === "unsupported";
@@ -54,6 +55,7 @@ export const ConnectionsTab: React.FC = () => {
             ))}
         </div>
       </section>
+      <DataTypeRoutingSection profileId={profileId} byDataType={byDataType} />
       <ConnectionsUnsupported sources={sources.filter(isUnsupported)} />
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingGroup.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingGroup.tsx
@@ -1,0 +1,34 @@
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { DataTypeGroup } from "../../../application/connections/data-type-groups";
+import type { DataTypeRoutingRow as RoutingRow } from "../../../application/connections/data-type-routing";
+import { useTranslate } from "../../../i18n/use-translate";
+import { DataTypeRoutingRow } from "./DataTypeRoutingRow";
+
+type Props = {
+  group: DataTypeGroup;
+  byType: ReadonlyMap<ManagedDataType, RoutingRow>;
+  lastSyncedAt: ReadonlyMap<string, string | undefined>;
+};
+
+export function DataTypeRoutingGroup({ group, byType, lastSyncedAt }: Props) {
+  const t = useTranslate("connections");
+  const rows = group.types.flatMap((dataType) => byType.get(dataType) ?? []);
+
+  return (
+    <div className="space-y-2" data-testid={`routing-group-${group.id}`}>
+      <h3 className="text-[13.5px] font-bold text-ink-strong">
+        {t(`routing.groups.${group.id}`)}
+      </h3>
+      <div className="space-y-2">
+        {rows.map((row) => (
+          <DataTypeRoutingRow
+            key={row.dataType}
+            row={row}
+            lastSyncedAt={lastSyncedAt}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingRow.tsx
@@ -1,0 +1,79 @@
+import type { DataTypeRoutingRow as RoutingRow } from "../../../application/connections/data-type-routing";
+import { useTranslate } from "../../../i18n/use-translate";
+import { Pill } from "../../atoms/Pill";
+import { originLabel, originSourceId, sourceName } from "./routing-copy";
+import { RoutingFreshness } from "./RoutingFreshness";
+
+type Props = {
+  row: RoutingRow;
+  lastSyncedAt: ReadonlyMap<string, string | undefined>;
+};
+
+const CAPTION =
+  "text-[10.5px] font-bold uppercase tracking-wider text-ink-muted";
+
+/**
+ * "Also sent to" renders only when an export route could exist at all. Eleven
+ * of the thirteen types have no export capability in the registry, so the
+ * design's "Nowhere" would there be describing an absence of something that
+ * was never possible rather than a route the user has not switched on.
+ */
+export function DataTypeRoutingRow({ row, lastSyncedAt }: Props) {
+  const t = useTranslate("connections");
+  const sourceId = originSourceId(row.origin);
+
+  return (
+    <div
+      data-testid={`routing-row-${row.dataType}`}
+      data-origin={row.origin.kind}
+      className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-edge bg-surface px-4 py-3"
+    >
+      <div className="min-w-0 flex-[1_1_180px]">
+        <div className="text-[14px] font-bold text-ink-strong">
+          {t(`dataTypes.${row.dataType}`)}
+        </div>
+        <div className="text-[12px] text-ink-muted">
+          {t(`dataTypeHints.${row.dataType}`)}
+        </div>
+      </div>
+
+      <div className="flex flex-[1_1_220px] flex-wrap items-center gap-2">
+        <span className={CAPTION}>{t("routing.from")}</span>
+        <Pill
+          tone={row.origin.kind === "none" ? "neutral" : "accent"}
+          data-testid={`routing-from-${row.dataType}`}
+          title={
+            row.origin.kind === "unranked"
+              ? t("routing.unrankedHint")
+              : undefined
+          }
+        >
+          {originLabel(row.origin, t)}
+        </Pill>
+        {sourceId !== undefined && (
+          <RoutingFreshness
+            sourceId={sourceId}
+            at={lastSyncedAt.get(sourceId)}
+          />
+        )}
+      </div>
+
+      {row.exportable && (
+        <div className="flex flex-[1_1_180px] flex-wrap items-center gap-2">
+          <span className={CAPTION}>{t("routing.sentTo")}</span>
+          {row.sentTo.length === 0 ? (
+            <span className="text-[12.5px] text-ink-muted">
+              {t("routing.nowhere")}
+            </span>
+          ) : (
+            row.sentTo.map((id) => (
+              <Pill key={id} tone="neutral">
+                {sourceName(id)}
+              </Pill>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingRow.tsx
@@ -1,7 +1,8 @@
 import type { DataTypeRoutingRow as RoutingRow } from "../../../application/connections/data-type-routing";
 import { useTranslate } from "../../../i18n/use-translate";
 import { Pill } from "../../atoms/Pill";
-import { originLabel, originSourceId, sourceName } from "./routing-copy";
+import { originLabel, originNote, originSourceId } from "./routing-copy";
+import { RoutingExportTargets } from "./RoutingExportTargets";
 import { RoutingFreshness } from "./RoutingFreshness";
 
 type Props = {
@@ -12,6 +13,11 @@ type Props = {
 const CAPTION =
   "text-[10.5px] font-bold uppercase tracking-wider text-ink-muted";
 
+/* A ring, not a border tint: `border-edge` and an amber border are the same
+   property at the same specificity, so which wins would depend on stylesheet
+   order (same reasoning as ConnectionSourceCard's attention ring). */
+const STALLED_RING = "ring-1 ring-amber-500/40";
+
 /**
  * "Also sent to" renders only when an export route could exist at all. Eleven
  * of the thirteen types have no export capability in the registry, so the
@@ -21,12 +27,14 @@ const CAPTION =
 export function DataTypeRoutingRow({ row, lastSyncedAt }: Props) {
   const t = useTranslate("connections");
   const sourceId = originSourceId(row.origin);
+  const note = originNote(row.origin, t);
+  const stalled = row.origin.kind === "rankedUnavailable";
 
   return (
     <div
       data-testid={`routing-row-${row.dataType}`}
       data-origin={row.origin.kind}
-      className="flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-edge bg-surface px-4 py-3"
+      className={`flex flex-wrap items-center gap-x-4 gap-y-2 rounded-xl border border-edge bg-surface px-4 py-3 ${stalled ? STALLED_RING : ""}`}
     >
       <div className="min-w-0 flex-[1_1_180px]">
         <div className="text-[14px] font-bold text-ink-strong">
@@ -40,13 +48,8 @@ export function DataTypeRoutingRow({ row, lastSyncedAt }: Props) {
       <div className="flex flex-[1_1_220px] flex-wrap items-center gap-2">
         <span className={CAPTION}>{t("routing.from")}</span>
         <Pill
-          tone={row.origin.kind === "none" ? "neutral" : "accent"}
+          tone={sourceId === undefined ? "neutral" : "accent"}
           data-testid={`routing-from-${row.dataType}`}
-          title={
-            row.origin.kind === "unranked"
-              ? t("routing.unrankedHint")
-              : undefined
-          }
         >
           {originLabel(row.origin, t)}
         </Pill>
@@ -56,23 +59,18 @@ export function DataTypeRoutingRow({ row, lastSyncedAt }: Props) {
             at={lastSyncedAt.get(sourceId)}
           />
         )}
+        {note !== undefined && (
+          <span
+            className="text-[12px] text-ink-muted"
+            data-testid={`routing-note-${row.dataType}`}
+          >
+            {note}
+          </span>
+        )}
       </div>
 
       {row.exportable && (
-        <div className="flex flex-[1_1_180px] flex-wrap items-center gap-2">
-          <span className={CAPTION}>{t("routing.sentTo")}</span>
-          {row.sentTo.length === 0 ? (
-            <span className="text-[12.5px] text-ink-muted">
-              {t("routing.nowhere")}
-            </span>
-          ) : (
-            row.sentTo.map((id) => (
-              <Pill key={id} tone="neutral">
-                {sourceName(id)}
-              </Pill>
-            ))
-          )}
-        </div>
+        <RoutingExportTargets dataType={row.dataType} sentTo={row.sentTo} />
       )}
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingSection.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingSection.test.tsx
@@ -1,0 +1,135 @@
+import type { ManagedDataType } from "@kaiord/core";
+import { managedDataTypes } from "@kaiord/core";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DataTypeSourcePolicy } from "../../../types/data-type-source-policy";
+import type { IntegrationPolicy } from "../../../types/integration-policy";
+import type { DataFlowsByType } from "../ProfileManager/components/useDataFlows";
+import { DataTypeRoutingSection } from "./DataTypeRoutingSection";
+
+const state = vi.hoisted(() => ({
+  policies: [] as DataTypeSourcePolicy[],
+  syncedAt: new Map<string, string | undefined>(),
+}));
+
+vi.mock("../../../contexts/persistence-context", () => ({
+  usePersistence: () => ({}),
+}));
+vi.mock("../../../hooks/data-hub/use-bridge-sync-states", () => ({
+  useBridgeSyncStates: () => state.syncedAt,
+}));
+vi.mock("../../../hooks/data-hub/use-data-type-source-policies", () => ({
+  useDataTypeSourcePolicies: () => state.policies,
+}));
+
+const route = (bridgeId: string, enabled = true): IntegrationPolicy =>
+  ({ bridgeId, enabled }) as IntegrationPolicy;
+
+const flows = (
+  entries: Partial<
+    Record<
+      ManagedDataType,
+      { import?: IntegrationPolicy[]; export?: IntegrationPolicy[] }
+    >
+  >
+): DataFlowsByType =>
+  new Map(
+    Object.entries(entries).map(([dataType, value]) => [
+      dataType as ManagedDataType,
+      { import: value?.import ?? [], export: value?.export ?? [] },
+    ])
+  );
+
+const renderSection = (byDataType: DataFlowsByType = flows({})) =>
+  render(<DataTypeRoutingSection profileId="p1" byDataType={byDataType} />);
+
+describe("DataTypeRoutingSection", () => {
+  beforeEach(() => {
+    state.policies = [];
+    state.syncedAt = new Map();
+  });
+
+  it("should render every managed data type inside one of the three groups", () => {
+    // Arrange
+    // The grouping is SPA-side; this pins that the page renders the whole
+    // domain list rather than the subset someone remembered to add.
+    renderSection();
+
+    // Act
+    const rows = managedDataTypes.map((dataType) =>
+      screen.queryByTestId(`routing-row-${dataType}`)
+    );
+
+    // Assert
+    expect(rows.filter(Boolean)).toHaveLength(managedDataTypes.length);
+    for (const group of ["training", "recovery", "body"]) {
+      expect(screen.getByTestId(`routing-group-${group}`)).toBeInTheDocument();
+    }
+  });
+
+  it("should count union-mode sources instead of naming one of them", () => {
+    // Arrange
+    // One enabled Garmin route on a type that also has a manual path, with no
+    // stored policy — the DEFAULT union mode, which has no winner. This is the
+    // exact row on which the reference design shows a confident "From: Garmin".
+    renderSection(flows({ sleep: { import: [route("garmin-bridge")] } }));
+
+    // Act
+    const pill = screen.getByTestId("routing-from-sleep");
+
+    // Assert
+    expect(pill).toHaveTextContent("2 sources");
+    expect(pill).not.toHaveTextContent("Garmin");
+  });
+
+  it("should offer an export target only on a type that can be exported", () => {
+    // Arrange
+    // `planned-session` has no export capability at all, so "Nowhere" would
+    // describe a route that cannot exist; `workout` has one and can honestly
+    // report that none is switched on.
+    renderSection();
+
+    // Act
+    const plannedRow = screen.getByTestId("routing-row-planned-session");
+    const workoutRow = screen.getByTestId("routing-row-workout");
+
+    // Assert
+    expect(plannedRow).not.toHaveTextContent("Also sent to");
+    expect(workoutRow).toHaveTextContent("Also sent to");
+    expect(workoutRow).toHaveTextContent("Nowhere");
+  });
+
+  it("should date a row by its source rather than by the data type", () => {
+    // Arrange
+    // `coachingSyncState` is keyed by (source, profile) and holds no data
+    // type, so the only true sentence names the source. Train2Go is a
+    // single-source row: `planned-session` has no manual path to add a second.
+    state.syncedAt = new Map([["train2go", new Date().toISOString()]]);
+    renderSection(
+      flows({ "planned-session": { import: [route("train2go-bridge")] } })
+    );
+
+    // Act
+    const row = screen.getByTestId("routing-row-planned-session");
+
+    // Assert
+    expect(row).toHaveTextContent("Train2Go last sent data just now");
+  });
+
+  it("should show no time for a source that has never written a sync row", () => {
+    // Arrange
+    // Manual entry never writes to `coachingSyncState`, so there is no
+    // timestamp to render and none is invented.
+    renderSection();
+
+    // Act
+    const row = screen.getByTestId("routing-row-stress");
+
+    // Assert
+    expect(row).toHaveTextContent("Manual Entry");
+    expect(
+      screen.queryByTestId("routing-synced-manual")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingSection.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingSection.test.tsx
@@ -70,17 +70,101 @@ describe("DataTypeRoutingSection", () => {
 
   it("should count union-mode sources instead of naming one of them", () => {
     // Arrange
-    // One enabled Garmin route on a type that also has a manual path, with no
-    // stored policy — the DEFAULT union mode, which has no winner. This is the
-    // exact row on which the reference design shows a confident "From: Garmin".
-    renderSection(flows({ sleep: { import: [route("garmin-bridge")] } }));
+    // WHOOP is the only bridge announcing `read:sleep`; with the manual path
+    // that is two sources under the DEFAULT union mode, which has no winner.
+    // This is the exact row on which the design shows "From: Garmin".
+    renderSection(flows({ sleep: { import: [route("whoop-bridge")] } }));
 
     // Act
     const pill = screen.getByTestId("routing-from-sleep");
 
     // Assert
     expect(pill).toHaveTextContent("2 sources");
-    expect(pill).not.toHaveTextContent("Garmin");
+    expect(pill).not.toHaveTextContent("WHOOP");
+    expect(screen.getByTestId("routing-note-sleep")).toHaveTextContent(
+      "none ranked first"
+    );
+  });
+
+  it("should date a primary row by its head, not by another ranked source", () => {
+    // Arrange
+    // Both sources have a sync row, with different times. A regression that
+    // dated the row from `sources[0]` — or from whichever entry the map yields
+    // first — would show WHOOP's instead of the ranked head's.
+    state.syncedAt = new Map([
+      ["whoop", "2026-07-29T09:00:00.000Z"],
+      ["tanita", new Date().toISOString()],
+    ]);
+    state.policies = [
+      {
+        dataType: "weight",
+        mode: "priority",
+        sourceOrder: ["tanita-bridge", "whoop-bridge"],
+      } as DataTypeSourcePolicy,
+    ];
+    renderSection(
+      flows({
+        weight: { import: [route("whoop-bridge"), route("tanita-bridge")] },
+      })
+    );
+
+    // Act
+    const row = screen.getByTestId("routing-row-weight");
+
+    // Assert
+    expect(row).toHaveTextContent("Tanita last sent data just now");
+    expect(
+      screen.queryByTestId("routing-synced-whoop")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should date no row that has no single owning source", () => {
+    // Arrange
+    // Both union-mode sources have a recorded sync, so a regression that
+    // started dating an unranked row from any of them would render a time
+    // here. The empty-map version of this test could not have caught it.
+    state.syncedAt = new Map([
+      ["whoop", new Date().toISOString()],
+      ["tanita", new Date().toISOString()],
+    ]);
+    renderSection(
+      flows({
+        weight: { import: [route("whoop-bridge"), route("tanita-bridge")] },
+      })
+    );
+
+    // Act
+    const row = screen.getByTestId("routing-row-weight");
+
+    // Assert
+    expect(row).toHaveAttribute("data-origin", "unranked");
+    expect(row).not.toHaveTextContent("last sent data");
+  });
+
+  it("should report a ranked row whose sources are all switched off", () => {
+    // Arrange
+    // Chat can set stress priority to ["garmin"] — it resolves — but Garmin
+    // announces no `read:body`, so that import can never be enabled. The
+    // resolver returns NOTHING for stress; naming manual entry would say the
+    // opposite of what the user experiences on Daily.
+    state.policies = [
+      {
+        dataType: "stress",
+        mode: "priority",
+        sourceOrder: ["garmin-bridge"],
+      } as DataTypeSourcePolicy,
+    ];
+    renderSection();
+
+    // Act
+    const row = screen.getByTestId("routing-row-stress");
+
+    // Assert
+    expect(row).toHaveAttribute("data-origin", "rankedUnavailable");
+    expect(row).not.toHaveTextContent("Manual Entry");
+    expect(screen.getByTestId("routing-note-stress")).toHaveTextContent(
+      "nothing is being read"
+    );
   });
 
   it("should offer an export target only on a type that can be exported", () => {
@@ -119,8 +203,10 @@ describe("DataTypeRoutingSection", () => {
 
   it("should show no time for a source that has never written a sync row", () => {
     // Arrange
-    // Manual entry never writes to `coachingSyncState`, so there is no
-    // timestamp to render and none is invented.
+    // Manual entry never writes to `coachingSyncState`. Other sources DO have
+    // times here, so a regression that fell back to any available timestamp
+    // would surface rather than being masked by an empty map.
+    state.syncedAt = new Map([["whoop", new Date().toISOString()]]);
     renderSection();
 
     // Act

--- a/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingSection.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingSection.tsx
@@ -1,0 +1,51 @@
+import type { ManagedDataType } from "@kaiord/core";
+import { useMemo } from "react";
+
+import { DATA_TYPE_GROUPS } from "../../../application/connections/data-type-groups";
+import { useDataTypeRouting } from "../../../hooks/connections/use-data-type-routing";
+import { useTranslate } from "../../../i18n/use-translate";
+import type { DataFlowsByType } from "../ProfileManager/components/useDataFlows";
+import { DataTypeRoutingGroup } from "./DataTypeRoutingGroup";
+
+type Props = { profileId: string; byDataType: DataFlowsByType };
+
+/**
+ * Read-only. Choosing a source of truth is Wave 2b; until then the section
+ * reports what the stored policies already decide and claims nothing about
+ * fallbacks — `usedFallback` is priority-mode only, is per-(type, day), and
+ * means "no record that day" rather than "this source broke".
+ */
+export function DataTypeRoutingSection({ profileId, byDataType }: Props) {
+  const t = useTranslate("connections");
+  const { rows, lastSyncedAt } = useDataTypeRouting(profileId, byDataType);
+  const byType = useMemo(
+    () =>
+      new Map<ManagedDataType, (typeof rows)[number]>(
+        rows.map((row) => [row.dataType, row])
+      ),
+    [rows]
+  );
+
+  return (
+    <section className="space-y-3" data-testid="data-type-routing">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-[11px] font-bold uppercase tracking-widest text-ink-muted">
+          {t("routing.title")}
+        </h2>
+        <span className="text-[12.5px] text-ink-muted">
+          {t("routing.freshnessHint")}
+        </span>
+      </div>
+      <div className="space-y-4">
+        {DATA_TYPE_GROUPS.map((group) => (
+          <DataTypeRoutingGroup
+            key={group.id}
+            group={group}
+            byType={byType}
+            lastSyncedAt={lastSyncedAt}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/RoutingExportTargets.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/RoutingExportTargets.tsx
@@ -1,0 +1,36 @@
+import { useTranslate } from "../../../i18n/use-translate";
+import { Pill } from "../../atoms/Pill";
+import { sourceName } from "./routing-copy";
+
+type Props = { dataType: string; sentTo: readonly string[] };
+
+/**
+ * Rendered only for the two types the registry gives an export capability.
+ * "Nowhere" here means a route the user has not switched on; on the other
+ * eleven types it would mean a route that cannot be created, which is why the
+ * caller omits this whole block rather than passing an empty list.
+ */
+export function RoutingExportTargets({ dataType, sentTo }: Props) {
+  const t = useTranslate("connections");
+  return (
+    <div className="flex flex-[1_1_180px] flex-wrap items-center gap-2">
+      <span className="text-[10.5px] font-bold uppercase tracking-wider text-ink-muted">
+        {t("routing.sentTo")}
+      </span>
+      {sentTo.length === 0 ? (
+        <span
+          className="text-[12.5px] text-ink-muted"
+          data-testid={`routing-nowhere-${dataType}`}
+        >
+          {t("routing.nowhere")}
+        </span>
+      ) : (
+        sentTo.map((id) => (
+          <Pill key={id} tone="neutral">
+            {sourceName(id)}
+          </Pill>
+        ))
+      )}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/RoutingFreshness.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/RoutingFreshness.tsx
@@ -1,0 +1,35 @@
+import { useActiveLocale } from "../../../i18n/LocaleProvider";
+import { useTranslate } from "../../../i18n/use-translate";
+import { formatRelativeTime } from "../../../utils/format-relative-time";
+import { sourceName } from "./routing-copy";
+
+type Props = { sourceId: string; at: string | undefined };
+
+/**
+ * When this row's source last sent Kaiord anything — deliberately phrased with
+ * the SOURCE as the subject. `coachingSyncState` is keyed by (source, profile)
+ * and carries no data type, so "Sleep arrived 2 minutes ago" is not a sentence
+ * the state can support; every row Garmin feeds shows Garmin's one timestamp.
+ *
+ * Nothing renders without a stored timestamp: manual entry writes no sync row
+ * at all, and a bridge that has never delivered already says so on its card.
+ */
+export function RoutingFreshness({ sourceId, at }: Props) {
+  const t = useTranslate("connections");
+  const tCommon = useTranslate("common");
+  const locale = useActiveLocale();
+  if (at === undefined) return null;
+
+  const relative = formatRelativeTime(new Date(at), new Date(), locale);
+  return (
+    <span
+      className="text-[12px] text-ink-muted"
+      data-testid={`routing-synced-${sourceId}`}
+    >
+      {t("routing.sourceLastSent", {
+        name: sourceName(sourceId),
+        when: tCommon(relative.key, relative.params),
+      })}
+    </span>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/routing-copy.ts
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/routing-copy.ts
@@ -32,7 +32,26 @@ export const originLabel = (origin: RoutingOrigin, t: Translate): string => {
       return t("routing.noSource");
     case "unranked":
       return t("routing.manySources", { count: origin.count });
+    case "rankedUnavailable":
+      return t("routing.noUsableSource");
     default:
       return sourceName(origin.sourceId);
   }
+};
+
+/**
+ * Visible, not a `title`: a native tooltip on a `<span>` is unreachable by
+ * keyboard and inconsistently announced, and these two states are exactly the
+ * ones a pill alone misreads. "N sources" without the note reads as healthy
+ * redundancy; `rankedUnavailable` without it reads as merely unconfigured,
+ * when in fact the resolver is returning nothing for the type.
+ */
+export const originNote = (
+  origin: RoutingOrigin,
+  t: Translate
+): string | undefined => {
+  if (origin.kind === "unranked") return t("routing.unrankedNote");
+  if (origin.kind === "rankedUnavailable")
+    return t("routing.rankedUnavailableNote");
+  return undefined;
 };

--- a/packages/workout-spa-editor/src/components/organisms/Connections/routing-copy.ts
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/routing-copy.ts
@@ -1,0 +1,38 @@
+import type { RoutingOrigin } from "../../../application/connections/data-type-routing";
+import type { Translate } from "../../../i18n/use-translate";
+import { INTEGRATION_REGISTRY } from "../../../integrations/integration-registry";
+
+const NAMES: ReadonlyMap<string, string> = new Map(
+  INTEGRATION_REGISTRY.map((entry) => [entry.id, entry.name])
+);
+
+export const sourceName = (integrationId: string): string =>
+  NAMES.get(integrationId) ?? integrationId;
+
+/**
+ * The one source a row's freshness may be attributed to — undefined when no
+ * single source owns the type. `coachingSyncState` has a row per source, so
+ * with several sources there is no non-arbitrary one to date the row by, and
+ * showing none beats showing whichever happens to be first.
+ */
+export const originSourceId = (origin: RoutingOrigin): string | undefined =>
+  origin.kind === "only" || origin.kind === "primary"
+    ? origin.sourceId
+    : undefined;
+
+/**
+ * A name is printed only when one is real. Under `union` — the DEFAULT mode —
+ * several sources all keep writing and nothing ranks them, so the row states
+ * how many there are; the design's confident "From: Garmin" would be showing
+ * write order as a decision the user never made.
+ */
+export const originLabel = (origin: RoutingOrigin, t: Translate): string => {
+  switch (origin.kind) {
+    case "none":
+      return t("routing.noSource");
+    case "unranked":
+      return t("routing.manySources", { count: origin.count });
+    default:
+      return sourceName(origin.sourceId);
+  }
+};

--- a/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.test.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.test.ts
@@ -258,21 +258,53 @@ describe("doSetDataRoute — set_source_policy", () => {
     expect(stored).toBeUndefined();
   });
 
-  it("should keep a priority order that resolves partially", async () => {
+  it("should refuse a priority order rather than silently promote what survives", async () => {
     // Arrange
-    // Only a TOTAL resolution failure is refused: one usable source still
-    // ranks something, so the write is honest and goes through.
+    // The dangerous case, because it looks like success. "whoop-bridge" is the
+    // STORAGE key, not a chat-facing id, so it fails to resolve while "tanita"
+    // succeeds — dropping the first and keeping the rest would durably rank
+    // Tanita first, the resolver would honour it, and the Connections pill
+    // would name Tanita as the source of truth for a request that asked for
+    // WHOOP.
     const persistence = createInMemoryPersistence();
 
     // Act
     const result = await doSetDataRoute(persistence, PROFILE_ID, {
       action: "set_source_policy",
-      dataType: "sleep",
+      dataType: "weight",
       mode: "priority",
-      sourceOrder: ["strava", "whoop"],
+      sourceOrder: ["whoop-bridge", "tanita"],
     });
 
     // Assert
-    expect(result).toMatchObject({ sourceOrder: ["whoop-bridge"] });
+    expect(result).toMatchObject({
+      error: "unresolvable_source_order",
+      unresolved: ["whoop-bridge"],
+    });
+    const stored = await persistence.dataTypeSourcePolicy.findByProfileAndType({
+      profileId: PROFILE_ID,
+      dataType: "weight",
+    });
+    expect(stored).toBeUndefined();
+  });
+
+  it("should store a priority order in which every source resolves", async () => {
+    // Arrange
+    // The refusal is exact, not a blanket ban: WHOOP and Tanita both announce
+    // read:body and both serve weight, so this order is honourable in full.
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "set_source_policy",
+      dataType: "weight",
+      mode: "priority",
+      sourceOrder: ["whoop", "tanita"],
+    });
+
+    // Assert
+    expect(result).toMatchObject({
+      sourceOrder: ["whoop-bridge", "tanita-bridge"],
+    });
   });
 });

--- a/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.test.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.test.ts
@@ -231,4 +231,48 @@ describe("doSetDataRoute — set_source_policy", () => {
       sourceOrder: [],
     });
   });
+
+  it("should refuse a priority order whose sources all fail to resolve", async () => {
+    // Arrange
+    // The tool schema rejects an ABSENT sourceOrder, but only counts the raw
+    // array — "strava" is a real registry entry with no bridge id, so it
+    // passes the length check and then drops out during resolution. Persisting
+    // the mode without its ordering stores a policy resolveEffectiveSource
+    // reads no record through, and leaves every reader to invent a head.
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "set_source_policy",
+      dataType: "sleep",
+      mode: "priority",
+      sourceOrder: ["strava"],
+    });
+
+    // Assert
+    expect(result).toMatchObject({ error: "unresolvable_source_order" });
+    const stored = await persistence.dataTypeSourcePolicy.findByProfileAndType({
+      profileId: PROFILE_ID,
+      dataType: "sleep",
+    });
+    expect(stored).toBeUndefined();
+  });
+
+  it("should keep a priority order that resolves partially", async () => {
+    // Arrange
+    // Only a TOTAL resolution failure is refused: one usable source still
+    // ranks something, so the write is honest and goes through.
+    const persistence = createInMemoryPersistence();
+
+    // Act
+    const result = await doSetDataRoute(persistence, PROFILE_ID, {
+      action: "set_source_policy",
+      dataType: "sleep",
+      mode: "priority",
+      sourceOrder: ["strava", "whoop"],
+    });
+
+    // Assert
+    expect(result).toMatchObject({ sourceOrder: ["whoop-bridge"] });
+  });
 });

--- a/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.ts
@@ -23,6 +23,19 @@ const applySourcePolicy = async (
           .map(resolveSourceKey)
           .filter((id): id is string => id !== undefined)
       : [];
+  // The tool schema already rejects `priority` with an empty sourceOrder; this
+  // is the same rule applied AFTER resolution, where ids the model plausibly
+  // emits drop out silently — "strava" and "wahoo" are real registry entries
+  // with no bridge id, and "whoop-bridge" is not a chat-facing id at all.
+  // Persisting the mode without its ordering stores a policy `resolveEffective
+  // Source` reads NO record through, and leaves every reader to invent a head.
+  if (input.mode === "priority" && sourceOrder.length === 0) {
+    return {
+      error: "unresolvable_source_order",
+      dataType: input.dataType,
+      sourceOrder: input.sourceOrder ?? [],
+    };
+  }
   await persistence.dataTypeSourcePolicy.put({
     profileId,
     dataType: input.dataType,

--- a/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.ts
+++ b/packages/workout-spa-editor/src/hooks/chat/do-set-data-route.ts
@@ -17,23 +17,31 @@ const applySourcePolicy = async (
   profileId: string,
   input: SourcePolicyInput
 ): Promise<unknown> => {
-  const sourceOrder =
-    input.mode === "priority"
-      ? (input.sourceOrder ?? [])
-          .map(resolveSourceKey)
-          .filter((id): id is string => id !== undefined)
-      : [];
-  // The tool schema already rejects `priority` with an empty sourceOrder; this
-  // is the same rule applied AFTER resolution, where ids the model plausibly
-  // emits drop out silently — "strava" and "wahoo" are real registry entries
-  // with no bridge id, and "whoop-bridge" is not a chat-facing id at all.
-  // Persisting the mode without its ordering stores a policy `resolveEffective
-  // Source` reads NO record through, and leaves every reader to invent a head.
-  if (input.mode === "priority" && sourceOrder.length === 0) {
+  const requested = input.mode === "priority" ? (input.sourceOrder ?? []) : [];
+  const resolved = requested.map((id) => ({ id, key: resolveSourceKey(id) }));
+  const unresolved = resolved.flatMap((r) =>
+    r.key === undefined ? [r.id] : []
+  );
+  const sourceOrder = resolved.flatMap((r) =>
+    r.key === undefined ? [] : [r.key]
+  );
+  // Dropping the ids that fail to resolve and keeping the rest would REORDER
+  // the request: "whoop-bridge" is not a chat-facing id, so
+  // ["whoop-bridge", "tanita"] would durably rank Tanita FIRST — the opposite
+  // of what was asked, stored as if it had succeeded, honoured by the resolver
+  // and then named by the Connections pill. Partial failure is refused for the
+  // same reason total failure is. An empty order is refused too, because
+  // `resolveEffectiveSource` reads NO record through a ranked policy whose
+  // order is empty.
+  if (
+    input.mode === "priority" &&
+    (unresolved.length > 0 || sourceOrder.length === 0)
+  ) {
     return {
       error: "unresolvable_source_order",
       dataType: input.dataType,
-      sourceOrder: input.sourceOrder ?? [],
+      requested,
+      unresolved,
     };
   }
   await persistence.dataTypeSourcePolicy.put({

--- a/packages/workout-spa-editor/src/hooks/connections/use-data-type-routing.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/use-data-type-routing.ts
@@ -1,0 +1,48 @@
+/**
+ * useDataTypeRouting — the Connections page's per-data-type routing rows.
+ *
+ * `byDataType` is passed in rather than read again: the page already holds one
+ * `useDataFlows` subscription, and a second would re-run its 26 queries for
+ * the same answer.
+ *
+ * Freshness bypasses the Data Hub matrix entirely. The rows are per-TYPE and
+ * each already resolves at most one source, so the per-source read is the one
+ * that fits — and nothing here is stranded when Wave 4 deletes the matrix UI.
+ */
+import { useMemo } from "react";
+
+import {
+  buildDataTypeRoutingRows,
+  type DataTypeRoutingRow,
+} from "../../application/connections/data-type-routing";
+import type { DataFlowsByType } from "../../components/organisms/ProfileManager/components/useDataFlows";
+import { usePersistence } from "../../contexts/persistence-context";
+import { useBridgeSyncStates } from "../data-hub/use-bridge-sync-states";
+import { useDataTypeSourcePolicies } from "../data-hub/use-data-type-source-policies";
+
+export type DataTypeRouting = {
+  readonly rows: readonly DataTypeRoutingRow[];
+  /**
+   * Integration id → last sync. `coachingSyncState` is keyed by
+   * (source, profile) and never by data type, so this is when that SOURCE last
+   * sent Kaiord anything — not when this type last arrived. Every row fed by
+   * the same source shows the same instant; the copy has to say so.
+   */
+  readonly lastSyncedAt: ReadonlyMap<string, string | undefined>;
+};
+
+export const useDataTypeRouting = (
+  profileId: string | null,
+  byDataType: DataFlowsByType
+): DataTypeRouting => {
+  const persistence = usePersistence();
+  const lastSyncedAt = useBridgeSyncStates(persistence, profileId);
+  const policies = useDataTypeSourcePolicies(profileId);
+
+  const rows = useMemo(
+    () => buildDataTypeRoutingRows(byDataType, policies),
+    [byDataType, policies]
+  );
+
+  return { rows, lastSyncedAt };
+};

--- a/packages/workout-spa-editor/src/hooks/data-hub/use-data-type-source-policies.ts
+++ b/packages/workout-spa-editor/src/hooks/data-hub/use-data-type-source-policies.ts
@@ -1,10 +1,6 @@
 /**
- * useDataTypeSourcePolicies — the profile's raw DataTypeSourcePolicy rows.
- *
- * One `useLiveQuery` shared by every surface that needs per-type multi-source
- * semantics: the Data Hub's priority editor (which then narrows to 2+ source
- * types) and the Connections page's routing rows (which do not). Keeping the
- * query in one place stops the two from drifting on what "no row" means.
+ * One `useLiveQuery` for the profile's raw policy rows, so the surfaces that
+ * read them cannot drift on what an absent row means.
  */
 import { useLiveQuery } from "dexie-react-hooks";
 

--- a/packages/workout-spa-editor/src/hooks/data-hub/use-data-type-source-policies.ts
+++ b/packages/workout-spa-editor/src/hooks/data-hub/use-data-type-source-policies.ts
@@ -1,0 +1,29 @@
+/**
+ * useDataTypeSourcePolicies — the profile's raw DataTypeSourcePolicy rows.
+ *
+ * One `useLiveQuery` shared by every surface that needs per-type multi-source
+ * semantics: the Data Hub's priority editor (which then narrows to 2+ source
+ * types) and the Connections page's routing rows (which do not). Keeping the
+ * query in one place stops the two from drifting on what "no row" means.
+ */
+import { useLiveQuery } from "dexie-react-hooks";
+
+import { db } from "../../adapters/dexie/dexie-database";
+import type { DataTypeSourcePolicy } from "../../types/data-type-source-policy";
+
+const EMPTY: DataTypeSourcePolicy[] = [];
+
+export const useDataTypeSourcePolicies = (
+  profileId: string | null
+): readonly DataTypeSourcePolicy[] => {
+  const policies = useLiveQuery(async (): Promise<DataTypeSourcePolicy[]> => {
+    if (!profileId) return EMPTY;
+    return db
+      .table<DataTypeSourcePolicy>("dataTypeSourcePolicy")
+      .where("profileId")
+      .equals(profileId)
+      .toArray();
+  }, [profileId]);
+
+  return policies ?? EMPTY;
+};

--- a/packages/workout-spa-editor/src/hooks/data-hub/use-source-policies.ts
+++ b/packages/workout-spa-editor/src/hooks/data-hub/use-source-policies.ts
@@ -4,34 +4,23 @@
  * useDataFlows) with its DataTypeSourcePolicy rows, keeping only the data
  * types that currently have 2+ enabled import sources.
  */
-import { useLiveQuery } from "dexie-react-hooks";
 import { useMemo } from "react";
 
-import { db } from "../../adapters/dexie/dexie-database";
 import {
   buildSourcePolicyRows,
   type SourcePolicyRow,
 } from "../../application/data-hub/source-policy-rows";
 import { useDataFlows } from "../../components/organisms/ProfileManager/components/useDataFlows";
-import type { DataTypeSourcePolicy } from "../../types/data-type-source-policy";
-
-const EMPTY: DataTypeSourcePolicy[] = [];
+import { useDataTypeSourcePolicies } from "./use-data-type-source-policies";
 
 export const useSourcePolicies = (
   profileId: string | null
 ): SourcePolicyRow[] => {
   const { byDataType } = useDataFlows(profileId ?? "");
-  const policies = useLiveQuery(async (): Promise<DataTypeSourcePolicy[]> => {
-    if (!profileId) return EMPTY;
-    return db
-      .table<DataTypeSourcePolicy>("dataTypeSourcePolicy")
-      .where("profileId")
-      .equals(profileId)
-      .toArray();
-  }, [profileId]);
+  const policies = useDataTypeSourcePolicies(profileId);
 
   return useMemo(
-    () => buildSourcePolicyRows(byDataType, policies ?? EMPTY),
+    () => buildSourcePolicyRows(byDataType, policies),
     [byDataType, policies]
   );
 };

--- a/packages/workout-spa-editor/src/i18n/connections-data-types.test.ts
+++ b/packages/workout-spa-editor/src/i18n/connections-data-types.test.ts
@@ -9,6 +9,11 @@ const CATALOGS = [
   ["es", es.dataTypes as Record<string, string>],
 ] as const;
 
+const HINTS = [
+  ["en", en.dataTypeHints as Record<string, string>],
+  ["es", es.dataTypeHints as Record<string, string>],
+] as const;
+
 describe("connections data-type labels", () => {
   it.each(CATALOGS)(
     "should name every managed data type in %s",
@@ -23,6 +28,22 @@ describe("connections data-type labels", () => {
 
       // Assert
       expect(named).toEqual(expected);
+    }
+  );
+
+  it.each(HINTS)(
+    "should describe every managed data type in %s",
+    (_locale, hints) => {
+      // Arrange
+      // Same drift, one row lower: a routing row whose hint key is missing
+      // prints the dotted key itself under the type's name.
+      const expected = [...managedDataTypes].sort();
+
+      // Act
+      const described = Object.keys(hints).sort();
+
+      // Assert
+      expect(described).toEqual(expected);
     }
   );
 });

--- a/packages/workout-spa-editor/src/i18n/locales/en/connections.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/connections.json
@@ -53,6 +53,37 @@
     "connect": "Connect",
     "cancel": "Cancel"
   },
+  "routing": {
+    "title": "Where each data type comes from",
+    "freshnessHint": "Times below are per source — when that source last sent Kaiord anything, not this type alone.",
+    "from": "From",
+    "sentTo": "Also sent to",
+    "nowhere": "Nowhere",
+    "noSource": "No source",
+    "manySources": "{{count}} sources",
+    "unrankedHint": "Kaiord keeps every source's record for this type. Nothing ranks them, so no single source is the one it comes from.",
+    "sourceLastSent": "{{name}} last sent data {{when}}",
+    "groups": {
+      "training": "Training",
+      "recovery": "Recovery",
+      "body": "Body"
+    }
+  },
+  "dataTypeHints": {
+    "workout": "Completed structured sessions",
+    "planned-session": "What your coach scheduled",
+    "activity": "Unstructured rides, runs and walks",
+    "training-zones": "FTP, threshold HR, max HR",
+    "weight": "Scale readings",
+    "sleep": "Duration, stages, efficiency",
+    "hrv": "Heart-rate variability, overnight or spot",
+    "daily-wellness": "Steps, calories, intensity minutes",
+    "body-composition": "Body fat, lean mass, body water",
+    "stress": "All-day stress level",
+    "strain": "Cardiovascular load for the day",
+    "vitals": "Resting HR, SpO₂, respiration",
+    "heart-rate-series": "Sampled heart-rate traces"
+  },
   "dataTypes": {
     "workout": "Workout",
     "planned-session": "Planned Session",

--- a/packages/workout-spa-editor/src/i18n/locales/en/connections.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/connections.json
@@ -61,7 +61,9 @@
     "nowhere": "Nowhere",
     "noSource": "No source",
     "manySources": "{{count}} sources",
-    "unrankedHint": "Kaiord keeps every source's record for this type. Nothing ranks them, so no single source is the one it comes from.",
+    "unrankedNote": "kept side by side, none ranked first",
+    "noUsableSource": "No usable source",
+    "rankedUnavailableNote": "ranked to sources that are switched off — nothing is being read",
     "sourceLastSent": "{{name}} last sent data {{when}}",
     "groups": {
       "training": "Training",

--- a/packages/workout-spa-editor/src/i18n/locales/es/connections.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/connections.json
@@ -53,6 +53,37 @@
     "connect": "Conectar",
     "cancel": "Cancelar"
   },
+  "routing": {
+    "title": "De dónde viene cada tipo de dato",
+    "freshnessHint": "Las horas de abajo son por fuente: cuándo esa fuente envió algo a Kaiord por última vez, no solo este tipo.",
+    "from": "De",
+    "sentTo": "También se envía a",
+    "nowhere": "A ningún sitio",
+    "noSource": "Sin fuente",
+    "manySources": "{{count}} fuentes",
+    "unrankedHint": "Kaiord guarda el registro de todas las fuentes para este tipo. Ninguna se impone, así que no hay una única fuente de la que venga.",
+    "sourceLastSent": "{{name}} envió datos por última vez {{when}}",
+    "groups": {
+      "training": "Entrenamiento",
+      "recovery": "Recuperación",
+      "body": "Cuerpo"
+    }
+  },
+  "dataTypeHints": {
+    "workout": "Sesiones estructuradas completadas",
+    "planned-session": "Lo que ha programado tu entrenador",
+    "activity": "Salidas, carreras y paseos sin estructura",
+    "training-zones": "FTP, FC de umbral, FC máxima",
+    "weight": "Lecturas de la báscula",
+    "sleep": "Duración, fases y eficiencia",
+    "hrv": "Variabilidad cardiaca, nocturna o puntual",
+    "daily-wellness": "Pasos, calorías y minutos de intensidad",
+    "body-composition": "Grasa corporal, masa magra y agua corporal",
+    "stress": "Nivel de estrés de todo el día",
+    "strain": "Carga cardiovascular del día",
+    "vitals": "FC en reposo, SpO₂ y respiración",
+    "heart-rate-series": "Trazas de frecuencia cardiaca muestreadas"
+  },
   "dataTypes": {
     "workout": "Entrenamiento",
     "planned-session": "Sesión planificada",

--- a/packages/workout-spa-editor/src/i18n/locales/es/connections.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/connections.json
@@ -61,7 +61,9 @@
     "nowhere": "A ningún sitio",
     "noSource": "Sin fuente",
     "manySources": "{{count}} fuentes",
-    "unrankedHint": "Kaiord guarda el registro de todas las fuentes para este tipo. Ninguna se impone, así que no hay una única fuente de la que venga.",
+    "unrankedNote": "se guardan a la vez, ninguna tiene prioridad",
+    "noUsableSource": "Sin fuente utilizable",
+    "rankedUnavailableNote": "prioriza fuentes que están apagadas: no se está leyendo nada",
     "sourceLastSent": "{{name}} envió datos por última vez {{when}}",
     "groups": {
       "training": "Entrenamiento",


### PR DESCRIPTION
## Summary

The 13 managed data types, grouped Training / Recovery / Body, each showing where it comes from, where it goes, and how fresh it is. Read-only — the inline "Change" control is W2b.

## The design's organising idea does not match the product

The reference design is built around *"one source of truth per type · others stay as backup"*. But `DEFAULT_DATA_TYPE_SOURCE_MODE` is **`union`**, and union is documented as keeping *every* source's record for the day, each tagged with its own `sourceBridgeId`. There is no winner. When something needs a single value, `pick-effective-health-record.ts` takes `records.at(-1)` — whichever was written last.

So a confident **"From: Garmin"** pill on a union-mode row would be showing **write order**, not a user's choice. With two or more sources and no ranking, the pill says **"2 sources"** and explains itself:

> Kaiord keeps every source's record for this type. Nothing ranks them, so no single source is the one it comes from.

Where a `priority` policy *does* exist, the head is named — and it comes from the same `orderSources` that `resolveEffectiveSource` consults first, so the pill and the resolver cannot drift apart.

`manual` is included as a source (it is exempt from the enabled-policy filter and covers 9 of 13 types) but appended **last**, so a saved priority order — which the Data Hub editor only ever fills with bridge ids — keeps deciding the head.

## What was refused, and why

- **"Also sent to" on 11 of 13 rows.** Only `workout` and `body-composition` have an export capability at all. Where none exists the affordance is **absent** rather than reading "Nowhere" — "Nowhere" describes the absence of a route that could be created, which is a different claim. `workout` with no enabled export route does say "Nowhere", because there it is true.
- **Fallback display** (strikethrough → next source, "backup since <date>"). `usedFallback` is priority-mode only, per-(type, day), means "no record that day" rather than "source broken", and covers 6 of 13 types — `strain`, `vitals` and `heart-rate-series` return undefined, and Strain is the row the design uses to demo it.
- **"No source since <date>"** and **"stopped syncing N days ago"** — no transition timestamp exists anywhere.
- **"Baseline reset — 3 days of new data"** and **"Tanita would be more accurate here"** — no state at all.
- **"WHOOP-only metric"** as Strain's description — capability-wise it is not. Now "Cardiovascular load for the day".
- **"Readiness and body battery"** for daily-wellness — nothing ingests a body battery; the schema carries steps, calories and intensity minutes.

**Freshness names its subject.** `coachingSyncState` is per-(source, profile), not per-type, so the copy reads *"Garmin last sent data 2 minutes ago"* and the section says once that these times are per source. A row with no single owning source shows **no time** rather than picking one of several and implying it covers the row.

## Every test names the reachable state it fails on

Rather than list all fifteen: the discipline was to ask, for each test, which state it excludes and whether a user can reach it. That surfaced a real one — **"no source" is unreachable for the 9 types with a manual path**, so the no-source test uses `planned-session`, one of only four types where it can happen at all. The union test uses the configuration any user reaches by enabling a single route, which is exactly the row the design demos "From: Garmin" on.

One state is deliberately **untested and unguarded**: `mode:"priority"` with an empty `sourceOrder`. `setMode` always writes a ≥2 order and `move` reorders a non-empty one, so it cannot occur — and adding a guard against an unreachable state is the same mistake as testing one.

## Notes

- No second `useDataFlows` subscription — `byDataType` comes from the page, per the warning already in the tab.
- Zero changes to the matrix code; freshness reads `useBridgeSyncStates` directly, so nothing is stranded when W4 retires the matrix UI.
- A parity test asserts every `managedDataTypes` member is in exactly one group; a 14th type added to core would otherwise vanish from the page silently — which is exactly how `strain`, `vitals` and `heart-rate-series` were added.
- **W2b's decision now has a concrete cost**: with union as the default, most multi-source rows read "2 sources". If "Change" writes `mode:"priority"` on first use it silently changes read semantics for that type. Recorded as a rejected alternative rather than pre-empted.

## Verification

`pnpm -r build` · SPA **877 files / 6193 tests** · `tsc -b --noEmit` · `pnpm test:scripts` 616/616 · root `pnpm lint` · `lint:specs` 64 · `playwright test --list` 1794 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Connections routing section showing where each managed data type comes from.
  * Data types are organized into Training, Recovery, and Body groups.
  * Displays source names, multi-source counts, manual-entry origins, and source priority.
  * Shows source-specific freshness information when available.
  * Identifies export destinations and indicates when supported data is not sent anywhere.
* **Localization**
  * Added English and Spanish labels and descriptions for routing and data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->