### PR TITLE
fix(spa-editor): keep anchored coach marks inside the viewport

### DIFF
--- a/packages/workout-spa-editor/e2e/mobile-responsive.spec.ts
+++ b/packages/workout-spa-editor/e2e/mobile-responsive.spec.ts
@@ -8,6 +8,33 @@ const MOBILE_STEP_COUNT = 10;
 const TABLET_VIEWPORT_WIDTH_PX = 768;
 const STEP_BASE_WATTS = 200;
 const STEP_WATTS_INCREMENT = 10;
+const PIXEL_5_WIDTH_PX = 393;
+const COACH_MARK_STEP_COUNT = 4;
+const COACH_MARK_STEP_SECONDS = 300;
+
+/** Four uniform steps: enough to ctrl-select two and fire the create-block mark. */
+const buildCoachMarkWorkout = () => ({
+  version: "1.0",
+  type: "structured_workout",
+  metadata: { created: new Date().toISOString(), sport: "cycling" },
+  extensions: {
+    structured_workout: {
+      name: "Coach Mark Workout",
+      sport: "cycling",
+      steps: Array.from({ length: COACH_MARK_STEP_COUNT }, (_, stepIndex) => ({
+        stepIndex,
+        durationType: "time",
+        duration: { type: "time", seconds: COACH_MARK_STEP_SECONDS },
+        targetType: "power",
+        target: {
+          type: "power",
+          value: { unit: "watts", value: STEP_BASE_WATTS },
+        },
+        intensity: "active",
+      })),
+    },
+  },
+});
 
 /**
  * Critical Path: Mobile Responsiveness and Touch Interactions
@@ -381,5 +408,52 @@ test.describe("Workout Actions Overflow", () => {
     expect(discardBox!.x + discardBox!.width).toBeLessThanOrEqual(
       headerBox!.x + headerBox!.width + 1
     );
+  });
+});
+
+/**
+ * Regression guard for the coach-mark overflow that failed on Mobile Chrome
+ * only (issue #1084).
+ *
+ * An absolutely-positioned bubble placed past the right edge widens the
+ * document. Chrome then grows the layout viewport away from the visual
+ * viewport, so the page can be panned sideways and every coordinate-based
+ * click lands somewhere other than where the page paints its target — which is
+ * how this surfaced: Playwright reporting "element is visible, enabled and
+ * stable" and then hitting a sibling. The invariant is asserted directly
+ * because the symptom is several steps removed from the cause.
+ */
+test.describe("Viewport containment", () => {
+  test.use({ viewport: { width: PIXEL_5_WIDTH_PX, height: 727 } });
+
+  test("should not scroll horizontally while a coach mark is anchored", async ({
+    page,
+  }) => {
+    await seedEmptyWorkout(page, buildCoachMarkWorkout());
+
+    const stepCards = page.locator('[data-testid="step-card"]');
+    await expect(stepCards.first()).toBeVisible({ timeout: 10000 });
+
+    // Two selected steps is the precondition that fires the create-block mark.
+    for (const index of [1, 2]) {
+      await stepCards.nth(index).evaluate((el) => {
+        el.dispatchEvent(
+          new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+            ctrlKey: true,
+          })
+        );
+      });
+    }
+    await expect(page.getByTestId("coach-mark-create-block")).toBeVisible({
+      timeout: 10000,
+    });
+
+    const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }));
+    expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
   });
 });

--- a/packages/workout-spa-editor/src/components/atoms/Tooltip/compute-position.test.ts
+++ b/packages/workout-spa-editor/src/components/atoms/Tooltip/compute-position.test.ts
@@ -1,7 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import type { Align, Side } from "./compute-position";
 import { computeTooltipPosition } from "./compute-position";
+
+// jsdom performs no layout, so `documentElement.clientWidth` is 0 and
+// `computeTooltipPosition` falls back to `window.innerWidth`. Driving that is
+// how these tests emulate a narrow screen.
+const DEFAULT_INNER_WIDTH = window.innerWidth;
+
+const setViewportWidth = (width: number) => {
+  Object.defineProperty(window, "innerWidth", {
+    value: width,
+    configurable: true,
+    writable: true,
+  });
+};
+
+const makeRect = (r: Partial<DOMRect>) =>
+  ({ ...r, toJSON: () => ({}) }) as DOMRect;
 
 // Fixture: triggerRect at (200,100), size 80x30 -> right=280, bottom=130.
 // Tooltip size 60x20. SIDE_OFFSET=5. jsdom default window.scrollX=scrollY=0.
