### PR TITLE
feat(spa-editor): health summary and consequence banner (Wave 3)

### DIFF
--- a/openspec/changes/add-connections-health-summary/.openspec.yaml
+++ b/openspec/changes/add-connections-health-summary/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-29

--- a/openspec/changes/add-connections-health-summary/design.md
+++ b/openspec/changes/add-connections-health-summary/design.md
@@ -1,0 +1,194 @@
+# Design — Connections health summary
+
+## D1. One attention predicate, shared by construction
+
+Two surfaces now summarise the same page: the Settings shell's banner and this
+section's own counter. The shell already learned this lesson once — it shipped
+with its own `error || needsReauth` predicate, Wave 1 shipped `bridgeSourceStatus`,
+and the two disagreed on a reachable case (a reachable probed source with no
+session: the predicate said healthy, the card said amber). Git merged both
+without complaint.
+
+So the predicate is not re-derived here. `sourceNeedsAttention` moves into
+`application/connections/connection-source.ts`, beside the type it tests, and
+`connection-attention.ts` re-exports it under the name its own tests use. Both
+surfaces now call one function over the list the cards are rendered from.
+Disagreement is no longer possible without changing the cards too.
+
+`calendarDay` moves for the same reason: the shell's banner and this one state
+the same date about the same source.
+
+## D2. "Detected", not "active"
+
+The reference design's first counter is "Active sources · 2 of 5 linked". A
+count of live sessions cannot reach 5. `tanita-bridge` has no session prober by
+design — its `checkSession` action downloads the entire export CSV, so polling
+it would re-fetch the user's whole body-composition history every pass — and it
+is therefore permanently session-inactive. The counter would sit at 4 of 5 for a
+user with everything installed and working, which reads as a bug report.
+
+`add-settings-attention-model` hit this exact wall on the Settings index row and
+answered it by counting `discovered`. The same answer is taken here, with the
+same word: a page cannot enumerate installed extensions, only the ones that
+announced themselves and answered this page-life, and "detected" is what that
+is.
+
+## D3. "Types covered", not "data flowing"
+
+The design's second counter is "Data flowing · 9 of 13 types". The number is
+derivable; the words are the problem, and so is the denominator.
+
+Bridge capabilities are announced at runtime, and the union across all five
+bridges is `read:activities`, `read:training-plan`, `read:training-zones`,
+`read:body` and `read:sleep`. **No bridge announces `read:workouts`.** So
+`workout` can never be delivered by an extension: counting only bridge routes
+puts the ceiling at 12 of 13, which is D2's defect one counter over.
+
+Manual entry closes it. `MANUAL_ENTRY_TYPES` records the nine types with a real
+manual code path, `workout` among them, and the four it omits — planned-session,
+strain, vitals, heart-rate-series — are all reachable from a bridge
+(train2go for the first, WHOOP for the rest). With manual included, 13 of 13 is
+genuinely reachable.
+
+But manual entry is not data flowing. Nothing arrives because a manual path
+exists; the reader has to type it. So the counter is labelled for what it
+actually measures — a type having a source at all — and the design's wording is
+not used. The floor for a reader with no extensions is 9, and that is honest:
+they can enter nine kinds of thing by hand today.
+
+"An enabled route" is the right gate for the bridge half because it is the gate
+the product itself uses: every runner in `hooks/bridge-import/` passes
+`policyRepo` to a use case that resolves import policies before it touches a
+bridge. A switched-off route delivers nothing, whatever the extension is doing.
+
+## D3b. Why `covered` and `paused` are not complements
+
+`covered` counts manual entry; `paused` does not. A reader whose Tanita signed
+out still has `weight` covered (they can type it) and still needs to be told
+that their scale stopped feeding it. Deriving `paused` as `!covered` would
+silently drop every manual-entry type from the banner — nine of the thirteen,
+including every type Tanita and TrainingPeaks serve.
+
+They answer different questions and are computed in one pass over the same
+inputs, so they cannot drift.
+
+`checking` counts as delivering in both. A probe is in flight for a few hundred
+milliseconds on every five-minute poll; excluding it would make the headline
+number twitch while nothing about the reader's setup changed.
+
+## D4. What the banner refuses to say
+
+The reference design asserts five things in one banner. Two are inventions and
+one is unstatable.
+
+**"WHOOP stopped syncing 3 days ago"** — there is no transition timestamp
+anywhere in the product. The nearest candidate, `lastCheckedAt`, is when the SPA
+last probed: after a reload it reads as seconds ago no matter how long a source
+has been down, so "3 days" would be fiction on every fresh page. `lastSyncAt` is
+persisted `coachingSyncState` and survives the reload, so "No new data since
+<date>" is sayable and is what ships. It is attached only when exactly one
+source is affected, so one source's date is never presented as a set's.
+
+**"Sleep and HRV have quietly fallen back to Garmin"** — `union` is
+`DEFAULT_DATA_TYPE_SOURCE_MODE`, and union returns every source's record for the
+day with no ranked winner (`resolve-effective-source.use-case.ts` says so in its
+own comment, and `pick-effective-health-record` resolves ties by write order).
+Nothing ever "falls back", because nothing was ever in front. `usedFallback`
+exists only in `priority` mode, is per-(type, day), and means "the preferred
+source had no record that day" — not "the source broke". It covers 6 of 13
+types. Naming a successor is not available at any confidence, so the banner
+names what stopped and stops there. Per-row fallback for genuinely
+priority-mode types is a Wave 2 question, not this one.
+
+**"Its access token expired"** — no bridge can tell an expired credential from
+one that was never issued; `probeWhoopSession` leaves `needsReauth` false in
+both cases, and only `trainingpeaks-bridge` ever sets it. The wording is the one
+the cards and the extension popups already settled on: signed out.
+
+**"Reconnecting backfills the last 30 days"** — `CYCLES_WINDOW_DAYS` is 30 but
+`HR_WINDOW_DAYS` and `STRESS_WINDOW_DAYS` are both 7. One number would be false
+for two of the types WHOOP carries, and a per-type breakdown is not a banner
+sentence. No backfill promise ships.
+
+**The design contradicts itself** — its banner says Daily Wellness "fell back"
+while its WHOOP card calls the same thing "paused". Resolved as paused, applied
+only to types that genuinely lost every delivering source.
+
+## D4b. Why the banner declares no action
+
+The design's CTA is "Reconnect WHOOP". The fix for a signed-out bridge is a
+sign-in on the provider's own site; this page cannot perform it, and the card
+that explains it sits immediately below the banner. A button that only scrolled
+the reader four hundred pixels is a control that does not fix the thing it
+names. `add-settings-attention-model` declined a CTA on the same reasoning, and
+"Refresh all" — which does act, on the one thing this page can act on — is
+already in the header.
+
+## D5. The cold-load window, again
+
+`add-settings-attention-model` shipped "0 of 5" on every cold load. Its guard
+was `connections.length === 0`, which never fires: `createSnapshotReader`
+synthesises a row per known bridge from the first render, so the list is never
+empty and the counter rendered zeros until the probes answered.
+
+The reachable bad state is not "no rows", it is "rows that have not been asked
+yet". `useBridgeConnectionsRefreshed()` is the discriminator, and it is what
+gates the counters here. The placeholder is a distinct value, not a zero, so
+"we have not asked" and "the answer is none" no longer look the same.
+
+The banner is deliberately NOT gated. Before the first pass every bridge is
+undiscovered, which makes every source `available` rather than `attention`, so
+the banner is silent for exactly the same reason a healthy browser leaves it
+silent. There is no window in which it can raise a false alarm.
+
+## D6. The refresh cooldown, and why 60 seconds
+
+`refresh({ force: true })` is already correct: `refreshConnections` fans out over
+`KNOWN_BRIDGE_IDS` with `Promise.allSettled`, so one unreachable extension
+cannot abort the pass, and it genuinely replaces the old control that only
+re-detected garmin and train2go.
+
+What it lacks is a floor. `force` bypasses the 30-second positive cache by
+definition, and the 60-second visibility floor lives in `createLifecycle`'s
+visibility handler rather than in the store — so nothing at all limits a manual
+call. Probes also run outside `BRIDGE_QUEUE` (deliberately: a status probe must
+not queue behind a 30-second read, and must not eat the 60-per-hour budget), so
+there is no downstream backpressure either. A held button messages four
+extensions as fast as they answer.
+
+The window matches the visibility floor rather than the positive cache, because
+both trigger the same forced whole-bridge pass: pressing the button can never be
+more aggressive than switching tabs already is. It also equals
+`IMPORT_COOLDOWN_MS`, so the section has one number rather than two.
+
+The guard is module-scoped, mirroring `import-cooldown`: it protects
+extensions, so it must outlive the component that renders the button, and
+reading the in-flight flag synchronously settles the two-clicks-in-one-tick case
+that a captured `status` cannot. A refused press says so — a control that
+silently does nothing reads as broken.
+
+## D7. Tanita is not a spinner
+
+A bridge with no prober is written as `discovered: true` and returns before
+`probeBridge`, so `checking` is never set and `lastCheckedAt` stays null;
+`bridgeSourceStatus` reads `hasProbe` and answers `installed`. Both halves are
+already pinned by Wave 1 — `bridge-connection-store.test.ts` asserts the whole
+runtime row including `checking: false` and that the probe was never called, and
+`connection-source-status.test.ts` asserts the `installed` verdict. `force`
+does not reach either path. No test is added here; a third assertion of the same
+two facts would be the decorative-test failure this repo's test-minimality spec
+exists to prevent.
+
+## D8. File placement
+
+The three derivations are pure and live in `application/connections/` beside
+`build-connection-sources`, so their copy and their arithmetic are asserted
+without rendering. `connection-coverage` imports the `DataFlowsByType` view type
+from the components tree, which `application/data-hub/source-policy-rows.ts`
+already does — a type-only import, no adapter reached, and the boundaries
+allowlist is untouched.
+
+The tiles' copy is a separate data module rather than JSX, which keeps both the
+80-line file cap and the 60-line component cap satisfied without splitting the
+row into four near-identical components, and makes the cold-load placeholder one
+branch instead of four.

--- a/openspec/changes/add-connections-health-summary/design.md
+++ b/openspec/changes/add-connections-health-summary/design.md
@@ -124,22 +124,88 @@ names. `add-settings-attention-model` declined a CTA on the same reasoning, and
 "Refresh all" — which does act, on the one thing this page can act on — is
 already in the header.
 
-## D5. The cold-load window, again
+## D4c. The date attaches to a loss, or to nothing
 
-`add-settings-attention-model` shipped "0 of 5" on every cold load. Its guard
-was `connections.length === 0`, which never fires: `createSnapshotReader`
-synthesises a row per known bridge from the first render, so the list is never
-empty and the counter rendered zeros until the probes answered.
+`sinceOf` originally branched only on "exactly one affected source with a
+parseable date", and was joined to whichever sentence `consequenceOf` produced.
+Two of those three sentences say that nothing stopped arriving, so the banner
+could read:
 
-The reachable bad state is not "no rows", it is "rows that have not been asked
-yet". `useBridgeConnectionsRefreshed()` is the discriminator, and it is what
-gates the counters here. The placeholder is a distinct value, not a zero, so
-"we have not asked" and "the answer is none" no longer look the same.
+> Nothing has stopped: every affected type also has another source switched on.
+> **No new data since 2026-07-20.**
 
-The banner is deliberately NOT gated. Before the first pass every bridge is
-undiscovered, which makes every source `available` rather than `attention`, so
-the banner is silent for exactly the same reason a healthy browser leaves it
-silent. There is no window in which it can raise a false alarm.
+That is not exotic. A signed-out WHOOP whose only enabled route is `weight`,
+with Tanita also importing `weight` and installed, produces exactly it — and
+WHOOP has a `lastSyncAt` because any past import wrote one.
+
+The date qualifies a loss, so it is now attached only to the sentence that
+names one. The two spec requirements that produced this were simultaneously
+satisfiable with no precedence between them, which is a spec defect rather than
+only a code one; the precedence and its scenario are now stated.
+
+## D5. The cold-load window: "have we asked" is the wrong question
+
+`add-settings-attention-model` shipped "0 of 5" on every cold load behind a
+`connections.length === 0` guard that can never fire — `createSnapshotReader`
+synthesises a row per known bridge from the first render. This change first
+replaced it with `hasRefreshed()`, which is a better question and still the
+wrong one.
+
+Discovery is not request/response. `bridgeDiscovery.start()` installs a
+`message` listener and arms a timer; `ids` is empty and nothing has been sent.
+`lifecycle.start()` then calls `refresh()` immediately, `refreshBridge` reads
+`getExtensionId` → null for all five, writes `undiscoveredEntry` with no
+awaits, `allSettled` settles on the next microtask and `hasRefreshed()` flips
+true — all within microseconds of boot, with `detected: 0`. An announcement
+needs a `postMessage` macrotask plus an extension round-trip, so it cannot have
+happened. The gate protected a window microseconds wide and left the real one —
+discovery's — unguarded, so a hard reload with five extensions installed showed
+"0 of 5" and then climbed.
+
+The question is therefore not "have we asked" (nobody asks) but "has discovery
+had its chance", and there are two ways to know:
+
+- **Any bridge detected.** Positive evidence that announcements are arriving.
+  The count is explicitly of what has answered _so far this page-life_, and it
+  climbs in step with the cards beside it, each flipping as its own
+  announcement verifies. Waiting out the full window here would withhold an
+  answer already known.
+- **The grace period elapsed**, for the browser where nothing ever announces.
+  `DISCOVER_REQUEST_DELAY_MS + PING_TIMEOUT_MS` — the delay before discovery
+  broadcasts a request into silence, plus the ceiling on verifying an
+  announcement that answers it. Both derived from the constants that govern
+  them, so the window cannot drift from the behaviour it waits on.
+
+The clock is stamped at app boot, not at surface mount, so a reader opening the
+page ten minutes in waits for nothing. `loadedAt` is the floor because React
+runs child effects before parent ones: a cold boot straight onto this page can
+render before the root bootstrap stamps anything, and a reference slightly
+earlier than discovery's start can only delay the gate, never open it early.
+
+The placeholder is explicitly not permanent — a reader with no extensions has
+to be told so, which is why "any bridge detected" alone cannot be the gate.
+
+**The Settings index row is corrected in the same change.** It has the same bug
+from the same cause, and fixing only this surface would put a row reading
+"0 of 5" one click from a section reading "3 of 5" — reintroducing exactly the
+divergence D1 exists to prevent. Its unreachable `connections.length === 0`
+guard and the test covering it are removed rather than carried forward.
+
+The banner is deliberately NOT gated at all. Before a bridge is discovered
+every source reads `available` rather than `attention`, so the banner is silent
+for exactly the reason a healthy browser leaves it silent. There is no window
+in which it can raise a false alarm.
+
+## D5b. Why the counter and the banner may disagree about a type
+
+"Types covered 13 of 13" can render directly above "No source is sending Weight
+right now", and both are true: the tile counts _has a path_, the banner reports
+_is delivering_. Nothing on screen carried that distinction, so the pair read as
+a flat contradiction.
+
+The tile's note now says what makes the difference — "of 13 types · incl.
+manual entry" — which reconciles the two without enumerating which types are
+which, and without weakening either claim.
 
 ## D6. The refresh cooldown, and why 60 seconds
 

--- a/openspec/changes/add-connections-health-summary/proposal.md
+++ b/openspec/changes/add-connections-health-summary/proposal.md
@@ -28,11 +28,21 @@ rather than softened.
   prober by design, since its only session call downloads the whole export CSV
   — so the counter would sit one short forever and read as a defect. This is
   the choice and the word the Settings index row already made.
-- **The counters render nothing until the store has answered.** Every bridge
-  row exists from the first render and reads undiscovered, because nothing has
-  been asked yet — a count rendered then tells a fully equipped user "0 of 5"
-  on every cold load. The row waits on `useBridgeConnectionsRefreshed()` and
-  renders a placeholder, which is a different claim from zero.
+- **The counters render nothing until discovery has had its window.** Nobody
+  asks the extensions anything — they announce themselves when injected, and
+  discovery only broadcasts a request after three seconds of silence. So a
+  connection refresh pass over a browser where nothing has announced completes
+  microseconds after boot having sent no message at all, and gating on it
+  states a confident "0 of 5" to a fully equipped reader for as long as
+  discovery actually takes. The gate is instead any bridge being detected, or a
+  grace window derived from `DISCOVER_REQUEST_DELAY_MS + PING_TIMEOUT_MS`. The
+  placeholder is a different claim from zero, and it is not permanent: a reader
+  with no extensions is told so once the window elapses.
+- **The Settings index row is corrected with it.** It counts the same thing
+  from the same store and had the same bug; fixing only the section would put a
+  row reading "0 of 5" one click from a section reading "3 of 5". Its
+  `connections.length === 0` guard is deleted as unreachable — the snapshot
+  reader synthesises a row per known bridge from the first render.
 - **"Types covered" counts manual entry; the label is written for that.** A
   type is covered when an enabled import route's source is present, OR the type
   has a real manual-entry path. Excluding manual would put the denominator out
@@ -113,6 +123,10 @@ sentence the product cannot honour.
 - `spa-connections-page`: the section gains a health header above the cards —
   counters, the consequence of a broken source, and a refresh covering every
   bridge — all derived from the per-source state the section already resolves.
+- `spa-settings-shell`: the connections row's cold-load gate is corrected to
+  the same discovery-settled gate, and its unreachable empty-list guard is
+  removed, so the row and the section it leads to cannot disagree while both
+  are settling.
 
 ## Impact
 

