### PR TITLE
feat(spa-editor): choose where each data type is read from (Wave 2b)

### DIFF
--- a/openspec/changes/add-connections-change-source/design.md
+++ b/openspec/changes/add-connections-change-source/design.md
@@ -1,0 +1,162 @@
+# Design — the inline source-of-truth control
+
+## D1. "Change" writes `priority`, and says so first
+
+The alternative Wave 2a recorded and deferred was to leave the control writing
+nothing but an order, keeping `union`. That is incoherent: `union` has no order —
+`resolveEffectiveSource` returns every source's record and ignores `sourceOrder`
+entirely, and `use-source-policy-editor.ts` erases the order when the user picks
+union. A control that stored a ranking under `union` would store a value nothing
+reads and leave the pill saying "2 sources" immediately after the user chose one.
+
+So picking a source stores `mode: "priority"`. The user operating a control whose
+whole purpose is to choose a source of truth IS expressing a ranking; recording
+one is the honest reading of the action, not an inference about it.
+
+What that cannot be allowed to become is a silent change. `priority` genuinely
+changes how the type is read: `union` keeps every source's record for a day and a
+consumer needing one value takes `records.at(-1)`; `priority` consults the order
+and returns the first source with a record that day, or nothing. A user who came
+to "pick where my weight comes from" did not necessarily come to change what is
+STORED for it, and this programme has already shipped one requirement that could
+be satisfied while surprising the user.
+
+The panel therefore states, before either button is reachable:
+
+> Right now Kaiord keeps every source's Weight and ranks none of them; when it
+> needs a single value it uses whichever arrived last.
+>
+> Pick a source below and that changes: Kaiord will read Weight from the one you
+> pick, and use the others only on days it has nothing. You can go back to
+> keeping every source right here.
+
+Three properties are load-bearing. It names THIS row's type rather than "this
+data type". It states the current behaviour as well as the new one, because
+"prefer WHOOP" only reads as a change against "keep everything". And it states
+the reversal in the same breath as the change, because a reversible consequence
+and an irreversible one warrant different amounts of hesitation.
+
+### D1a. An already-ranked row is not warned
+
+Re-picking on a `priority` row changes which source leads. Read semantics do not
+change. Repeating the warning there would describe a consequence that cannot
+happen, which trains the user to skip it on the row where it is true. That row's
+intro states what it reads today instead ("Kaiord reads Weight from Tanita first,
+and falls back to the others on days it has nothing").
+
+`rankedUnavailable` gets its own third intro: it is ranked, so no mode changes,
+but there is no head to name and the resolver is returning nothing. Wave 2a could
+only report that state; this is the change that makes it fixable.
+
+## D2. Reversibility is a first-class option, not an escape hatch
+
+"Keep every source" is the first choice in the list, present on every row that
+shows the control. It is not a "reset" buried under the thing that caused the
+change, and it takes exactly one click from the same panel.
+
+It also drives the render rule: the control appears when the row has at least
+two sources, or at least one under a stored ranking.
+
+| row state                    | control | why                                                          |
+| ---------------------------- | ------- | ------------------------------------------------------------ |
+| no source, either mode       | absent  | nothing to pick and nothing to keep; both modes read nothing |
+| one source, default mode     | absent  | no second way to read it; the mode flip buys nothing         |
+| two or more sources, default | present | the case the warning exists for                              |
+| one or more, `priority`      | present | a ranked type stays un-rankable-back as sources drop away    |
+
+The `priority` half exists for reversibility: rank a type while two sources
+exist, then switch the second import off, and a `choices >= 2` rule alone would
+strand it in `priority` with no way back from either this page or the Data Hub
+(whose editor applies the same `< 2` skip).
+
+The zero-source row is excluded even when ranked, which the first cut got wrong.
+It is reachable — rank `planned-session` through chat, then Disconnect Train2Go,
+which switches off every policy on the bridge, leaving a type with no manual path
+and no route. There the panel would have to open with "it is ranked to sources
+that are switched off", describing a ranking problem the row does not have: its
+trouble is that the type has no source at all, which the pill already says. The
+two modes are also indistinguishable there — both read nothing — so nothing is
+lost by waiting until a source returns.
+
+## D3. The writer and the reader share one definition of "first"
+
+Wave 2a deliberately did not use `orderSources` for attribution: it APPENDS
+available-but-unranked sources, so its head can be a source
+`resolveEffectiveSource` never reaches — a shipped bug. That reasoning is about
+READING a head out of a possibly-incomplete stored order, and it still holds:
+`current` (which choice is marked as the one in use) is `rankedHead`, the first
+SAVED entry that is still available, exactly what the resolver consults.
+
+`orderSources` is exactly right for the other direction. `promoteSource` composes
+the order to STORE as `[picked, ...everything else]` over the merged candidate
+list, so after the write the stored order really does contain every source — the
+appending is materialised in storage rather than imagined by a reader. The
+end-to-end test feeds the written order straight back into
+`buildDataTypeRoutingRows` and asserts the pill names the picked source, so the
+two directions cannot drift.
+
+The set both directions range over is now one function, `availableSources`,
+moved out of `data-type-routing.ts` into `data-type-sources.ts`. Two copies of
+"enabled import routes ∪ manual" would let the pill name a source the control
+cannot offer.
+
+## D4. An order that resolves to nothing cannot be composed here
+
+The chat writer refuses to persist a ranked order whose names do not resolve,
+because `resolveEffectiveSource` then reads NO record for the type. This control
+is held to the same standard, structurally rather than by a guard:
+`promoteSource` builds the order out of `choices`, `picked` is always one of
+them, and the control does not render at all when there is nothing to pick. The
+empty order has no construction site.
+
+No runtime check is added for it. A guard against a state the code cannot reach
+is the same defect as a test aimed at one — it stays green while proving nothing,
+and it invites a later reader to believe the state is reachable.
+
+## D5. Capability: offered sources are ones that can actually serve the type
+
+`applyRouteToggle` (chat `enable_route`) performs no capability check — issue
+#1085, not fixed here. So an enabled import policy exists for pairings the Data
+Hub renders `na`: `enable_route stress garmin import` succeeds even though Garmin
+announces `write:workouts`, `read:activities` and `write:body` and can never
+deliver stress. Wave 2a counts such a route (correctly — it mirrors what the
+resolver filters by). Offering it as a SOURCE OF TRUTH is different: it would
+rank first a source that can never produce a record.
+
+`canServe` therefore filters the candidates by both halves of the check the rest
+of the SPA uses — `bridgeSupportsRoute` (static: narrows a shared token such as
+`read:body` to the routes the SPA actually serves) and the announced wire token.
+
+The subtlety is the third state. `bridgeDiscovery.getCapabilities` returns `null`
+for a bridge it has not verified, which is every bridge before discovery answers
+and any bridge whose extension is not installed in this browser. `null` is
+treated as "not asked yet", NOT as "cannot": an enabled WHOOP sleep route owns
+stored records the resolver reads whether or not the extension is running today,
+and dropping it would take a real source off the list on every page load that
+beat discovery to it.
+
+**Known, accepted divergence**: two chat calls (`enable_route` an incapable
+route, then `set_source_policy` ranking it first) leave the pill naming a source
+`canServe` refuses to offer, so no choice is marked current. The row is honest in
+both directions — the resolver really would consult that source and it really
+cannot serve the type — and picking any offered source fixes it. Compensating
+further here would mean re-implementing #1085's missing check at the display
+layer, where it cannot stop the write.
+
+## D6. Every test names a reachable state and the writer that creates it
+
+Following D4a of Wave 2a, whose fixtures described routes the capability gate
+forbids. Each test below states the state it fails on and the writer that mints
+it; the guards were then mutated one at a time and the failing test recorded, so
+none of them is aimed at a state the code cannot reach.
+
+| guard                                            | mutation                           | test that fails                                                                 |
+| ------------------------------------------------ | ---------------------------------- | ------------------------------------------------------------------------------- |
+| capability filter                                | filter removed                     | "should not offer a source whose bridge cannot serve the type"                  |
+| `null` capabilities mean unverified              | `null` treated as incapable        | "should keep offering a source whose extension has not been verified"           |
+| `promoteSource` leads with the pick              | pick ignored                       | 4 tests, incl. the end-to-end reader agreement                                  |
+| render rule (lone source)                        | offered on every row with a source | "should offer no change on a row with a single source under the default mode"   |
+| render rule (ranked, no source left)             | offered on any ranked row          | "should offer no choice on a ranked row that has no source left at all"         |
+| `current` is `rankedHead`, not `orderSources[0]` | read via `orderSources` head       | "should report no current source when the stored order ranks nothing available" |
+| the union warning                                | never shown / always shown         | the two warning tests, one each way                                             |
+| `keepAll` clears the order                       | order survives the union write     | "should offer the way back to keeping every source from a ranked row"           |

--- a/openspec/changes/add-connections-change-source/proposal.md
+++ b/openspec/changes/add-connections-change-source/proposal.md
@@ -1,0 +1,84 @@
+## Why
+
+Wave 2a made every routing row answer "where does my sleep data come from",
+including the answer nobody wants to hear: on a `union`-mode type there is no
+source of truth, so the row can only say "2 sources", and on a row whose stored
+ranking pins nothing available it can only say "nothing is being read". Both are
+true and neither is actionable — the surface reports a decision the user cannot
+reach from it. The Data Hub's priority editor can, but only for the types with
+two or more enabled BRIDGE imports, and only on a different page.
+
+## What Changes
+
+- **An inline "Change" control on the rows that have a decision to make**: two
+  or more sources, or a ranking already stored. Picking a source stores
+  `mode: "priority"` with that source at the head; "Keep every source" stores
+  `union` and clears the order.
+
+- **The mode change is stated before it happens.** Using a control whose purpose
+  is to choose a source of truth _is_ the user expressing a ranking, so recording
+  one is the honest reading of the action — but it changes how the type is READ,
+  from "keep every source's record" to "prefer this one", and a consequence that
+  can only be discovered afterwards is a defect. On an unranked row the panel
+  says, before either button is reachable, what the type does today, what picking
+  will change, and that the change is reversible from the same place. A row
+  already in `priority` is only reordering and warns about nothing.
+
+- **"Keep every source" is listed first and always**, including on a row whose
+  last remaining source would otherwise hide the control, so returning a type to
+  the default is exactly as reachable as leaving it.
+
+- **A shared definition of a type's sources.** `availableSources` and
+  `rankedHead` move into `application/connections/data-type-sources.ts`, read by
+  the Wave 2a pill and by this control, so what the row NAMES and what the
+  control OFFERS cannot drift apart.
+
+- **A capability filter on what may be offered.** Chat `enable_route` performs no
+  capability check, so an enabled import route exists for pairings the Data Hub
+  itself renders `na`. Those are not offerable as a source of truth: ranking one
+  first would name a source that can never produce a record.
+
+Deliberately NOT shipped:
+
+- **No control on a single-source row under the default mode.** There is no
+  second way to read the type, so the control could only flip the mode without
+  changing what is read — a semantic change bought for nothing.
+- **No free reordering of the fallback chain.** The control picks a head; the
+  remaining sources keep their previous relative order behind it. Ranking
+  positions 2..n is the Data Hub priority editor's job and no state needs it here.
+- **No "connect first" choices for sources the type does not have.** Offering a
+  bridge that is not yet an import route for this type is adding a route, which
+  is the Data Hub cell toggle's job and carries the capability question this
+  change explicitly does not reopen.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `spa-connections-page`: gains the source-of-truth control — which rows offer
+  it, what it may offer, what it stores, the requirement that the mode change be
+  stated before it is made, and the requirement that it be reversible. The
+  capability is introduced by `add-connections-page` (Wave 1) and extended by
+  `add-connections-data-type-rows` (Wave 2a); this delta is additive to both and
+  contradicts no requirement in either.
+
+## Impact
+
+- **Package**: `@kaiord/workout-spa-editor` (private SPA) only. No domain, port
+  or adapter-package change; no dependency added; no Dexie version bump; no new
+  table and no new write path — the control writes `DataTypeSourcePolicy`
+  through the same `persistence.dataTypeSourcePolicy.put` the chat tool uses.
+- **Shared code touched**: `data-type-routing.ts` keeps its behaviour and now
+  imports the source derivation it used to inline; `buildSourcePolicyRows` and
+  its `< 2 sources` skip are untouched. `orderSources` is reused, for composing
+  an order to STORE — never for reading a head out of one, which is the mismatch
+  Wave 2a documented.
+- **Behaviour change**: a user who uses the control changes the read semantics of
+  that one data type, deliberately and after being told. Nothing changes for a
+  user who does not.
+- **i18n**: `connections.routing.change.*` in both locales, covered by
+  `resource-parity.test.ts`.
+- **e2e**: no test id and no URL changed; new ids (`routing-change-<type>`,
+  `routing-picker-<type>`, `routing-choice-<type>-<source>`) are additive.
+- **No** changeset (the SPA is private and excluded from the changeset-bot
+  PUBLISHABLE set).

--- a/openspec/changes/add-connections-change-source/specs/spa-connections-page/spec.md
+++ b/openspec/changes/add-connections-change-source/specs/spa-connections-page/spec.md
@@ -1,0 +1,137 @@
+## ADDED Requirements
+
+### Requirement: A row offers its source of truth to be changed only where that is a choice
+
+The system SHALL offer a source-of-truth control on a data type's row when the
+type has two or more sources it can be read from, or when a ranking is already
+stored for it. It SHALL NOT offer one where the type has a single source under
+the default unranked mode, because there is no second way to read it and the
+control could only change the stored semantics without changing what is read.
+
+A ranking already stored SHALL keep the control present as sources drop away, so
+a type can always be returned to the default from the place it left it — down to
+the last source, but no further: with no source at all there is nothing to pick,
+nothing to keep, and no difference between the two modes, so the system SHALL NOT
+offer a control there whatever mode is stored.
+
+#### Scenario: A single-source type under the default mode offers no control
+
+- **GIVEN** a data type with exactly one source and no stored ranking
+- **WHEN** its row renders
+- **THEN** no source-of-truth control SHALL be offered
+
+#### Scenario: A ranked type keeps the control after losing a source
+
+- **GIVEN** a data type with a stored ranking and only one source left
+- **WHEN** its row renders
+- **THEN** the control SHALL still be offered
+
+#### Scenario: A ranked type with no source left offers no control
+
+- **GIVEN** a data type with a stored ranking and no source at all
+- **WHEN** its row renders
+- **THEN** no source-of-truth control SHALL be offered
+
+### Requirement: The change of read semantics is stated before it is made
+
+Choosing a source of truth stores a ranked mode, which changes how the type is
+READ: instead of keeping every source's record, the system consults the order and
+reads the first source with a record. That consequence SHALL be presented on the
+row, in terms of the row's own data type, before any control that would cause it
+can be operated, and opening the control SHALL store nothing.
+
+The statement SHALL describe both what the type does now and what picking would
+change, and SHALL state that the change can be undone from the same place. A
+requirement that can be satisfied while surprising the user is not satisfied.
+
+Where a ranking is already stored, picking again only changes which source leads
+and no read semantics change; the system SHALL NOT repeat the consequence
+statement there, because a warning attached to a state it does not apply to
+trains the reader to ignore it where it does.
+
+#### Scenario: An unranked row explains the consequence before it happens
+
+- **GIVEN** a data type with two or more sources and no stored ranking
+- **WHEN** its source-of-truth control is opened
+- **THEN** the row SHALL state that every source is currently kept with none ranked
+- **AND** SHALL state that picking one will make the type be read from it first
+- **AND** SHALL state that the choice can be undone from the same place
+- **AND** no policy SHALL have been stored
+
+#### Scenario: An already-ranked row is not warned about a change it cannot make
+
+- **GIVEN** a data type with a stored ranking
+- **WHEN** its source-of-truth control is opened
+- **THEN** the row SHALL state which source it is read from today
+- **AND** SHALL NOT present the consequence statement given to an unranked row
+
+### Requirement: Returning a type to keeping every source is as reachable as leaving it
+
+The system SHALL offer "keep every source" among the choices on every row that
+offers the control, and SHALL present it as a peer of the sources rather than
+behind a further step. Choosing it SHALL store the default unranked mode AND
+discard the stored order, so a ranking cannot decide the type again the moment
+the mode changes back.
+
+#### Scenario: A ranked type can be returned to the default in one action
+
+- **GIVEN** a data type with a stored ranked order
+- **WHEN** "keep every source" is chosen
+- **THEN** the unranked mode SHALL be stored
+- **AND** the stored order SHALL be emptied
+
+### Requirement: A source is offered only where it can serve the type
+
+The system SHALL offer as a source of truth only sources the type is actually
+read from, and only those able to serve it. An enabled import route whose bridge
+does not support the route, or does not announce the capability the type
+requires, SHALL NOT be offered — ranking it first would name a source that can
+never produce a record.
+
+A bridge whose capabilities are not yet known SHALL NOT be treated as unable:
+absence of an answer is not a negative answer, and a source whose extension is
+not running still owns the records the read resolver returns.
+
+#### Scenario: An incapable but enabled route is not offered
+
+- **GIVEN** an enabled import route whose bridge announces no capability for that data type
+- **WHEN** the row's choices are derived
+- **THEN** that source SHALL NOT be among them
+
+#### Scenario: An unverified bridge stays offerable
+
+- **GIVEN** an enabled import route whose bridge has announced no capabilities yet
+- **WHEN** the row's choices are derived
+- **THEN** that source SHALL still be among them
+
+### Requirement: What is stored is what the reader resolves
+
+The stored order SHALL begin with the source that was picked and SHALL retain
+every other source the row can be read from, in their previous relative order, so
+they remain ranked fallbacks rather than being dropped from a type they can still
+serve. The source named by the row after the write SHALL be the source that was
+picked.
+
+A ranked order that resolves to no source SHALL NOT be stored. The control SHALL
+achieve this by construction — it composes the order from the sources it offered,
+and is not offered where there is none — rather than by rejecting a request it
+cannot produce.
+
+#### Scenario: The picked source leads and the others follow
+
+- **GIVEN** a data type read from several sources
+- **WHEN** one of them is picked as the source of truth
+- **THEN** the stored order SHALL begin with it
+- **AND** SHALL still contain every other source the type is read from
+
+#### Scenario: A previous ranking survives beneath a new pick
+
+- **GIVEN** a data type with a stored ranked order
+- **WHEN** a different source is picked
+- **THEN** the previously ranked sources SHALL keep their relative order behind it
+
+#### Scenario: The row names the source that was picked
+
+- **GIVEN** a source picked as the source of truth
+- **WHEN** the row's origin is derived from what was stored
+- **THEN** it SHALL name that source

--- a/openspec/changes/add-connections-change-source/tasks.md
+++ b/openspec/changes/add-connections-change-source/tasks.md
@@ -1,0 +1,83 @@
+## 1. One definition of a type's sources
+
+- [x] 1.1 `application/connections/data-type-sources.ts`: move
+      `availableSources`, `rankedHead`, `toIntegrationId` and `MANUAL_SOURCE_ID`
+      out of `data-type-routing.ts`, which now imports them. The pill and the
+      control must range over the same set or the row can name a source the
+      control cannot offer. See design.md D3.
+- [x] 1.2 Keep `rankedHead`'s contract explicit in its own comment: the first
+      SAVED entry still available, never `orderSources(...)[0]`, which appends
+      sources the resolver never reaches.
+- [x] 1.3 Leave `buildSourcePolicyRows` and its `< 2 sources` skip untouched.
+
+## 2. What the control may offer and what it stores
+
+- [x] 2.1 `application/connections/source-of-truth-options.ts`:
+      `buildSourceOfTruthOptions` → `{ mode, choices, current }`, with `current`
+      derived by `rankedHead` so the marked choice is the one
+      `resolveEffectiveSource` consults. See design.md D3.
+- [x] 2.2 `canServe`: filter candidates by `bridgeSupportsRoute` AND the
+      announced wire token. Chat `enable_route` has no capability check
+      (issue #1085), so an enabled route exists for pairings the Data Hub
+      renders `na`. See design.md D5.
+- [x] 2.3 Treat `null` capabilities as unverified, not incapable — an enabled
+      route whose extension is not running still owns records the resolver
+      reads. See design.md D5.
+- [x] 2.4 `canChooseSource`: two or more sources, or one under a stored ranking.
+      The `priority` half exists for reversibility, not symmetry — a `>= 2` rule
+      alone strands a ranked type whose second source is switched off. A ranked
+      row with NO source left is excluded: both modes read nothing there and the
+      panel could only describe a ranking problem the row does not have. See
+      design.md D2.
+- [x] 2.5 `promoteSource`: reuse `orderSources` to COMPOSE the stored order
+      (`[picked, ...the rest]`), never to read a head out of one. After the write
+      every source really is in the order. See design.md D3.
+- [x] 2.6 Add NO runtime guard against an empty stored order: `picked` is always
+      one of `choices` and the control is absent where there is nothing to pick,
+      so the state has no construction site. A guard against an unreachable state
+      is the same defect as a test aimed at one. See design.md D4.
+
+## 3. Write path
+
+- [x] 3.1 `hooks/connections/use-source-of-truth-editor.ts`: `pick` and
+      `keepAll` through `persistence.dataTypeSourcePolicy.put` — the same port
+      the chat tool writes. No new write path, no new table.
+- [x] 3.2 `keepAll` clears `sourceOrder`, as `useSourcePolicyEditor` already
+      does, so a stale ranking cannot decide the type again.
+- [x] 3.3 `use-data-type-routing.ts` returns the per-type options, reading
+      capabilities inside the memo keyed on the connection rows (the
+      `useConnectionSources` shape), so nothing re-reads discovery on every render.
+
+## 4. UI
+
+- [x] 4.1 `RoutingSourcePicker`: a disclosure that stores nothing on open; the
+      consequence sits above the buttons that would cause it.
+- [x] 4.2 `RoutingSourceChoices`: "Keep every source" first and always, peers
+      with the sources, `aria-pressed` on the current one.
+- [x] 4.3 `routing-change-copy.ts` `pickerIntro`: three intros — unranked (state + consequence + reversal), ranked (what it reads today, no warning),
+      ranked-to-nothing (nothing is being read, pick one). See design.md D1a.
+- [x] 4.4 Thread `profileId` and the options map through
+      `DataTypeRoutingSection` → `Group` → `Row`; render the control only when
+      `canChooseSource`.
+- [x] 4.5 Theme tokens only (`border-edge`, `border-edge-soft`,
+      `bg-surface-page`, `text-ink-*`, `text-accent`) — `check-theme-dialect`
+      rejects a bare `border` with no colour token.
+
+## 5. Copy
+
+- [x] 5.1 `connections.routing.change.*` in `en` and `es`, both in one commit
+      (`resource-parity.test.ts`).
+- [x] 5.2 The unranked intro names the row's own data type, states today's
+      behaviour AND the new one, and states the reversal. See design.md D1.
+
+## 6. Verification
+
+- [x] 6.1 Each test states the reachable state it fails on and the writer that
+      creates it: the Data Hub cell toggle, its priority editor, chat
+      `set_source_policy`, chat `enable_route`, or this control.
+- [x] 6.2 Mutate each guard in turn and record the failing test — proof the tests
+      are not vacuous. Table in design.md D6.
+- [x] 6.3 `pnpm -r build`
+- [x] 6.4 SPA `pnpm test` and `pnpm lint` (`tsc -b --noEmit`)
+- [x] 6.5 `pnpm test:scripts`, root `pnpm lint`, `pnpm lint:specs`
+- [x] 6.6 `npx playwright test --list`

--- a/packages/workout-spa-editor/src/application/connections/data-type-routing.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-routing.ts
@@ -16,12 +16,16 @@ import type { ManagedDataType } from "@kaiord/core";
 import { MANAGED_DATA_REGISTRY, managedDataTypes } from "@kaiord/core";
 
 import type { DataFlowsByType } from "../../components/organisms/ProfileManager/components/useDataFlows";
-import { integrationIdForBridge } from "../../integrations/integration-registry";
-import { MANUAL_ENTRY_TYPES } from "../../integrations/manual-entry-types";
 import type { DataTypeSourcePolicy } from "../../types/data-type-source-policy";
 import { DEFAULT_DATA_TYPE_SOURCE_MODE } from "../../types/data-type-source-policy";
+import {
+  availableSources,
+  MANUAL_SOURCE_ID,
+  rankedHead,
+  toIntegrationId,
+} from "./data-type-sources";
 
-export const MANUAL_SOURCE_ID = "manual";
+export { MANUAL_SOURCE_ID };
 
 export type RoutingOrigin =
   | { readonly kind: "none" }
@@ -46,27 +50,6 @@ export type DataTypeRoutingRow = {
       be created. */
   readonly exportable: boolean;
 };
-
-const toIntegrationId = (sourceId: string): string =>
-  sourceId === MANUAL_SOURCE_ID
-    ? MANUAL_SOURCE_ID
-    : (integrationIdForBridge(sourceId) ?? sourceId);
-
-const enabledSources = (
-  rows: readonly { bridgeId: string; enabled: boolean }[]
-): string[] => [
-  ...new Set(rows.filter((row) => row.enabled).map((row) => row.bridgeId)),
-];
-
-/**
- * The saved order's first entry that is still an available source — exactly
- * what `resolveEffectiveSource` consults, so the pill cannot name a source the
- * resolver would not read from.
- */
-const rankedHead = (
-  sources: readonly string[],
-  saved: readonly string[]
-): string | undefined => saved.find((sourceId) => sources.includes(sourceId));
 
 /**
  * The mode is consulted for ONE source too, not just for several. A ranked
@@ -101,25 +84,20 @@ export const buildDataTypeRoutingRows = (
   policies: readonly DataTypeSourcePolicy[]
 ): DataTypeRoutingRow[] => {
   const byType = new Map(policies.map((policy) => [policy.dataType, policy]));
-  return managedDataTypes.map((dataType) => {
-    const flows = byDataType.get(dataType);
-    const sources = enabledSources(flows?.import ?? []);
-    // Appended last so a saved priority order (which the Data Hub editor only
-    // ever fills with bridges) keeps deciding the head.
-    //
-    // ⚠ ASYMMETRY: this gate is MANUAL_ENTRY_TYPES, while
-    // `resolveEffectiveSource` exempts "manual" from its enabled filter
-    // UNCONDITIONALLY. Giving a type a manual entry path without adding it here
-    // makes the pill and the resolver disagree silently. Widening this to every
-    // type is not the fix — it would claim a source for types with no way to
-    // enter one (`planned-session` has no manual authoring path at all).
-    if (MANUAL_ENTRY_TYPES.has(dataType)) sources.push(MANUAL_SOURCE_ID);
-    return {
-      dataType,
-      origin: originOf(sources, byType.get(dataType)),
-      sentTo: enabledSources(flows?.export ?? []).map(toIntegrationId),
-      exportable:
-        MANAGED_DATA_REGISTRY[dataType].capabilities.export !== undefined,
-    };
-  });
+  return managedDataTypes.map((dataType) => ({
+    dataType,
+    origin: originOf(
+      availableSources(byDataType, dataType),
+      byType.get(dataType)
+    ),
+    sentTo: [
+      ...new Set(
+        (byDataType.get(dataType)?.export ?? [])
+          .filter((route) => route.enabled)
+          .map((route) => toIntegrationId(route.bridgeId))
+      ),
+    ],
+    exportable:
+      MANAGED_DATA_REGISTRY[dataType].capabilities.export !== undefined,
+  }));
 };

--- a/packages/workout-spa-editor/src/application/connections/data-type-sources.ts
+++ b/packages/workout-spa-editor/src/application/connections/data-type-sources.ts
@@ -1,0 +1,58 @@
+/**
+ * The sources a managed data type actually has, expressed in the STORAGE KEYS
+ * `resolveEffectiveSource` filters by: enabled import routes, plus `manual`
+ * where a real manual-entry path exists.
+ *
+ * ONE definition, deliberately. The routing rows read a head out of this set
+ * and the "Change" control writes an order over it; two copies would let the
+ * pill name a source the control cannot offer, or the control rank a source
+ * the resolver never reaches.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { DataFlowsByType } from "../../components/organisms/ProfileManager/components/useDataFlows";
+import { integrationIdForBridge } from "../../integrations/integration-registry";
+import { MANUAL_ENTRY_TYPES } from "../../integrations/manual-entry-types";
+
+export const MANUAL_SOURCE_ID = "manual";
+
+export const toIntegrationId = (sourceId: string): string =>
+  sourceId === MANUAL_SOURCE_ID
+    ? MANUAL_SOURCE_ID
+    : (integrationIdForBridge(sourceId) ?? sourceId);
+
+export const availableSources = (
+  byDataType: DataFlowsByType,
+  dataType: ManagedDataType
+): string[] => {
+  const enabled = (byDataType.get(dataType)?.import ?? []).filter(
+    (route) => route.enabled
+  );
+  const sources = [...new Set(enabled.map((route) => route.bridgeId))];
+  // Appended last so a saved priority order (which the Data Hub editor only
+  // ever fills with bridges) keeps deciding the head.
+  //
+  // ⚠ ASYMMETRY: this gate is MANUAL_ENTRY_TYPES, while
+  // `resolveEffectiveSource` exempts "manual" from its enabled filter
+  // UNCONDITIONALLY. Giving a type a manual entry path without adding it here
+  // makes this set and the resolver disagree silently. Widening it to every
+  // type is not the fix — it would claim a source for types with no way to
+  // enter one (`planned-session` has no manual authoring path at all).
+  if (MANUAL_ENTRY_TYPES.has(dataType)) sources.push(MANUAL_SOURCE_ID);
+  return sources;
+};
+
+/**
+ * The saved order's first entry that is still an available source — exactly
+ * what `resolveEffectiveSource` consults, so no surface can name a source the
+ * resolver would not read from.
+ *
+ * Deliberately NOT `orderSources`: that APPENDS available-but-unranked sources,
+ * so its head can be a source the resolver never reaches. It is the right
+ * helper for COMPOSING an order to store (afterwards every source really is in
+ * the order) and the wrong one for reading a head out of one.
+ */
+export const rankedHead = (
+  sources: readonly string[],
+  saved: readonly string[]
+): string | undefined => saved.find((sourceId) => sources.includes(sourceId));

--- a/packages/workout-spa-editor/src/application/connections/source-of-truth-options.test.ts
+++ b/packages/workout-spa-editor/src/application/connections/source-of-truth-options.test.ts
@@ -1,0 +1,297 @@
+import type { ManagedDataType } from "@kaiord/core";
+import { describe, expect, it } from "vitest";
+
+import type { DataFlowsByType } from "../../components/organisms/ProfileManager/components/useDataFlows";
+import type { DataTypeSourcePolicy } from "../../types/data-type-source-policy";
+import type { IntegrationPolicy } from "../../types/integration-policy";
+import { buildDataTypeRoutingRows } from "./data-type-routing";
+import { availableSources } from "./data-type-sources";
+import {
+  buildSourceOfTruthOptions,
+  canChooseSource,
+  promoteSource,
+  type SourceCapabilitySignals,
+} from "./source-of-truth-options";
+
+const route = (bridgeId: string, enabled = true): IntegrationPolicy =>
+  ({ bridgeId, enabled }) as IntegrationPolicy;
+
+const flows = (
+  entries: Partial<Record<ManagedDataType, { import?: IntegrationPolicy[] }>>
+): DataFlowsByType =>
+  new Map(
+    Object.entries(entries).map(([dataType, value]) => [
+      dataType as ManagedDataType,
+      { import: value?.import ?? [], export: [] },
+    ])
+  );
+
+const priority = (
+  dataType: ManagedDataType,
+  sourceOrder: string[]
+): DataTypeSourcePolicy =>
+  ({ dataType, mode: "priority", sourceOrder }) as DataTypeSourcePolicy;
+
+/** Every bridge announces everything, and nothing narrows a shared token —
+    the neutral baseline against which a capability refusal is visible. */
+const PERMISSIVE: SourceCapabilitySignals = {
+  capabilitiesFor: () => null,
+  supportsRoute: () => true,
+};
+
+const signals = (
+  announced: Record<string, readonly string[]>
+): SourceCapabilitySignals => ({
+  capabilitiesFor: (bridgeId) => announced[bridgeId] ?? null,
+  supportsRoute: () => true,
+});
+
+const optionsFor = (
+  dataType: ManagedDataType,
+  byDataType: DataFlowsByType,
+  policy?: DataTypeSourcePolicy,
+  caps: SourceCapabilitySignals = PERMISSIVE
+) =>
+  buildSourceOfTruthOptions(
+    dataType,
+    availableSources(byDataType, dataType),
+    policy,
+    caps
+  );
+
+describe("buildSourceOfTruthOptions", () => {
+  it("should offer every source the row already reads from, manual included", () => {
+    // Arrange
+    // WHOOP is the only bridge announcing `read:sleep`; the Data Hub
+    // sleep/WHOOP import cell is the writer that enables it. Manual entry is a
+    // source for sleep by product decision, and the resolver exempts it from
+    // the enabled filter, so it must be pickable too.
+    const byDataType = flows({ sleep: { import: [route("whoop-bridge")] } });
+
+    // Act
+    const options = optionsFor("sleep", byDataType);
+
+    // Assert
+    expect(options.choices).toEqual(["whoop-bridge", "manual"]);
+    expect(options.mode).toBe("union");
+    expect(options.current).toBeUndefined();
+  });
+
+  it("should not offer a source whose bridge cannot serve the type", () => {
+    // Arrange
+    // Writer: chat `enable_route stress garmin import`, the one writer with NO
+    // capability check (issue #1085). It mints an enabled import policy the
+    // Data Hub itself renders `na`, because Garmin announces write:workouts,
+    // read:activities and write:body — never `read:body` for stress.
+    const byDataType = flows({ stress: { import: [route("garmin-bridge")] } });
+    const garmin = signals({
+      "garmin-bridge": ["write:workouts", "read:activities", "write:body"],
+    });
+
+    // Act
+    const options = optionsFor("stress", byDataType, undefined, garmin);
+
+    // Assert
+    expect(options.choices).toEqual(["manual"]);
+  });
+
+  it("should keep offering a source whose extension has not been verified", () => {
+    // Arrange
+    // Writer: the Data Hub sleep/WHOOP cell toggle, run while the extension
+    // was present. On a later load — extension uninstalled, or discovery not
+    // finished — `getCapabilities` is null. WHOOP's stored sleep records are
+    // still what the resolver reads, so dropping it would take a real source
+    // off the list for a reason that is only "we have not asked yet".
+    const byDataType = flows({ sleep: { import: [route("whoop-bridge")] } });
+    const unverified = signals({});
+
+    // Act
+    const options = optionsFor("sleep", byDataType, undefined, unverified);
+
+    // Assert
+    expect(options.choices).toContain("whoop-bridge");
+  });
+
+  it("should not offer an import route the user switched off", () => {
+    // Arrange
+    // Toggling the Data Hub's weight/WHOOP cell off writes enabled:false
+    // rather than deleting the row, so a disabled route stays visible to this
+    // derivation and must be filtered rather than offered.
+    const byDataType = flows({
+      weight: { import: [route("whoop-bridge", false)] },
+    });
+
+    // Act
+    const options = optionsFor("weight", byDataType);
+
+    // Assert
+    expect(options.choices).toEqual(["manual"]);
+  });
+
+  it("should name the ranked head as current, never an appended source", () => {
+    // Arrange
+    // Writer: the Data Hub priority editor storing ["tanita-bridge"] for
+    // weight, after which the WHOOP weight import is switched on and never
+    // ranked. `orderSources` would append WHOOP; only Tanita is ranked, and
+    // only Tanita is what `resolveEffectiveSource` consults first.
+    const byDataType = flows({
+      weight: { import: [route("whoop-bridge"), route("tanita-bridge")] },
+    });
+
+    // Act
+    const options = optionsFor(
+      "weight",
+      byDataType,
+      priority("weight", ["tanita-bridge"])
+    );
+
+    // Assert
+    expect(options.current).toBe("tanita-bridge");
+    expect(options.choices).toEqual([
+      "tanita-bridge",
+      "whoop-bridge",
+      "manual",
+    ]);
+  });
+
+  it("should report no current source when the stored order ranks nothing available", () => {
+    // Arrange
+    // Writer: chat `set_source_policy stress priority ["garmin"]` — it
+    // resolves, so no writer guard stops it — while a Garmin stress import can
+    // never be enabled. The panel must not mark any choice as the one in use.
+    // Act
+    const options = optionsFor(
+      "stress",
+      flows({}),
+      priority("stress", ["garmin-bridge"])
+    );
+
+    // Assert
+    expect(options.mode).toBe("priority");
+    expect(options.current).toBeUndefined();
+    expect(options.choices).toEqual(["manual"]);
+  });
+});
+
+describe("canChooseSource", () => {
+  it("should offer no choice on a lone source under the default mode", () => {
+    // Arrange
+    // The state of a profile that has linked nothing: stress has manual entry
+    // and nothing else. There is no second way to read it, so a control that
+    // only ever flipped the mode would be a semantic change with no benefit.
+    // Act
+    const options = optionsFor("stress", flows({}));
+
+    // Assert
+    expect(options.choices).toEqual(["manual"]);
+    expect(canChooseSource(options)).toBe(false);
+  });
+
+  it("should keep the way back reachable once a ranking is stored", () => {
+    // Arrange
+    // Writer: this control, or the Data Hub priority editor, ranking weight
+    // while two sources existed; the user then switched the WHOOP weight
+    // import off. Reversibility must not depend on the second source still
+    // being there.
+    const byDataType = flows({ weight: { import: [route("tanita-bridge")] } });
+
+    // Act
+    const options = optionsFor(
+      "weight",
+      byDataType,
+      priority("weight", ["tanita-bridge"])
+    );
+
+    // Assert
+    expect(canChooseSource(options)).toBe(true);
+  });
+
+  it("should offer no choice on a ranked row that has no source left at all", () => {
+    // Arrange
+    // Writers, in order: chat `set_source_policy planned-session priority
+    // ["train2go"]`, then Disconnect on the Train2Go card, which switches off
+    // every policy on the bridge. `planned-session` has no manual path, so
+    // nothing remains. Both modes read nothing here, and the row already says
+    // "No source" — a panel could only describe a ranking problem it does not
+    // have.
+    // Act
+    const options = optionsFor(
+      "planned-session",
+      flows({
+        "planned-session": { import: [route("train2go-bridge", false)] },
+      }),
+      priority("planned-session", ["train2go-bridge"])
+    );
+
+    // Assert
+    expect(options.choices).toEqual([]);
+    expect(canChooseSource(options)).toBe(false);
+  });
+});
+
+describe("promoteSource", () => {
+  it("should put the picked source first and keep the others behind it", () => {
+    // Arrange
+    // Writer: two Data Hub weight import cells (WHOOP and Tanita both announce
+    // read:body and both serve weight). Nothing is ranked yet, so this is the
+    // very first ranking the control writes.
+    const byDataType = flows({
+      weight: { import: [route("whoop-bridge"), route("tanita-bridge")] },
+    });
+    const options = optionsFor("weight", byDataType);
+
+    // Act
+    const order = promoteSource(options, "tanita-bridge");
+
+    // Assert
+    expect(order).toEqual(["tanita-bridge", "whoop-bridge", "manual"]);
+  });
+
+  it("should keep the previous ranking behind a newly picked source", () => {
+    // Arrange
+    // Writer: this control, having already ranked Tanita first. Re-picking
+    // must reorder rather than discard what was there, so the fallbacks the
+    // user chose survive.
+    const byDataType = flows({
+      weight: { import: [route("whoop-bridge"), route("tanita-bridge")] },
+    });
+    const options = optionsFor(
+      "weight",
+      byDataType,
+      priority("weight", ["tanita-bridge", "whoop-bridge"])
+    );
+
+    // Act
+    const order = promoteSource(options, "manual");
+
+    // Assert
+    expect(order).toEqual(["manual", "tanita-bridge", "whoop-bridge"]);
+  });
+
+  it("should write an order the row's own reader resolves to the picked source", () => {
+    // Arrange
+    // The writer/reader agreement, end to end: what this control stores is fed
+    // straight back into the Wave 2a derivation that draws the pill. A head
+    // the reader would skip — the shipped bug `orderSources` reintroduces —
+    // shows up here as `rankedUnavailable` or as the wrong name.
+    const byDataType = flows({
+      weight: { import: [route("whoop-bridge"), route("tanita-bridge")] },
+    });
+    const options = optionsFor("weight", byDataType);
+
+    // Act
+    // Tanita is deliberately NOT the first candidate: a writer that stored the
+    // candidate order untouched would still look right if the pick led it.
+    const stored = priority("weight", promoteSource(options, "tanita-bridge"));
+    const row = buildDataTypeRoutingRows(byDataType, [stored]).find(
+      (candidate) => candidate.dataType === "weight"
+    );
+
+    // Assert
+    expect(row?.origin).toEqual({
+      kind: "primary",
+      sourceId: "tanita",
+      count: 3,
+    });
+  });
+});

--- a/packages/workout-spa-editor/src/application/connections/source-of-truth-options.ts
+++ b/packages/workout-spa-editor/src/application/connections/source-of-truth-options.ts
@@ -1,0 +1,113 @@
+/**
+ * What the row's "Change" control may offer, and what it stores when a source
+ * is picked.
+ *
+ * Two rules keep this honest:
+ *
+ * 1. Every offered source is one `resolveEffectiveSource` would consult — the
+ *    candidates come from `availableSources`, the same set the row's pill
+ *    counts, so the writer and the reader cannot disagree about "first".
+ * 2. A source that CANNOT serve the type is not offered. Chat `enable_route`
+ *    performs no capability check (issue #1085), so an enabled import route
+ *    exists for pairings the Data Hub itself renders `na` — ranking one of
+ *    those first would name a source that can never produce a record.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+import { MANAGED_DATA_REGISTRY } from "@kaiord/core";
+
+import type {
+  DataTypeSourceMode,
+  DataTypeSourcePolicy,
+} from "../../types/data-type-source-policy";
+import { DEFAULT_DATA_TYPE_SOURCE_MODE } from "../../types/data-type-source-policy";
+import type { IntegrationPolicyDirection } from "../../types/integration-policy";
+import { orderSources } from "../data-hub/source-policy-rows";
+import { MANUAL_SOURCE_ID, rankedHead } from "./data-type-sources";
+
+export type SourceCapabilitySignals = {
+  /** Announced wire tokens, or `null` while the bridge is unverified. */
+  capabilitiesFor: (bridgeId: string) => readonly string[] | null;
+  supportsRoute: (
+    bridgeId: string,
+    dataType: ManagedDataType,
+    direction: IntegrationPolicyDirection
+  ) => boolean;
+};
+
+export type SourceOfTruthOptions = {
+  readonly mode: DataTypeSourceMode;
+  /** Storage keys, in the order the type is read today. */
+  readonly choices: readonly string[];
+  /** The choice ranked first, when the stored order ranks one of them. */
+  readonly current: string | undefined;
+};
+
+/**
+ * `null` capabilities mean "not verified yet", NOT "cannot": an enabled route
+ * whose extension is not running in this browser still owns records the
+ * resolver reads, and dropping it would take a real source off the list every
+ * time the page loads before discovery answers.
+ */
+const canServe = (
+  sourceId: string,
+  dataType: ManagedDataType,
+  signals: SourceCapabilitySignals
+): boolean => {
+  if (sourceId === MANUAL_SOURCE_ID) return true;
+  if (!signals.supportsRoute(sourceId, dataType, "import")) return false;
+  const announced = signals.capabilitiesFor(sourceId);
+  if (announced === null) return true;
+  const token = MANAGED_DATA_REGISTRY[dataType].capabilities.import;
+  return token !== undefined && announced.includes(token);
+};
+
+export const buildSourceOfTruthOptions = (
+  dataType: ManagedDataType,
+  sources: readonly string[],
+  policy: DataTypeSourcePolicy | undefined,
+  signals: SourceCapabilitySignals
+): SourceOfTruthOptions => {
+  const saved = policy?.sourceOrder ?? [];
+  const capable = sources.filter((id) => canServe(id, dataType, signals));
+  const mode = policy?.mode ?? DEFAULT_DATA_TYPE_SOURCE_MODE;
+  return {
+    mode,
+    choices: orderSources(capable, saved),
+    current: mode === "priority" ? rankedHead(capable, saved) : undefined,
+  };
+};
+
+/**
+ * Offered only where the row has a decision to make: two or more sources, or
+ * one source under a ranking already stored — which must stay reversible
+ * however few sources are left. A lone source under the DEFAULT mode has
+ * nothing to choose between, so a control there could only change the stored
+ * semantics without changing what is read.
+ *
+ * A row with no source at all is excluded even under a stored ranking. There is
+ * nothing to pick and nothing to keep, the two modes read identically (both
+ * return nothing), and a panel would have to describe a ranking problem the row
+ * does not have — its trouble is that the type has no source, which it already
+ * says. Reachable: rank `planned-session` through chat, then Disconnect
+ * Train2Go, which switches off every policy on the bridge.
+ *
+ * It is also why this control can never store an order that resolves to
+ * nothing: `picked` is always one of `choices`, and where `choices` is empty
+ * there is no control to pick from.
+ */
+export const canChooseSource = (options: SourceOfTruthOptions): boolean =>
+  options.choices.length >= (options.mode === "priority" ? 1 : 2);
+
+/**
+ * The order to store when `picked` becomes the source of truth: it leads, and
+ * every other choice stays behind it as a ranked fallback rather than being
+ * dropped. `choices` is already `orderSources`-merged, so a previous ranking
+ * survives underneath the new head.
+ */
+export const promoteSource = (
+  options: SourceOfTruthOptions,
+  picked: string
+): string[] => [
+  picked,
+  ...options.choices.filter((sourceId) => sourceId !== picked),
+];

--- a/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingGroup.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingGroup.tsx
@@ -2,16 +2,25 @@ import type { ManagedDataType } from "@kaiord/core";
 
 import type { DataTypeGroup } from "../../../application/connections/data-type-groups";
 import type { DataTypeRoutingRow as RoutingRow } from "../../../application/connections/data-type-routing";
+import type { SourceOfTruthOptions } from "../../../application/connections/source-of-truth-options";
 import { useTranslate } from "../../../i18n/use-translate";
 import { DataTypeRoutingRow } from "./DataTypeRoutingRow";
 
 type Props = {
   group: DataTypeGroup;
+  profileId: string;
   byType: ReadonlyMap<ManagedDataType, RoutingRow>;
   lastSyncedAt: ReadonlyMap<string, string | undefined>;
+  options: ReadonlyMap<ManagedDataType, SourceOfTruthOptions>;
 };
 
-export function DataTypeRoutingGroup({ group, byType, lastSyncedAt }: Props) {
+export function DataTypeRoutingGroup({
+  group,
+  profileId,
+  byType,
+  lastSyncedAt,
+  options,
+}: Props) {
   const t = useTranslate("connections");
   const rows = group.types.flatMap((dataType) => byType.get(dataType) ?? []);
 
@@ -25,7 +34,9 @@ export function DataTypeRoutingGroup({ group, byType, lastSyncedAt }: Props) {
           <DataTypeRoutingRow
             key={row.dataType}
             row={row}
+            profileId={profileId}
             lastSyncedAt={lastSyncedAt}
+            options={options.get(row.dataType)}
           />
         ))}
       </div>

--- a/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingRow.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingRow.tsx
@@ -1,13 +1,18 @@
 import type { DataTypeRoutingRow as RoutingRow } from "../../../application/connections/data-type-routing";
+import type { SourceOfTruthOptions } from "../../../application/connections/source-of-truth-options";
+import { canChooseSource } from "../../../application/connections/source-of-truth-options";
 import { useTranslate } from "../../../i18n/use-translate";
 import { Pill } from "../../atoms/Pill";
 import { originLabel, originNote, originSourceId } from "./routing-copy";
 import { RoutingExportTargets } from "./RoutingExportTargets";
 import { RoutingFreshness } from "./RoutingFreshness";
+import { RoutingSourcePicker } from "./RoutingSourcePicker";
 
 type Props = {
   row: RoutingRow;
+  profileId: string;
   lastSyncedAt: ReadonlyMap<string, string | undefined>;
+  options: SourceOfTruthOptions | undefined;
 };
 
 const CAPTION =
@@ -24,7 +29,12 @@ const STALLED_RING = "ring-1 ring-amber-500/40";
  * design's "Nowhere" would there be describing an absence of something that
  * was never possible rather than a route the user has not switched on.
  */
-export function DataTypeRoutingRow({ row, lastSyncedAt }: Props) {
+export function DataTypeRoutingRow({
+  row,
+  profileId,
+  lastSyncedAt,
+  options,
+}: Props) {
   const t = useTranslate("connections");
   const sourceId = originSourceId(row.origin);
   const note = originNote(row.origin, t);
@@ -71,6 +81,14 @@ export function DataTypeRoutingRow({ row, lastSyncedAt }: Props) {
 
       {row.exportable && (
         <RoutingExportTargets dataType={row.dataType} sentTo={row.sentTo} />
+      )}
+
+      {options !== undefined && canChooseSource(options) && (
+        <RoutingSourcePicker
+          dataType={row.dataType}
+          profileId={profileId}
+          options={options}
+        />
       )}
     </div>
   );

--- a/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingSection.test.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingSection.test.tsx
@@ -1,6 +1,6 @@
 import type { ManagedDataType } from "@kaiord/core";
 import { managedDataTypes } from "@kaiord/core";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { DataTypeSourcePolicy } from "../../../types/data-type-source-policy";
@@ -11,16 +11,24 @@ import { DataTypeRoutingSection } from "./DataTypeRoutingSection";
 const state = vi.hoisted(() => ({
   policies: [] as DataTypeSourcePolicy[],
   syncedAt: new Map<string, string | undefined>(),
+  put: vi.fn(),
 }));
 
 vi.mock("../../../contexts/persistence-context", () => ({
-  usePersistence: () => ({}),
+  usePersistence: () => ({ dataTypeSourcePolicy: { put: state.put } }),
 }));
 vi.mock("../../../hooks/data-hub/use-bridge-sync-states", () => ({
   useBridgeSyncStates: () => state.syncedAt,
 }));
 vi.mock("../../../hooks/data-hub/use-data-type-source-policies", () => ({
   useDataTypeSourcePolicies: () => state.policies,
+}));
+// Discovery is not running in jsdom, so `getCapabilities` answers null for
+// every bridge — the "not verified yet" branch, which offers every enabled
+// route. The capability REFUSAL is covered where the signals can be injected,
+// in source-of-truth-options.test.ts.
+vi.mock("../../../hooks/use-bridge-connections", () => ({
+  useBridgeConnections: () => [],
 }));
 
 const route = (bridgeId: string, enabled = true): IntegrationPolicy =>
@@ -48,6 +56,7 @@ describe("DataTypeRoutingSection", () => {
   beforeEach(() => {
     state.policies = [];
     state.syncedAt = new Map();
+    state.put = vi.fn();
   });
 
   it("should render every managed data type inside one of the three groups", () => {
@@ -217,5 +226,160 @@ describe("DataTypeRoutingSection", () => {
     expect(
       screen.queryByTestId("routing-synced-manual")
     ).not.toBeInTheDocument();
+  });
+
+  it("should offer no change on a row with a single source under the default mode", () => {
+    // Arrange
+    // The profile that has linked nothing: `stress` has manual entry and no
+    // enabled import route, so there is no second way to read it. A control
+    // here could only flip the mode without changing what is read.
+    renderSection();
+
+    // Act
+    const row = screen.getByTestId("routing-row-stress");
+
+    // Assert
+    expect(row).toHaveAttribute("data-origin", "only");
+    expect(
+      screen.queryByTestId("routing-change-stress")
+    ).not.toBeInTheDocument();
+  });
+
+  it("should say that picking a source changes how the type is read, before anything is stored", () => {
+    // Arrange
+    // Writer: the Data Hub sleep/WHOOP import cell. Two sources under the
+    // DEFAULT union mode, so picking one really does change the read
+    // semantics — the row must say so while nothing has been written yet.
+    renderSection(flows({ sleep: { import: [route("whoop-bridge")] } }));
+
+    // Act
+    fireEvent.click(screen.getByTestId("routing-change-sleep"));
+    const panel = screen.getByTestId("routing-picker-sleep");
+
+    // Assert
+    expect(panel).toHaveTextContent(
+      "keeps every source's Sleep and ranks none"
+    );
+    expect(panel).toHaveTextContent(
+      "use the others only on days it has nothing"
+    );
+    expect(panel).toHaveTextContent("go back to keeping every source");
+    expect(state.put).not.toHaveBeenCalled();
+  });
+
+  it("should store a ranked order led by the picked source", () => {
+    // Arrange
+    // Writer: two Data Hub weight import cells (WHOOP and Tanita both announce
+    // read:body and both serve weight), union by default. Tanita is picked
+    // second on purpose: an order stored in candidate sequence would still
+    // look correct if the pick already happened to lead it.
+    renderSection(
+      flows({
+        weight: { import: [route("whoop-bridge"), route("tanita-bridge")] },
+      })
+    );
+    fireEvent.click(screen.getByTestId("routing-change-weight"));
+
+    // Act
+    fireEvent.click(screen.getByTestId("routing-choice-weight-tanita-bridge"));
+
+    // Assert
+    // Every other source stays in the order behind it: they remain fallbacks
+    // rather than being dropped from a type they can still serve.
+    expect(state.put).toHaveBeenCalledWith({
+      profileId: "p1",
+      dataType: "weight",
+      mode: "priority",
+      sourceOrder: ["tanita-bridge", "whoop-bridge", "manual"],
+    });
+  });
+
+  it("should offer the way back to keeping every source from a ranked row", () => {
+    // Arrange
+    // Writer: this control, or the Data Hub priority editor, having ranked
+    // weight. Returning to union must clear the order too — a surviving
+    // ranking would decide the row again the moment the mode flipped back.
+    state.policies = [
+      {
+        dataType: "weight",
+        mode: "priority",
+        sourceOrder: ["tanita-bridge", "whoop-bridge"],
+      } as DataTypeSourcePolicy,
+    ];
+    renderSection(
+      flows({
+        weight: { import: [route("whoop-bridge"), route("tanita-bridge")] },
+      })
+    );
+    fireEvent.click(screen.getByTestId("routing-change-weight"));
+
+    // Act
+    fireEvent.click(screen.getByTestId("routing-choice-weight-union"));
+
+    // Assert
+    expect(state.put).toHaveBeenCalledWith({
+      profileId: "p1",
+      dataType: "weight",
+      mode: "union",
+      sourceOrder: [],
+    });
+  });
+
+  it("should not warn about a change of meaning on a row that is already ranked", () => {
+    // Arrange
+    // Same ranked weight row. Reordering a ranked type changes which source
+    // leads and nothing else, so repeating the union warning here would be
+    // describing a consequence that cannot happen.
+    state.policies = [
+      {
+        dataType: "weight",
+        mode: "priority",
+        sourceOrder: ["tanita-bridge", "whoop-bridge"],
+      } as DataTypeSourcePolicy,
+    ];
+    renderSection(
+      flows({
+        weight: { import: [route("whoop-bridge"), route("tanita-bridge")] },
+      })
+    );
+
+    // Act
+    fireEvent.click(screen.getByTestId("routing-change-weight"));
+    const panel = screen.getByTestId("routing-picker-weight");
+
+    // Assert
+    expect(panel).toHaveTextContent("reads Weight from Tanita first");
+    expect(panel).not.toHaveTextContent("ranks none of them");
+    expect(
+      screen.getByTestId("routing-choice-weight-tanita-bridge")
+    ).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("should let a row that is ranked to nothing available pick a source that works", () => {
+    // Arrange
+    // Writer: chat `set_source_policy stress priority ["garmin"]` — it
+    // resolves, so no writer guard stops it, but a Garmin stress import can
+    // never be enabled and the resolver reads nothing. This is the one row
+    // Wave 2a could only report; it must now be fixable.
+    state.policies = [
+      {
+        dataType: "stress",
+        mode: "priority",
+        sourceOrder: ["garmin-bridge"],
+      } as DataTypeSourcePolicy,
+    ];
+    renderSection();
+    fireEvent.click(screen.getByTestId("routing-change-stress"));
+
+    // Act
+    fireEvent.click(screen.getByTestId("routing-choice-stress-manual"));
+
+    // Assert
+    expect(state.put).toHaveBeenCalledWith({
+      profileId: "p1",
+      dataType: "stress",
+      mode: "priority",
+      sourceOrder: ["manual"],
+    });
   });
 });

--- a/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingSection.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/DataTypeRoutingSection.tsx
@@ -10,14 +10,18 @@ import { DataTypeRoutingGroup } from "./DataTypeRoutingGroup";
 type Props = { profileId: string; byDataType: DataFlowsByType };
 
 /**
- * Read-only. Choosing a source of truth is Wave 2b; until then the section
- * reports what the stored policies already decide and claims nothing about
- * fallbacks — `usedFallback` is priority-mode only, is per-(type, day), and
- * means "no record that day" rather than "this source broke".
+ * Rows report what the stored policies already decide, and — where the row has
+ * a decision to make — offer the source of truth to be changed. The section
+ * still claims nothing about fallbacks: `usedFallback` is priority-mode only,
+ * is per-(type, day), and means "no record that day" rather than "this source
+ * broke".
  */
 export function DataTypeRoutingSection({ profileId, byDataType }: Props) {
   const t = useTranslate("connections");
-  const { rows, lastSyncedAt } = useDataTypeRouting(profileId, byDataType);
+  const { rows, lastSyncedAt, options } = useDataTypeRouting(
+    profileId,
+    byDataType
+  );
   const byType = useMemo(
     () =>
       new Map<ManagedDataType, (typeof rows)[number]>(
@@ -41,8 +45,10 @@ export function DataTypeRoutingSection({ profileId, byDataType }: Props) {
           <DataTypeRoutingGroup
             key={group.id}
             group={group}
+            profileId={profileId}
             byType={byType}
             lastSyncedAt={lastSyncedAt}
+            options={options}
           />
         ))}
       </div>

--- a/packages/workout-spa-editor/src/components/organisms/Connections/RoutingSourceChoices.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/RoutingSourceChoices.tsx
@@ -1,0 +1,76 @@
+import type { ManagedDataType } from "@kaiord/core";
+
+import type { SourceOfTruthOptions } from "../../../application/connections/source-of-truth-options";
+import { useTranslate } from "../../../i18n/use-translate";
+import { choiceLabel } from "./routing-change-copy";
+
+type Props = {
+  dataType: ManagedDataType;
+  options: SourceOfTruthOptions;
+  onPick: (sourceId: string) => void;
+  onKeepAll: () => void;
+};
+
+const BASE =
+  "rounded-lg border px-2.5 py-1.5 text-[12.5px] font-semibold transition-colors";
+const ON = "border-transparent bg-accent/15 text-accent";
+const OFF = "border-edge bg-surface text-ink-body";
+
+type ChoiceProps = {
+  testId: string;
+  selected: boolean;
+  label: string;
+  onClick: () => void;
+};
+
+const Choice = ({ testId, selected, label, onClick }: ChoiceProps) => (
+  <button
+    type="button"
+    aria-pressed={selected}
+    data-testid={testId}
+    onClick={onClick}
+    className={`${BASE} ${selected ? ON : OFF}`}
+  >
+    {label}
+  </button>
+);
+
+/**
+ * "Keep every source" is listed first and always, so returning a type to the
+ * default is exactly as reachable as leaving it — the reversal is not buried
+ * behind the choice that caused it.
+ */
+export function RoutingSourceChoices({
+  dataType,
+  options,
+  onPick,
+  onKeepAll,
+}: Props) {
+  const t = useTranslate("connections");
+
+  return (
+    <div
+      className="flex flex-wrap gap-2"
+      role="group"
+      aria-label={t("routing.change.title", {
+        type: t(`dataTypes.${dataType}`),
+      })}
+    >
+      <Choice
+        testId={`routing-choice-${dataType}-union`}
+        selected={options.mode !== "priority"}
+        label={t("routing.change.keepAll")}
+        onClick={onKeepAll}
+      />
+      {options.choices.map((sourceId) => (
+        <Choice
+          key={sourceId}
+          testId={`routing-choice-${dataType}-${sourceId}`}
+          selected={options.current === sourceId}
+          label={choiceLabel(sourceId)}
+          onClick={() => onPick(sourceId)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/RoutingSourcePicker.tsx
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/RoutingSourcePicker.tsx
@@ -1,0 +1,65 @@
+import type { ManagedDataType } from "@kaiord/core";
+import { useState } from "react";
+
+import type { SourceOfTruthOptions } from "../../../application/connections/source-of-truth-options";
+import { useSourceOfTruthEditor } from "../../../hooks/connections/use-source-of-truth-editor";
+import { useTranslate } from "../../../i18n/use-translate";
+import { pickerIntro } from "./routing-change-copy";
+import { RoutingSourceChoices } from "./RoutingSourceChoices";
+
+type Props = {
+  dataType: ManagedDataType;
+  profileId: string;
+  options: SourceOfTruthOptions;
+};
+
+/**
+ * The panel opens before it writes: the consequence of ranking is on screen,
+ * in this row's own words, above the buttons that would cause it. Nothing is
+ * stored by opening the control.
+ */
+export function RoutingSourcePicker({ dataType, profileId, options }: Props) {
+  const t = useTranslate("connections");
+  const [open, setOpen] = useState(false);
+  const { pick, keepAll } = useSourceOfTruthEditor(profileId);
+  const type = t(`dataTypes.${dataType}`);
+
+  return (
+    <div className="flex w-full flex-col gap-2">
+      <button
+        type="button"
+        aria-expanded={open}
+        data-testid={`routing-change-${dataType}`}
+        onClick={() => setOpen((wasOpen) => !wasOpen)}
+        className="self-start rounded-lg border border-edge px-2.5 py-1 text-[12px] font-semibold text-accent"
+      >
+        {open ? t("routing.change.close") : t("routing.change.open")}
+      </button>
+      {open && (
+        <div
+          data-testid={`routing-picker-${dataType}`}
+          className="space-y-2 rounded-xl border border-edge-soft bg-surface-page p-3"
+        >
+          <p className="text-[12.5px] font-bold text-ink-strong">
+            {t("routing.change.title", { type })}
+          </p>
+          {pickerIntro(options, type, t).map((line) => (
+            <p key={line} className="text-[12px] text-ink-muted">
+              {line}
+            </p>
+          ))}
+          <RoutingSourceChoices
+            dataType={dataType}
+            options={options}
+            onPick={(sourceId) => {
+              void pick(dataType, options, sourceId);
+            }}
+            onKeepAll={() => {
+              void keepAll(dataType);
+            }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/workout-spa-editor/src/components/organisms/Connections/routing-change-copy.ts
+++ b/packages/workout-spa-editor/src/components/organisms/Connections/routing-change-copy.ts
@@ -1,0 +1,42 @@
+import { toIntegrationId } from "../../../application/connections/data-type-sources";
+import type { SourceOfTruthOptions } from "../../../application/connections/source-of-truth-options";
+import type { Translate } from "../../../i18n/use-translate";
+import { sourceName } from "./routing-copy";
+
+export const choiceLabel = (sourceId: string): string =>
+  sourceName(toIntegrationId(sourceId));
+
+/**
+ * What the panel says BEFORE either button is reachable.
+ *
+ * The unranked case gets two sentences rather than one: the first states what
+ * the type does today (every source kept, last write wins), the second states
+ * that picking below replaces that with a ranking and that the choice is
+ * reversible here. Storing a ranking changes how the type is READ, so it may
+ * not be discovered after the fact — a "Change source" button that quietly
+ * flipped the mode would be a requirement satisfied while surprising the user.
+ *
+ * An already-ranked row is only reordering: it says what it reads today and
+ * warns about nothing, because nothing about the semantics changes.
+ */
+export const pickerIntro = (
+  options: SourceOfTruthOptions,
+  type: string,
+  t: Translate
+): string[] => {
+  if (options.mode !== "priority") {
+    return [
+      t("routing.change.unranked", { type }),
+      t("routing.change.willRank", { type }),
+    ];
+  }
+  if (options.current === undefined) {
+    return [t("routing.change.stalled", { type })];
+  }
+  return [
+    t("routing.change.ranked", {
+      type,
+      name: choiceLabel(options.current),
+    }),
+  ];
+};

--- a/packages/workout-spa-editor/src/hooks/connections/use-data-type-routing.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/use-data-type-routing.ts
@@ -9,16 +9,26 @@
  * each already resolves at most one source, so the per-source read is the one
  * that fits — and nothing here is stranded when Wave 4 deletes the matrix UI.
  */
+import type { ManagedDataType } from "@kaiord/core";
+import { managedDataTypes } from "@kaiord/core";
 import { useMemo } from "react";
 
+import { bridgeDiscovery } from "../../adapters/bridge/bridge-discovery";
 import {
   buildDataTypeRoutingRows,
   type DataTypeRoutingRow,
 } from "../../application/connections/data-type-routing";
+import { availableSources } from "../../application/connections/data-type-sources";
+import {
+  buildSourceOfTruthOptions,
+  type SourceOfTruthOptions,
+} from "../../application/connections/source-of-truth-options";
 import type { DataFlowsByType } from "../../components/organisms/ProfileManager/components/useDataFlows";
 import { usePersistence } from "../../contexts/persistence-context";
+import { bridgeSupportsRoute } from "../../integrations/bridge-supported-routes";
 import { useBridgeSyncStates } from "../data-hub/use-bridge-sync-states";
 import { useDataTypeSourcePolicies } from "../data-hub/use-data-type-source-policies";
+import { useBridgeConnections } from "../use-bridge-connections";
 
 export type DataTypeRouting = {
   readonly rows: readonly DataTypeRoutingRow[];
@@ -29,6 +39,7 @@ export type DataTypeRouting = {
    * the same source shows the same instant; the copy has to say so.
    */
   readonly lastSyncedAt: ReadonlyMap<string, string | undefined>;
+  readonly options: ReadonlyMap<ManagedDataType, SourceOfTruthOptions>;
 };
 
 export const useDataTypeRouting = (
@@ -38,11 +49,40 @@ export const useDataTypeRouting = (
   const persistence = usePersistence();
   const lastSyncedAt = useBridgeSyncStates(persistence, profileId);
   const policies = useDataTypeSourcePolicies(profileId);
+  const connections = useBridgeConnections(profileId);
 
   const rows = useMemo(
     () => buildDataTypeRoutingRows(byDataType, policies),
     [byDataType, policies]
   );
 
-  return { rows, lastSyncedAt };
+  // Capabilities are read inside the memo, which re-runs whenever a connection
+  // row changes — and a row changes exactly when an extension id does, which is
+  // the only thing that changes capabilities (same shape as useConnectionSources).
+  const options = useMemo(() => {
+    const announced = new Map(
+      connections.map((row) => [
+        row.bridgeId,
+        bridgeDiscovery.getCapabilities(row.bridgeId),
+      ])
+    );
+    const signals = {
+      capabilitiesFor: (bridgeId: string) => announced.get(bridgeId) ?? null,
+      supportsRoute: bridgeSupportsRoute,
+    };
+    const byType = new Map(policies.map((policy) => [policy.dataType, policy]));
+    return new Map(
+      managedDataTypes.map((dataType) => [
+        dataType,
+        buildSourceOfTruthOptions(
+          dataType,
+          availableSources(byDataType, dataType),
+          byType.get(dataType),
+          signals
+        ),
+      ])
+    );
+  }, [byDataType, policies, connections]);
+
+  return { rows, lastSyncedAt, options };
 };

--- a/packages/workout-spa-editor/src/hooks/connections/use-source-of-truth-editor.ts
+++ b/packages/workout-spa-editor/src/hooks/connections/use-source-of-truth-editor.ts
@@ -1,0 +1,64 @@
+/**
+ * The two writes the row's "Change" control performs, through the same
+ * `dataTypeSourcePolicy` port the chat tool and the Data Hub editor use — no
+ * new write path.
+ *
+ * `pick` stores `priority`, which genuinely changes how the type is READ: the
+ * resolver stops returning every source's record and starts consulting the
+ * order. That consequence is stated in the panel before either button is
+ * reachable. `keepAll` is the way back, and clears the order the way
+ * `useSourcePolicyEditor` already does, so a stale ranking cannot resurface.
+ */
+import type { ManagedDataType } from "@kaiord/core";
+import { useCallback } from "react";
+
+import {
+  promoteSource,
+  type SourceOfTruthOptions,
+} from "../../application/connections/source-of-truth-options";
+import { usePersistence } from "../../contexts/persistence-context";
+
+export type SourceOfTruthEditor = {
+  pick: (
+    dataType: ManagedDataType,
+    options: SourceOfTruthOptions,
+    sourceId: string
+  ) => Promise<void>;
+  keepAll: (dataType: ManagedDataType) => Promise<void>;
+};
+
+export const useSourceOfTruthEditor = (
+  profileId: string
+): SourceOfTruthEditor => {
+  const persistence = usePersistence();
+
+  const pick = useCallback(
+    async (
+      dataType: ManagedDataType,
+      options: SourceOfTruthOptions,
+      sourceId: string
+    ) => {
+      await persistence.dataTypeSourcePolicy.put({
+        profileId,
+        dataType,
+        mode: "priority",
+        sourceOrder: promoteSource(options, sourceId),
+      });
+    },
+    [persistence, profileId]
+  );
+
+  const keepAll = useCallback(
+    async (dataType: ManagedDataType) => {
+      await persistence.dataTypeSourcePolicy.put({
+        profileId,
+        dataType,
+        mode: "union",
+        sourceOrder: [],
+      });
+    },
+    [persistence, profileId]
+  );
+
+  return { pick, keepAll };
+};

--- a/packages/workout-spa-editor/src/i18n/locales/en/connections.json
+++ b/packages/workout-spa-editor/src/i18n/locales/en/connections.json
@@ -65,6 +65,16 @@
     "noUsableSource": "No usable source",
     "rankedUnavailableNote": "ranked to sources that are switched off — nothing is being read",
     "sourceLastSent": "{{name}} last sent data {{when}}",
+    "change": {
+      "open": "Change",
+      "close": "Done",
+      "title": "Where should Kaiord read {{type}} from?",
+      "unranked": "Right now Kaiord keeps every source's {{type}} and ranks none of them; when it needs a single value it uses whichever arrived last.",
+      "willRank": "Pick a source below and that changes: Kaiord will read {{type}} from the one you pick, and use the others only on days it has nothing. You can go back to keeping every source right here.",
+      "ranked": "Kaiord reads {{type}} from {{name}} first, and falls back to the others on days it has nothing.",
+      "stalled": "Nothing is being read for {{type}} — it is ranked to sources that are switched off. Pick one below, or go back to keeping every source.",
+      "keepAll": "Keep every source"
+    },
     "groups": {
       "training": "Training",
       "recovery": "Recovery",

--- a/packages/workout-spa-editor/src/i18n/locales/es/connections.json
+++ b/packages/workout-spa-editor/src/i18n/locales/es/connections.json
@@ -65,6 +65,16 @@
     "noUsableSource": "Sin fuente utilizable",
     "rankedUnavailableNote": "prioriza fuentes que están apagadas: no se está leyendo nada",
     "sourceLastSent": "{{name}} envió datos por última vez {{when}}",
+    "change": {
+      "open": "Cambiar",
+      "close": "Hecho",
+      "title": "¿De dónde debería leer Kaiord {{type}}?",
+      "unranked": "Ahora mismo Kaiord guarda {{type}} de todas las fuentes y no prioriza ninguna; cuando necesita un solo valor usa el último que llegó.",
+      "willRank": "Si eliges una fuente abajo eso cambia: Kaiord leerá {{type}} de la que elijas y solo usará las demás los días en que no tenga nada. Puedes volver a guardarlas todas desde aquí mismo.",
+      "ranked": "Kaiord lee {{type}} de {{name}} primero y recurre a las demás los días en que no tenga nada.",
+      "stalled": "No se está leyendo nada de {{type}}: está priorizado a fuentes que están apagadas. Elige una abajo o vuelve a guardarlas todas.",
+      "keepAll": "Guardar todas las fuentes"
+    },
     "groups": {
       "training": "Entrenamiento",
       "recovery": "Recuperación",


### PR DESCRIPTION
## Summary

The inline "Change" control on each data-type row: pick which source Kaiord reads a type from, or go back to keeping every source. Writes through the same `dataTypeSourcePolicy` port the chat tool uses — no new write path, no Dexie change.

## The decision this wave forced, and how it is handled

The default multi-source mode is `union`: every source's record is kept, nothing ranks them, and when a single value is needed **the last write wins**. Choosing a source therefore has to write `mode: "priority"` — using a control whose purpose is to pick a source of truth *is* expressing a ranking.

But that changes how the type is **read**, from "keep everything" to "prefer this one". So the consequence is stated before it happens, in the row's own words:

> Right now Kaiord keeps every source's **Weight** and ranks none of them; when it needs a single value it uses whichever arrived last.
>
> Pick a source below and that changes: Kaiord will read **Weight** from the one you pick, and use the others only on days it has nothing. **You can go back to keeping every source right here.**

Three deliberate properties: it names *this* type; it states **today's** behaviour as well as the new one, so "prefer WHOOP" reads as a change rather than a setting; and it states the way back in the same breath. An already-ranked row gets no warning at all — reordering changes nothing semantically. Opening the disclosure stores nothing.

## What it refuses to offer

- **No control on a lone source under the default mode** — there is no second way to read the type, so it could only flip the mode without changing what is read.
- **No control on a ranked row with no sources left** (reachable: rank `planned-session` via chat, then Disconnect Train2Go). Both modes read nothing there, so the panel could only describe a ranking problem the row does not have. The first cut got this wrong and rendered a misleading panel; caught before commit, test added.
- **No "connect first" choices** for sources the type does not have — that is adding a route, which belongs to the Data Hub cell toggle and would reopen #1085.
- **No runtime guard against an order that resolves to nothing.** `picked` is always one of the offered choices and the control is absent when there are none, so the empty order has no construction site. Guarding it would be the inverted form of the defect this programme keeps producing.

## Capability, including the third state

Candidates are filtered by `bridgeSupportsRoute` **and** the announced wire token. `bridgeDiscovery.getCapabilities` returns `null` for an unverified bridge, and that is treated as **"not asked yet", not "cannot"** — an enabled WHOOP sleep route owns stored records whether or not the extension is running right now.

One divergence accepted and documented: two chat calls (`enable_route` on an incapable route, then `set_source_policy` ranking it) leave Wave 2a's pill naming a source this control will not offer, so no choice shows as current. Both statements are true, and picking any offered source fixes it. Compensating further would mean re-implementing #1085's missing capability check at the display layer, where it cannot stop the write anyway.

## Writer and reader cannot drift

`orderSources` is used only to **compose** an order to store — `[picked, ...candidates minus picked]` — where its appending behaviour is the point: after the write the stored order really does contain every source, so no later reader imagines one. Which choice shows as *in use* stays `rankedHead`, the first saved entry still available, which is exactly what `resolveEffectiveSource` consults. One test feeds a written order straight back into the reader and asserts the pill names the picked source; mutating the current-marker to `orderSources(...)[0]` — the shape of the bug Wave 2a shipped and fixed — fails a test.

## Mutation-tested, and it found two weak tests

Eight guards mutated, all eight caught. The `promoteSource` mutation exposed **two tests where the picked source happened to already lead**, so they would have passed against a control that ignored the pick entirely. Both re-pointed at a non-leading source. That is the programme's own failure mode — a test that cannot fail — caught by deliberately breaking the code first.

Every test records the reachable state it fails on **and which writer creates it**: a Data Hub cell toggle, its priority editor, chat `set_source_policy`, chat `enable_route`, or this control.

## Verification

`pnpm -r build` · SPA **878 files / 6220 tests** · `tsc -b --noEmit` + eslint + prettier clean · `pnpm test:scripts` 616/616 · root `pnpm lint` · `lint:specs` 64 · `check-theme-dialect` clean · `playwright test --list` 1794 · boundaries allowlist untouched.

⚠️ Wave 2a's `DataTypeRoutingSection.test.tsx` now mocks `use-bridge-connections`, since this hook subscribes to it for the capability lookup. If a later wave changes that hook's shape, that mock is what goes stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