@@ -64,4 +80,72 @@ describe("computeTooltipPosition", () => {
       expect(result).toEqual({ top, left });
     }
   );
+});
+
+/**
+ * Regression: an unclamped `side: "right"` coach mark rendered 125px past the
+ * right edge of a 393px Pixel 5 screen. A document wider than the screen makes
+ * Chrome grow the layout viewport away from the visual viewport, which
+ * desynchronises Playwright's click coordinates from the browser's hit test —
+ * the "Mobile Chrome only" repetition-block e2e failures.
+ */
+describe("computeTooltipPosition viewport clamping", () => {
+  const PIXEL_5_WIDTH = 393;
+  /** Mirrors `VIEWPORT_MARGIN` in compute-position.ts. */
+  const MARGIN = 8;
+  const MARK = makeRect({ width: 161, height: 120 });
+  /** Anchor right (100) + SIDE_OFFSET (5): fits, so the clamp is a no-op. */
+  const UNCLAMPED_LEFT = 105;
+
+  afterEach(() => setViewportWidth(DEFAULT_INNER_WIDTH));
+
+  it("should keep a right-side bubble inside a narrow viewport", () => {
+    // Arrange
+    setViewportWidth(PIXEL_5_WIDTH);
+    const anchor = makeRect({ top: 400, bottom: 446, left: 16, right: 352 });
+
+    // Act
+    const { left } = computeTooltipPosition(anchor, MARK, "right", "start");
+
+    // Assert
+    expect(left).toBe(PIXEL_5_WIDTH - MARK.width - MARGIN);
+    expect(left + MARK.width).toBeLessThanOrEqual(PIXEL_5_WIDTH);
+  });
+
+  it("should keep a left-side bubble off the left edge", () => {
+    // Arrange
+    setViewportWidth(PIXEL_5_WIDTH);
+    const anchor = makeRect({ top: 400, bottom: 446, left: 20, right: 120 });
+
+    // Act
+    const { left } = computeTooltipPosition(anchor, MARK, "left", "start");
+
+    // Assert
+    expect(left).toBe(MARGIN);
+  });
+
+  it("should pin a bubble wider than the viewport to the left margin", () => {
+    // Arrange
+    setViewportWidth(PIXEL_5_WIDTH);
+    const wide = makeRect({ width: 400, height: 120 });
+    const anchor = makeRect({ top: 400, bottom: 446, left: 16, right: 352 });
+
+    // Act
+    const { left } = computeTooltipPosition(anchor, wide, "right", "start");
+
+    // Assert
+    expect(left).toBe(MARGIN);
+  });
+
+  it("should leave a bubble that already fits untouched", () => {
+    // Arrange
+    setViewportWidth(PIXEL_5_WIDTH);
+    const anchor = makeRect({ top: 400, bottom: 446, left: 16, right: 100 });
+
+    // Act
+    const { left } = computeTooltipPosition(anchor, MARK, "right", "start");
+
+    // Assert
+    expect(left).toBe(UNCLAMPED_LEFT);
+  });
 });

--- a/packages/workout-spa-editor/src/components/atoms/Tooltip/compute-position.ts
+++ b/packages/workout-spa-editor/src/components/atoms/Tooltip/compute-position.ts
@@ -4,6 +4,31 @@ export type Align = "start" | "center" | "end";
 
 const SIDE_OFFSET = 5;
 