--- a/openspec/changes/add-connections-health-summary/proposal.md
+++ b/openspec/changes/add-connections-health-summary/proposal.md
@@ -1,0 +1,142 @@
+## Why
+
+`add-connections-page` shipped the source cards. A reader who opens
+`/settings/connections` still has to read nine cards to answer the two
+questions they came with: is my data arriving, and if not, what stopped?
+
+The state to answer both exists. `useConnectionSources` resolves one status per
+source; `coachingSyncState` records when each source last delivered; the
+`IntegrationPolicy` rows every importer gates on record which types are
+switched on for which bridge. Nothing reads them together.
+
+This change adds the health header: four counters, a consequence banner, and
+one refresh that covers every bridge instead of two.
+
+It is also the densest claim surface in the redesign, and most of the reference
+design's assertions here are not backed. They are enumerated and refused below
+rather than softened.
+
+## What Changes
+
+- **Four counters, derived from the list the cards are rendered from.**
+  `sources detected`, `types covered`, `needs attention`, `last data in`. No
+  counter carries its own predicate: attention is `sourceNeedsAttention` over
+  the same array the section maps, so the summary cannot contradict the cards
+  beneath it.
+- **The detected counter counts extensions, not sessions.** A live-session
+  count cannot reach its own denominator — `tanita-bridge` has no session
+  prober by design, since its only session call downloads the whole export CSV
+  — so the counter would sit one short forever and read as a defect. This is
+  the choice and the word the Settings index row already made.
+- **The counters render nothing until the store has answered.** Every bridge
+  row exists from the first render and reads undiscovered, because nothing has
+  been asked yet — a count rendered then tells a fully equipped user "0 of 5"
+  on every cold load. The row waits on `useBridgeConnectionsRefreshed()` and
+  renders a placeholder, which is a different claim from zero.
+- **"Types covered" counts manual entry; the label is written for that.** A
+  type is covered when an enabled import route's source is present, OR the type
+  has a real manual-entry path. Excluding manual would put the denominator out
+  of reach: no bridge announces `read:workouts`, so `workout` can never be fed
+  by an extension and the ceiling would be 12 of 13 — the same unreachable
+  ceiling, one counter over. Including it means the number is about having a
+  source, not about data being in flight, and it is worded that way rather than
+  as the design's "data flowing".
+- **The banner states which types stopped, and nothing else.** Types with an
+  enabled route on a source needing attention, and no other source still
+  delivering them. Every input exists. Where the broken source's types are all
+  still delivered by something else the banner says so, and where it feeds no
+  route at all it says that instead — both are reachable states and neither is
+  a guess.
+- **The banner dates itself from the last data received.** `lastSyncAt` is
+  persisted and survives a reload. The date is attached only when exactly one
+  source is affected, so one source's date is never presented as a set's.
+- **One refresh covering every bridge, with a client-side cooldown.**
+  `refresh({ force: true })` already fans out over `KNOWN_BRIDGE_IDS` with
+  `Promise.allSettled`, so it genuinely replaces the old control that only
+  re-detected garmin and train2go. But it bypasses BOTH the store's 30-second
+  positive cache (that is what `force` means) and the 60-second visibility
+  floor, which lives in the visibility handler and not in the store — and
+  probes run outside `BRIDGE_QUEUE`, so nothing downstream pushes back. A held
+  button would message four extensions as fast as they answer. The cooldown
+  window matches the visibility floor: both trigger the same forced pass, so
+  the button can never be more aggressive than switching tabs already is.
+- **Tanita renders as installed, never as a spinner.** It is never probed, so
+  it never enters `checking` and never leaves it. `bridgeSourceStatus` already
+  resolves this from `hasProbe`; the refresh does not change it.
+- **The calendar-day formatter is shared, not copied.** The Settings banner and
+  this one state the same date about the same source; two formatters would
+  eventually disagree about which day that was.
+- **Sixteen keys in `en` and `es`.** No source name reaches a toast or a
+  `console.*` call.
+
+### Claims refused
+
+Each was checked against code before being cut, and each would have shipped a
+sentence the product cannot honour.
+
+1. **"WHOOP stopped syncing 3 days ago"** — no transition timestamp is recorded
+   anywhere. `lastCheckedAt` is when the SPA last probed, so after a reload it
+   reads as seconds ago however long a source has been down. Shipped as "No new
+   data since <date>", from the persisted `lastSyncAt`.
+2. **"Sleep and HRV have quietly fallen back to Garmin"** — `union` is the
+   default multi-source mode (`DEFAULT_DATA_TYPE_SOURCE_MODE`), and union
+   returns every source's record with no winner, so nothing ever "takes over".
+   `usedFallback` exists only in `priority` mode, is per-(type, day), and
+   covers 6 of 13 types. Not shipped in any form; the banner names what stopped
+   instead of naming a successor.
+3. **"Its access token expired"** — the SPA cannot distinguish an expired token
+   from never having signed in; only `trainingpeaks-bridge` propagates
+   `needsReauth` at all. Shipped as "is signed out", the wording already
+   settled on by the cards and the extension popups.
+4. **"Reconnecting backfills the last 30 days"** — true for WHOOP cycle metrics
+   (`CYCLES_WINDOW_DAYS = 30`) and false for stress and heart rate, which are
+   `7`. A single number cannot be stated, and a per-type breakdown is not a
+   banner. No backfill promise is made.
+5. **"Reconnect WHOOP" as the banner's call to action** — the fix for a
+   signed-out source is a sign-in on the provider's own site, which this page
+   cannot perform. The card that says more sits directly below the banner, so a
+   button here would either dead-end or merely scroll. The banner declares no
+   action.
+6. **"Active sources · 2 of 5 linked"** — unreachable as a session count, per
+   above. Reworded and re-derived.
+7. **"Data flowing · 9 of 13"** — the number is derivable but the words are
+   not, unless manual entry counts as data flowing. It does not. See "Types
+   covered" above.
+8. **The design's own contradiction** — its banner says Daily Wellness "fell
+   back" while its WHOOP card calls the same thing "paused". Resolved as
+   paused, and only for types that genuinely lost every delivering source.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `spa-connections-page`: the section gains a health header above the cards —
+  counters, the consequence of a broken source, and a refresh covering every
+  bridge — all derived from the per-source state the section already resolves.
+
+## Impact
+
+- **Package**: `@kaiord/workout-spa-editor` (private SPA) only. No domain,
+  application-port or adapter change; no dependency added; no Dexie schema
+  change and no new table. Bridge runtime state stays in memory and the
+  persistence boundary guard's file list is untouched — no `bridge-connection-*`
+  module was added, renamed or split.
+- **New files**: `calendar-day.ts`, `connection-coverage.ts`,
+  `connection-summary.ts` and `connection-consequence.ts` under
+  `application/connections/`; `refresh-cooldown.ts` and
+  `use-connections-refresh.ts` under `hooks/connections/`;
+  `ConnectionsHealth`, `ConnectionSummaryRow`, `ConnectionSummaryTile`,
+  `ConnectionsBanner`, `ConnectionRefreshButton` and
+  `connection-summary-tiles.ts` under `components/organisms/Connections/`.
+- **Moved, not duplicated**: `needsAttention` becomes a re-export of
+  `sourceNeedsAttention` in `application/connections/connection-source.ts`, and
+  `connection-attention.ts`'s private `dayOf` becomes the shared `calendarDay`.
+  Both keep their existing names and tests.
+- **Runtime cost**: one extra forced pass per press, floored at 60 seconds. No
+  new poll, no new subscription — `useBridgeConnectionsRefreshed` and
+  `useConnectionSources` were already mounted by this section.
+- **i18n**: sixteen keys added in both locales, none removed or re-worded.
+- **e2e**: no test id and no URL change; the header adds ids rather than
+  altering any. `settings-row-*` and `settings-panel-*` are untouched.
+- **No** changeset (the SPA is private and excluded from the changeset-bot
+  PUBLISHABLE set).

--- a/openspec/changes/add-connections-health-summary/specs/spa-connections-page/spec.md
+++ b/openspec/changes/add-connections-health-summary/specs/spa-connections-page/spec.md
@@ -1,0 +1,273 @@
+## ADDED Requirements
+
+<!-- ADDED to the capability introduced by the ACTIVE sibling change
+add-connections-page. That capability is not published under openspec/specs/
+yet, so its current text lives in that change's delta; nothing there is
+modified here. -->
+
+### Requirement: The section answers its own headline questions before the cards
+
+The Connections section SHALL open with a small set of counters answering,
+without reading any card, how many sources are present, how much of what the
+product manages has a source, how many sources need attention, and when data
+last arrived.
+
+Every counter SHALL be derived from the same per-source state the section
+renders its cards from. No counter SHALL carry its own predicate for a
+question a card already answers: a summary that can disagree with the surface
+beneath it is worse than no summary.
+
+A counter SHALL NOT state a denominator it cannot reach. In particular the
+count of present sources SHALL count detected extensions rather than live
+sessions, because at least one bridge is never session-probed and a session
+count could therefore never equal its own total — a counter fixed one short of
+completion reads as a defect rather than as a state.
+
+#### Scenario: The counters agree with the cards
+
+- **GIVEN** a set of sources of which some number are marked as needing attention
+- **WHEN** the counters render
+- **THEN** the attention counter SHALL equal that number
+
+#### Scenario: The present-source count reaches its denominator
+
+- **GIVEN** every known bridge is detected, including one that is never session-probed
+- **WHEN** the counters render
+- **THEN** the present-source counter SHALL equal its own total
+
+#### Scenario: Sources with no extension are outside the count
+
+- **GIVEN** the section also renders manual entry and brands that cannot be connected
+- **WHEN** the present-source counter is derived
+- **THEN** neither its count nor its total SHALL include them
+
+#### Scenario: Freshness comes from delivered data, not from the last check
+
+- **GIVEN** several sources with recorded last-delivery times
+- **WHEN** the freshness counter renders
+- **THEN** it SHALL report the most recent delivery and the source that made it, and SHALL NOT report when a source was last probed
+
+#### Scenario: An unusable delivery time is ignored
+
+- **GIVEN** a source whose recorded last-delivery value does not parse as a date
+- **WHEN** the freshness counter is derived
+- **THEN** that source SHALL be skipped rather than rendered as an invalid value
+
+### Requirement: The counters claim nothing until the connection store has answered
+
+The counters SHALL render a placeholder, distinct from zero, until the
+connection store has completed a refresh pass. Every bridge row exists from the
+first render and reads undetected until then — because nothing has been asked
+yet, not because nothing is there — so a count rendered from that state would
+be wrong rather than merely early, and would tell a fully equipped reader that
+none of their sources are present on every cold load.
+
+#### Scenario: A cold load counts nothing
+
+- **GIVEN** the connection store has not completed a refresh pass
+- **WHEN** the counters render
+- **THEN** they SHALL render a placeholder and SHALL NOT render a count
+
+#### Scenario: The counters appear once the store has answered
+
+- **GIVEN** the connection store has completed a refresh pass
+- **WHEN** the counters render
+- **THEN** they SHALL render counts derived from the resolved sources
+
+### Requirement: Coverage is counted over having a source, not over data in flight
+
+A managed data type SHALL be counted as covered when an enabled import route
+exists for it whose source is present, or when the type has a real manual-entry
+path in the product. The counter's wording SHALL describe having a source
+rather than data arriving, because manual entry is a path the reader has to
+walk themselves.
+
+Manual entry SHALL be included. At least one managed type has no bridge
+capability token announced by any bridge and can therefore only ever be entered
+by hand; excluding manual entry would put the counter's denominator permanently
+out of reach.
+
+A route SHALL be counted only while it is switched on. Every importer gates on
+an enabled route before contacting a bridge, so a switched-off route delivers
+nothing however healthy its source is.
+
+A type SHALL remain counted while its source is being probed. A probe is in
+flight for a moment on every poll, and dropping the type for that window would
+make the counter change while nothing about the reader's setup did.
+
+#### Scenario: A live route covers its type
+
+- **GIVEN** an enabled import route for a type whose source is present
+- **WHEN** coverage is derived
+- **THEN** that type SHALL be counted as covered
+
+#### Scenario: A switched-off route covers nothing
+
+- **GIVEN** an import route that exists but is switched off
+- **WHEN** coverage is derived
+- **THEN** its type SHALL NOT be counted as covered
+
+#### Scenario: A hand-entered type is covered with no extension at all
+
+- **GIVEN** no source is present and no route is switched on
+- **WHEN** coverage is derived
+- **THEN** every type with a manual-entry path SHALL still be counted as covered
+
+#### Scenario: A type with no path at all is not covered
+
+- **GIVEN** a type with no manual-entry path and no enabled route
+- **WHEN** coverage is derived
+- **THEN** it SHALL NOT be counted as covered
+
+#### Scenario: A probe in flight does not uncover a type
+
+- **GIVEN** an enabled route whose source is currently being probed
+- **WHEN** coverage is derived
+- **THEN** its type SHALL remain counted as covered
+
+### Requirement: A broken source states its consequence, and only what is recorded
+
+When one or more sources need attention the section SHALL state, above the
+cards, what broke and what stopped arriving because of it. When no source needs
+attention it SHALL render nothing at all — no container and no placeholder.
+
+The consequence SHALL name the data types that lost every delivering source:
+types with an enabled route on an affected source and no other present source
+serving them. Where the affected sources' types are all still served elsewhere,
+the statement SHALL say that nothing stopped; where an affected source feeds no
+switched-on route at all, it SHALL say that instead. Both are reachable states
+and neither SHALL be reported as a loss.
+
+A type that can also be entered by hand SHALL still be named when its automatic
+delivery stops. Manual entry is a path the reader must walk deliberately, so it
+does not make a stopped source unremarkable.
+
+The statement SHALL NOT name a source that has taken over for the affected one.
+The default multi-source mode returns every source's record with no ranked
+winner, so no source ever succeeds another, and a named successor would be an
+invention.
+
+The statement SHALL NOT claim a credential expired, and SHALL NOT state how
+long a source has been broken or when it broke. No transition timestamp is
+recorded anywhere, and the time of the last probe is not one: after a reload it
+reads as moments ago however long a source has been down. A date SHALL be
+attached only from a recorded last delivery, only when exactly one source is
+affected, and only in the reader's own calendar day.
+
+A cause SHALL be named only when it holds for every affected source. With
+several affected, only the count holds for all of them; in particular one
+extension speaking an unsupported protocol version does not make the others
+out of date.
+
+An extension speaking an unsupported protocol version SHALL be reported as out
+of date rather than as signed out, because the probe succeeded and signing in
+again would fix nothing.
+
+The statement SHALL declare no call to action while the fix is a sign-in on the
+provider's own site, which this page cannot perform.
+
+#### Scenario: A healthy section states no consequence
+
+- **GIVEN** no source needs attention
+- **WHEN** the section renders
+- **THEN** no consequence SHALL be rendered
+
+#### Scenario: The types that lost their source are named
+
+- **GIVEN** an affected source serving types no other present source serves
+- **WHEN** the consequence is stated
+- **THEN** it SHALL name those types, and SHALL NOT name a source that took over from the affected one
+
+#### Scenario: A type served elsewhere is not reported as lost
+
+- **GIVEN** an affected source whose types are all also served by a present source
+- **WHEN** the consequence is stated
+- **THEN** it SHALL state that nothing stopped arriving
+
+#### Scenario: A source feeding no route reports no loss
+
+- **GIVEN** an affected source with no switched-on route
+- **WHEN** the consequence is stated
+- **THEN** it SHALL state that nothing stopped arriving rather than naming a type
+
+#### Scenario: A session problem is described as signed out
+
+- **GIVEN** exactly one affected source whose probe reports no usable session
+- **WHEN** the consequence is stated
+- **THEN** it SHALL describe the source as signed out, and SHALL NOT claim a credential expired
+
+#### Scenario: The date comes from the last delivery
+
+- **GIVEN** exactly one affected source with a recorded last delivery
+- **WHEN** the consequence is stated
+- **THEN** it SHALL state that no new data has arrived since that date, in the reader's own calendar day, and SHALL NOT state how long the source has been broken
+
+#### Scenario: Several affected sources carry no date
+
+- **GIVEN** more than one affected source, at least one with a recorded last delivery
+- **WHEN** the consequence is stated
+- **THEN** no date SHALL be stated
+
+#### Scenario: An outdated extension is told to update
+
+- **GIVEN** exactly one affected source whose probe answered with an unsupported protocol version
+- **WHEN** the consequence is stated
+- **THEN** it SHALL say the extension is out of date, and SHALL NOT tell the reader to sign in
+
+#### Scenario: A cause held by one of several is not generalised
+
+- **GIVEN** two affected sources of which only one answered with an unsupported protocol version
+- **WHEN** the consequence is stated
+- **THEN** it SHALL state the count alone, and SHALL NOT describe either source's cause
+
+### Requirement: One refresh covers every bridge and cannot be held down
+
+The section SHALL offer a single refresh that re-checks every known bridge, not
+a subset, and SHALL survive an unreachable bridge without abandoning the rest
+of the pass.
+
+The refresh SHALL be rate-limited on the client. It forces a pass, which
+deliberately bypasses the store's positive cache, and the floor that limits
+automatic forced passes lives outside the store; status probes also run outside
+the operation queue, so nothing downstream provides backpressure. The window
+SHALL be no shorter than the floor already applied to automatic forced passes,
+so pressing the control can never be more aggressive than the product already
+is on its own.
+
+A press inside that window SHALL be refused visibly rather than silently, and a
+press while a pass is already running SHALL join that pass rather than start a
+second. The window SHALL be applied after a failed pass as well as a successful
+one, so a failing bridge cannot be retried in a tight loop.
+
+A bridge that is never session-probed SHALL be reported as present through a
+refresh, and SHALL NOT be shown as being checked. Nothing will ever answer for
+it, so a pending state would never resolve.
+
+#### Scenario: The refresh reaches every bridge
+
+- **WHEN** the refresh runs
+- **THEN** every known bridge SHALL be re-checked
+
+#### Scenario: A repeated press inside the window is refused visibly
+
+- **GIVEN** a refresh completed within the rate-limit window
+- **WHEN** the control is pressed again
+- **THEN** no pass SHALL start and the refusal SHALL be stated to the reader
+
+#### Scenario: A second press joins the running pass
+
+- **GIVEN** a refresh already in flight
+- **WHEN** the control is pressed again
+- **THEN** no second pass SHALL start
+
+#### Scenario: A failed pass still takes the window
+
+- **GIVEN** a refresh pass that failed
+- **WHEN** the control is pressed again inside the window
+- **THEN** no pass SHALL start
+
+#### Scenario: An unprobed bridge never shows as being checked
+
+- **GIVEN** a bridge with no session prober
+- **WHEN** a refresh completes
+- **THEN** it SHALL be reported as present and SHALL NOT be reported as being checked

--- a/openspec/changes/add-connections-health-summary/specs/spa-connections-page/spec.md
+++ b/openspec/changes/add-connections-health-summary/specs/spa-connections-page/spec.md
@@ -53,26 +53,58 @@ completion reads as a defect rather than as a state.
 - **WHEN** the freshness counter is derived
 - **THEN** that source SHALL be skipped rather than rendered as an invalid value
 
-### Requirement: The counters claim nothing until the connection store has answered
+### Requirement: The counters claim nothing until discovery has had its window
 
-The counters SHALL render a placeholder, distinct from zero, until the
-connection store has completed a refresh pass. Every bridge row exists from the
-first render and reads undetected until then — because nothing has been asked
-yet, not because nothing is there — so a count rendered from that state would
-be wrong rather than merely early, and would tell a fully equipped reader that
-none of their sources are present on every cold load.
+The counters SHALL render a placeholder, distinct from zero, until bridge
+discovery has had the opportunity to hear from the extensions.
+
+The completion of a connection refresh pass SHALL NOT be treated as that
+opportunity. Nothing asks the extensions anything: they announce themselves
+when injected, and discovery only broadcasts a request after a delay of
+silence. A pass over a browser where nothing has yet announced therefore
+completes almost immediately, having sent no message at all, so a surface
+gated on it renders a confident zero to a fully equipped reader for as long as
+discovery actually takes.
+
+Discovery SHALL be treated as having had its window once any bridge is
+detected — positive evidence that announcements are arriving — or once a grace
+period has elapsed since discovery began listening. That period SHALL be
+derived from the delay before discovery requests announcements and the ceiling
+on verifying one, so it cannot drift from the behaviour it waits on. It SHALL
+be measured from the start of discovery for the application, not from the mount
+of the surface reading it, so a reader opening the surface later is not made to
+wait for a window that closed long ago.
+
+The placeholder SHALL NOT be permanent. A reader with no extensions installed
+SHALL eventually be told so, so the surface SHALL state the count once the
+grace period has elapsed even when nothing was ever detected.
+
+Every surface that counts detected bridges SHALL apply this same gate, so two
+surfaces counting the same thing cannot disagree while both are settling.
 
 #### Scenario: A cold load counts nothing
 
-- **GIVEN** the connection store has not completed a refresh pass
+- **GIVEN** discovery has just begun listening and no bridge has been detected
 - **WHEN** the counters render
 - **THEN** they SHALL render a placeholder and SHALL NOT render a count
 
-#### Scenario: The counters appear once the store has answered
+#### Scenario: A completed pass is not mistaken for an answer
 
-- **GIVEN** the connection store has completed a refresh pass
+- **GIVEN** a connection refresh pass has completed while discovery is still in its grace period and no bridge has been detected
 - **WHEN** the counters render
-- **THEN** they SHALL render counts derived from the resolved sources
+- **THEN** they SHALL still render a placeholder
+
+#### Scenario: A detection answers immediately
+
+- **GIVEN** at least one bridge has been detected, within the grace period
+- **WHEN** the counters render
+- **THEN** they SHALL render counts without waiting for the period to elapse
+
+#### Scenario: An empty browser is eventually told so
+
+- **GIVEN** no bridge was detected and the grace period has elapsed
+- **WHEN** the counters render
+- **THEN** they SHALL render the count, stating that none were detected
 
 ### Requirement: Coverage is counted over having a source, not over data in flight
 
@@ -154,6 +186,13 @@ reads as moments ago however long a source has been down. A date SHALL be
 attached only from a recorded last delivery, only when exactly one source is
 affected, and only in the reader's own calendar day.
 
+A date SHALL be attached ONLY to a statement that names a loss. It qualifies
+one, so appending it to either statement that nothing stopped arriving would
+contradict the sentence it is joined to — and that combination is ordinary
+rather than exotic, since an affected source whose types another source still
+covers has a recorded last delivery like any other. This precedence is
+required: the two rules are otherwise simultaneously satisfiable.
+
 A cause SHALL be named only when it holds for every affected source. With
 several affected, only the count holds for all of them; in particular one
 extension speaking an unsupported protocol version does not make the others
@@ -207,6 +246,12 @@ provider's own site, which this page cannot perform.
 - **GIVEN** more than one affected source, at least one with a recorded last delivery
 - **WHEN** the consequence is stated
 - **THEN** no date SHALL be stated
+
+#### Scenario: A statement that nothing stopped carries no date
+
+- **GIVEN** exactly one affected source with a recorded last delivery, whose types are all still served by a present source
+- **WHEN** the consequence is stated
+- **THEN** it SHALL state that nothing stopped arriving and SHALL NOT state a date
 
 #### Scenario: An outdated extension is told to update
 

--- a/openspec/changes/add-connections-health-summary/specs/spa-settings-shell/spec.md
+++ b/openspec/changes/add-connections-health-summary/specs/spa-settings-shell/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+<!-- MODIFIED FROM the ACTIVE sibling change add-settings-attention-model /
+spa-settings-shell. The capability is not published under openspec/specs/ yet,
+so the prior text lives in that change's delta. Whichever sync publishes this
+capability MUST take the version below.
+
+This change is not cosmetic: the prior requirement's gate is unreachable in
+one half and ineffective in the other, and this change corrects the same
+defect on the Connections section. Both surfaces count detected bridges, so
+they are corrected together — leaving one behind would put a row saying
+"0 of 5" one click from a section saying "3 of 5". -->
+
+### Requirement: The connections row counts a total it can reach, once it can count
+
+The Settings index row leading to the connection surfaces SHALL answer itself
+with how many known bridges are answering in this browser, out of all known
+bridges. It SHALL count detected bridges rather than live sessions, because at
+least one bridge is never probed and a session count could therefore never
+equal its own denominator — a counter fixed one short of completion reads as a
+defect rather than as a state.
+
+The count SHALL be described as detected rather than installed: a page cannot
+enumerate installed extensions, only those that announced themselves and
+answered this page-life.
+
+The row SHALL render no value until bridge discovery has had the opportunity to
+hear from the extensions, and SHALL apply the same gate as every other surface
+counting detected bridges, so two surfaces counting the same thing cannot
+disagree while both are settling.
+
+The completion of a connection refresh pass SHALL NOT be treated as that
+opportunity. Nothing asks the extensions anything — they announce themselves
+when injected — so a pass over a browser where nothing has yet announced
+completes almost immediately having sent no message, and a row gated on it
+states a confident zero to a fully equipped reader for as long as discovery
+actually takes.
+
+The row SHALL NOT withhold its value indefinitely: once the grace period has
+elapsed it SHALL state the count even when nothing was detected, because a
+reader with no extensions installed has to be told so.
+
+<!-- The prior requirement also said the row renders no value "when no bridge
+is known at all, rather than a zero-of-zero count". That condition is removed:
+the snapshot reader synthesises one row per known bridge from the first render,
+so the empty list it guards cannot occur in the application. It was a guard on
+an unreachable state standing next to the reachable one it was mistaken for. -->
+
+#### Scenario: The row states detected out of known
+
+- **GIVEN** discovery has settled and two of five known bridges answered
+- **WHEN** the Settings index renders
+- **THEN** the connections row SHALL state two of five detected
+
+#### Scenario: The count reaches its denominator
+
+- **GIVEN** every known bridge answered, including one that is never probed
+- **WHEN** the Settings index renders
+- **THEN** the connections row SHALL state the full count of detected bridges out of the same total
+
+#### Scenario: A cold load claims nothing
+
+- **GIVEN** discovery has just begun listening and no bridge has been detected
+- **WHEN** the Settings index renders
+- **THEN** the connections row SHALL render no count
+
+#### Scenario: A detection answers immediately
+
+- **GIVEN** at least one bridge has been detected, within the grace period
+- **WHEN** the Settings index renders
+- **THEN** the connections row SHALL state its count without waiting for the period to elapse
+
+#### Scenario: An empty browser is eventually told so
+
+- **GIVEN** no bridge was detected and the grace period has elapsed
+- **WHEN** the Settings index renders
+- **THEN** the connections row SHALL state that none of the known bridges were detected

--- a/openspec/changes/add-connections-health-summary/tasks.md
+++ b/openspec/changes/add-connections-health-summary/tasks.md
@@ -51,6 +51,22 @@
 - [x] 6.4 `ConnectionRefreshButton` in the header.
 - [x] 6.5 Give every new element a `data-testid`, following the section's `connections-*` convention.
 
+## 6b. Review round
+
+- [x] 6b.1 Attach the banner's date only when something is actually paused. Establish the reachable shape — one affected source, its types still covered elsewhere, a `lastSyncAt` from any past import — which read "Nothing has stopped … No new data since <date>". See design.md D4c.
+- [x] 6b.2 State the precedence in the spec too: the loss-vs-date requirements were simultaneously satisfiable with nothing ranking them, which is a spec defect and not only a code one.
+- [x] 6b.3 Replace the `hasRefreshed()` gate with a discovery-settled gate. Establish that `bridgeDiscovery.start()` only arms a timer, that the first pass writes five undiscovered rows with no awaits, and that `hasRefreshed()` therefore flips within microseconds of boot — so "0 of 5" was reachable and on screen for seconds. See design.md D5.
+- [x] 6b.4 Derive the grace window from `DISCOVER_REQUEST_DELAY_MS + PING_TIMEOUT_MS` rather than writing a literal; open early on any detection so an equipped reader is not made to wait out a window whose answer is already known.
+- [x] 6b.5 Stamp the clock at app boot in `use-bridge-discovery-bootstrap`, with module load as the floor — React runs child effects before parent ones, so a cold boot straight onto the page can render before the root has stamped.
+- [x] 6b.6 Guarantee the placeholder resolves: a reader with no extensions is told so once the window elapses, pinned by its own test.
+- [x] 6b.7 Apply the same gate to the Settings index row, and delete its `connections.length === 0` guard plus the test covering it — the snapshot reader synthesises a row per known bridge, so the empty list cannot occur. Fixing one surface alone would put "0 of 5" one click from "3 of 5".
+- [x] 6b.8 Assert the gate with the REAL hook: `ConnectionsTab.test.tsx` had mocked `useBridgeConnectionsRefreshed`, so it asserted its own stub rather than the behaviour.
+- [x] 6b.9 Mutation-check the round: guard removed → 2 consequence tests fail; gate forced open → 2 cold-load tests fail; gate forced never-open → the empty-browser test fails; cooldown effect removed → its test fails.
+- [x] 6b.10 Qualify the coverage tile's note ("incl. manual entry") so "13 of 13" above "No source is sending Weight" reconciles. See design.md D5b.
+- [x] 6b.11 Swap the paused-manual-type fixture from `tanita-bridge` to `trainingpeaks-bridge`: tanita has no prober, so it can only ever read `installed` and the test named the one scale bridge that cannot sign out.
+- [x] 6b.12 Make `banner.noRoutes` source-count neutral — it said "switched on for it" under a plural title.
+- [x] 6b.13 Clear the refresh cooldown message when the window passes, via `refreshCooldownRemaining`, so "Try again in a minute" does not outlive the minute.
+
 ## 7. Copy and verification
 
 - [x] 7.1 Sixteen keys in `en` AND `es` in the same commit (`resource-parity.test.ts` fails on an EN-only file).

--- a/openspec/changes/add-connections-health-summary/tasks.md
+++ b/openspec/changes/add-connections-health-summary/tasks.md
@@ -1,0 +1,59 @@
+## 1. One derivation, shared
+
+- [x] 1.1 Move the attention predicate to `sourceNeedsAttention` in `application/connections/connection-source.ts` and re-export it from `connection-attention.ts` under its existing name. See design.md D1.
+- [x] 1.2 Move `connection-attention.ts`'s private `dayOf` to `application/connections/calendar-day.ts`; both banners state the same date about the same source.
+- [x] 1.3 Leave every existing S3 test untouched — the names both modules export are unchanged, which is the point of the re-export.
+
+## 2. Coverage derivation
+
+- [x] 2.1 Add `connection-coverage.ts` returning `covered`, `broken` and `paused` from one pass over `managedDataTypes`.
+- [x] 2.2 Gate on ENABLED import policies. Establish from `hooks/bridge-import/*` that every runner resolves import policies before contacting a bridge, so a switched-off route delivers nothing.
+- [x] 2.3 Include `MANUAL_ENTRY_TYPES` in `covered`. Establish that no bridge announces `read:workouts`, so a bridge-only count has a ceiling of 12 of 13 — the unreachable-denominator defect, one counter over. See design.md D3.
+- [x] 2.4 Exclude manual entry from `paused`, and pin the asymmetry with a test: deriving `paused` as `!covered` silently drops 9 of the 13 types from the banner. See design.md D3b.
+- [x] 2.5 Treat `checking` as delivering, so the headline does not twitch during every poll's probe.
+
+## 3. The counters
+
+- [x] 3.1 Add `connection-summary.ts`: detected, covered, attention, last sync.
+- [x] 3.2 Count `bridgeDetected` over bridge-mechanism sources only — not live sessions (`tanita-bridge` has no prober, so the ceiling would be 4 of 5) and not manual/unsupported cards (they have no extension to detect). See design.md D2.
+- [x] 3.3 Take `lastSyncAt`, never `lastCheckedAt`: the latter reads as seconds ago after every reload.
+- [x] 3.4 Skip a `lastSyncAt` that does not parse rather than rendering `Invalid Date`.
+- [x] 3.5 Render a placeholder, distinct from zero, until `useBridgeConnectionsRefreshed()`. Establish that S3's `connections.length === 0` guard covers a state production never reaches, so the reachable failure is "0 of 5" on every cold load. See design.md D5.
+- [x] 3.6 Keep the tile copy in `connection-summary-tiles.ts` so it is asserted without rendering and the cold-load branch is written once.
+
+## 4. The consequence banner
+
+- [x] 4.1 Add `connection-consequence.ts` over the same source list, returning `null` when nothing needs attention.
+- [x] 4.2 Name the paused types. Ship NO successor: `union` is the default mode and has no winner, so "fell back to Garmin" describes a mechanism the product does not have. See design.md D4.
+- [x] 4.3 Say "is signed out", never "token expired" — indistinguishable from never-signed-in, and only trainingpeaks sets `needsReauth`.
+- [x] 4.4 Date it from `lastSyncAt` in the reader's calendar day, only when exactly one source is affected.
+- [x] 4.5 Ship NO breakage duration and NO "since <n> days" — no transition timestamp exists.
+- [x] 4.6 Ship NO backfill promise: `CYCLES_WINDOW_DAYS` is 30 but HR and stress are 7, so one number would be false for two of WHOOP's types.
+- [x] 4.7 Name a cause only for a lone affected source; with several, state the count alone.
+- [x] 4.8 Report an unsupported protocol version as out of date, not as signed out.
+- [x] 4.9 Declare no action: the fix is a sign-in on the provider's site, and the card that says so is directly below. See design.md D4b.
+- [x] 4.10 Resolve the design's own paused-vs-fell-back contradiction in favour of paused.
+
+## 5. Refresh all
+
+- [x] 5.1 Add `refresh-cooldown.ts` (module-scoped, in-memory) and `use-connections-refresh.ts` calling `refresh({ force: true })`.
+- [x] 5.2 Set the window to 60s, matching the visibility floor rather than the 30s positive cache: both trigger the same forced pass. Establish that `force` bypasses the cache by definition, that the floor lives in the visibility handler and not the store, and that probes run outside `BRIDGE_QUEUE`. See design.md D6.
+- [x] 5.3 Join an in-flight pass instead of starting a second, read synchronously so two clicks in one tick cannot both start one.
+- [x] 5.4 Stamp the window on failure too, so an erroring bridge is not retried in a tight loop.
+- [x] 5.5 Report a refused press rather than swallowing it.
+- [x] 5.6 Tanita renders installed, never a spinner. Already pinned twice by Wave 1 (`bridge-connection-store.test.ts` asserts `checking: false` and that the probe is never called; `connection-source-status.test.ts` asserts the `installed` verdict), and `force` reaches neither path — so NO third test is added. See design.md D7.
+
+## 6. UI
+
+- [x] 6.1 `ConnectionsHealth` above the cards, taking the `sources` and `byDataType` the tab already reads — no second hook, no second query.
+- [x] 6.2 `ConnectionSummaryRow` + `ConnectionSummaryTile`, theme tokens only (`bg-surface`, `border-edge`, `text-ink-*`); every `border` carries a colour in the same class list.
+- [x] 6.3 `ConnectionsBanner` as a polite live region — it appears seconds after the page and again on any later poll.
+- [x] 6.4 `ConnectionRefreshButton` in the header.
+- [x] 6.5 Give every new element a `data-testid`, following the section's `connections-*` convention.
+
+## 7. Copy and verification
+
+- [x] 7.1 Sixteen keys in `en` AND `es` in the same commit (`resource-parity.test.ts` fails on an EN-only file).
+- [x] 7.2 Interpolate no source name into a toast or `console.*` (R-PIIInterpolation).
+- [x] 7.3 State, for every test added, the reachable state it fails on — in the test body, not the commit message.
+- [x] 7.4 `pnpm -r build`, SPA `test`, SPA `lint`, `pnpm test:scripts`, root `pnpm lint`, `playwright test --list`.

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-discovery.ts
@@ -16,7 +16,9 @@ import {
 } from "./bridge-discovery-types";
 import { verifyAnnouncement } from "./bridge-discovery-verify";
 
-const DISCOVER_REQUEST_DELAY_MS = 3_000;
+/** Exported so callers can derive when a silent discovery has had its
+    opening chance: nothing is asked before this elapses. */
+export const DISCOVER_REQUEST_DELAY_MS = 3_000;
 
 type VerifyFn = (ann: BridgeAnnouncement) => Promise<BridgeManifest | null>;
 