+/** Gap kept between a clamped bubble and the edge of the screen. */
+const VIEWPORT_MARGIN = 8;
+
+/**
+ * Keeps the bubble inside the viewport horizontally.
+ *
+ * Without this, `side: "right"` on a narrow screen places the bubble past the
+ * right edge. That widens the document, and a document wider than the screen
+ * makes Chrome grow the layout viewport away from the visual viewport, so the
+ * page can be panned sideways and every coordinate the page reports is offset
+ * from the coordinate the browser hit-tests.
+ *
+ * Measured against `documentElement.clientWidth`, not `window.innerWidth`:
+ * once the layout viewport has grown, `innerWidth` reports the grown value and
+ * would keep re-admitting the overflow that caused it. `clientWidth` stays at
+ * the real screen width.
+ */
+const clampLeft = (left: number, width: number): number => {
+  if (typeof document === "undefined") return left;
+  const viewport = document.documentElement.clientWidth || window.innerWidth;
+  const max = viewport - width - VIEWPORT_MARGIN;
+  if (max <= VIEWPORT_MARGIN) return VIEWPORT_MARGIN;
+  return Math.min(Math.max(left, VIEWPORT_MARGIN), max);
+};
+
 export const computeTooltipPosition = (
   triggerRect: DOMRect,
   tooltipRect: DOMRect,
@@ -30,5 +55,8 @@ export const computeTooltipPosition = (
     else if (align === "end") top = triggerRect.bottom - tooltipRect.height;
     else top = triggerRect.top + (triggerRect.height - tooltipRect.height) / 2;
   }
-  return { top: top + window.scrollY, left: left + window.scrollX };
+  return {
+    top: top + window.scrollY,
+    left: clampLeft(left, tooltipRect.width) + window.scrollX,
+  };
 };


### PR DESCRIPTION
## A coach mark hung off the screen, and that broke clicking anywhere on the page

**This is a user-facing bug, not a test bug.** The e2e failure was the symptom.

`computeTooltipPosition` placed a `side: "right"` bubble at `triggerRect.right + 5` with **no viewport awareness at all**. On a 393px-wide Pixel 5, the create-block coach mark landed at `left = 357` with a width of 161 — so **125px of it hung off the right edge**. Its body text was clipped and its own buttons ("Open the block dialog" / "Not now") were unreachable. A coach mark that cannot be dismissed or acted on is worse than no coach mark.

## Why that broke unrelated clicks

The overflow widened the document to **518px**. Chrome answers a document wider than the screen by growing the **layout** viewport away from the **visual** viewport, making the page pannable:

| | before | after |
|---|---|---|
| `window.innerWidth` | 393 | **518** |
| `visualViewport.offsetLeft` | 0 | **51** |

Every coordinate-based hit test is then offset from where the page paints. That is exactly what the failing tests showed: Playwright reported the confirm button **"visible, enabled and stable"**, then clicked 51px away and hit a sibling — which is why the intercepting element kept alternating between the dialog's own Cancel button and its own header.

Mobile Chrome only, because it needs a viewport narrow enough for the bubble to overflow.

## The fix, and the trap inside it

Clamp the horizontal position into the viewport — measured against **`documentElement.clientWidth`, not `window.innerWidth`**.

That distinction is load-bearing: once the layout viewport has already grown, `innerWidth` reports the *grown* value, so clamping against it would keep re-admitting the very overflow that caused the growth. A self-referential measurement that silently does nothing.

## Three hypotheses I disproved on the way, one of which I was wrong to disprove

1. **Dialog taller than the viewport.** Genuinely wrong — measured 393×727 usable, far taller than the dialog.
2. **A coach mark overlaying the dialog.** **I was right to suspect this and wrong to rule it out.** I checked whether the mark overlaid the confirm button, saw the interceptors were the dialog's own children, and stopped. The mark never overlaid anything — it shifted the coordinate space out from under everything. I tested the wrong consequence of the right suspicion.
3. **Footer buttons overflowing.** Genuinely wrong.

## The new guard

Asserts the mobile no-horizontal-overflow invariant, so this fails on the *class* — any future element positioned past the right edge on a narrow viewport — rather than only on the coach mark that happened to do it first.

## Verification

Both named tests green on Mobile Chrome · the whole `repetition-blocks.spec.ts` green on Mobile Chrome · still green on chromium and Mobile Safari · `pnpm -r build` · SPA test + lint · `pnpm test:scripts` · root `pnpm lint` · `playwright test --list`.

Closes #1084.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