--- a/packages/workout-spa-editor/src/adapters/bridge/bridge-transport.ts
+++ b/packages/workout-spa-editor/src/adapters/bridge/bridge-transport.ts
@@ -19,7 +19,9 @@ export type ExtensionResponse = {
   delivered?: boolean;
 };
 
-const PING_TIMEOUT_MS = 3_000;
+/** Exported so callers can derive how long an announcement's verification
+    ping may take before it can be treated as never arriving. */
+export const PING_TIMEOUT_MS = 3_000;
 
 export const sendBridgeMessage = (
   extensionId: string,

--- a/packages/workout-spa-editor/src/application/connections/calendar-day.ts
+++ b/packages/workout-spa-editor/src/application/connections/calendar-day.ts
@@ -1,0 +1,20 @@
+/**
+ * The reader's calendar day for a stored timestamp.
+ *
+ * Not `toISOString()`'s: a sync at 02:00Z happened the previous evening in New
+ * York, and every sentence built on this is about the reader's day. Nothing
+ * when the stored value does not parse, so no surface renders `Invalid Date`.
+ *
+ * Shared rather than duplicated per surface: the Settings banner and the
+ * Connections banner state the same date about the same source, and two
+ * formatters would eventually disagree about which day that was.
+ */
+export const calendarDay = (
+  timestamp: string | undefined
+): string | undefined => {
+  if (timestamp === undefined) return undefined;
+  const at = new Date(timestamp);
+  if (Number.isNaN(at.getTime())) return undefined;
+  const month = String(at.getMonth() + 1).padStart(2, "0");
+  return `${at.getFullYear()}-${month}-${String(at.getDate()).padStart(2, "0")}`;
+};

--- a/packages/workout-spa-editor/src/application/connections/connection-consequence.test.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-consequence.test.ts
@@ -169,9 +169,11 @@ describe("buildConnectionConsequence", () => {
 
   it("should say nothing stopped while another source still delivers", () => {
     // Arrange
-    // The broken source's types all have a second source switched on, so the
-    // reader is told the truth rather than left to assume the worst.
-    const sources = [source()];
+    // WHOOP is signed out with only its `weight` route on, and Tanita imports
+    // `weight` too and is installed — the shape of connection-coverage's own
+    // "pause a type only when no other source still delivers it" case. WHOOP
+    // has a last sync because any past import wrote one, which is ordinary.
+    const sources = [source({ lastSyncAt: LAST_SYNC_AT })];
 
     // Act
     const consequence = buildConnectionConsequence(
@@ -182,13 +184,17 @@ describe("buildConnectionConsequence", () => {
 
     // Assert
     expect(consequence?.detail).toContain("Nothing has stopped");
+    // The date qualifies a loss. Appended here it contradicts the sentence it
+    // is joined to: "Nothing has stopped … No new data since 2026-07-25."
+    expect(consequence?.detail).not.toContain("No new data since");
   });
 
   it("should say nothing stopped when the broken source feeds no route", () => {
     // Arrange
     // Reachable on a fresh profile: an extension is installed and signed out
-    // before any import route has ever been switched on for it.
-    const sources = [source()];
+    // before any import route has ever been switched on for it. It still
+    // carries a last sync from before the routes were switched off.
+    const sources = [source({ lastSyncAt: LAST_SYNC_AT })];
 
     // Act
     const consequence = buildConnectionConsequence(
@@ -199,5 +205,6 @@ describe("buildConnectionConsequence", () => {
 
     // Assert
     expect(consequence?.detail).toContain("No data routes are switched on");
+    expect(consequence?.detail).not.toContain("No new data since");
   });
 });

--- a/packages/workout-spa-editor/src/application/connections/connection-consequence.test.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-consequence.test.ts
@@ -1,0 +1,203 @@
+import type { ManagedDataType } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import { getTranslate } from "../../i18n/use-translate";
+import { buildConnectionConsequence } from "./connection-consequence";
+import type { ConnectionCoverage } from "./connection-coverage";
+import type { ConnectionSource } from "./connection-source";
+
+const t = getTranslate("connections");
+
+/**
+ * A date-time with no timezone designator parses as LOCAL time, so this is
+ * local noon on 2026-07-25 wherever the runner is: the asserted calendar day
+ * holds in every timezone, and it is the LOCAL day being asserted.
+ */
+const LAST_SYNC_AT = new Date("2026-07-25T12:00:00").toISOString();
+
+const source = (over: Partial<ConnectionSource> = {}): ConnectionSource => ({
+  id: "whoop",
+  name: "WHOOP",
+  mark: "Wh",
+  mechanism: "bridge",
+  bridgeId: "whoop-bridge",
+  status: "attention",
+  bridgeDetected: true,
+  disconnected: false,
+  needsReauth: false,
+  outdated: false,
+  sessionVerifiable: true,
+  lastSyncAt: undefined,
+  importTypes: [],
+  exportTypes: [],
+  ...over,
+});
+
+const coverage = (
+  paused: ManagedDataType[],
+  broken: ManagedDataType[] = paused
+): ConnectionCoverage => ({ covered: [], broken, paused, total: 13 });
+
+describe("buildConnectionConsequence", () => {
+  it("should render nothing while no source needs attention", () => {
+    // Arrange
+    const sources = [source({ status: "connected" })];
+
+    // Act
+    const consequence = buildConnectionConsequence(sources, coverage([]), t);
+
+    // Assert
+    // A banner that renders on a healthy page is a permanent false alarm.
+    expect(consequence).toBeNull();
+  });
+
+  it("should name the paused types instead of claiming a fallback", () => {
+    // Arrange
+    // `union` is the default multi-source mode and has no winner, so no source
+    // ever "takes over" for another. Naming one would be an invention.
+    const sources = [source()];
+
+    // Act
+    const consequence = buildConnectionConsequence(
+      sources,
+      coverage(["sleep", "hrv"]),
+      t
+    );
+
+    // Assert
+    expect(consequence?.detail).toContain("No source is sending Sleep, HRV");
+    expect(consequence?.detail).not.toMatch(/fell back|fallen back/i);
+  });
+
+  it("should say a source is signed out rather than that its token expired", () => {
+    // Arrange
+    // No bridge distinguishes an expired credential from one never issued —
+    // `probeWhoopSession` leaves `needsReauth` false either way.
+    const sources = [source()];
+
+    // Act
+    const consequence = buildConnectionConsequence(sources, coverage([]), t);
+
+    // Assert
+    expect(consequence?.title).toBe("WHOOP is signed out");
+    expect(consequence?.title).not.toMatch(/expired/i);
+  });
+
+  it("should date the consequence from the last data received", () => {
+    // Arrange
+    // `lastCheckedAt` is when the SPA last probed, so after a reload it reads
+    // as seconds ago however long the source has been down. `lastSyncAt` is
+    // persisted and survives that reload.
+    const sources = [source({ lastSyncAt: LAST_SYNC_AT })];
+
+    // Act
+    const consequence = buildConnectionConsequence(
+      sources,
+      coverage(["sleep"]),
+      t
+    );
+
+    // Assert
+    expect(consequence?.detail).toContain("No new data since 2026-07-25.");
+    expect(consequence?.detail).not.toMatch(/stopped syncing/i);
+  });
+
+  it("should not attach one source's date when several are affected", () => {
+    // Arrange
+    // Two bridges break at different times routinely — a shared date would be
+    // wrong for at least one of them.
+    const sources = [
+      source({ lastSyncAt: LAST_SYNC_AT }),
+      source({ id: "trainingpeaks", name: "TrainingPeaks" }),
+    ];
+
+    // Act
+    const consequence = buildConnectionConsequence(
+      sources,
+      coverage(["weight"]),
+      t
+    );
+
+    // Assert
+    expect(consequence?.title).toBe("2 sources need attention");
+    expect(consequence?.detail).not.toContain("No new data since");
+  });
+
+  it("should ignore a stored sync time that does not parse", () => {
+    // Arrange
+    const sources = [source({ lastSyncAt: "not-a-date" })];
+
+    // Act
+    const consequence = buildConnectionConsequence(
+      sources,
+      coverage(["sleep"]),
+      t
+    );
+
+    // Assert
+    expect(consequence?.detail).not.toMatch(/Invalid Date/);
+  });
+
+  it("should tell the reader to update an out-of-date bridge, not to sign in", () => {
+    // Arrange
+    // The probe SUCCEEDED and answered in a protocol version this build cannot
+    // read. Signing in again fixes nothing, so the sign-in line would send the
+    // reader round a loop that cannot end.
+    const sources = [source({ outdated: true })];
+
+    // Act
+    const consequence = buildConnectionConsequence(sources, coverage([]), t);
+
+    // Assert
+    expect(consequence?.title).toBe("WHOOP's browser bridge is out of date");
+  });
+
+  it("should not name a cause that holds for only one of several sources", () => {
+    // Arrange
+    // One out-of-date extension does not make the other one out of date.
+    const sources = [
+      source({ outdated: true }),
+      source({ id: "trainingpeaks", name: "TrainingPeaks" }),
+    ];
+
+    // Act
+    const consequence = buildConnectionConsequence(sources, coverage([]), t);
+
+    // Assert
+    expect(consequence?.title).toBe("2 sources need attention");
+  });
+
+  it("should say nothing stopped while another source still delivers", () => {
+    // Arrange
+    // The broken source's types all have a second source switched on, so the
+    // reader is told the truth rather than left to assume the worst.
+    const sources = [source()];
+
+    // Act
+    const consequence = buildConnectionConsequence(
+      sources,
+      coverage([], ["weight"]),
+      t
+    );
+
+    // Assert
+    expect(consequence?.detail).toContain("Nothing has stopped");
+  });
+
+  it("should say nothing stopped when the broken source feeds no route", () => {
+    // Arrange
+    // Reachable on a fresh profile: an extension is installed and signed out
+    // before any import route has ever been switched on for it.
+    const sources = [source()];
+
+    // Act
+    const consequence = buildConnectionConsequence(
+      sources,
+      coverage([], []),
+      t
+    );
+
+    // Assert
+    expect(consequence?.detail).toContain("No data routes are switched on");
+  });
+});

--- a/packages/workout-spa-editor/src/application/connections/connection-consequence.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-consequence.ts
@@ -50,13 +50,21 @@ const consequenceOf = (coverage: ConnectionCoverage, t: Translate): string => {
 };
 
 /**
- * The date is attached only for a lone affected source, so one source's last
+ * The date qualifies a loss, so it is attached ONLY to the paused sentence.
+ * The other two branches state that nothing stopped arriving, and "no new data
+ * since <date>" appended to them contradicts the sentence it is joined to —
+ * which is reachable and ordinary: a signed-out source whose types another
+ * source still covers has a last sync like any other.
+ *
+ * It is also attached only for a lone affected source, so one source's last
  * sync is never presented as a set's.
  */
 const sinceOf = (
   affected: readonly ConnectionSource[],
+  coverage: ConnectionCoverage,
   t: Translate
 ): string | undefined => {
+  if (coverage.paused.length === 0) return undefined;
   const day =
     affected.length === 1 ? calendarDay(affected[0]?.lastSyncAt) : undefined;
   return day === undefined ? undefined : t("banner.since", { date: day });
@@ -69,7 +77,7 @@ export const buildConnectionConsequence = (
 ): ConnectionConsequence | null => {
   const affected = sources.filter(sourceNeedsAttention);
   if (affected.length === 0) return null;
-  const detail = [consequenceOf(coverage, t), sinceOf(affected, t)]
+  const detail = [consequenceOf(coverage, t), sinceOf(affected, coverage, t)]
     .filter((line): line is string => line !== undefined)
     .join(" ");
   return { title: titleOf(affected, t), detail };

--- a/packages/workout-spa-editor/src/application/connections/connection-consequence.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-consequence.ts
@@ -1,0 +1,76 @@
+/**
+ * The consequence banner above the source cards: what broke, and what stopped
+ * arriving because of it.
+ *
+ * Three claims the reference design makes are absent, because no state backs
+ * them. There is no "stopped syncing 3 days ago" — no transition timestamp is
+ * recorded anywhere, so the date comes from the persisted `lastSyncAt` and is
+ * phrased as the last data received. There is no "fell back to Garmin" —
+ * `union` is the default multi-source mode and has no winner, so no source
+ * ever "took over". And there is no "its access token expired" — only
+ * `trainingpeaks-bridge` reports `needsReauth` at all, and no bridge can tell
+ * an expired credential from one that was never issued.
+ */
+import type { Translate } from "../../i18n/use-translate";
+import { calendarDay } from "./calendar-day";
+import type { ConnectionCoverage } from "./connection-coverage";
+import type { ConnectionSource } from "./connection-source";
+import { sourceNeedsAttention } from "./connection-source";
+
+export type ConnectionConsequence = {
+  readonly title: string;
+  readonly detail: string;
+};
+
+/**
+ * A cause is named only for a lone source. With several affected, one of them
+ * being out of date does not make the others out of date, and the count is the
+ * only claim that holds for all of them.
+ */
+const titleOf = (
+  affected: readonly ConnectionSource[],
+  t: Translate
+): string => {
+  const only = affected.length === 1 ? affected[0] : undefined;
+  if (only === undefined) return t("banner.many", { count: affected.length });
+  return only.outdated
+    ? t("banner.oneOutdated", { name: only.name })
+    : t("banner.one", { name: only.name });
+};
+
+const consequenceOf = (coverage: ConnectionCoverage, t: Translate): string => {
+  if (coverage.paused.length > 0) {
+    return t("banner.paused", {
+      types: coverage.paused.map((type) => t(`dataTypes.${type}`)).join(", "),
+    });
+  }
+  return coverage.broken.length > 0
+    ? t("banner.covered")
+    : t("banner.noRoutes");
+};
+
+/**
+ * The date is attached only for a lone affected source, so one source's last
+ * sync is never presented as a set's.
+ */
+const sinceOf = (
+  affected: readonly ConnectionSource[],
+  t: Translate
+): string | undefined => {
+  const day =
+    affected.length === 1 ? calendarDay(affected[0]?.lastSyncAt) : undefined;
+  return day === undefined ? undefined : t("banner.since", { date: day });
+};
+
+export const buildConnectionConsequence = (
+  sources: readonly ConnectionSource[],
+  coverage: ConnectionCoverage,
+  t: Translate
+): ConnectionConsequence | null => {
+  const affected = sources.filter(sourceNeedsAttention);
+  if (affected.length === 0) return null;
+  const detail = [consequenceOf(coverage, t), sinceOf(affected, t)]
+    .filter((line): line is string => line !== undefined)
+    .join(" ");
+  return { title: titleOf(affected, t), detail };
+};

--- a/packages/workout-spa-editor/src/application/connections/connection-consequence.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-consequence.ts
@@ -2,14 +2,13 @@
  * The consequence banner above the source cards: what broke, and what stopped
  * arriving because of it.
  *
- * Three claims the reference design makes are absent, because no state backs
- * them. There is no "stopped syncing 3 days ago" — no transition timestamp is
- * recorded anywhere, so the date comes from the persisted `lastSyncAt` and is
- * phrased as the last data received. There is no "fell back to Garmin" —
- * `union` is the default multi-source mode and has no winner, so no source
- * ever "took over". And there is no "its access token expired" — only
- * `trainingpeaks-bridge` reports `needsReauth` at all, and no bridge can tell
- * an expired credential from one that was never issued.
+ * Three sentences this banner must never grow, because nothing can back them:
+ * a duration ("down for 3 days") — no transition timestamp exists, so the date
+ * is `lastSyncAt` and says when data last arrived; a hand-off ("fell back to
+ * Garmin") — `union` is the default and has no winner, so nothing takes over;
+ * and an expiry ("its token expired") — only `trainingpeaks-bridge` reports
+ * `needsReauth`, and no bridge distinguishes an expired credential from one
+ * that was never issued.
  */
 import type { Translate } from "../../i18n/use-translate";
 import { calendarDay } from "./calendar-day";

--- a/packages/workout-spa-editor/src/application/connections/connection-coverage.test.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-coverage.test.ts
@@ -89,13 +89,21 @@ describe("buildConnectionCoverage", () => {
 
   it("should name a manual-entry type as paused while still counting it covered", () => {
     // Arrange
-    // Reachable whenever a scale bridge signs out: `weight` can be typed in,
-    // so it still has a source, but nobody types a weight in because a bridge
-    // broke — the automatic delivery stopped and the banner has to say so.
-    // Deriving `paused` as the complement of `covered` would silently drop
-    // every manual-entry type from the banner, which is 9 of the 13.
-    const sources = [source("tanita", "tanita-bridge", "attention")];
-    const byDataType = flows([["weight", [route("weight", "tanita-bridge")]]]);
+    // TrainingPeaks, not Tanita: `tanita-bridge` has no session prober, so
+    // `bridgeSourceStatus` can only ever call it `installed` and it cannot
+    // reach this state at all. `trainingpeaks-bridge` is probed, imports
+    // `weight`, and is the one bridge that reports `needsReauth`.
+    //
+    // `weight` can be typed in, so it still has a source — but nobody types a
+    // weight in because a bridge broke, so the delivery stopped and the banner
+    // has to say so. Deriving `paused` as the complement of `covered` would
+    // silently drop every manual-entry type from the banner, 9 of the 13.
+    const sources = [
+      source("trainingpeaks", "trainingpeaks-bridge", "attention"),
+    ];
+    const byDataType = flows([
+      ["weight", [route("weight", "trainingpeaks-bridge")]],
+    ]);
 
     // Act
     const coverage = buildConnectionCoverage(sources, byDataType);

--- a/packages/workout-spa-editor/src/application/connections/connection-coverage.test.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-coverage.test.ts
@@ -1,0 +1,191 @@
+import type { ManagedDataType } from "@kaiord/core";
+import { managedDataTypes } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import type { DataFlowsByType } from "../../components/organisms/ProfileManager/components/useDataFlows";
+import { MANUAL_ENTRY_TYPES } from "../../integrations/manual-entry-types";
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import { buildConnectionCoverage } from "./connection-coverage";
+import type {
+  ConnectionSource,
+  ConnectionSourceStatus,
+} from "./connection-source";
+
+const source = (
+  id: string,
+  bridgeId: string,
+  status: ConnectionSourceStatus
+): ConnectionSource => ({
+  id,
+  name: id,
+  mark: id[0] ?? "?",
+  mechanism: "bridge",
+  bridgeId,
+  status,
+  bridgeDetected: status !== "available",
+  disconnected: false,
+  needsReauth: false,
+  outdated: false,
+  sessionVerifiable: true,
+  lastSyncAt: undefined,
+  importTypes: [],
+  exportTypes: [],
+});
+
+const route = (
+  dataType: ManagedDataType,
+  bridgeId: string,
+  enabled = true
+): IntegrationPolicy => ({
+  id: `${dataType}-${bridgeId}`,
+  profileId: "p1",
+  dataType,
+  bridgeId,
+  direction: "import",
+  mode: "auto",
+  enabled,
+  updatedAt: "2026-07-01T00:00:00.000Z",
+});
+
+const flows = (
+  entries: ReadonlyArray<[ManagedDataType, IntegrationPolicy[]]>
+): DataFlowsByType =>
+  new Map(
+    entries.map(([dataType, imports]) => [
+      dataType,
+      { import: imports, export: [] },
+    ])
+  );
+
+describe("buildConnectionCoverage", () => {
+  it("should count a type as covered while an enabled route's source is present", () => {
+    // Arrange
+    const sources = [source("whoop", "whoop-bridge", "connected")];
+    const byDataType = flows([["sleep", [route("sleep", "whoop-bridge")]]]);
+
+    // Act
+    const coverage = buildConnectionCoverage(sources, byDataType);
+
+    // Assert
+    expect(coverage.covered).toContain("sleep");
+    expect(coverage.paused).not.toContain("sleep");
+  });
+
+  it("should drop a type whose only enabled route needs attention", () => {
+    // Arrange
+    // `strain` has no manual-entry path and only WHOOP announces a route for
+    // it, so a signed-out WHOOP leaves nothing sending it at all — the counter
+    // must not keep claiming it has a source.
+    const sources = [source("whoop", "whoop-bridge", "attention")];
+    const byDataType = flows([["strain", [route("strain", "whoop-bridge")]]]);
+
+    // Act
+    const coverage = buildConnectionCoverage(sources, byDataType);
+
+    // Assert
+    expect(coverage.covered).not.toContain("strain");
+    expect(coverage.paused).toContain("strain");
+  });
+
+  it("should name a manual-entry type as paused while still counting it covered", () => {
+    // Arrange
+    // Reachable whenever a scale bridge signs out: `weight` can be typed in,
+    // so it still has a source, but nobody types a weight in because a bridge
+    // broke — the automatic delivery stopped and the banner has to say so.
+    // Deriving `paused` as the complement of `covered` would silently drop
+    // every manual-entry type from the banner, which is 9 of the 13.
+    const sources = [source("tanita", "tanita-bridge", "attention")];
+    const byDataType = flows([["weight", [route("weight", "tanita-bridge")]]]);
+
+    // Act
+    const coverage = buildConnectionCoverage(sources, byDataType);
+
+    // Assert
+    expect(coverage.paused).toContain("weight");
+    expect(coverage.covered).toContain("weight");
+  });
+
+  it("should pause a type only when no other source still delivers it", () => {
+    // Arrange
+    // Both bridges import `weight`; one is broken and one is not. Naming this
+    // type in the banner would tell the reader their weight stopped arriving
+    // while it is still arriving.
+    const sources = [
+      source("whoop", "whoop-bridge", "attention"),
+      source("tanita", "tanita-bridge", "installed"),
+    ];
+    const byDataType = flows([
+      [
+        "weight",
+        [route("weight", "whoop-bridge"), route("weight", "tanita-bridge")],
+      ],
+    ]);
+
+    // Act
+    const coverage = buildConnectionCoverage(sources, byDataType);
+
+    // Assert
+    expect(coverage.broken).toContain("weight");
+    expect(coverage.paused).not.toContain("weight");
+  });
+
+  it("should keep a type covered while its source is being probed", () => {
+    // Arrange
+    // Every poll flips a source to `checking` for the duration of the probe.
+    // Dropping the type for that window makes the headline count twitch while
+    // nothing has actually changed.
+    const sources = [source("whoop", "whoop-bridge", "checking")];
+    const byDataType = flows([["sleep", [route("sleep", "whoop-bridge")]]]);
+
+    // Act
+    const coverage = buildConnectionCoverage(sources, byDataType);
+
+    // Assert
+    expect(coverage.covered).toContain("sleep");
+  });
+
+  it("should ignore a route the user switched off", () => {
+    // Arrange
+    // Every importer gates on an ENABLED policy row before touching a bridge,
+    // so a disabled route delivers nothing however healthy its source is.
+    const sources = [source("whoop", "whoop-bridge", "connected")];
+    const byDataType = flows([
+      ["strain", [route("strain", "whoop-bridge", false)]],
+    ]);
+
+    // Act
+    const coverage = buildConnectionCoverage(sources, byDataType);
+
+    // Assert
+    expect(coverage.covered).not.toContain("strain");
+    expect(coverage.paused).not.toContain("strain");
+  });
+
+  it("should cover a manual-entry type with no bridge present at all", () => {
+    // Arrange
+    // No bridge announces `read:workouts`, so `workout` can never be fed by an
+    // extension. Excluding manual entry would put the denominator permanently
+    // out of reach — the "5 of 5" defect, one surface over.
+
+    // Act
+    const coverage = buildConnectionCoverage([], new Map());
+
+    // Assert
+    expect(coverage.covered).toContain("workout");
+    expect(coverage.total).toBe(managedDataTypes.length);
+  });
+
+  it("should leave a type with no source at all uncovered", () => {
+    // Arrange
+    // `strain` has no manual-entry path and no enabled route here.
+
+    // Act
+    const coverage = buildConnectionCoverage([], new Map());
+
+    // Assert
+    expect(coverage.covered).not.toContain("strain");
+    // With nothing connected, coverage is exactly the hand-entry set — no
+    // bridge route may be counted before a bridge has answered.
+    expect(coverage.covered).toHaveLength(MANUAL_ENTRY_TYPES.size);
+  });
+});

--- a/packages/workout-spa-editor/src/application/connections/connection-coverage.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-coverage.ts
@@ -1,0 +1,78 @@
+/**
+ * Which managed data types have a source, and which lost the one they had.
+ *
+ * An import only ever runs behind an ENABLED `IntegrationPolicy` row — every
+ * runner in `bridge-import/` gates on the policy repository before it touches
+ * a bridge — so "a route is switched on, and its source is present" is the
+ * strongest claim the product can make about a type being fed.
+ *
+ * `covered` counts manual entry, `paused` does not, and the two are
+ * deliberately not complements. Manual entry is a real path (it is what
+ * `MANUAL_ENTRY_TYPES` records) so a type it serves is not sourceless; but
+ * nobody types a weight in because a bridge broke, so a source that stops
+ * sending still stopped, and the banner says so.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+import { managedDataTypes } from "@kaiord/core";
+
+import type { DataFlowsByType } from "../../components/organisms/ProfileManager/components/useDataFlows";
+import { MANUAL_ENTRY_TYPES } from "../../integrations/manual-entry-types";
+import type {
+  ConnectionSource,
+  ConnectionSourceStatus,
+} from "./connection-source";
+
+/**
+ * Statuses under which a route's data can still arrive. `checking` is one of
+ * them on purpose: a probe is in flight for a few hundred milliseconds every
+ * poll, and dropping the type for that window would make the counter twitch
+ * without anything having changed.
+ */
+const DELIVERING: ReadonlySet<ConnectionSourceStatus> = new Set([
+  "connected",
+  "installed",
+  "checking",
+]);
+
+export type ConnectionCoverage = {
+  /** A route is on and its source is present, or the type can be typed in. */
+  readonly covered: readonly ManagedDataType[];
+  /** A route is on and its source needs attention — whatever else is true. */
+  readonly broken: readonly ManagedDataType[];
+  /** Broken with nothing else delivering it: no source is sending this. */
+  readonly paused: readonly ManagedDataType[];
+  readonly total: number;
+};
+
+export const buildConnectionCoverage = (
+  sources: readonly ConnectionSource[],
+  byDataType: DataFlowsByType
+): ConnectionCoverage => {
+  const statusOf = new Map<string, ConnectionSourceStatus>(
+    sources.flatMap((source) =>
+      source.bridgeId === null ? [] : [[source.bridgeId, source.status]]
+    )
+  );
+  const covered: ManagedDataType[] = [];
+  const broken: ManagedDataType[] = [];
+  const paused: ManagedDataType[] = [];
+
+  for (const dataType of managedDataTypes) {
+    const enabled = (byDataType.get(dataType)?.import ?? []).filter(
+      (policy) => policy.enabled
+    );
+    const status = (policy: { bridgeId: string }) =>
+      statusOf.get(policy.bridgeId);
+    const delivering = enabled.some((policy) => {
+      const value = status(policy);
+      return value !== undefined && DELIVERING.has(value);
+    });
+    const failing = enabled.some((policy) => status(policy) === "attention");
+
+    if (delivering || MANUAL_ENTRY_TYPES.has(dataType)) covered.push(dataType);
+    if (failing) broken.push(dataType);
+    if (failing && !delivering) paused.push(dataType);
+  }
+
+  return { covered, broken, paused, total: managedDataTypes.length };
+};

--- a/packages/workout-spa-editor/src/application/connections/connection-source.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-source.ts
@@ -51,6 +51,15 @@ export type ConnectionSource = {
 };
 
 /**
+ * The one attention predicate. Every surface that summarises this page — the
+ * Settings banner, the section's own counter and its consequence banner —
+ * calls this over the same list the cards are rendered from, so a summary can
+ * never contradict the cards beneath it.
+ */
+export const sourceNeedsAttention = (source: ConnectionSource): boolean =>
+  source.status === "attention";
+
+/**
  * Card order: what is working, then what needs a decision, then what is not
  * there. Manual entry and the unsupported brands sit last because neither is
  * ever actionable.

--- a/packages/workout-spa-editor/src/application/connections/connection-summary.test.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-summary.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+
+import { buildConnectionCoverage } from "./connection-coverage";
+import type {
+  ConnectionSource,
+  ConnectionSourceStatus,
+} from "./connection-source";
+import { buildConnectionSummary } from "./connection-summary";
+
+const EMPTY_COVERAGE = buildConnectionCoverage([], new Map());
+
+const source = (over: Partial<ConnectionSource> = {}): ConnectionSource => ({
+  id: "garmin",
+  name: "Garmin",
+  mark: "G",
+  mechanism: "bridge",
+  bridgeId: "garmin-bridge",
+  status: "connected" as ConnectionSourceStatus,
+  bridgeDetected: true,
+  disconnected: false,
+  needsReauth: false,
+  outdated: false,
+  sessionVerifiable: true,
+  lastSyncAt: undefined,
+  importTypes: [],
+  exportTypes: [],
+  ...over,
+});
+
+describe("buildConnectionSummary", () => {
+  it("should count detected bridges rather than live sessions", () => {
+    // Arrange
+    // `tanita-bridge` has no session prober by design — its only session call
+    // downloads the whole export CSV — so it is permanently session-inactive.
+    // A live-session count would report 1 of 2 with both extensions running.
+    const sources = [
+      source(),
+      source({
+        id: "tanita",
+        bridgeId: "tanita-bridge",
+        status: "installed",
+        sessionVerifiable: false,
+      }),
+    ];
+
+    // Act
+    const summary = buildConnectionSummary(sources, EMPTY_COVERAGE);
+
+    // Assert
+    expect(summary.detected).toBe(2);
+    expect(summary.detectedTotal).toBe(2);
+  });
+
+  it("should leave non-bridge sources out of both halves of the count", () => {
+    // Arrange
+    // Manual entry and the unsupported brands are rendered as cards but have
+    // no extension to detect; counting them would put the denominator out of
+    // reach for every user.
+    const sources = [
+      source(),
+      source({
+        id: "manual",
+        mechanism: "manual",
+        bridgeId: null,
+        status: "manual",
+        bridgeDetected: false,
+      }),
+      source({
+        id: "strava",
+        mechanism: "not-supported",
+        bridgeId: null,
+        status: "unsupported",
+        bridgeDetected: false,
+      }),
+    ];
+
+    // Act
+    const summary = buildConnectionSummary(sources, EMPTY_COVERAGE);
+
+    // Assert
+    expect(summary.detected).toBe(1);
+    expect(summary.detectedTotal).toBe(1);
+  });
+
+  it("should count attention with the predicate the cards are marked by", () => {
+    // Arrange
+    // A card rendered amber that the counter above it reads as zero is the
+    // failure this shares one derivation to prevent.
+    const sources = [source(), source({ id: "whoop", status: "attention" })];
+
+    // Act
+    const summary = buildConnectionSummary(sources, EMPTY_COVERAGE);
+
+    // Assert
+    expect(summary.attention).toBe(1);
+  });
+
+  it("should report the newest last sync and the source that wrote it", () => {
+    // Arrange
+    const sources = [
+      source({ lastSyncAt: "2026-07-20T10:00:00.000Z" }),
+      source({
+        id: "whoop",
+        name: "WHOOP",
+        lastSyncAt: "2026-07-25T09:00:00.000Z",
+      }),
+    ];
+
+    // Act
+    const summary = buildConnectionSummary(sources, EMPTY_COVERAGE);
+
+    // Assert
+    expect(summary.lastSync).toEqual({
+      at: "2026-07-25T09:00:00.000Z",
+      sourceName: "WHOOP",
+    });
+  });
+
+  it("should ignore a stored sync time that does not parse", () => {
+    // Arrange
+    // `coachingSyncState` rows are written by five separate use cases; one
+    // unparseable value must not render as `Invalid Date` in the headline.
+    const sources = [
+      source({ lastSyncAt: "not-a-date" }),
+      source({
+        id: "whoop",
+        name: "WHOOP",
+        lastSyncAt: "2026-07-25T09:00:00.000Z",
+      }),
+    ];
+
+    // Act
+    const summary = buildConnectionSummary(sources, EMPTY_COVERAGE);
+
+    // Assert
+    expect(summary.lastSync?.sourceName).toBe("WHOOP");
+  });
+
+  it("should report no last sync when nothing has ever synced", () => {
+    // Arrange
+    // The reachable state on a fresh profile: extensions present, no import
+    // has run yet.
+
+    // Act
+    const summary = buildConnectionSummary([source()], EMPTY_COVERAGE);
+
+    // Assert
+    expect(summary.lastSync).toBeUndefined();
+  });
+});

--- a/packages/workout-spa-editor/src/application/connections/connection-summary.ts
+++ b/packages/workout-spa-editor/src/application/connections/connection-summary.ts
@@ -1,0 +1,62 @@
+/**
+ * The four numbers above the source cards, derived from the same list the
+ * cards are rendered from.
+ *
+ * `detected` counts discovered extensions, not live sessions. A session count
+ * cannot reach its own denominator — `tanita-bridge` has no session prober by
+ * design, so it is permanently session-inactive and the counter would sit one
+ * short forever, which reads as a defect rather than as a state. This is the
+ * same choice, and the same word, as the Settings index row.
+ *
+ * `lastSync` is `coachingSyncState`'s newest row, which is persisted and
+ * survives a reload. `lastCheckedAt` is deliberately not used anywhere here:
+ * it records when the SPA last probed, which is seconds ago after every
+ * reload however long a source has been quiet.
+ */
+import type { ConnectionCoverage } from "./connection-coverage";
+import type { ConnectionSource } from "./connection-source";
+import { sourceNeedsAttention } from "./connection-source";
+
+export type ConnectionLastSync = {
+  readonly at: string;
+  readonly sourceName: string;
+};
+
+export type ConnectionSummary = {
+  readonly detected: number;
+  readonly detectedTotal: number;
+  readonly covered: number;
+  readonly coveredTotal: number;
+  readonly attention: number;
+  readonly lastSync: ConnectionLastSync | undefined;
+};
+
+const newestSync = (
+  sources: readonly ConnectionSource[]
+): ConnectionLastSync | undefined => {
+  let best: ConnectionLastSync | undefined;
+  let bestAt = -Infinity;
+  for (const source of sources) {
+    if (source.lastSyncAt === undefined) continue;
+    const at = new Date(source.lastSyncAt).getTime();
+    if (Number.isNaN(at) || at <= bestAt) continue;
+    bestAt = at;
+    best = { at: source.lastSyncAt, sourceName: source.name };
+  }
+  return best;
+};
+
+export const buildConnectionSummary = (
+  sources: readonly ConnectionSource[],
+  coverage: ConnectionCoverage
+): ConnectionSummary => {
+  const bridges = sources.filter((source) => source.mechanism === "bridge");
+  return {
+    detected: bridges.filter((source) => source.bridgeDetected).length,
+    detectedTotal: bridges.length,
+    covered: coverage.covered.length,
+    coveredTotal: coverage.total,
+    attention: sources.filter(sourceNeedsAttention).length,
+    lastSync: newestSync(sources),
+  };
+};

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionRefreshButton.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionRefreshButton.tsx
@@ -1,0 +1,37 @@
+import { useConnectionsRefresh } from "../../../hooks/connections/use-connections-refresh";
+import { useTranslate } from "../../../i18n/use-translate";
+import { Button } from "../../atoms/Button";
+
+/**
+ * One forced pass over every bridge, replacing the old control that only
+ * re-detected two of them. The refusal is reported rather than swallowed: a
+ * button that silently does nothing reads as broken.
+ */
+export function ConnectionRefreshButton() {
+  const t = useTranslate("connections");
+  const refresh = useConnectionsRefresh();
+  const running = refresh.status === "running";
+
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <Button
+        size="sm"
+        variant="secondary"
+        disabled={running}
+        onClick={refresh.run}
+        data-testid="connections-refresh"
+      >
+        {running ? t("summary.refreshing") : t("summary.refresh")}
+      </Button>
+      {refresh.status === "cooldown" && (
+        <p
+          role="status"
+          className="text-[12px] text-ink-muted"
+          data-testid="connections-refresh-feedback"
+        >
+          {t("summary.refreshCooldown")}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionSummaryRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionSummaryRow.tsx
@@ -1,0 +1,38 @@
+import type { ConnectionSummary } from "../../../application/connections/connection-summary";
+import { useActiveLocale } from "../../../i18n/LocaleProvider";
+import { useTranslate } from "../../../i18n/use-translate";
+import { summaryTiles } from "./connection-summary-tiles";
+import { ConnectionSummaryTile } from "./ConnectionSummaryTile";
+
+/**
+ * `null` means the connection store has not completed a pass yet, which is a
+ * different thing from "nothing is connected" and is rendered as such.
+ */
+type Props = { summary: ConnectionSummary | null };
+
+export function ConnectionSummaryRow({ summary }: Props) {
+  const tiles = summaryTiles(summary, {
+    t: useTranslate("connections"),
+    tCommon: useTranslate("common"),
+    locale: useActiveLocale(),
+  });
+
+  return (
+    <div
+      className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
+      data-testid="connections-summary"
+      data-pending={summary === null}
+    >
+      {tiles.map((tile) => (
+        <ConnectionSummaryTile
+          key={tile.id}
+          testId={`connections-summary-${tile.id}`}
+          label={tile.label}
+          value={tile.value}
+          note={tile.note}
+          tone={tile.tone}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionSummaryTile.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionSummaryTile.tsx
@@ -1,0 +1,40 @@
+type Props = {
+  testId: string;
+  label: string;
+  /** The headline number, or the placeholder while nothing is known yet. */
+  value: string;
+  /** The unit or qualifier the number is meaningless without. */
+  note?: string;
+  tone?: "plain" | "good" | "warn";
+};
+
+const TONE: Record<NonNullable<Props["tone"]>, string> = {
+  plain: "text-ink-strong",
+  good: "text-emerald-600 dark:text-emerald-400",
+  warn: "text-amber-600 dark:text-amber-400",
+};
+
+export function ConnectionSummaryTile({
+  testId,
+  label,
+  value,
+  note,
+  tone = "plain",
+}: Props) {
+  return (
+    <div
+      data-testid={testId}
+      className="flex flex-col gap-1.5 rounded-2xl border border-edge bg-surface p-4"
+    >
+      <span className="text-[11px] font-bold uppercase tracking-widest text-ink-muted">
+        {label}
+      </span>
+      <span className="flex flex-wrap items-baseline gap-x-1.5">
+        <span className={`text-2xl font-extrabold ${TONE[tone]}`}>{value}</span>
+        {note !== undefined && (
+          <span className="text-[12.5px] text-ink-muted">{note}</span>
+        )}
+      </span>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsBanner.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsBanner.tsx
@@ -1,0 +1,45 @@
+import type { ConnectionConsequence } from "../../../application/connections/connection-consequence";
+
+/**
+ * Absent consequence renders nothing at all — no container, no placeholder.
+ *
+ * No call to action: the fix for a signed-out source is a sign-in on the
+ * provider's own site, which this page cannot perform, and the card that can
+ * say more about it sits directly below. A button that only scrolled the
+ * reader to that card would be a control that does not fix the thing it names.
+ */
+type Props = { consequence: ConnectionConsequence | null };
+
+export function ConnectionsBanner({ consequence }: Props) {
+  if (consequence === null) return null;
+
+  return (
+    // It appears seconds after the page renders, and again on any later poll,
+    // so it announces itself rather than waiting to be found.
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="connections-banner"
+      className="flex gap-3 rounded-2xl border border-amber-400/40 bg-amber-50 p-4 dark:bg-amber-950/30"
+    >
+      <span
+        aria-hidden="true"
+        className="mt-1.5 h-2 w-2 flex-none rounded-full bg-amber-500"
+      />
+      <div className="min-w-0 flex-1 space-y-1">
+        <p
+          className="text-sm font-semibold text-ink-strong"
+          data-testid="connections-banner-title"
+        >
+          {consequence.title}
+        </p>
+        <p
+          className="text-[12.5px] leading-relaxed text-ink-body"
+          data-testid="connections-banner-detail"
+        >
+          {consequence.detail}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsHealth.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsHealth.tsx
@@ -2,7 +2,7 @@ import { buildConnectionConsequence } from "../../../application/connections/con
 import { buildConnectionCoverage } from "../../../application/connections/connection-coverage";
 import type { ConnectionSource } from "../../../application/connections/connection-source";
 import { buildConnectionSummary } from "../../../application/connections/connection-summary";
-import { useBridgeConnectionsRefreshed } from "../../../hooks/use-bridge-connections";
+import { useDiscoverySettled } from "../../../hooks/connections/use-discovery-settled";
 import { useTranslate } from "../../../i18n/use-translate";
 import type { DataFlowsByType } from "../ProfileManager/components/useDataFlows";
 import { ConnectionRefreshButton } from "./ConnectionRefreshButton";
@@ -20,15 +20,18 @@ type Props = {
  * Every number is derived from the same `sources` list the cards below are
  * rendered from, so the summary cannot contradict the surface it summarises.
  *
- * The counters wait for the store's first pass; the banner does not need to.
- * Before that pass every bridge reads undiscovered, which makes each source
- * "not connected" rather than broken — so the banner is silent for the same
- * reason a healthy browser leaves it silent, and no false alarm is possible.
+ * The counters wait for discovery to have had its window — NOT for the store
+ * to have completed a pass, which happens microseconds after boot and long
+ * before any extension could have announced. The banner needs no such wait:
+ * until a bridge is discovered every source reads "not connected" rather than
+ * broken, so it is silent for exactly the reason a healthy browser leaves it
+ * silent, and there is no window in which it can raise a false alarm.
  */
 export function ConnectionsHealth({ sources, byDataType }: Props) {
   const t = useTranslate("connections");
-  const refreshed = useBridgeConnectionsRefreshed();
   const coverage = buildConnectionCoverage(sources, byDataType);
+  const summary = buildConnectionSummary(sources, coverage);
+  const settled = useDiscoverySettled(summary.detected);
 
   return (
     <div className="space-y-4">
@@ -36,9 +39,7 @@ export function ConnectionsHealth({ sources, byDataType }: Props) {
         <p className="max-w-[58ch] text-sm text-ink-body">{t("intro")}</p>
         <ConnectionRefreshButton />
       </div>
-      <ConnectionSummaryRow
-        summary={refreshed ? buildConnectionSummary(sources, coverage) : null}
-      />
+      <ConnectionSummaryRow summary={settled ? summary : null} />
       <ConnectionsBanner
         consequence={buildConnectionConsequence(sources, coverage, t)}
       />

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsHealth.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsHealth.tsx
@@ -1,0 +1,47 @@
+import { buildConnectionConsequence } from "../../../application/connections/connection-consequence";
+import { buildConnectionCoverage } from "../../../application/connections/connection-coverage";
+import type { ConnectionSource } from "../../../application/connections/connection-source";
+import { buildConnectionSummary } from "../../../application/connections/connection-summary";
+import { useBridgeConnectionsRefreshed } from "../../../hooks/use-bridge-connections";
+import { useTranslate } from "../../../i18n/use-translate";
+import type { DataFlowsByType } from "../ProfileManager/components/useDataFlows";
+import { ConnectionRefreshButton } from "./ConnectionRefreshButton";
+import { ConnectionsBanner } from "./ConnectionsBanner";
+import { ConnectionSummaryRow } from "./ConnectionSummaryRow";
+
+type Props = {
+  sources: readonly ConnectionSource[];
+  byDataType: DataFlowsByType;
+};
+
+/**
+ * The health header: four counters, then the consequence of anything broken.
+ *
+ * Every number is derived from the same `sources` list the cards below are
+ * rendered from, so the summary cannot contradict the surface it summarises.
+ *
+ * The counters wait for the store's first pass; the banner does not need to.
+ * Before that pass every bridge reads undiscovered, which makes each source
+ * "not connected" rather than broken — so the banner is silent for the same
+ * reason a healthy browser leaves it silent, and no false alarm is possible.
+ */
+export function ConnectionsHealth({ sources, byDataType }: Props) {
+  const t = useTranslate("connections");
+  const refreshed = useBridgeConnectionsRefreshed();
+  const coverage = buildConnectionCoverage(sources, byDataType);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <p className="max-w-[58ch] text-sm text-ink-body">{t("intro")}</p>
+        <ConnectionRefreshButton />
+      </div>
+      <ConnectionSummaryRow
+        summary={refreshed ? buildConnectionSummary(sources, coverage) : null}
+      />
+      <ConnectionsBanner
+        consequence={buildConnectionConsequence(sources, coverage, t)}
+      />
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsTab.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsTab.test.tsx
@@ -5,11 +5,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ConnectionSource } from "../../../application/connections/connection-source";
 import { useConnectionSources } from "../../../hooks/connections/use-connection-sources";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
+import { useBridgeConnectionsRefreshed } from "../../../hooks/use-bridge-connections";
 import { useDataFlows } from "../ProfileManager/components/useDataFlows";
 import { ConnectionsTab } from "./ConnectionsTab";
 
 vi.mock("../../../hooks/connections/use-connection-sources", () => ({
   useConnectionSources: vi.fn(),
+}));
+vi.mock("../../../hooks/use-bridge-connections", () => ({
+  useBridgeConnectionsRefreshed: vi.fn(),
+}));
+vi.mock("../../../hooks/connections/use-connections-refresh", () => ({
+  useConnectionsRefresh: () => ({ status: "idle", run: vi.fn() }),
 }));
 vi.mock("../../../hooks/use-active-profile-live", () => ({
   useActiveProfileLive: vi.fn(),
@@ -55,6 +62,7 @@ describe("ConnectionsTab", () => {
       byDataType: new Map(),
       hasAny: false,
     });
+    vi.mocked(useBridgeConnectionsRefreshed).mockReturnValue(true);
   });
 
   it("should give every card an addressable test id and status", () => {
@@ -205,5 +213,79 @@ describe("ConnectionsTab", () => {
     expect(
       screen.getByText(/may have been removed since/i)
     ).toBeInTheDocument();
+  });
+
+  it("should claim no counts before the connection store has answered", () => {
+    // Arrange
+    // The reachable failure this guards: every bridge row exists from the
+    // first render and reads undiscovered because nothing has been asked yet,
+    // so a fully equipped user would be told "0 of 5" on every cold load.
+    vi.mocked(useBridgeConnectionsRefreshed).mockReturnValue(false);
+    setSources([source({ bridgeDetected: false, status: "available" })]);
+
+    // Act
+    render(<ConnectionsTab />);
+
+    // Assert
+    expect(screen.getByTestId("connections-summary")).toHaveAttribute(
+      "data-pending",
+      "true"
+    );
+    expect(
+      screen.getByTestId("connections-summary-detected")
+    ).not.toHaveTextContent("0");
+  });
+
+  it("should count detected sources once the store has answered", () => {
+    // Arrange
+    setSources([
+      source(),
+      source({ id: "whoop", bridgeId: "whoop-bridge", bridgeDetected: false }),
+    ]);
+
+    // Act
+    render(<ConnectionsTab />);
+
+    // Assert
+    expect(
+      screen.getByTestId("connections-summary-detected")
+    ).toHaveTextContent("1of 2");
+  });
+
+  it("should state the consequence of a source needing attention", () => {
+    // Arrange
+    setSources([source({ id: "whoop", name: "WHOOP", status: "attention" })]);
+
+    // Act
+    render(<ConnectionsTab />);
+
+    // Assert
+    expect(screen.getByTestId("connections-banner-title")).toHaveTextContent(
+      "WHOOP is signed out"
+    );
+  });
+
+  it("should stay silent while every source is healthy", () => {
+    // Arrange
+    // A banner that renders on a healthy page is a permanent false alarm, and
+    // this is the state most users are in most of the time.
+    setSources([source()]);
+
+    // Act
+    render(<ConnectionsTab />);
+
+    // Assert
+    expect(screen.queryByTestId("connections-banner")).not.toBeInTheDocument();
+  });
+
+  it("should offer one refresh covering every bridge", () => {
+    // Arrange
+    setSources([source()]);
+
+    // Act
+    render(<ConnectionsTab />);
+
+    // Assert
+    expect(screen.getByTestId("connections-refresh")).toBeInTheDocument();
   });
 });

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsTab.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsTab.test.tsx
@@ -1,19 +1,19 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { ConnectionSource } from "../../../application/connections/connection-source";
 import { useConnectionSources } from "../../../hooks/connections/use-connection-sources";
+import { DISCOVERY_SETTLE_MS } from "../../../hooks/connections/use-discovery-settled";
+import { resetDiscoveryClock } from "../../../hooks/discovery-clock";
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
-import { useBridgeConnectionsRefreshed } from "../../../hooks/use-bridge-connections";
 import { useDataFlows } from "../ProfileManager/components/useDataFlows";
 import { ConnectionsTab } from "./ConnectionsTab";
 
+// `use-discovery-settled` is deliberately NOT mocked: it is the gate these
+// tests are about, and mocking it would leave them asserting their own stub.
 vi.mock("../../../hooks/connections/use-connection-sources", () => ({
   useConnectionSources: vi.fn(),
-}));
-vi.mock("../../../hooks/use-bridge-connections", () => ({
-  useBridgeConnectionsRefreshed: vi.fn(),
 }));
 vi.mock("../../../hooks/connections/use-connections-refresh", () => ({
   useConnectionsRefresh: () => ({ status: "idle", run: vi.fn() }),
@@ -62,7 +62,13 @@ describe("ConnectionsTab", () => {
       byDataType: new Map(),
       hasAny: false,
     });
-    vi.mocked(useBridgeConnectionsRefreshed).mockReturnValue(true);
+    // Most cases are about what the section says once discovery has settled;
+    // the cold-load case places the clock itself.
+    resetDiscoveryClock(Date.now() - DISCOVERY_SETTLE_MS);
+  });
+
+  afterEach(() => {
+    resetDiscoveryClock();
   });
 
   it("should give every card an addressable test id and status", () => {
@@ -215,12 +221,13 @@ describe("ConnectionsTab", () => {
     ).toBeInTheDocument();
   });
 
-  it("should claim no counts before the connection store has answered", () => {
+  it("should claim no counts while discovery is still in its opening window", () => {
     // Arrange
-    // The reachable failure this guards: every bridge row exists from the
-    // first render and reads undiscovered because nothing has been asked yet,
-    // so a fully equipped user would be told "0 of 5" on every cold load.
-    vi.mocked(useBridgeConnectionsRefreshed).mockReturnValue(false);
+    // The reachable failure: a hard reload with the extensions installed.
+    // Discovery only installs a listener and arms a 3-second timer, so every
+    // row reads undiscovered — and the store's first pass, which asks nothing
+    // and settles microseconds later, must not be mistaken for an answer.
+    resetDiscoveryClock(Date.now());
     setSources([source({ bridgeDetected: false, status: "available" })]);
 
     // Act
@@ -236,7 +243,7 @@ describe("ConnectionsTab", () => {
     ).not.toHaveTextContent("0");
   });
 
-  it("should count detected sources once the store has answered", () => {
+  it("should count detected sources once discovery has settled", () => {
     // Arrange
     setSources([
       source(),

--- a/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsTab.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/ConnectionsTab.tsx
@@ -3,6 +3,7 @@ import { useConnectionSources } from "../../../hooks/connections/use-connection-
 import { useActiveProfileLive } from "../../../hooks/use-active-profile-live";
 import { useTranslate } from "../../../i18n/use-translate";
 import { useDataFlows } from "../ProfileManager/components/useDataFlows";
+import { ConnectionsHealth } from "./ConnectionsHealth";
 import { ConnectionSourceCard } from "./ConnectionSourceCard";
 import { ConnectionsUnsupported } from "./ConnectionsUnsupported";
 
@@ -31,7 +32,7 @@ export const ConnectionsTab: React.FC = () => {
 
   return (
     <div className="space-y-5" data-testid="connections-tab">
-      <p className="text-sm text-ink-body">{t("intro")}</p>
+      <ConnectionsHealth sources={sources} byDataType={byDataType} />
       <section className="space-y-3">
         <div className="flex flex-wrap items-baseline justify-between gap-2">
           <h2 className="text-[11px] font-bold uppercase tracking-widest text-ink-muted">

--- a/packages/workout-spa-editor/src/components/organisms/Connections/connection-summary-tiles.ts
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/connection-summary-tiles.ts
@@ -1,0 +1,90 @@
+/**
+ * The four tiles' copy, as data. Kept out of the component so each number's
+ * wording is asserted without rendering — and so the cold-load placeholder is
+ * one branch instead of four.
+ *
+ * A `null` summary is the state before the connection store has completed a
+ * pass: every bridge row reads undiscovered because nothing has been asked
+ * yet, so every tile renders a placeholder rather than a zero.
+ */
+import type { Locale } from "@kaiord/i18n";
+
+import type { ConnectionSummary } from "../../../application/connections/connection-summary";
+import type { Translate } from "../../../i18n/use-translate";
+import { formatRelativeTime } from "../../../utils/format-relative-time";
+
+export type SummaryTile = {
+  readonly id: string;
+  readonly label: string;
+  readonly value: string;
+  readonly note?: string;
+  readonly tone?: "plain" | "good" | "warn";
+};
+
+export type SummaryTileDeps = {
+  readonly t: Translate;
+  readonly tCommon: Translate;
+  readonly locale: Locale;
+};
+
+const LABELS = ["detected", "covered", "attention", "lastSync"] as const;
+
+const lastSyncValue = (
+  summary: ConnectionSummary,
+  deps: SummaryTileDeps
+): string => {
+  if (summary.lastSync === undefined) return deps.t("summary.lastSyncNever");
+  const relative = formatRelativeTime(
+    new Date(summary.lastSync.at),
+    new Date(),
+    deps.locale
+  );
+  return deps.tCommon(relative.key, relative.params);
+};
+
+export const summaryTiles = (
+  summary: ConnectionSummary | null,
+  deps: SummaryTileDeps
+): readonly SummaryTile[] => {
+  const { t } = deps;
+  const label = (key: (typeof LABELS)[number]) => t(`summary.${key}`);
+  if (summary === null) {
+    return LABELS.map((key) => ({
+      id: key,
+      label: label(key),
+      value: t("summary.pending"),
+    }));
+  }
+  return [
+    {
+      id: "detected",
+      label: label("detected"),
+      value: String(summary.detected),
+      note: t("summary.detectedNote", { total: summary.detectedTotal }),
+    },
+    {
+      id: "covered",
+      label: label("covered"),
+      value: String(summary.covered),
+      note: t("summary.coveredNote", { total: summary.coveredTotal }),
+      tone: summary.covered > 0 ? "good" : "plain",
+    },
+    {
+      id: "attention",
+      label: label("attention"),
+      value: String(summary.attention),
+      note: t(
+        summary.attention === 1
+          ? "summary.attentionNote_one"
+          : "summary.attentionNote_other"
+      ),
+      tone: summary.attention > 0 ? "warn" : "plain",
+    },
+    {
+      id: "lastSync",
+      label: label("lastSync"),
+      value: lastSyncValue(summary, deps),
+      note: summary.lastSync?.sourceName,
+    },
+  ];
+};

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/connection-attention.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/connection-attention.ts
@@ -6,13 +6,15 @@
  * reads as installed rather than broken, an unlinked one as available, and one
  * whose first probe has not answered as checking rather than as failing.
  */
+import { calendarDay } from "../../../application/connections/calendar-day";
 import type { ConnectionSource } from "../../../application/connections/connection-source";
+import { sourceNeedsAttention } from "../../../application/connections/connection-source";
 import type { BridgeConnectionState } from "../../../hooks/use-bridge-connections";
 import type { Translate } from "../../../i18n/use-translate";
 import type { SettingsAttentionModel } from "./SettingsAttention";
 
-export const needsAttention = (source: ConnectionSource): boolean =>
-  source.status === "attention";
+/** Re-exported under this surface's own name; the derivation is shared. */
+export const needsAttention = sourceNeedsAttention;
 
 /**
  * How many bridges answered. A page cannot enumerate installed extensions:
@@ -22,19 +24,6 @@ export const needsAttention = (source: ConnectionSource): boolean =>
 export const countDetected = (
   connections: readonly BridgeConnectionState[]
 ): number => connections.filter((entry) => entry.discovered).length;
-
-/**
- * The user's calendar day, not `toISOString()`'s: a sync at 02:00Z happened
- * the previous evening in New York, and the sentence is about their day.
- * Nothing when the stored value does not parse as a date.
- */
-const dayOf = (timestamp: string | undefined): string | undefined => {
-  if (timestamp === undefined) return undefined;
-  const at = new Date(timestamp);
-  if (Number.isNaN(at.getTime())) return undefined;
-  const month = String(at.getMonth() + 1).padStart(2, "0");
-  return `${at.getFullYear()}-${month}-${String(at.getDate()).padStart(2, "0")}`;
-};
 
 /**
  * Ranked by what the reader can do about it: an instruction outranks a date.
@@ -60,7 +49,7 @@ const detailOf = (
   if (affected.some((source) => source.outdated))
     return t("attention.extensionOutdated");
   const since =
-    affected.length === 1 ? dayOf(affected[0]?.lastSyncAt) : undefined;
+    affected.length === 1 ? calendarDay(affected[0]?.lastSyncAt) : undefined;
   if (since !== undefined)
     return t("attention.noNewDataSince", { date: since });
   return t("attention.signedOut");

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/use-connections-value.test.tsx
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/use-connections-value.test.tsx
@@ -1,17 +1,15 @@
-import { renderHook } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { DISCOVERY_SETTLE_MS } from "../../../hooks/connections/use-discovery-settled";
+import { resetDiscoveryClock } from "../../../hooks/discovery-clock";
 import type { BridgeConnectionState } from "../../../hooks/use-bridge-connections";
 import { useConnectionsValue } from "./use-connections-value";
 
-const store = vi.hoisted(() => ({
-  value: [] as BridgeConnectionState[],
-  refreshed: true,
-}));
+const store = vi.hoisted(() => ({ value: [] as BridgeConnectionState[] }));
 
 vi.mock("../../../hooks/use-bridge-connections", () => ({
   useBridgeConnections: () => store.value,
-  useBridgeConnectionsRefreshed: () => store.refreshed,
 }));
 
 const connection = (
@@ -34,10 +32,26 @@ const bridges = (...discovered: boolean[]): BridgeConnectionState[] =>
     connection({ bridgeId: `bridge-${index}`, discovered: found })
   );
 
+/** Discovery started long enough ago that its window has closed. */
+const discoverySettled = () =>
+  resetDiscoveryClock(Date.now() - DISCOVERY_SETTLE_MS);
+
+/** Discovery started just now: nothing can have announced yet. */
+const discoveryJustStarted = () => resetDiscoveryClock(Date.now());
+
 describe("useConnectionsValue", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetDiscoveryClock();
+  });
+
   it("should count the detected bridges against every known bridge", () => {
     // Arrange
-    store.refreshed = true;
+    discoverySettled();
     store.value = bridges(true, true, false, false, false);
 
     // Act
@@ -52,7 +66,7 @@ describe("useConnectionsValue", () => {
     // The count reads `discovered`, so a probe-less bridge still counts and
     // the ceiling is the full set — unlike a live-session count, which
     // `tanita-bridge` would cap one short forever.
-    store.refreshed = true;
+    discoverySettled();
     store.value = [
       ...bridges(true, true, true, true),
       connection({ bridgeId: "tanita-bridge", discovered: true }),
@@ -65,12 +79,13 @@ describe("useConnectionsValue", () => {
     expect(result.current).toBe("5 of 5 detected");
   });
 
-  it("should render no value until the first refresh pass has completed", () => {
+  it("should render no value while discovery is still in its opening window", () => {
     // Arrange
-    // Every row exists from the first render and reads undiscovered because
-    // nothing has been asked yet. Rendering then would tell a fully equipped
-    // user "0 of 5" for as long as discovery takes.
-    store.refreshed = false;
+    // The reachable failure: a hard reload with five extensions installed.
+    // Discovery only installs a listener and arms a timer, so every row reads
+    // undiscovered — while the store's first pass finishes microseconds later
+    // and would otherwise unlock a confident "0 of 5" on screen for seconds.
+    discoveryJustStarted();
     store.value = bridges(false, false, false, false, false);
 
     // Act
@@ -80,15 +95,36 @@ describe("useConnectionsValue", () => {
     expect(result.current).toBeUndefined();
   });
 
-  it("should render no value while no bridge is known at all", () => {
+  it("should state the honest zero once discovery's window has closed", () => {
     // Arrange
-    store.refreshed = true;
-    store.value = [];
+    // The other reachable failure, and the reason the gate cannot simply wait
+    // for a detection: a reader with no extensions installed must eventually
+    // be told so rather than left on a placeholder forever.
+    discoveryJustStarted();
+    store.value = bridges(false, false, false, false, false);
+    const { result } = renderHook(() => useConnectionsValue());
+
+    // Act
+    act(() => {
+      vi.advanceTimersByTime(DISCOVERY_SETTLE_MS);
+    });
+
+    // Assert
+    expect(result.current).toBe("0 of 5 detected");
+  });
+
+  it("should answer as soon as a bridge is detected, without waiting out the window", () => {
+    // Arrange
+    // A detection is positive evidence that announcements are arriving, so
+    // making an equipped reader stare at a blank row for the full window
+    // would withhold an answer already known.
+    discoveryJustStarted();
+    store.value = bridges(true, false, false, false, false);
 
     // Act
     const { result } = renderHook(() => useConnectionsValue());
 
     // Assert
-    expect(result.current).toBeUndefined();
+    expect(result.current).toBe("1 of 5 detected");
   });
 });

--- a/packages/workout-spa-editor/src/components/pages/SettingsPage/use-connections-value.ts
+++ b/packages/workout-spa-editor/src/components/pages/SettingsPage/use-connections-value.ts
@@ -12,10 +12,8 @@
  * answered a ping this page-life.
  */
 
-import {
-  useBridgeConnections,
-  useBridgeConnectionsRefreshed,
-} from "../../../hooks/use-bridge-connections";
+import { useDiscoverySettled } from "../../../hooks/connections/use-discovery-settled";
+import { useBridgeConnections } from "../../../hooks/use-bridge-connections";
 import { useTranslate } from "../../../i18n/use-translate";
 import { countDetected } from "./connection-attention";
 
@@ -24,14 +22,18 @@ export const useConnectionsValue = (): string | undefined => {
   // No profile is passed: the count reads `discovered` only, so the
   // per-profile sync timestamps this hook can join are not needed here.
   const connections = useBridgeConnections(null);
-  const refreshed = useBridgeConnectionsRefreshed();
+  const found = countDetected(connections);
+  // Gated on discovery having had its window, NOT on the store having
+  // completed a pass: that pass finishes microseconds after boot with every
+  // row undiscovered, because nothing has announced yet and nothing asked it
+  // to. Waiting on it rendered "0 of 5" to a fully equipped reader. The
+  // Connections section counts the same thing behind the same gate, so the
+  // row and the section it leads to cannot disagree while both are settling.
+  const settled = useDiscoverySettled(found);
 
-  // Every row exists from the first render and reads undiscovered, so a value
-  // rendered before the first pass completes would tell a fully equipped user
-  // "0 of 5" for as long as discovery takes.
-  if (!refreshed || connections.length === 0) return undefined;
+  if (!settled) return undefined;
   return t("values.connections.detected", {
-    found: countDetected(connections),
+    found,
     total: connections.length,
   });
 };

--- a/packages/workout-spa-editor/src/hooks/connections/refresh-cooldown.test.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/refresh-cooldown.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  isRefreshCoolingDown,
+  isRefreshRunning,
+  REFRESH_COOLDOWN_MS,
+  resetRefreshCooldown,
+  startOrJoinRefresh,
+} from "./refresh-cooldown";
+
+afterEach(() => {
+  resetRefreshCooldown();
+});
+
+describe("refresh-cooldown", () => {
+  it("should hold the caller off for the whole window after a pass", async () => {
+    // Arrange
+    // The reachable failure: a forced pass bypasses the store's 30-second
+    // positive cache and the 60-second visibility floor, and probes run
+    // outside BRIDGE_QUEUE — so a held button messages four extensions with
+    // no backpressure at all.
+    const start = 1_000_000;
+    const now = vi.fn(() => start);
+
+    // Act
+    await startOrJoinRefresh(() => Promise.resolve(), now);
+
+    // Assert
+    expect(isRefreshCoolingDown(start + REFRESH_COOLDOWN_MS - 1)).toBe(true);
+    expect(isRefreshCoolingDown(start + REFRESH_COOLDOWN_MS)).toBe(false);
+  });
+
+  it("should join a pass already in flight instead of starting a second", async () => {
+    // Arrange
+    // Two clicks inside the same tick: a captured status cannot settle this,
+    // because neither click has seen the other's state update yet.
+    const passes = vi.fn(() => Promise.resolve());
+
+    // Act
+    const first = startOrJoinRefresh(passes);
+    const second = startOrJoinRefresh(passes);
+    await Promise.all([first, second]);
+
+    // Assert
+    expect(passes).toHaveBeenCalledTimes(1);
+    expect(first).toBe(second);
+  });
+
+  it("should report a pass as running until it settles", async () => {
+    // Arrange
+    let release = () => {};
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    // Act
+    const running = startOrJoinRefresh(() => pending);
+    const duringPass = isRefreshRunning();
+    release();
+    await running;
+
+    // Assert
+    expect(duringPass).toBe(true);
+    expect(isRefreshRunning()).toBe(false);
+  });
+
+  it("should stamp the cooldown after a pass that failed", async () => {
+    // Arrange
+    // Without this, a bridge that throws can be retried in a tight loop —
+    // exactly the case where backing off matters most.
+    const start = 2_000_000;
+    const now = vi.fn(() => start);
+
+    // Act
+    await expect(
+      startOrJoinRefresh(() => Promise.reject(new Error("gone")), now)
+    ).rejects.toThrow("gone");
+
+    // Assert
+    expect(isRefreshRunning()).toBe(false);
+    expect(isRefreshCoolingDown(start + 1)).toBe(true);
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/connections/refresh-cooldown.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/refresh-cooldown.ts
@@ -1,0 +1,56 @@
+/**
+ * Throttle for the manual "Refresh all", for the whole browsing session.
+ *
+ * `refresh({ force: true })` bypasses BOTH of the store's own guards: the
+ * 30-second positive cache (explicitly, that is what `force` means) and the
+ * 60-second visibility floor, which lives in the visibility handler and not in
+ * the store. Probes also run outside `BRIDGE_QUEUE`, so nothing downstream
+ * provides backpressure either — a held button would message four extensions
+ * as fast as they answer.
+ *
+ * The window matches the visibility floor rather than the positive cache: both
+ * trigger the same forced whole-bridge pass, so pressing the button can never
+ * be more aggressive than switching tabs already is.
+ *
+ * Module-scoped rather than hook state, and in-memory only: it protects
+ * extensions, so it must outlive the component that renders the button, and it
+ * is transient rate-limiting state that never belongs on disk.
+ */
+export const REFRESH_COOLDOWN_MS = 60_000;
+
+let lastRefreshAt: number | null = null;
+let inFlight: Promise<void> | null = null;
+
+export const isRefreshCoolingDown = (now: number): boolean =>
+  lastRefreshAt !== null && now - lastRefreshAt < REFRESH_COOLDOWN_MS;
+
+export const isRefreshRunning = (): boolean => inFlight !== null;
+
+/**
+ * Joins the pass already in flight rather than launching a second one, so a
+ * remounted button adopts the running state and settles with the pass it did
+ * not start. The cooldown is stamped on settle, including on failure, so a
+ * failing pass cannot be retried in a tight loop.
+ */
+export const startOrJoinRefresh = (
+  start: () => Promise<void>,
+  now: () => number = Date.now
+): Promise<void> => {
+  if (inFlight !== null) return inFlight;
+  const settle = () => {
+    inFlight = null;
+    lastRefreshAt = now();
+  };
+  const pending = start().then(settle, (error: unknown) => {
+    settle();
+    throw error;
+  });
+  inFlight = pending;
+  return pending;
+};
+
+/** Test seam: module state, so a suite must be able to clear it. */
+export const resetRefreshCooldown = (): void => {
+  lastRefreshAt = null;
+  inFlight = null;
+};

--- a/packages/workout-spa-editor/src/hooks/connections/refresh-cooldown.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/refresh-cooldown.ts
@@ -22,7 +22,13 @@ let lastRefreshAt: number | null = null;
 let inFlight: Promise<void> | null = null;
 
 export const isRefreshCoolingDown = (now: number): boolean =>
-  lastRefreshAt !== null && now - lastRefreshAt < REFRESH_COOLDOWN_MS;
+  refreshCooldownRemaining(now) > 0;
+
+/** How long until a press would be accepted again; 0 once it would be. */
+export const refreshCooldownRemaining = (now: number): number =>
+  lastRefreshAt === null
+    ? 0
+    : Math.max(lastRefreshAt + REFRESH_COOLDOWN_MS - now, 0);
 
 export const isRefreshRunning = (): boolean => inFlight !== null;
 

--- a/packages/workout-spa-editor/src/hooks/connections/use-connections-refresh.test.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/use-connections-refresh.test.ts
@@ -1,0 +1,62 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { REFRESH_COOLDOWN_MS, resetRefreshCooldown } from "./refresh-cooldown";
+import { useConnectionsRefresh } from "./use-connections-refresh";
+
+const refresh = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+vi.mock("../../adapters/bridge/bridge-connection-store", () => ({
+  bridgeConnections: { refresh },
+}));
+
+describe("useConnectionsRefresh", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetRefreshCooldown();
+    refresh.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    resetRefreshCooldown();
+  });
+
+  it("should force a pass over every bridge", async () => {
+    // Arrange
+    const { result } = renderHook(() => useConnectionsRefresh());
+
+    // Act
+    await act(async () => {
+      result.current.run();
+    });
+
+    // Assert
+    expect(refresh).toHaveBeenCalledWith({ force: true });
+  });
+
+  it("should stop telling the reader to wait once the window has passed", async () => {
+    // Arrange
+    // Reachable in two presses: the second is refused inside the window, and
+    // nothing else re-renders this control afterwards — so "Try again in a
+    // minute" would outlive the minute and read as a dead button.
+    const { result } = renderHook(() => useConnectionsRefresh());
+    await act(async () => {
+      result.current.run();
+    });
+
+    // Act
+    act(() => {
+      result.current.run();
+    });
+    const refused = result.current.status;
+    act(() => {
+      vi.advanceTimersByTime(REFRESH_COOLDOWN_MS);
+    });
+
+    // Assert
+    expect(refused).toBe("cooldown");
+    expect(result.current.status).toBe("idle");
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/workout-spa-editor/src/hooks/connections/use-connections-refresh.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/use-connections-refresh.ts
@@ -12,12 +12,13 @@
  * flag synchronously also settles the two-fast-clicks case that a captured
  * `status` could not.
  */
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { bridgeConnections } from "../../adapters/bridge/bridge-connection-store";
 import {
   isRefreshCoolingDown,
   isRefreshRunning,
+  refreshCooldownRemaining,
   startOrJoinRefresh,
 } from "./refresh-cooldown";
 
@@ -44,6 +45,17 @@ export const useConnectionsRefresh = (): ConnectionsRefresh => {
       () => setStatus("idle")
     );
   }, []);
+
+  // "Try again in a minute" has to stop being displayed when the minute is
+  // up, or it outlives the refusal it describes and reads as a dead control.
+  useEffect(() => {
+    if (status !== "cooldown") return;
+    const timer = setTimeout(
+      () => setStatus("idle"),
+      refreshCooldownRemaining(Date.now())
+    );
+    return () => clearTimeout(timer);
+  }, [status]);
 
   return { status, run };
 };

--- a/packages/workout-spa-editor/src/hooks/connections/use-connections-refresh.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/use-connections-refresh.ts
@@ -1,0 +1,49 @@
+/**
+ * useConnectionsRefresh — the Connections section's "Refresh all".
+ *
+ * One forced pass over every known bridge. It genuinely replaces the old
+ * partial control, which only re-detected garmin and train2go:
+ * `refreshConnections` fans out over `KNOWN_BRIDGE_IDS` with
+ * `Promise.allSettled`, so one unreachable extension cannot abort the rest.
+ *
+ * Both guards live in `refresh-cooldown`, not in this hook's state — the
+ * button is inside a section the user can leave and return to, and hook state
+ * dies with it while the extensions it protects do not. Reading the in-flight
+ * flag synchronously also settles the two-fast-clicks case that a captured
+ * `status` could not.
+ */
+import { useCallback, useState } from "react";
+
+import { bridgeConnections } from "../../adapters/bridge/bridge-connection-store";
+import {
+  isRefreshCoolingDown,
+  isRefreshRunning,
+  startOrJoinRefresh,
+} from "./refresh-cooldown";
+
+export type ConnectionsRefreshStatus = "idle" | "running" | "cooldown";
+
+export type ConnectionsRefresh = {
+  readonly status: ConnectionsRefreshStatus;
+  readonly run: () => void;
+};
+
+export const useConnectionsRefresh = (): ConnectionsRefresh => {
+  const [status, setStatus] = useState<ConnectionsRefreshStatus>("idle");
+
+  const run = useCallback(() => {
+    if (!isRefreshRunning() && isRefreshCoolingDown(Date.now())) {
+      setStatus("cooldown");
+      return;
+    }
+    setStatus("running");
+    void startOrJoinRefresh(() =>
+      bridgeConnections.refresh({ force: true })
+    ).then(
+      () => setStatus("idle"),
+      () => setStatus("idle")
+    );
+  }, []);
+
+  return { status, run };
+};

--- a/packages/workout-spa-editor/src/hooks/connections/use-discovery-settled.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/use-discovery-settled.ts
@@ -1,18 +1,11 @@
 /**
  * Whether a count of detected bridges is worth rendering yet.
  *
- * The store's `hasRefreshed()` is the wrong gate for this, and reads as the
- * right one. A pass over a browser where nothing has announced completes in
- * microseconds — `getExtensionId` returns null for every bridge, no probe is
- * sent, and the pass settles on the next microtask — so it flips true long
- * before any extension could have answered. Meanwhile an announcement needs a
- * `postMessage` macrotask plus a verification round-trip, and discovery only
- * broadcasts a DISCOVER request after `DISCOVER_REQUEST_DELAY_MS` of silence.
- * Gating on the pass therefore renders a confident "0 of 5" to a fully
- * equipped reader for as long as discovery takes.
- *
- * So the question is not "have we asked" — nobody asks — but "has discovery
- * had its chance":
+ * The question is not "have we asked" — nobody asks, extensions announce
+ * themselves — but "has discovery had its chance". A refresh pass is not that
+ * signal: over a browser where nothing has announced it settles on the next
+ * microtask, long before any extension could answer, which would render a
+ * confident "0 of 5" to a fully equipped reader.
  *
  *   - Any bridge detected ends it immediately. That is positive evidence that
  *     announcements are arriving, and the count is explicitly of what has

--- a/packages/workout-spa-editor/src/hooks/connections/use-discovery-settled.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/use-discovery-settled.ts
@@ -1,0 +1,53 @@
+/**
+ * Whether a count of detected bridges is worth rendering yet.
+ *
+ * The store's `hasRefreshed()` is the wrong gate for this, and reads as the
+ * right one. A pass over a browser where nothing has announced completes in
+ * microseconds — `getExtensionId` returns null for every bridge, no probe is
+ * sent, and the pass settles on the next microtask — so it flips true long
+ * before any extension could have answered. Meanwhile an announcement needs a
+ * `postMessage` macrotask plus a verification round-trip, and discovery only
+ * broadcasts a DISCOVER request after `DISCOVER_REQUEST_DELAY_MS` of silence.
+ * Gating on the pass therefore renders a confident "0 of 5" to a fully
+ * equipped reader for as long as discovery takes.
+ *
+ * So the question is not "have we asked" — nobody asks — but "has discovery
+ * had its chance":
+ *
+ *   - Any bridge detected ends it immediately. That is positive evidence that
+ *     announcements are arriving, and the count is explicitly of what has
+ *     answered so far this page-life: it climbs in step with the cards beside
+ *     it, each of which flips as its own announcement verifies.
+ *   - Otherwise the window is the discover request's own delay plus the
+ *     ceiling on the verification ping that answers it. Both are derived from
+ *     the constants that govern them, so this cannot drift from the behaviour
+ *     it is waiting on.
+ */
+import { useEffect, useState } from "react";
+
+import { DISCOVER_REQUEST_DELAY_MS } from "../../adapters/bridge/bridge-discovery";
+import { PING_TIMEOUT_MS } from "../../adapters/bridge/bridge-transport";
+import { discoveryStartedAt } from "../discovery-clock";
+
+export const DISCOVERY_SETTLE_MS = DISCOVER_REQUEST_DELAY_MS + PING_TIMEOUT_MS;
+
+export const useDiscoverySettled = (detected: number): boolean => {
+  const [, retick] = useState(0);
+  const startedAt = discoveryStartedAt();
+  const settled = detected > 0 || Date.now() - startedAt >= DISCOVERY_SETTLE_MS;
+
+  useEffect(() => {
+    // Nothing else will wake this surface: with no extension present no row
+    // ever changes, so the store's poll notifies no one and the placeholder
+    // would outlive the window it stands for.
+    if (settled) return;
+    const remaining = startedAt + DISCOVERY_SETTLE_MS - Date.now();
+    const timer = setTimeout(
+      () => retick((n) => n + 1),
+      Math.max(remaining, 0)
+    );
+    return () => clearTimeout(timer);
+  }, [settled, startedAt]);
+
+  return settled;
+};

--- a/packages/workout-spa-editor/src/hooks/discovery-clock.ts
+++ b/packages/workout-spa-editor/src/hooks/discovery-clock.ts
@@ -1,0 +1,36 @@
+/**
+ * When bridge discovery started listening, for the whole app boot.
+ *
+ * Discovery is not a request/response: nothing asks the extensions anything.
+ * They announce themselves when their content script injects, and discovery
+ * only broadcasts a DISCOVER request after `DISCOVER_REQUEST_DELAY_MS` if it
+ * has heard nothing at all. So "have we asked?" is not a question the product
+ * can answer, and a surface counting detected bridges needs to know instead
+ * how long discovery has been listening.
+ *
+ * Module-scoped, in-memory, and stamped once: the reference point is the app
+ * boot, not the mount of whichever surface reads it. A per-mount clock would
+ * restart the grace window every time the reader opened the page, long after
+ * the answer had settled.
+ *
+ * `loadedAt` is the floor because React runs child effects before parent ones:
+ * a cold boot straight onto a surface that reads this can render before the
+ * bootstrap effect at the root has stamped anything. This module is imported
+ * by that bootstrap, so its load is the same boot — and reporting a reference
+ * slightly EARLIER than discovery started can only delay the gate, never open
+ * it before discovery has had its window.
+ */
+const loadedAt = Date.now();
+
+let startedAt: number | null = null;
+
+export const markDiscoveryStarted = (at: number = Date.now()): void => {
+  if (startedAt === null) startedAt = at;
+};
+
+export const discoveryStartedAt = (): number => startedAt ?? loadedAt;
+
+/** Test seam: module state, so a suite must be able to place it in time. */
+export const resetDiscoveryClock = (at: number | null = null): void => {
+  startedAt = at;
+};

--- a/packages/workout-spa-editor/src/hooks/use-bridge-discovery-bootstrap.ts
+++ b/packages/workout-spa-editor/src/hooks/use-bridge-discovery-bootstrap.ts
@@ -9,9 +9,14 @@
 import { useEffect } from "react";
 
 import { bridgeDiscovery } from "../adapters/bridge/bridge-discovery";
+import { markDiscoveryStarted } from "./discovery-clock";
 
 export const useBridgeDiscoveryBootstrap = () => {
   useEffect(() => {
+    // Stamped here rather than inside the singleton because this is the point
+    // at which listening actually begins for this boot; surfaces that count
+    // detected bridges measure their grace window from it.
+    markDiscoveryStarted();
     bridgeDiscovery.start();
     return () => {
       bridgeDiscovery.stop();

--- a/packages/workout-spa-editor/src/i18n/locales/en/connections.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/connections.json
@@ -5,6 +5,30 @@
   "sourcesHint": "Each source carries its own browser bridge and permissions",
   "unsupported": "Not available yet",
   "unsupportedHint": "Connecting these needs a server Kaiord does not run.",
+  "summary": {
+    "detected": "Sources detected",
+    "detectedNote": "of {{total}}",
+    "covered": "Types covered",
+    "coveredNote": "of {{total}} types",
+    "attention": "Needs attention",
+    "attentionNote_one": "source",
+    "attentionNote_other": "sources",
+    "lastSync": "Last data in",
+    "lastSyncNever": "None yet",
+    "pending": "—",
+    "refresh": "Refresh all",
+    "refreshing": "Refreshing…",
+    "refreshCooldown": "Just refreshed. Try again in a minute."
+  },
+  "banner": {
+    "one": "{{name}} is signed out",
+    "oneOutdated": "{{name}}'s browser bridge is out of date",
+    "many": "{{count}} sources need attention",
+    "paused": "No source is sending {{types}} right now.",
+    "covered": "Nothing has stopped: every affected type also has another source switched on.",
+    "noRoutes": "No data routes are switched on for it, so nothing has stopped arriving.",
+    "since": "No new data since {{date}}."
+  },
   "status": {
     "connected": "Connected",
     "installed": "Detected on load",

--- a/packages/workout-spa-editor/src/i18n/locales/en/connections.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/connections.json
@@ -9,7 +9,7 @@
     "detected": "Sources detected",
     "detectedNote": "of {{total}}",
     "covered": "Types covered",
-    "coveredNote": "of {{total}} types",
+    "coveredNote": "of {{total}} types · incl. manual entry",
     "attention": "Needs attention",
     "attentionNote_one": "source",
     "attentionNote_other": "sources",
@@ -26,7 +26,7 @@
     "many": "{{count}} sources need attention",
     "paused": "No source is sending {{types}} right now.",
     "covered": "Nothing has stopped: every affected type also has another source switched on.",
-    "noRoutes": "No data routes are switched on for it, so nothing has stopped arriving.",
+    "noRoutes": "No data routes are switched on, so nothing has stopped arriving.",
     "since": "No new data since {{date}}."
   },
   "status": {

--- a/packages/workout-spa-editor/src/i18n/locales/es/connections.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/connections.json
@@ -5,6 +5,30 @@
   "sourcesHint": "Cada fuente lleva su propio puente de navegador y sus permisos",
   "unsupported": "Todavía no disponibles",
   "unsupportedHint": "Conectarlas necesita un servidor que Kaiord no tiene.",
+  "summary": {
+    "detected": "Fuentes detectadas",
+    "detectedNote": "de {{total}}",
+    "covered": "Tipos con fuente",
+    "coveredNote": "de {{total}} tipos",
+    "attention": "Necesitan atención",
+    "attentionNote_one": "fuente",
+    "attentionNote_other": "fuentes",
+    "lastSync": "Últimos datos",
+    "lastSyncNever": "Todavía ninguno",
+    "pending": "—",
+    "refresh": "Actualizar todo",
+    "refreshing": "Actualizando…",
+    "refreshCooldown": "Acabas de actualizar. Inténtalo dentro de un minuto."
+  },
+  "banner": {
+    "one": "{{name}} tiene la sesión cerrada",
+    "oneOutdated": "El puente de navegador de {{name}} está desactualizado",
+    "many": "{{count}} fuentes necesitan atención",
+    "paused": "Ahora mismo ninguna fuente está enviando {{types}}.",
+    "covered": "No se ha parado nada: cada tipo afectado tiene otra fuente activada.",
+    "noRoutes": "No hay ninguna ruta de datos activada para ella, así que no ha dejado de llegar nada.",
+    "since": "No llegan datos nuevos desde el {{date}}."
+  },
   "status": {
     "connected": "Conectado",
     "installed": "Detectada al cargar",

--- a/packages/workout-spa-editor/src/i18n/locales/es/connections.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/connections.json
@@ -9,7 +9,7 @@
     "detected": "Fuentes detectadas",
     "detectedNote": "de {{total}}",
     "covered": "Tipos con fuente",
-    "coveredNote": "de {{total}} tipos",
+    "coveredNote": "de {{total}} tipos · incl. entrada manual",
     "attention": "Necesitan atención",
     "attentionNote_one": "fuente",
     "attentionNote_other": "fuentes",
@@ -26,7 +26,7 @@
     "many": "{{count}} fuentes necesitan atención",
     "paused": "Ahora mismo ninguna fuente está enviando {{types}}.",
     "covered": "No se ha parado nada: cada tipo afectado tiene otra fuente activada.",
-    "noRoutes": "No hay ninguna ruta de datos activada para ella, así que no ha dejado de llegar nada.",
+    "noRoutes": "No hay ninguna ruta de datos activada, así que no ha dejado de llegar nada.",
     "since": "No llegan datos nuevos desde el {{date}}."
   },
   "status": {


### PR DESCRIPTION
## Summary

The four counters and the consequence banner at the top of the Connections section, plus "Refresh all".

This is the most claim-dense surface in the redesign, so most of the work was deciding what **not** to say.

## Claims refused

| design says | why not |
|---|---|
| "stopped syncing 3 days ago" | no transition timestamp exists anywhere; `lastCheckedAt` is probe time and resets on reload. Ships as **"No new data since \<date\>"** from persisted `lastSyncAt`, and only when exactly one source is affected |
| "Sleep and HRV have fallen back to Garmin" | cut entirely, not even per-row. `union` is the default and returns every record with no winner; `usedFallback` is priority-only, per-(type, day), 6 of 13 types |
| "its access token expired" | the SPA cannot distinguish expired from never-signed-in → **"is signed out"** |
| "reconnecting backfills the last 30 days" | 30 for cycles but **7** for heart-rate and stress. One number is false for two of WHOOP's types, and a per-type breakdown is not a banner sentence, so there is no backfill promise |
| "2 of 5 linked" | **"Sources detected"**, same derivation and same word as Wave S3 — tanita has no prober, so a session-based count can never reach its denominator |
| "Reconnect WHOOP" CTA | the fix is signing in on the provider's site, and the card that does it is directly below |

The design also contradicts itself — the banner says Daily Wellness "fell back" while the WHOOP card calls it "paused". Resolved as **paused**, and only for types that lost *every* delivering source.

## One the brief did not flag, same defect class as "5 of 5"

**No bridge announces `read:workouts`.** Verified across all five: garmin is `write:workouts, read:activities, write:body`; the others carry no workout capability at all. So `workout` can never be bridge-fed, and a bridge-only "data flowing" counter has a **ceiling of 12 of 13** — structurally stuck, exactly like "5 of 5".

That settled the open question about manual: **manual counts**, which makes 13 of 13 genuinely reachable, since the four non-manual types are all bridge-reachable. And because manual entry is not data in flight, the counter is **"Types covered"** rather than "Data flowing".

Consequence worth stating: `covered` and `paused` are **not complements** — covered counts manual, paused does not. A signed-out Tanita leaves `weight` covered *and* paused; both are true, they answer different questions. A test pins it, because writing `paused = !covered` would silently drop 9 of 13 types out of the banner.

## Refresh all

Genuinely replaces the old partial refresh, which only re-detected garmin and train2go. Rate-limited to 60s — matching the visibility floor, since it is the same forced pass, so the button can never be more aggressive than an alt-tab. Without it a held button spams four extensions: probes run outside `BRIDGE_QUEUE` and a forced pass bypasses both the 30s positive cache and that floor.

## Every test names a reachable failing state

32 of them. The ones worth calling out: **"0 of 5" on every cold load** — the exact defect Wave S3 shipped and had to fix, so the counters are gated on `useBridgeConnectionsRefreshed()` with a placeholder that is not a zero. `lastCheckedAt` → "3 days ago" being wrong after every reload. One source's date presented as a set's. A never-signed-in bridge reported as expired. An erroring bridge retried in a tight loop.

**One test deliberately not written**: "tanita is never a spinner". Wave 1 already pins both halves — the store asserts `checking: false` and that the probe is never called, and the status test asserts the `installed` verdict — and `force` reaches neither path. A third assertion would be precisely the decorative test `spec/test-minimality` exists to prevent.

Also refactored `sourceNeedsAttention` and `calendarDay` into `application/connections/`, with the old module re-exporting under its existing names. Wave 1 and S3 each grew their own attention predicate, git merged them without complaint, and they disagreed; this removes the second copy before it can happen again.

## Verification

`pnpm -r build` · SPA **878 files / 6210 tests** · `tsc -b --noEmit` + eslint + prettier, **0 warnings** · `pnpm test:scripts` 616/616 · root `pnpm lint` · `lint:specs` 64 · `playwright test --list` 1794 · theme-dialect, PII and boundaries run directly, allowlist untouched at 28.

Expect a rebase against #1082; the contact point is one line in `ConnectionsTab.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Connections health summary with detected, covered, attention, and last-sync indicators.
  * Added clear banners explaining connection issues, paused data delivery, and sign-in or outdated states.
  * Added a “Refresh all” action with progress feedback and cooldown protection.
  * Improved discovery handling so connection counts appear only after results settle.
  * Added consistent date formatting and localized English and Spanish messaging.
* **Bug Fixes**
  * Corrected Settings connection counts to reflect detected connections, including unprobed connections.
  * Aligned attention and coverage messaging across Connections and Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->